### PR TITLE
mobile: fix quiz options wrapping word-per-line at narrow viewports

### DIFF
--- a/courses/SEL/index.html
+++ b/courses/SEL/index.html
@@ -2979,6 +2979,25 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     }
     .hero-stat { flex: 1 1 calc(50% - 0.5rem); min-width: 0; }
 }
+
+@media (max-width: 480px) {
+    /* Padding stacks across nested containers (section + quiz-section
+       + quiz-question + quiz-option) ate up ~150px of a 390px viewport,
+       leaving quiz labels with ~65px and forcing word-per-line wrapping. */
+    .section, .module-content, .content-wrapper > .section { padding: 1.25rem 0.75rem !important; }
+    .quiz-section, .mcq-section { padding: 1rem !important; margin-top: 1.5rem !important; }
+    .quiz-question, .mcq, .mcq-question { padding: 0.85rem !important; }
+    .quiz-options, .mcq-options { gap: 0.5rem !important; }
+    .quiz-option, .mcq-option { padding: 0.6rem 0.7rem !important; gap: 0.5rem !important; align-items: center !important; }
+    /* Make the label claim the rest of the row instead of shrinking
+       to its intrinsic content width. */
+    .quiz-option label, .mcq-option label { flex: 1 1 auto; min-width: 0; }
+    .quiz-option input[type="radio"], .mcq-option input[type="radio"] { flex-shrink: 0; }
+    .content-card { padding: 1rem !important; }
+    .feature-card { padding: 1rem !important; }
+    /* Module section headings tighten too */
+    .section-header { padding: 0 !important; }
+}
 /* MOBILE-FIX-2026-05-20 END */
 
 </style>

--- a/courses/dataviz/index.html
+++ b/courses/dataviz/index.html
@@ -2627,6 +2627,25 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     }
     .hero-stat { flex: 1 1 calc(50% - 0.5rem); min-width: 0; }
 }
+
+@media (max-width: 480px) {
+    /* Padding stacks across nested containers (section + quiz-section
+       + quiz-question + quiz-option) ate up ~150px of a 390px viewport,
+       leaving quiz labels with ~65px and forcing word-per-line wrapping. */
+    .section, .module-content, .content-wrapper > .section { padding: 1.25rem 0.75rem !important; }
+    .quiz-section, .mcq-section { padding: 1rem !important; margin-top: 1.5rem !important; }
+    .quiz-question, .mcq, .mcq-question { padding: 0.85rem !important; }
+    .quiz-options, .mcq-options { gap: 0.5rem !important; }
+    .quiz-option, .mcq-option { padding: 0.6rem 0.7rem !important; gap: 0.5rem !important; align-items: center !important; }
+    /* Make the label claim the rest of the row instead of shrinking
+       to its intrinsic content width. */
+    .quiz-option label, .mcq-option label { flex: 1 1 auto; min-width: 0; }
+    .quiz-option input[type="radio"], .mcq-option input[type="radio"] { flex-shrink: 0; }
+    .content-card { padding: 1rem !important; }
+    .feature-card { padding: 1rem !important; }
+    /* Module section headings tighten too */
+    .section-header { padding: 0 !important; }
+}
 /* MOBILE-FIX-2026-05-20 END */
 
 </style>

--- a/courses/devai/index.html
+++ b/courses/devai/index.html
@@ -653,6 +653,25 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     }
     .hero-stat { flex: 1 1 calc(50% - 0.5rem); min-width: 0; }
 }
+
+@media (max-width: 480px) {
+    /* Padding stacks across nested containers (section + quiz-section
+       + quiz-question + quiz-option) ate up ~150px of a 390px viewport,
+       leaving quiz labels with ~65px and forcing word-per-line wrapping. */
+    .section, .module-content, .content-wrapper > .section { padding: 1.25rem 0.75rem !important; }
+    .quiz-section, .mcq-section { padding: 1rem !important; margin-top: 1.5rem !important; }
+    .quiz-question, .mcq, .mcq-question { padding: 0.85rem !important; }
+    .quiz-options, .mcq-options { gap: 0.5rem !important; }
+    .quiz-option, .mcq-option { padding: 0.6rem 0.7rem !important; gap: 0.5rem !important; align-items: center !important; }
+    /* Make the label claim the rest of the row instead of shrinking
+       to its intrinsic content width. */
+    .quiz-option label, .mcq-option label { flex: 1 1 auto; min-width: 0; }
+    .quiz-option input[type="radio"], .mcq-option input[type="radio"] { flex-shrink: 0; }
+    .content-card { padding: 1rem !important; }
+    .feature-card { padding: 1rem !important; }
+    /* Module section headings tighten too */
+    .section-header { padding: 0 !important; }
+}
 /* MOBILE-FIX-2026-05-20 END */
 
 </style>

--- a/courses/devecon/index.html
+++ b/courses/devecon/index.html
@@ -3040,6 +3040,25 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     }
     .hero-stat { flex: 1 1 calc(50% - 0.5rem); min-width: 0; }
 }
+
+@media (max-width: 480px) {
+    /* Padding stacks across nested containers (section + quiz-section
+       + quiz-question + quiz-option) ate up ~150px of a 390px viewport,
+       leaving quiz labels with ~65px and forcing word-per-line wrapping. */
+    .section, .module-content, .content-wrapper > .section { padding: 1.25rem 0.75rem !important; }
+    .quiz-section, .mcq-section { padding: 1rem !important; margin-top: 1.5rem !important; }
+    .quiz-question, .mcq, .mcq-question { padding: 0.85rem !important; }
+    .quiz-options, .mcq-options { gap: 0.5rem !important; }
+    .quiz-option, .mcq-option { padding: 0.6rem 0.7rem !important; gap: 0.5rem !important; align-items: center !important; }
+    /* Make the label claim the rest of the row instead of shrinking
+       to its intrinsic content width. */
+    .quiz-option label, .mcq-option label { flex: 1 1 auto; min-width: 0; }
+    .quiz-option input[type="radio"], .mcq-option input[type="radio"] { flex-shrink: 0; }
+    .content-card { padding: 1rem !important; }
+    .feature-card { padding: 1rem !important; }
+    /* Module section headings tighten too */
+    .section-header { padding: 0 !important; }
+}
 /* MOBILE-FIX-2026-05-20 END */
 
 </style>

--- a/courses/gandhi/index.html
+++ b/courses/gandhi/index.html
@@ -2147,6 +2147,25 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     }
     .hero-stat { flex: 1 1 calc(50% - 0.5rem); min-width: 0; }
 }
+
+@media (max-width: 480px) {
+    /* Padding stacks across nested containers (section + quiz-section
+       + quiz-question + quiz-option) ate up ~150px of a 390px viewport,
+       leaving quiz labels with ~65px and forcing word-per-line wrapping. */
+    .section, .module-content, .content-wrapper > .section { padding: 1.25rem 0.75rem !important; }
+    .quiz-section, .mcq-section { padding: 1rem !important; margin-top: 1.5rem !important; }
+    .quiz-question, .mcq, .mcq-question { padding: 0.85rem !important; }
+    .quiz-options, .mcq-options { gap: 0.5rem !important; }
+    .quiz-option, .mcq-option { padding: 0.6rem 0.7rem !important; gap: 0.5rem !important; align-items: center !important; }
+    /* Make the label claim the rest of the row instead of shrinking
+       to its intrinsic content width. */
+    .quiz-option label, .mcq-option label { flex: 1 1 auto; min-width: 0; }
+    .quiz-option input[type="radio"], .mcq-option input[type="radio"] { flex-shrink: 0; }
+    .content-card { padding: 1rem !important; }
+    .feature-card { padding: 1rem !important; }
+    /* Module section headings tighten too */
+    .section-header { padding: 0 !important; }
+}
 /* MOBILE-FIX-2026-05-20 END */
 
 </style>

--- a/courses/gender/index.html
+++ b/courses/gender/index.html
@@ -1543,6 +1543,25 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
     }
     .hero-stat { flex: 1 1 calc(50% - 0.5rem); min-width: 0; }
 }
+
+@media (max-width: 480px) {
+    /* Padding stacks across nested containers (section + quiz-section
+       + quiz-question + quiz-option) ate up ~150px of a 390px viewport,
+       leaving quiz labels with ~65px and forcing word-per-line wrapping. */
+    .section, .module-content, .content-wrapper > .section { padding: 1.25rem 0.75rem !important; }
+    .quiz-section, .mcq-section { padding: 1rem !important; margin-top: 1.5rem !important; }
+    .quiz-question, .mcq, .mcq-question { padding: 0.85rem !important; }
+    .quiz-options, .mcq-options { gap: 0.5rem !important; }
+    .quiz-option, .mcq-option { padding: 0.6rem 0.7rem !important; gap: 0.5rem !important; align-items: center !important; }
+    /* Make the label claim the rest of the row instead of shrinking
+       to its intrinsic content width. */
+    .quiz-option label, .mcq-option label { flex: 1 1 auto; min-width: 0; }
+    .quiz-option input[type="radio"], .mcq-option input[type="radio"] { flex-shrink: 0; }
+    .content-card { padding: 1rem !important; }
+    .feature-card { padding: 1rem !important; }
+    /* Module section headings tighten too */
+    .section-header { padding: 0 !important; }
+}
 /* MOBILE-FIX-2026-05-20 END */
 
 </style>

--- a/courses/law/index.html
+++ b/courses/law/index.html
@@ -3008,6 +3008,25 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     }
     .hero-stat { flex: 1 1 calc(50% - 0.5rem); min-width: 0; }
 }
+
+@media (max-width: 480px) {
+    /* Padding stacks across nested containers (section + quiz-section
+       + quiz-question + quiz-option) ate up ~150px of a 390px viewport,
+       leaving quiz labels with ~65px and forcing word-per-line wrapping. */
+    .section, .module-content, .content-wrapper > .section { padding: 1.25rem 0.75rem !important; }
+    .quiz-section, .mcq-section { padding: 1rem !important; margin-top: 1.5rem !important; }
+    .quiz-question, .mcq, .mcq-question { padding: 0.85rem !important; }
+    .quiz-options, .mcq-options { gap: 0.5rem !important; }
+    .quiz-option, .mcq-option { padding: 0.6rem 0.7rem !important; gap: 0.5rem !important; align-items: center !important; }
+    /* Make the label claim the rest of the row instead of shrinking
+       to its intrinsic content width. */
+    .quiz-option label, .mcq-option label { flex: 1 1 auto; min-width: 0; }
+    .quiz-option input[type="radio"], .mcq-option input[type="radio"] { flex-shrink: 0; }
+    .content-card { padding: 1rem !important; }
+    .feature-card { padding: 1rem !important; }
+    /* Module section headings tighten too */
+    .section-header { padding: 0 !important; }
+}
 /* MOBILE-FIX-2026-05-20 END */
 
 </style>

--- a/courses/media/index.html
+++ b/courses/media/index.html
@@ -3300,6 +3300,25 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     }
     .hero-stat { flex: 1 1 calc(50% - 0.5rem); min-width: 0; }
 }
+
+@media (max-width: 480px) {
+    /* Padding stacks across nested containers (section + quiz-section
+       + quiz-question + quiz-option) ate up ~150px of a 390px viewport,
+       leaving quiz labels with ~65px and forcing word-per-line wrapping. */
+    .section, .module-content, .content-wrapper > .section { padding: 1.25rem 0.75rem !important; }
+    .quiz-section, .mcq-section { padding: 1rem !important; margin-top: 1.5rem !important; }
+    .quiz-question, .mcq, .mcq-question { padding: 0.85rem !important; }
+    .quiz-options, .mcq-options { gap: 0.5rem !important; }
+    .quiz-option, .mcq-option { padding: 0.6rem 0.7rem !important; gap: 0.5rem !important; align-items: center !important; }
+    /* Make the label claim the rest of the row instead of shrinking
+       to its intrinsic content width. */
+    .quiz-option label, .mcq-option label { flex: 1 1 auto; min-width: 0; }
+    .quiz-option input[type="radio"], .mcq-option input[type="radio"] { flex-shrink: 0; }
+    .content-card { padding: 1rem !important; }
+    .feature-card { padding: 1rem !important; }
+    /* Module section headings tighten too */
+    .section-header { padding: 0 !important; }
+}
 /* MOBILE-FIX-2026-05-20 END */
 
 </style>

--- a/courses/mel/index.html
+++ b/courses/mel/index.html
@@ -3309,6 +3309,25 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     }
     .hero-stat { flex: 1 1 calc(50% - 0.5rem); min-width: 0; }
 }
+
+@media (max-width: 480px) {
+    /* Padding stacks across nested containers (section + quiz-section
+       + quiz-question + quiz-option) ate up ~150px of a 390px viewport,
+       leaving quiz labels with ~65px and forcing word-per-line wrapping. */
+    .section, .module-content, .content-wrapper > .section { padding: 1.25rem 0.75rem !important; }
+    .quiz-section, .mcq-section { padding: 1rem !important; margin-top: 1.5rem !important; }
+    .quiz-question, .mcq, .mcq-question { padding: 0.85rem !important; }
+    .quiz-options, .mcq-options { gap: 0.5rem !important; }
+    .quiz-option, .mcq-option { padding: 0.6rem 0.7rem !important; gap: 0.5rem !important; align-items: center !important; }
+    /* Make the label claim the rest of the row instead of shrinking
+       to its intrinsic content width. */
+    .quiz-option label, .mcq-option label { flex: 1 1 auto; min-width: 0; }
+    .quiz-option input[type="radio"], .mcq-option input[type="radio"] { flex-shrink: 0; }
+    .content-card { padding: 1rem !important; }
+    .feature-card { padding: 1rem !important; }
+    /* Module section headings tighten too */
+    .section-header { padding: 0 !important; }
+}
 /* MOBILE-FIX-2026-05-20 END */
 
 </style>

--- a/courses/poa/index.html
+++ b/courses/poa/index.html
@@ -3114,6 +3114,25 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     }
     .hero-stat { flex: 1 1 calc(50% - 0.5rem); min-width: 0; }
 }
+
+@media (max-width: 480px) {
+    /* Padding stacks across nested containers (section + quiz-section
+       + quiz-question + quiz-option) ate up ~150px of a 390px viewport,
+       leaving quiz labels with ~65px and forcing word-per-line wrapping. */
+    .section, .module-content, .content-wrapper > .section { padding: 1.25rem 0.75rem !important; }
+    .quiz-section, .mcq-section { padding: 1rem !important; margin-top: 1.5rem !important; }
+    .quiz-question, .mcq, .mcq-question { padding: 0.85rem !important; }
+    .quiz-options, .mcq-options { gap: 0.5rem !important; }
+    .quiz-option, .mcq-option { padding: 0.6rem 0.7rem !important; gap: 0.5rem !important; align-items: center !important; }
+    /* Make the label claim the rest of the row instead of shrinking
+       to its intrinsic content width. */
+    .quiz-option label, .mcq-option label { flex: 1 1 auto; min-width: 0; }
+    .quiz-option input[type="radio"], .mcq-option input[type="radio"] { flex-shrink: 0; }
+    .content-card { padding: 1rem !important; }
+    .feature-card { padding: 1rem !important; }
+    /* Module section headings tighten too */
+    .section-header { padding: 0 !important; }
+}
 /* MOBILE-FIX-2026-05-20 END */
 
 </style>

--- a/courses/pubchoice/index.html
+++ b/courses/pubchoice/index.html
@@ -3270,6 +3270,25 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     }
     .hero-stat { flex: 1 1 calc(50% - 0.5rem); min-width: 0; }
 }
+
+@media (max-width: 480px) {
+    /* Padding stacks across nested containers (section + quiz-section
+       + quiz-question + quiz-option) ate up ~150px of a 390px viewport,
+       leaving quiz labels with ~65px and forcing word-per-line wrapping. */
+    .section, .module-content, .content-wrapper > .section { padding: 1.25rem 0.75rem !important; }
+    .quiz-section, .mcq-section { padding: 1rem !important; margin-top: 1.5rem !important; }
+    .quiz-question, .mcq, .mcq-question { padding: 0.85rem !important; }
+    .quiz-options, .mcq-options { gap: 0.5rem !important; }
+    .quiz-option, .mcq-option { padding: 0.6rem 0.7rem !important; gap: 0.5rem !important; align-items: center !important; }
+    /* Make the label claim the rest of the row instead of shrinking
+       to its intrinsic content width. */
+    .quiz-option label, .mcq-option label { flex: 1 1 auto; min-width: 0; }
+    .quiz-option input[type="radio"], .mcq-option input[type="radio"] { flex-shrink: 0; }
+    .content-card { padding: 1rem !important; }
+    .feature-card { padding: 1rem !important; }
+    /* Module section headings tighten too */
+    .section-header { padding: 0 !important; }
+}
 /* MOBILE-FIX-2026-05-20 END */
 
 </style>

--- a/courses/pubpol/index.html
+++ b/courses/pubpol/index.html
@@ -701,6 +701,25 @@ body.dark-mode, [data-theme="dark"] {
     }
     .hero-stat { flex: 1 1 calc(50% - 0.5rem); min-width: 0; }
 }
+
+@media (max-width: 480px) {
+    /* Padding stacks across nested containers (section + quiz-section
+       + quiz-question + quiz-option) ate up ~150px of a 390px viewport,
+       leaving quiz labels with ~65px and forcing word-per-line wrapping. */
+    .section, .module-content, .content-wrapper > .section { padding: 1.25rem 0.75rem !important; }
+    .quiz-section, .mcq-section { padding: 1rem !important; margin-top: 1.5rem !important; }
+    .quiz-question, .mcq, .mcq-question { padding: 0.85rem !important; }
+    .quiz-options, .mcq-options { gap: 0.5rem !important; }
+    .quiz-option, .mcq-option { padding: 0.6rem 0.7rem !important; gap: 0.5rem !important; align-items: center !important; }
+    /* Make the label claim the rest of the row instead of shrinking
+       to its intrinsic content width. */
+    .quiz-option label, .mcq-option label { flex: 1 1 auto; min-width: 0; }
+    .quiz-option input[type="radio"], .mcq-option input[type="radio"] { flex-shrink: 0; }
+    .content-card { padding: 1rem !important; }
+    .feature-card { padding: 1rem !important; }
+    /* Module section headings tighten too */
+    .section-header { padding: 0 !important; }
+}
 /* MOBILE-FIX-2026-05-20 END */
 
 </style>


### PR DESCRIPTION
## Summary

Follow-up to #417. On iPhone, the dataviz course quiz options wrapped to one word per line — "Using only pie charts" stacked vertically as 4 lines.

**Root cause:** padding stacking across nested containers.

At 390px viewport, the quiz layout was:
- `.section` padding 32px each side → 326px inner
- `.quiz-section` padding 32px each side → 262px inner
- `.quiz-question` padding 20px each side → 222px inner
- `.quiz-option` padding 16px each side → 190px inner
- radio + gap → ~28px, leaving the label with `flex: 0 1 auto` shrinking to **~66px of intrinsic content width**

That's why "Using\nonly\npie\ncharts" stacked vertically — there literally wasn't room for the words on one line.

## Fix
Scoped to `@media (max-width: 480px)`:
- Reduced padding on `.section`, `.quiz-section`, `.quiz-question`, `.quiz-option`, `.content-card`
- `.quiz-option label` and `.mcq-option label` set to `flex: 1 1 auto; min-width: 0` so the label claims the remaining row width
- Radio inputs set to `flex-shrink: 0` so they stay at natural size
- Mirrored rules for `.mcq-*` (the other quiz pattern used across courses)

## Test plan
- [x] At 390px label width measured **66px → 222px** after fix
- [x] Desktop (1280px) untouched: `.quiz-section` still has 32px padding, labels size naturally
- [x] CSS lives in the same `MOBILE-FIX-2026-05-20` block in all 12 flagship courses (quiz HTML is injected at runtime by `js/course-loader.js`)
- [ ] Manual phone check once Netlify deploys

(Supersedes #418, which conflicted with the squash-merge of #417.)

https://claude.ai/code/session_012uCmAm56wSwFB5rTQSgacC

---
_Generated by [Claude Code](https://claude.ai/code/session_012uCmAm56wSwFB5rTQSgacC)_