### PR TITLE
theme: unify localStorage key across all 12 flagship courses

### DIFF
--- a/courses/SEL/index.html
+++ b/courses/SEL/index.html
@@ -2,6 +2,31 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>
+    /* THEME-KEY-UNIFY 2026-05-20: migrate any legacy theme prefs to the
+       canonical `impactmojo-theme` key, then make sure data-theme is set
+       before first paint to avoid a flash. */
+    (function(){
+        try {
+            var canon = 'impactmojo-theme';
+            var legacy = ['theme','im-theme'];
+            if (!localStorage.getItem(canon)) {
+                for (var i = 0; i < legacy.length; i++) {
+                    var v = localStorage.getItem(legacy[i]);
+                    if (v) { localStorage.setItem(canon, v); break; }
+                }
+            }
+            legacy.forEach(function(k){ localStorage.removeItem(k); });
+            var saved = localStorage.getItem(canon);
+            var resolved = saved;
+            if (!saved || saved === 'system') {
+                resolved = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+            }
+            document.documentElement.setAttribute('data-theme', resolved);
+        } catch(e){}
+    })();
+    </script>
+
     <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
@@ -3689,7 +3714,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
         });
     }
-    var saved = localStorage.getItem('im-theme') || 'system';
+    var saved = localStorage.getItem('impactmojo-theme') || 'system';
     // Apply immediately before render
     applyTheme(saved);
     document.addEventListener('DOMContentLoaded', function() {
@@ -3698,7 +3723,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
             btn.addEventListener('click', function() {
                 var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
+                localStorage.setItem('impactmojo-theme', t);
                 applyTheme(t);
                 updateButtons(t);
             });
@@ -3706,7 +3731,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     });
     // Listen for system theme changes
     window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
+        if ((localStorage.getItem('impactmojo-theme') || 'system') === 'system') {
             applyTheme('system');
         }
     });

--- a/courses/dataviz/index.html
+++ b/courses/dataviz/index.html
@@ -2,6 +2,31 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>
+    /* THEME-KEY-UNIFY 2026-05-20: migrate any legacy theme prefs to the
+       canonical `impactmojo-theme` key, then make sure data-theme is set
+       before first paint to avoid a flash. */
+    (function(){
+        try {
+            var canon = 'impactmojo-theme';
+            var legacy = ['theme','im-theme'];
+            if (!localStorage.getItem(canon)) {
+                for (var i = 0; i < legacy.length; i++) {
+                    var v = localStorage.getItem(legacy[i]);
+                    if (v) { localStorage.setItem(canon, v); break; }
+                }
+            }
+            legacy.forEach(function(k){ localStorage.removeItem(k); });
+            var saved = localStorage.getItem(canon);
+            var resolved = saved;
+            if (!saved || saved === 'system') {
+                resolved = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+            }
+            document.documentElement.setAttribute('data-theme', resolved);
+        } catch(e){}
+    })();
+    </script>
+
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#0F172A">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -3940,7 +3965,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             
             function setTheme(isDark) {
                 document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');
-                localStorage.setItem('theme', isDark ? 'dark' : 'light');
+                localStorage.setItem('impactmojo-theme', isDark ? 'dark' : 'light');
                 
                 const label = themeToggle?.querySelector('.theme-label');
                 if (label) {
@@ -3954,7 +3979,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             }
             
             // Initialize theme - default to light
-            const savedTheme = localStorage.getItem('theme');
+            const savedTheme = localStorage.getItem('impactmojo-theme');
             if (savedTheme) {
                 setTheme(savedTheme === 'dark');
             } else {
@@ -4261,7 +4286,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
         });
     }
-    var saved = localStorage.getItem('im-theme') || 'system';
+    var saved = localStorage.getItem('impactmojo-theme') || 'system';
     // Apply immediately before render
     applyTheme(saved);
     document.addEventListener('DOMContentLoaded', function() {
@@ -4270,7 +4295,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
             btn.addEventListener('click', function() {
                 var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
+                localStorage.setItem('impactmojo-theme', t);
                 applyTheme(t);
                 updateButtons(t);
             });
@@ -4278,7 +4303,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     });
     // Listen for system theme changes
     window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
+        if ((localStorage.getItem('impactmojo-theme') || 'system') === 'system') {
             applyTheme('system');
         }
     });

--- a/courses/devai/index.html
+++ b/courses/devai/index.html
@@ -2,6 +2,31 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>
+    /* THEME-KEY-UNIFY 2026-05-20: migrate any legacy theme prefs to the
+       canonical `impactmojo-theme` key, then make sure data-theme is set
+       before first paint to avoid a flash. */
+    (function(){
+        try {
+            var canon = 'impactmojo-theme';
+            var legacy = ['theme','im-theme'];
+            if (!localStorage.getItem(canon)) {
+                for (var i = 0; i < legacy.length; i++) {
+                    var v = localStorage.getItem(legacy[i]);
+                    if (v) { localStorage.setItem(canon, v); break; }
+                }
+            }
+            legacy.forEach(function(k){ localStorage.removeItem(k); });
+            var saved = localStorage.getItem(canon);
+            var resolved = saved;
+            if (!saved || saved === 'system') {
+                resolved = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+            }
+            document.documentElement.setAttribute('data-theme', resolved);
+        } catch(e){}
+    })();
+    </script>
+
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#0F172A">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -1555,7 +1580,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             const themeLabel = themeToggle.querySelector('span');
             
             function getPreferredTheme() {
-                const saved = localStorage.getItem('theme');
+                const saved = localStorage.getItem('impactmojo-theme');
                 if (saved) return saved;
                 if (window.matchMedia('(prefers-color-scheme: dark)').matches) return 'dark';
                 const hour = new Date().getHours();
@@ -1564,7 +1589,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             
             function setTheme(theme) {
                 document.documentElement.setAttribute('data-theme', theme);
-                localStorage.setItem('theme', theme);
+                localStorage.setItem('impactmojo-theme', theme);
                 themeLabel.textContent = theme === 'dark' ? 'Dark mode' : 'Light mode';
             }
             
@@ -1699,7 +1724,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
         });
     }
-    var saved = localStorage.getItem('im-theme') || 'system';
+    var saved = localStorage.getItem('impactmojo-theme') || 'system';
     // Apply immediately before render
     applyTheme(saved);
     document.addEventListener('DOMContentLoaded', function() {
@@ -1708,7 +1733,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
             btn.addEventListener('click', function() {
                 var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
+                localStorage.setItem('impactmojo-theme', t);
                 applyTheme(t);
                 updateButtons(t);
             });
@@ -1716,7 +1741,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     });
     // Listen for system theme changes
     window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
+        if ((localStorage.getItem('impactmojo-theme') || 'system') === 'system') {
             applyTheme('system');
         }
     });

--- a/courses/devecon/index.html
+++ b/courses/devecon/index.html
@@ -2,6 +2,31 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>
+    /* THEME-KEY-UNIFY 2026-05-20: migrate any legacy theme prefs to the
+       canonical `impactmojo-theme` key, then make sure data-theme is set
+       before first paint to avoid a flash. */
+    (function(){
+        try {
+            var canon = 'impactmojo-theme';
+            var legacy = ['theme','im-theme'];
+            if (!localStorage.getItem(canon)) {
+                for (var i = 0; i < legacy.length; i++) {
+                    var v = localStorage.getItem(legacy[i]);
+                    if (v) { localStorage.setItem(canon, v); break; }
+                }
+            }
+            legacy.forEach(function(k){ localStorage.removeItem(k); });
+            var saved = localStorage.getItem(canon);
+            var resolved = saved;
+            if (!saved || saved === 'system') {
+                resolved = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+            }
+            document.documentElement.setAttribute('data-theme', resolved);
+        } catch(e){}
+    })();
+    </script>
+
     <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
@@ -4014,7 +4039,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
         });
     }
-    var saved = localStorage.getItem('im-theme') || 'system';
+    var saved = localStorage.getItem('impactmojo-theme') || 'system';
     // Apply immediately before render
     applyTheme(saved);
     document.addEventListener('DOMContentLoaded', function() {
@@ -4023,7 +4048,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
             btn.addEventListener('click', function() {
                 var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
+                localStorage.setItem('impactmojo-theme', t);
                 applyTheme(t);
                 updateButtons(t);
             });
@@ -4031,7 +4056,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     });
     // Listen for system theme changes
     window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
+        if ((localStorage.getItem('impactmojo-theme') || 'system') === 'system') {
             applyTheme('system');
         }
     });

--- a/courses/gandhi/index.html
+++ b/courses/gandhi/index.html
@@ -2,6 +2,31 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>
+    /* THEME-KEY-UNIFY 2026-05-20: migrate any legacy theme prefs to the
+       canonical `impactmojo-theme` key, then make sure data-theme is set
+       before first paint to avoid a flash. */
+    (function(){
+        try {
+            var canon = 'impactmojo-theme';
+            var legacy = ['theme','im-theme'];
+            if (!localStorage.getItem(canon)) {
+                for (var i = 0; i < legacy.length; i++) {
+                    var v = localStorage.getItem(legacy[i]);
+                    if (v) { localStorage.setItem(canon, v); break; }
+                }
+            }
+            legacy.forEach(function(k){ localStorage.removeItem(k); });
+            var saved = localStorage.getItem(canon);
+            var resolved = saved;
+            if (!saved || saved === 'system') {
+                resolved = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+            }
+            document.documentElement.setAttribute('data-theme', resolved);
+        } catch(e){}
+    })();
+    </script>
+
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#0F172A">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -3483,7 +3508,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             
             function setTheme(isDark) {
                 document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');
-                localStorage.setItem('theme', isDark ? 'dark' : 'light');
+                localStorage.setItem('impactmojo-theme', isDark ? 'dark' : 'light');
                 
                 const label = themeToggle?.querySelector('.theme-label');
                 if (label) {
@@ -3497,7 +3522,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             }
             
             // Initialize theme - default to light
-            const savedTheme = localStorage.getItem('theme');
+            const savedTheme = localStorage.getItem('impactmojo-theme');
             if (savedTheme) {
                 setTheme(savedTheme === 'dark');
             } else {
@@ -3734,7 +3759,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
         });
     }
-    var saved = localStorage.getItem('im-theme') || 'system';
+    var saved = localStorage.getItem('impactmojo-theme') || 'system';
     // Apply immediately before render
     applyTheme(saved);
     document.addEventListener('DOMContentLoaded', function() {
@@ -3743,7 +3768,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
             btn.addEventListener('click', function() {
                 var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
+                localStorage.setItem('impactmojo-theme', t);
                 applyTheme(t);
                 updateButtons(t);
             });
@@ -3751,7 +3776,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     });
     // Listen for system theme changes
     window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
+        if ((localStorage.getItem('impactmojo-theme') || 'system') === 'system') {
             applyTheme('system');
         }
     });

--- a/courses/gender/index.html
+++ b/courses/gender/index.html
@@ -2,6 +2,31 @@
 <html lang="en" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+    <script>
+    /* THEME-KEY-UNIFY 2026-05-20: migrate any legacy theme prefs to the
+       canonical `impactmojo-theme` key, then make sure data-theme is set
+       before first paint to avoid a flash. */
+    (function(){
+        try {
+            var canon = 'impactmojo-theme';
+            var legacy = ['theme','im-theme'];
+            if (!localStorage.getItem(canon)) {
+                for (var i = 0; i < legacy.length; i++) {
+                    var v = localStorage.getItem(legacy[i]);
+                    if (v) { localStorage.setItem(canon, v); break; }
+                }
+            }
+            legacy.forEach(function(k){ localStorage.removeItem(k); });
+            var saved = localStorage.getItem(canon);
+            var resolved = saved;
+            if (!saved || saved === 'system') {
+                resolved = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+            }
+            document.documentElement.setAttribute('data-theme', resolved);
+        } catch(e){}
+    })();
+    </script>
+
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Gender Studies: Feminisms, Power & Social Change | ImpactMojo</title>
 <meta name="description" content="A flagship course on feminist theory, gender & power, care work, law, movements, and development practice — with deep South Asian focus. Free forever.">
@@ -2249,7 +2274,7 @@ sections.forEach(section => {
             btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
         });
     }
-    var saved = localStorage.getItem('im-theme') || 'system';
+    var saved = localStorage.getItem('impactmojo-theme') || 'system';
     // Apply immediately before render
     applyTheme(saved);
     document.addEventListener('DOMContentLoaded', function() {
@@ -2258,7 +2283,7 @@ sections.forEach(section => {
         document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
             btn.addEventListener('click', function() {
                 var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
+                localStorage.setItem('impactmojo-theme', t);
                 applyTheme(t);
                 updateButtons(t);
             });
@@ -2266,7 +2291,7 @@ sections.forEach(section => {
     });
     // Listen for system theme changes
     window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
+        if ((localStorage.getItem('impactmojo-theme') || 'system') === 'system') {
             applyTheme('system');
         }
     });

--- a/courses/law/index.html
+++ b/courses/law/index.html
@@ -2,6 +2,31 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>
+    /* THEME-KEY-UNIFY 2026-05-20: migrate any legacy theme prefs to the
+       canonical `impactmojo-theme` key, then make sure data-theme is set
+       before first paint to avoid a flash. */
+    (function(){
+        try {
+            var canon = 'impactmojo-theme';
+            var legacy = ['theme','im-theme'];
+            if (!localStorage.getItem(canon)) {
+                for (var i = 0; i < legacy.length; i++) {
+                    var v = localStorage.getItem(legacy[i]);
+                    if (v) { localStorage.setItem(canon, v); break; }
+                }
+            }
+            legacy.forEach(function(k){ localStorage.removeItem(k); });
+            var saved = localStorage.getItem(canon);
+            var resolved = saved;
+            if (!saved || saved === 'system') {
+                resolved = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+            }
+            document.documentElement.setAttribute('data-theme', resolved);
+        } catch(e){}
+    })();
+    </script>
+
     <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
@@ -3956,7 +3981,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
         });
     }
-    var saved = localStorage.getItem('im-theme') || 'system';
+    var saved = localStorage.getItem('impactmojo-theme') || 'system';
     // Apply immediately before render
     applyTheme(saved);
     document.addEventListener('DOMContentLoaded', function() {
@@ -3965,7 +3990,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
             btn.addEventListener('click', function() {
                 var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
+                localStorage.setItem('impactmojo-theme', t);
                 applyTheme(t);
                 updateButtons(t);
             });
@@ -3973,7 +3998,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     });
     // Listen for system theme changes
     window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
+        if ((localStorage.getItem('impactmojo-theme') || 'system') === 'system') {
             applyTheme('system');
         }
     });

--- a/courses/media/index.html
+++ b/courses/media/index.html
@@ -2,6 +2,31 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>
+    /* THEME-KEY-UNIFY 2026-05-20: migrate any legacy theme prefs to the
+       canonical `impactmojo-theme` key, then make sure data-theme is set
+       before first paint to avoid a flash. */
+    (function(){
+        try {
+            var canon = 'impactmojo-theme';
+            var legacy = ['theme','im-theme'];
+            if (!localStorage.getItem(canon)) {
+                for (var i = 0; i < legacy.length; i++) {
+                    var v = localStorage.getItem(legacy[i]);
+                    if (v) { localStorage.setItem(canon, v); break; }
+                }
+            }
+            legacy.forEach(function(k){ localStorage.removeItem(k); });
+            var saved = localStorage.getItem(canon);
+            var resolved = saved;
+            if (!saved || saved === 'system') {
+                resolved = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+            }
+            document.documentElement.setAttribute('data-theme', resolved);
+        } catch(e){}
+    })();
+    </script>
+
     <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
@@ -4176,7 +4201,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
         });
     }
-    var saved = localStorage.getItem('im-theme') || 'system';
+    var saved = localStorage.getItem('impactmojo-theme') || 'system';
     // Apply immediately before render
     applyTheme(saved);
     document.addEventListener('DOMContentLoaded', function() {
@@ -4185,7 +4210,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
             btn.addEventListener('click', function() {
                 var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
+                localStorage.setItem('impactmojo-theme', t);
                 applyTheme(t);
                 updateButtons(t);
             });
@@ -4193,7 +4218,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     });
     // Listen for system theme changes
     window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
+        if ((localStorage.getItem('impactmojo-theme') || 'system') === 'system') {
             applyTheme('system');
         }
     });

--- a/courses/mel/index.html
+++ b/courses/mel/index.html
@@ -2,6 +2,31 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>
+    /* THEME-KEY-UNIFY 2026-05-20: migrate any legacy theme prefs to the
+       canonical `impactmojo-theme` key, then make sure data-theme is set
+       before first paint to avoid a flash. */
+    (function(){
+        try {
+            var canon = 'impactmojo-theme';
+            var legacy = ['theme','im-theme'];
+            if (!localStorage.getItem(canon)) {
+                for (var i = 0; i < legacy.length; i++) {
+                    var v = localStorage.getItem(legacy[i]);
+                    if (v) { localStorage.setItem(canon, v); break; }
+                }
+            }
+            legacy.forEach(function(k){ localStorage.removeItem(k); });
+            var saved = localStorage.getItem(canon);
+            var resolved = saved;
+            if (!saved || saved === 'system') {
+                resolved = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+            }
+            document.documentElement.setAttribute('data-theme', resolved);
+        } catch(e){}
+    })();
+    </script>
+
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -4253,7 +4278,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
         });
     }
-    var saved = localStorage.getItem('im-theme') || 'system';
+    var saved = localStorage.getItem('impactmojo-theme') || 'system';
     // Apply immediately before render
     applyTheme(saved);
     document.addEventListener('DOMContentLoaded', function() {
@@ -4262,7 +4287,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
             btn.addEventListener('click', function() {
                 var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
+                localStorage.setItem('impactmojo-theme', t);
                 applyTheme(t);
                 updateButtons(t);
             });
@@ -4270,7 +4295,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     });
     // Listen for system theme changes
     window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
+        if ((localStorage.getItem('impactmojo-theme') || 'system') === 'system') {
             applyTheme('system');
         }
     });

--- a/courses/poa/index.html
+++ b/courses/poa/index.html
@@ -2,6 +2,31 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>
+    /* THEME-KEY-UNIFY 2026-05-20: migrate any legacy theme prefs to the
+       canonical `impactmojo-theme` key, then make sure data-theme is set
+       before first paint to avoid a flash. */
+    (function(){
+        try {
+            var canon = 'impactmojo-theme';
+            var legacy = ['theme','im-theme'];
+            if (!localStorage.getItem(canon)) {
+                for (var i = 0; i < legacy.length; i++) {
+                    var v = localStorage.getItem(legacy[i]);
+                    if (v) { localStorage.setItem(canon, v); break; }
+                }
+            }
+            legacy.forEach(function(k){ localStorage.removeItem(k); });
+            var saved = localStorage.getItem(canon);
+            var resolved = saved;
+            if (!saved || saved === 'system') {
+                resolved = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+            }
+            document.documentElement.setAttribute('data-theme', resolved);
+        } catch(e){}
+    })();
+    </script>
+
     <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
@@ -4076,7 +4101,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
         });
     }
-    var saved = localStorage.getItem('im-theme') || 'system';
+    var saved = localStorage.getItem('impactmojo-theme') || 'system';
     // Apply immediately before render
     applyTheme(saved);
     document.addEventListener('DOMContentLoaded', function() {
@@ -4085,7 +4110,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
             btn.addEventListener('click', function() {
                 var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
+                localStorage.setItem('impactmojo-theme', t);
                 applyTheme(t);
                 updateButtons(t);
             });
@@ -4093,7 +4118,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     });
     // Listen for system theme changes
     window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
+        if ((localStorage.getItem('impactmojo-theme') || 'system') === 'system') {
             applyTheme('system');
         }
     });

--- a/courses/pubchoice/index.html
+++ b/courses/pubchoice/index.html
@@ -2,6 +2,31 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>
+    /* THEME-KEY-UNIFY 2026-05-20: migrate any legacy theme prefs to the
+       canonical `impactmojo-theme` key, then make sure data-theme is set
+       before first paint to avoid a flash. */
+    (function(){
+        try {
+            var canon = 'impactmojo-theme';
+            var legacy = ['theme','im-theme'];
+            if (!localStorage.getItem(canon)) {
+                for (var i = 0; i < legacy.length; i++) {
+                    var v = localStorage.getItem(legacy[i]);
+                    if (v) { localStorage.setItem(canon, v); break; }
+                }
+            }
+            legacy.forEach(function(k){ localStorage.removeItem(k); });
+            var saved = localStorage.getItem(canon);
+            var resolved = saved;
+            if (!saved || saved === 'system') {
+                resolved = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+            }
+            document.documentElement.setAttribute('data-theme', resolved);
+        } catch(e){}
+    })();
+    </script>
+
     <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
@@ -5538,7 +5563,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
         });
     }
-    var saved = localStorage.getItem('im-theme') || 'system';
+    var saved = localStorage.getItem('impactmojo-theme') || 'system';
     // Apply immediately before render
     applyTheme(saved);
     document.addEventListener('DOMContentLoaded', function() {
@@ -5547,7 +5572,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
             btn.addEventListener('click', function() {
                 var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
+                localStorage.setItem('impactmojo-theme', t);
                 applyTheme(t);
                 updateButtons(t);
             });
@@ -5555,7 +5580,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     });
     // Listen for system theme changes
     window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
+        if ((localStorage.getItem('impactmojo-theme') || 'system') === 'system') {
             applyTheme('system');
         }
     });

--- a/courses/pubpol/index.html
+++ b/courses/pubpol/index.html
@@ -2,6 +2,31 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>
+    /* THEME-KEY-UNIFY 2026-05-20: migrate any legacy theme prefs to the
+       canonical `impactmojo-theme` key, then make sure data-theme is set
+       before first paint to avoid a flash. */
+    (function(){
+        try {
+            var canon = 'impactmojo-theme';
+            var legacy = ['theme','im-theme'];
+            if (!localStorage.getItem(canon)) {
+                for (var i = 0; i < legacy.length; i++) {
+                    var v = localStorage.getItem(legacy[i]);
+                    if (v) { localStorage.setItem(canon, v); break; }
+                }
+            }
+            legacy.forEach(function(k){ localStorage.removeItem(k); });
+            var saved = localStorage.getItem(canon);
+            var resolved = saved;
+            if (!saved || saved === 'system') {
+                resolved = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+            }
+            document.documentElement.setAttribute('data-theme', resolved);
+        } catch(e){}
+    })();
+    </script>
+
     <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
@@ -1460,7 +1485,7 @@ body.dark-mode, [data-theme="dark"] {
             btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
         });
     }
-    var saved = localStorage.getItem('im-theme') || 'system';
+    var saved = localStorage.getItem('impactmojo-theme') || 'system';
     applyTheme(saved);
     document.addEventListener('DOMContentLoaded', function() {
         applyTheme(saved);
@@ -1468,14 +1493,14 @@ body.dark-mode, [data-theme="dark"] {
         document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
             btn.addEventListener('click', function() {
                 var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
+                localStorage.setItem('impactmojo-theme', t);
                 applyTheme(t);
                 updateButtons(t);
             });
         });
     });
     window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
+        if ((localStorage.getItem('impactmojo-theme') || 'system') === 'system') {
             applyTheme('system');
         }
     });


### PR DESCRIPTION
## Summary

Three different `localStorage` keys were tracking the same preference:
- `impactmojo-theme` — 8 courses (canonical)
- `theme` — dataviz, devai, gandhi (legacy course-level toggle)
- `im-theme` — every course's `im-topbar` component (so each course double-stores)

So toggling dark mode on devecon (writes `impactmojo-theme`) didn't carry over to dataviz (reads `theme`), or vice versa. The user saw some courses opening light, others dark.

## Fix
- 40 replacements across 12 files: every `theme` / `im-theme` read+write now uses `impactmojo-theme`
- Prepends a tiny migration block that runs **before first paint**: if a learner already has a value under `theme` or `im-theme`, copy it to `impactmojo-theme` once, then delete the legacy key
- The migration also resolves `system` → light/dark via `matchMedia('prefers-color-scheme: dark')` so `data-theme` is set before the first paint — kills the brief light→dark flash on dark-preferring devices

## Test plan
- [x] 7/7 migration scenarios pass (legacy keys, canonical-wins-over-legacy, system pref resolves, etc.)
- [x] Cross-course end-to-end: click dark in devecon → still dark in dataviz, gandhi; click light in gandhi → light in devecon. Preference persists everywhere.
- [ ] Phone check: clear site data, visit one course, toggle dark, navigate to another course — should stay dark

https://claude.ai/code/session_012uCmAm56wSwFB5rTQSgacC

---
_Generated by [Claude Code](https://claude.ai/code/session_012uCmAm56wSwFB5rTQSgacC)_