### PR TITLE
chrome: normalize footer markup + sidebar toggle class across 11 courses

### DIFF
--- a/courses/SEL/index.html
+++ b/courses/SEL/index.html
@@ -3296,47 +3296,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         </div>
         
         <!-- Footer -->
-        <footer class="footer">
-            <div class="footer-content">
-                <div class="footer-logo">
-                    <a href="/">
-                        <img src="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" height="40">
-                    </a>
-                    <p>Free development education for everyone.</p>
-                </div>
-                <div class="footer-links">
-                    <div class="footer-column">
-                        <h4>Learn</h4>
-                        <a href="/catalog">All Courses</a>
-                        <a href="/workshops">Workshops</a>
-                        <a href="/handouts">Handouts</a>
-                        <a href="/podcast">Podcast</a>
-                    </div>
-                    <div class="footer-column">
-                        <h4>Connect</h4>
-                        <a href="/about">About Us</a>
-                        <a href="/contact">Contact</a>
-                        <a href="/faq">FAQ</a>
-                        <a href="/blog">Blog</a>
-                    </div>
-                    <div class="footer-column">
-                        <h4>Support</h4>
-                        <a href="/premium">Premium</a>
-                        <a href="/premium">Support Us</a>
-                        <a href="/coaching">Coaching</a>
-                    </div>
-                </div>
-            </div>
-            <div class="footer-bottom">
-                <p>© 2026 ImpactMojo. Pay What You Think Is Fair.</p>
-                <div class="footer-legal">
-                    <a href="/privacy-policy">Privacy</a>
-                    <a href="/terms-of-service">Terms</a>
-                    <a href="/disclaimer">Disclaimer</a>
-                </div>
-            </div>
-            <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Docs (GitBook)</a></p>
-</footer>
+        
         
         <!-- JavaScript -->
         <script>
@@ -3751,31 +3711,40 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <footer class="footer">
     <div class="footer-content">
         <div class="footer-logo">
-            <img src="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo">
-            <p>Development Know-How for Social Impact</p>
+            <a href="/">
+                <img src="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" height="40">
+            </a>
+            <p>Free development education for everyone.</p>
         </div>
         <div class="footer-links">
             <div class="footer-column">
-                <h4>Courses</h4>
-                <a href="/courses/gandhi/">Gandhi Political Philosophy</a>
-                <a href="/courses/devecon/">Development Economics</a>
-                <a href="/courses/dataviz/">Data Visualization</a>
-                <a href="/courses/devai/">AI for Impact</a>
-                <a href="/courses/pubpol/">Public Policy</a>
+                <h4>Learn</h4>
+                <a href="/catalog">All Courses</a>
+                <a href="/workshops">Workshops</a>
+                <a href="/handouts">Handouts</a>
+                <a href="/podcast">Podcast</a>
             </div>
             <div class="footer-column">
-                <h4>Resources</h4>
-                <a href="/coaching">1:1 Coaching</a>
-                <a href="/#labs">Interactive Labs</a>
-                <a href="/catalog">Course Catalog</a>
+                <h4>Connect</h4>
+                <a href="/about">About Us</a>
+                <a href="/contact">Contact</a>
+                <a href="/faq">FAQ</a>
+                <a href="/blog">Blog</a>
+            </div>
+            <div class="footer-column">
+                <h4>Support</h4>
+                <a href="/premium">Premium</a>
+                <a href="/premium">Support Us</a>
+                <a href="/coaching">Coaching</a>
             </div>
         </div>
     </div>
     <div class="footer-bottom">
-        <p>&copy; 2026 ImpactMojo. Free for development professionals.</p>
+        <p>&copy; 2026 ImpactMojo. Pay What You Think Is Fair.</p>
         <div class="footer-legal">
-            <a href="/terms-of-service">Terms</a>
             <a href="/privacy-policy">Privacy</a>
+            <a href="/terms-of-service">Terms</a>
+            <a href="/disclaimer">Disclaimer</a>
         </div>
     </div>
     <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Docs (GitBook)</a></p>

--- a/courses/dataviz/index.html
+++ b/courses/dataviz/index.html
@@ -3917,45 +3917,45 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     </section>
 
     <footer class="footer">
-            <div class="footer-content">
-                <div class="footer-logo">
-                    <a href="/">
-                        <img src="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" height="40">
-                    </a>
-                    <p>Free development education for everyone.</p>
-                </div>
-                <div class="footer-links">
-                    <div class="footer-column">
-                        <h4>Learn</h4>
-                        <a href="/catalog">All Courses</a>
-                        <a href="/workshops">Workshops</a>
-                        <a href="/handouts">Handouts</a>
-                        <a href="/podcast">Podcast</a>
-                    </div>
-                    <div class="footer-column">
-                        <h4>Connect</h4>
-                        <a href="/about">About Us</a>
-                        <a href="/contact">Contact</a>
-                        <a href="/faq">FAQ</a>
-                        <a href="/blog">Blog</a>
-                    </div>
-                    <div class="footer-column">
-                        <h4>Support</h4>
-                        <a href="/premium">Premium</a>
-                        <a href="/premium">Support Us</a>
-                        <a href="/coaching">Coaching</a>
-                    </div>
-                </div>
+    <div class="footer-content">
+        <div class="footer-logo">
+            <a href="/">
+                <img src="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" height="40">
+            </a>
+            <p>Free development education for everyone.</p>
+        </div>
+        <div class="footer-links">
+            <div class="footer-column">
+                <h4>Learn</h4>
+                <a href="/catalog">All Courses</a>
+                <a href="/workshops">Workshops</a>
+                <a href="/handouts">Handouts</a>
+                <a href="/podcast">Podcast</a>
             </div>
-            <div class="footer-bottom">
-                <p>© 2026 ImpactMojo. Pay What You Think Is Fair.</p>
-                <div class="footer-legal">
-                    <a href="/privacy-policy">Privacy</a>
-                    <a href="/terms-of-service">Terms</a>
-                    <a href="/disclaimer">Disclaimer</a>
-                </div>
+            <div class="footer-column">
+                <h4>Connect</h4>
+                <a href="/about">About Us</a>
+                <a href="/contact">Contact</a>
+                <a href="/faq">FAQ</a>
+                <a href="/blog">Blog</a>
             </div>
-            <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Docs (GitBook)</a></p>
+            <div class="footer-column">
+                <h4>Support</h4>
+                <a href="/premium">Premium</a>
+                <a href="/premium">Support Us</a>
+                <a href="/coaching">Coaching</a>
+            </div>
+        </div>
+    </div>
+    <div class="footer-bottom">
+        <p>&copy; 2026 ImpactMojo. Pay What You Think Is Fair.</p>
+        <div class="footer-legal">
+            <a href="/privacy-policy">Privacy</a>
+            <a href="/terms-of-service">Terms</a>
+            <a href="/disclaimer">Disclaimer</a>
+        </div>
+    </div>
+    <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Docs (GitBook)</a></p>
 </footer>
     </main>
 

--- a/courses/devai/index.html
+++ b/courses/devai/index.html
@@ -344,7 +344,7 @@
         
         @media (max-width: 1024px) {
             .sidebar { transform: translateX(-100%); transition: transform var(--transition-base); }
-            .sidebar.open { transform: translateX(0); }
+            .sidebar.active { transform: translateX(0); }
             .main-content { margin-left: 0; }
             .mobile-header { display: flex; align-items: center; justify-content: space-between; padding: var(--spacing-md) var(--spacing-lg); background: var(--bg-primary); border-bottom: 1px solid var(--border-color); position: fixed; top: 0; left: 0; right: 0; z-index: 50; }
             .mobile-menu-btn { background: none; border: none; padding: var(--spacing-sm); cursor: pointer; }
@@ -1535,37 +1535,45 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     </section>
 
     <footer class="footer">
-                <div class="footer-content">
-                    <div>
-                        <div class="footer-brand"><img src="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo">ImpactMojo</div>
-                        <p class="footer-tagline">Free development education for everyone.</p>
-                    </div>
-                    <div class="footer-links">
-                        <div class="footer-column">
-                            <h5>Learn</h5>
-                            <a href='/catalog'>All Courses</a>
-                            <a href='/workshops'>Workshops</a>
-                            <a href='/handouts'>Handouts</a>
-                        </div>
-                        <div class="footer-column">
-                            <h5>Connect</h5>
-                            <a href='/about'>About Us</a>
-                            <a href='/contact'>Contact</a>
-                            <a href='/faq'>FAQ</a>
-                        </div>
-                        <div class="footer-column">
-                            <h5>Support</h5>
-                            <a href='/premium'>Premium</a>
-                            <a href="/premium">Support Us</a>
-                            <a href='/coaching'>Coaching</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="footer-bottom">
-                    <span>© 2026 ImpactMojo. Pay What You Think Is Fair.</span>
-                    <div><a href='/privacy-policy'>Privacy</a> • <a href='/terms-of-service'>Terms</a> • <a href='/disclaimer'>Disclaimer</a></div>
-                </div>
-                <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Docs (GitBook)</a></p>
+    <div class="footer-content">
+        <div class="footer-logo">
+            <a href="/">
+                <img src="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" height="40">
+            </a>
+            <p>Free development education for everyone.</p>
+        </div>
+        <div class="footer-links">
+            <div class="footer-column">
+                <h4>Learn</h4>
+                <a href="/catalog">All Courses</a>
+                <a href="/workshops">Workshops</a>
+                <a href="/handouts">Handouts</a>
+                <a href="/podcast">Podcast</a>
+            </div>
+            <div class="footer-column">
+                <h4>Connect</h4>
+                <a href="/about">About Us</a>
+                <a href="/contact">Contact</a>
+                <a href="/faq">FAQ</a>
+                <a href="/blog">Blog</a>
+            </div>
+            <div class="footer-column">
+                <h4>Support</h4>
+                <a href="/premium">Premium</a>
+                <a href="/premium">Support Us</a>
+                <a href="/coaching">Coaching</a>
+            </div>
+        </div>
+    </div>
+    <div class="footer-bottom">
+        <p>&copy; 2026 ImpactMojo. Pay What You Think Is Fair.</p>
+        <div class="footer-legal">
+            <a href="/privacy-policy">Privacy</a>
+            <a href="/terms-of-service">Terms</a>
+            <a href="/disclaimer">Disclaimer</a>
+        </div>
+    </div>
+    <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Docs (GitBook)</a></p>
 </footer>
         </main>
     </div>
@@ -1612,7 +1620,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             const mobileMenuBtn = document.getElementById('mobileMenuBtn');
             const sidebar = document.getElementById('sidebar');
             if (mobileMenuBtn) {
-                mobileMenuBtn.addEventListener('click', function() { sidebar.classList.toggle('open'); });
+                mobileMenuBtn.addEventListener('click', function() { sidebar.classList.toggle('active'); });
             }
             
             // Coach Callout Popup Animation - initialized via IIFE below
@@ -1620,7 +1628,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             // Update aria-expanded on mobile menu toggle
             if (mobileMenuBtn) {
                 mobileMenuBtn.addEventListener('click', function() {
-                    var isOpen = sidebar.classList.contains('open');
+                    var isOpen = sidebar.classList.contains('active');
                     mobileMenuBtn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
                 });
             }
@@ -1629,7 +1637,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 link.addEventListener('click', function(e) {
                     e.preventDefault();
                     const target = document.querySelector(this.getAttribute('href'));
-                    if (target) { target.scrollIntoView({ behavior: 'smooth' }); sidebar.classList.remove('open'); }
+                    if (target) { target.scrollIntoView({ behavior: 'smooth' }); sidebar.classList.remove('active'); }
                 });
             });
         });

--- a/courses/gandhi/index.html
+++ b/courses/gandhi/index.html
@@ -777,7 +777,7 @@
                 z-index: 9999;
                 box-shadow: 4px 0 20px rgba(0,0,0,0.3);
             }
-            .sidebar.open { transform: translateX(0); }
+            .sidebar.active { transform: translateX(0); }
             .main-content { margin-left: 0; }
             .hero { padding: 3.5rem 2rem; }
             .hero h1 { font-size: 2.2rem; }
@@ -1211,7 +1211,7 @@
                 transform: translateX(-100%);
                 transition: transform 0.3s ease;
             }
-            .sidebar.open {
+            .sidebar.active {
                 transform: translateX(0);
             }
             .main-content {
@@ -3468,37 +3468,45 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     </section>
 
     <footer class="footer">
-            <div class="footer-content">
-                <div class="footer-brand">
-                    <p><strong>ImpactMojo</strong></p>
-                    <p>Free development education for everyone.</p>
-                </div>
-                <div class="footer-section">
-                    <h4>Learn</h4>
-                    <a href="/catalog">All Courses</a>
-                    <a href="/workshops">Workshops</a>
-                    <a href="/handouts">Handouts</a>
-                    <a href="/podcast">Podcast</a>
-                </div>
-                <div class="footer-section">
-                    <h4>Connect</h4>
-                    <a href="/about">About Us</a>
-                    <a href="/contact">Contact</a>
-                    <a href="/faq">FAQ</a>
-                    <a href="/blog">Blog</a>
-                </div>
-                <div class="footer-section">
-                    <h4>Support</h4>
-                    <a href="/premium">Premium</a>
-                    <a href="/premium">Support Us</a>
-                    <a href="/coaching">Coaching</a>
-                </div>
+    <div class="footer-content">
+        <div class="footer-logo">
+            <a href="/">
+                <img src="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" height="40">
+            </a>
+            <p>Free development education for everyone.</p>
+        </div>
+        <div class="footer-links">
+            <div class="footer-column">
+                <h4>Learn</h4>
+                <a href="/catalog">All Courses</a>
+                <a href="/workshops">Workshops</a>
+                <a href="/handouts">Handouts</a>
+                <a href="/podcast">Podcast</a>
             </div>
-            <div class="footer-bottom">
-                <p>© 2026 ImpactMojo. Pay What You Think Is Fair.</p>
-                <p><a href="/privacy">Privacy</a> <a href="/terms">Terms</a> <a href="/disclaimer">Disclaimer</a></p>
+            <div class="footer-column">
+                <h4>Connect</h4>
+                <a href="/about">About Us</a>
+                <a href="/contact">Contact</a>
+                <a href="/faq">FAQ</a>
+                <a href="/blog">Blog</a>
             </div>
-            <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Docs (GitBook)</a></p>
+            <div class="footer-column">
+                <h4>Support</h4>
+                <a href="/premium">Premium</a>
+                <a href="/premium">Support Us</a>
+                <a href="/coaching">Coaching</a>
+            </div>
+        </div>
+    </div>
+    <div class="footer-bottom">
+        <p>&copy; 2026 ImpactMojo. Pay What You Think Is Fair.</p>
+        <div class="footer-legal">
+            <a href="/privacy-policy">Privacy</a>
+            <a href="/terms-of-service">Terms</a>
+            <a href="/disclaimer">Disclaimer</a>
+        </div>
+    </div>
+    <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Docs (GitBook)</a></p>
 </footer>
     </main>
 
@@ -3579,13 +3587,13 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         const mobileMenuBtn = document.getElementById('mobile-menu-btn');
 
         function toggleSidebar() {
-            sidebar.classList.toggle('open');
+            sidebar.classList.toggle('active');
             sidebarOverlay.classList.toggle('active');
-            document.body.style.overflow = sidebar.classList.contains('open') ? 'hidden' : '';
+            document.body.style.overflow = sidebar.classList.contains('active') ? 'hidden' : '';
         }
 
         function closeSidebar() {
-            sidebar.classList.remove('open');
+            sidebar.classList.remove('active');
             sidebarOverlay.classList.remove('active');
             document.body.style.overflow = '';
         }

--- a/courses/gender/index.html
+++ b/courses/gender/index.html
@@ -2100,42 +2100,46 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
     </section>
 
     <footer class="footer">
-      <div class="footer-inner">
-        <div class="footer-brand">
-          <div class="footer-logo">ImpactMojo</div>
-          <p>Free development education for everyone. Development Know-How at zero cost.</p>
+    <div class="footer-content">
+        <div class="footer-logo">
+            <a href="/">
+                <img src="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" height="40">
+            </a>
+            <p>Free development education for everyone.</p>
         </div>
-        <div class="footer-col">
-          <h5>Learn</h5>
-          <a href="https://www.impactmojo.in/catalog">All Courses</a>
-          <a href="https://www.impactmojo.in/workshops">Workshops</a>
-          <a href="https://www.impactmojo.in/handouts">Handouts</a>
-          <a href="https://www.impactmojo.in/podcast">Podcast</a>
+        <div class="footer-links">
+            <div class="footer-column">
+                <h4>Learn</h4>
+                <a href="/catalog">All Courses</a>
+                <a href="/workshops">Workshops</a>
+                <a href="/handouts">Handouts</a>
+                <a href="/podcast">Podcast</a>
+            </div>
+            <div class="footer-column">
+                <h4>Connect</h4>
+                <a href="/about">About Us</a>
+                <a href="/contact">Contact</a>
+                <a href="/faq">FAQ</a>
+                <a href="/blog">Blog</a>
+            </div>
+            <div class="footer-column">
+                <h4>Support</h4>
+                <a href="/premium">Premium</a>
+                <a href="/premium">Support Us</a>
+                <a href="/coaching">Coaching</a>
+            </div>
         </div>
-        <div class="footer-col">
-          <h5>Connect</h5>
-          <a href="https://www.impactmojo.in/about">About Us</a>
-          <a href="https://www.impactmojo.in/contact">Contact</a>
-          <a href="https://www.impactmojo.in/faq">FAQ</a>
-          <a href="https://www.impactmojo.in/blog">Blog</a>
+    </div>
+    <div class="footer-bottom">
+        <p>&copy; 2026 ImpactMojo. Pay What You Think Is Fair.</p>
+        <div class="footer-legal">
+            <a href="/privacy-policy">Privacy</a>
+            <a href="/terms-of-service">Terms</a>
+            <a href="/disclaimer">Disclaimer</a>
         </div>
-        <div class="footer-col">
-          <h5>Support</h5>
-          <a href="https://www.impactmojo.in/premium">Premium</a>
-          <a href="https://www.impactmojo.in/premium">Support Us</a>
-          <a href="https://www.impactmojo.in/coaching">Coaching</a>
-        </div>
-      </div>
-      <div class="footer-bottom">
-        <span>© 2026 ImpactMojo. Pay What You Think Is Fair.</span>
-        <div class="footer-bottom-links">
-          <a href="https://www.impactmojo.in/privacy-policy">Privacy</a>
-          <a href="https://www.impactmojo.in/terms-of-service">Terms</a>
-          <a href="https://www.impactmojo.in/disclaimer">Disclaimer</a>
-          <a href="/docs/">Docs (GitBook)</a>
-        </div>
-      </div>
-    </footer>
+    </div>
+    <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Docs (GitBook)</a></p>
+</footer>
 
   </main>
 </div>

--- a/courses/law/index.html
+++ b/courses/law/index.html
@@ -3565,45 +3565,45 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         </div>
         
         <footer class="footer">
-            <div class="footer-content">
-                <div class="footer-logo">
-                    <a href="/">
-                        <img src="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" height="40">
-                    </a>
-                    <p>Free development education for everyone.</p>
-                </div>
-                <div class="footer-links">
-                    <div class="footer-column">
-                        <h4>Learn</h4>
-                        <a href="/catalog">All Courses</a>
-                        <a href="/workshops">Workshops</a>
-                        <a href="/handouts">Handouts</a>
-                        <a href="/podcast">Podcast</a>
-                    </div>
-                    <div class="footer-column">
-                        <h4>Connect</h4>
-                        <a href="/about">About Us</a>
-                        <a href="/contact">Contact</a>
-                        <a href="/faq">FAQ</a>
-                        <a href="/blog">Blog</a>
-                    </div>
-                    <div class="footer-column">
-                        <h4>Support</h4>
-                        <a href="/premium">Premium</a>
-                        <a href="/premium">Support Us</a>
-                        <a href="/coaching">Coaching</a>
-                    </div>
-                </div>
+    <div class="footer-content">
+        <div class="footer-logo">
+            <a href="/">
+                <img src="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" height="40">
+            </a>
+            <p>Free development education for everyone.</p>
+        </div>
+        <div class="footer-links">
+            <div class="footer-column">
+                <h4>Learn</h4>
+                <a href="/catalog">All Courses</a>
+                <a href="/workshops">Workshops</a>
+                <a href="/handouts">Handouts</a>
+                <a href="/podcast">Podcast</a>
             </div>
-            <div class="footer-bottom">
-                <p>&copy; 2026 ImpactMojo. Pay What You Think Is Fair.</p>
-                <div class="footer-legal">
-                    <a href="/privacy-policy">Privacy</a>
-                    <a href="/terms-of-service">Terms</a>
-                    <a href="/disclaimer">Disclaimer</a>
-                </div>
+            <div class="footer-column">
+                <h4>Connect</h4>
+                <a href="/about">About Us</a>
+                <a href="/contact">Contact</a>
+                <a href="/faq">FAQ</a>
+                <a href="/blog">Blog</a>
             </div>
-            <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Docs (GitBook)</a></p>
+            <div class="footer-column">
+                <h4>Support</h4>
+                <a href="/premium">Premium</a>
+                <a href="/premium">Support Us</a>
+                <a href="/coaching">Coaching</a>
+            </div>
+        </div>
+    </div>
+    <div class="footer-bottom">
+        <p>&copy; 2026 ImpactMojo. Pay What You Think Is Fair.</p>
+        <div class="footer-legal">
+            <a href="/privacy-policy">Privacy</a>
+            <a href="/terms-of-service">Terms</a>
+            <a href="/disclaimer">Disclaimer</a>
+        </div>
+    </div>
+    <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Docs (GitBook)</a></p>
 </footer>
         <script>
             // ============================================

--- a/courses/media/index.html
+++ b/courses/media/index.html
@@ -3836,35 +3836,45 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 
     <!-- FOOTER -->
     <footer class="footer">
-        <div class="footer-content">
-            <div class="footer-logo">
-                <img src="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo">
-                <p>Development Know-How for Social Impact</p>
+    <div class="footer-content">
+        <div class="footer-logo">
+            <a href="/">
+                <img src="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" height="40">
+            </a>
+            <p>Free development education for everyone.</p>
+        </div>
+        <div class="footer-links">
+            <div class="footer-column">
+                <h4>Learn</h4>
+                <a href="/catalog">All Courses</a>
+                <a href="/workshops">Workshops</a>
+                <a href="/handouts">Handouts</a>
+                <a href="/podcast">Podcast</a>
             </div>
-            <div class="footer-links">
-                <div class="footer-column">
-                    <h4>Courses</h4>
-                    <a href="/courses/gandhi/">Gandhi Political Philosophy</a>
-                    <a href="/courses/devecon/">Development Economics</a>
-                    <a href="/courses/dataviz/">Data Visualization</a>
-                    <a href="/courses/devai/">AI for Impact</a>
-                </div>
-                <div class="footer-column">
-                    <h4>Resources</h4>
-                    <a href='/coaching'>1:1 Coaching</a>
-                    <a href='/#labs'>Interactive Labs</a>
-                    <a href='/catalog'>Course Catalog</a>
-                </div>
+            <div class="footer-column">
+                <h4>Connect</h4>
+                <a href="/about">About Us</a>
+                <a href="/contact">Contact</a>
+                <a href="/faq">FAQ</a>
+                <a href="/blog">Blog</a>
+            </div>
+            <div class="footer-column">
+                <h4>Support</h4>
+                <a href="/premium">Premium</a>
+                <a href="/premium">Support Us</a>
+                <a href="/coaching">Coaching</a>
             </div>
         </div>
-        <div class="footer-bottom">
-            <p>© 2026 ImpactMojo. Free for development professionals.</p>
-            <div class="footer-legal">
-                <a href="/terms-of-service">Terms</a>
-                <a href="/privacy-policy">Privacy</a>
-            </div>
+    </div>
+    <div class="footer-bottom">
+        <p>&copy; 2026 ImpactMojo. Pay What You Think Is Fair.</p>
+        <div class="footer-legal">
+            <a href="/privacy-policy">Privacy</a>
+            <a href="/terms-of-service">Terms</a>
+            <a href="/disclaimer">Disclaimer</a>
         </div>
-        <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Docs (GitBook)</a></p>
+    </div>
+    <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Docs (GitBook)</a></p>
 </footer>
     
     <script>

--- a/courses/mel/index.html
+++ b/courses/mel/index.html
@@ -3913,35 +3913,45 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 
     <!-- FOOTER -->
     <footer class="footer">
-        <div class="footer-content">
-            <div class="footer-logo">
-                <img src="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo">
-                <p>Development Know-How for Social Impact</p>
+    <div class="footer-content">
+        <div class="footer-logo">
+            <a href="/">
+                <img src="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" height="40">
+            </a>
+            <p>Free development education for everyone.</p>
+        </div>
+        <div class="footer-links">
+            <div class="footer-column">
+                <h4>Learn</h4>
+                <a href="/catalog">All Courses</a>
+                <a href="/workshops">Workshops</a>
+                <a href="/handouts">Handouts</a>
+                <a href="/podcast">Podcast</a>
             </div>
-            <div class="footer-links">
-                <div class="footer-column">
-                    <h4>Courses</h4>
-                    <a href="/courses/gandhi/">Gandhi Political Philosophy</a>
-                    <a href="/courses/devecon/">Development Economics</a>
-                    <a href="/courses/dataviz/">Data Visualization</a>
-                    <a href="/courses/devai/">AI for Impact</a>
-                </div>
-                <div class="footer-column">
-                    <h4>Resources</h4>
-                    <a href='/coaching'>1:1 Coaching</a>
-                    <a href='/#labs'>Interactive Labs</a>
-                    <a href='/catalog'>Course Catalog</a>
-                </div>
+            <div class="footer-column">
+                <h4>Connect</h4>
+                <a href="/about">About Us</a>
+                <a href="/contact">Contact</a>
+                <a href="/faq">FAQ</a>
+                <a href="/blog">Blog</a>
+            </div>
+            <div class="footer-column">
+                <h4>Support</h4>
+                <a href="/premium">Premium</a>
+                <a href="/premium">Support Us</a>
+                <a href="/coaching">Coaching</a>
             </div>
         </div>
-        <div class="footer-bottom">
-            <p>© 2026 ImpactMojo. Free for development professionals.</p>
-            <div class="footer-legal">
-                <a href="/terms-of-service">Terms</a>
-                <a href="/privacy-policy">Privacy</a>
-            </div>
+    </div>
+    <div class="footer-bottom">
+        <p>&copy; 2026 ImpactMojo. Pay What You Think Is Fair.</p>
+        <div class="footer-legal">
+            <a href="/privacy-policy">Privacy</a>
+            <a href="/terms-of-service">Terms</a>
+            <a href="/disclaimer">Disclaimer</a>
         </div>
-        <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Docs (GitBook)</a></p>
+    </div>
+    <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Docs (GitBook)</a></p>
 </footer>
     
     <script>

--- a/courses/poa/index.html
+++ b/courses/poa/index.html
@@ -3683,45 +3683,45 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         
         <!-- Footer -->
         <footer class="footer">
-            <div class="footer-content">
-                <div class="footer-logo">
-                    <a href="/">
-                        <img src="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" height="40">
-                    </a>
-                    <p>Free development education for everyone.</p>
-                </div>
-                <div class="footer-links">
-                    <div class="footer-column">
-                        <h4>Learn</h4>
-                        <a href="/catalog">All Courses</a>
-                        <a href="/workshops">Workshops</a>
-                        <a href="/handouts">Handouts</a>
-                        <a href="/podcast">Podcast</a>
-                    </div>
-                    <div class="footer-column">
-                        <h4>Connect</h4>
-                        <a href="/about">About Us</a>
-                        <a href="/contact">Contact</a>
-                        <a href="/faq">FAQ</a>
-                        <a href="/blog">Blog</a>
-                    </div>
-                    <div class="footer-column">
-                        <h4>Support</h4>
-                        <a href="/premium">Premium</a>
-                        <a href="/premium">Support Us</a>
-                        <a href="/coaching">Coaching</a>
-                    </div>
-                </div>
+    <div class="footer-content">
+        <div class="footer-logo">
+            <a href="/">
+                <img src="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" height="40">
+            </a>
+            <p>Free development education for everyone.</p>
+        </div>
+        <div class="footer-links">
+            <div class="footer-column">
+                <h4>Learn</h4>
+                <a href="/catalog">All Courses</a>
+                <a href="/workshops">Workshops</a>
+                <a href="/handouts">Handouts</a>
+                <a href="/podcast">Podcast</a>
             </div>
-            <div class="footer-bottom">
-                <p>© 2026 ImpactMojo. Pay What You Think Is Fair.</p>
-                <div class="footer-legal">
-                    <a href="/privacy-policy">Privacy</a>
-                    <a href="/terms-of-service">Terms</a>
-                    <a href="/disclaimer">Disclaimer</a>
-                </div>
+            <div class="footer-column">
+                <h4>Connect</h4>
+                <a href="/about">About Us</a>
+                <a href="/contact">Contact</a>
+                <a href="/faq">FAQ</a>
+                <a href="/blog">Blog</a>
             </div>
-            <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Docs (GitBook)</a></p>
+            <div class="footer-column">
+                <h4>Support</h4>
+                <a href="/premium">Premium</a>
+                <a href="/premium">Support Us</a>
+                <a href="/coaching">Coaching</a>
+            </div>
+        </div>
+    </div>
+    <div class="footer-bottom">
+        <p>&copy; 2026 ImpactMojo. Pay What You Think Is Fair.</p>
+        <div class="footer-legal">
+            <a href="/privacy-policy">Privacy</a>
+            <a href="/terms-of-service">Terms</a>
+            <a href="/disclaimer">Disclaimer</a>
+        </div>
+    </div>
+    <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Docs (GitBook)</a></p>
 </footer>
         
         <!-- JavaScript -->

--- a/courses/pubchoice/index.html
+++ b/courses/pubchoice/index.html
@@ -5145,45 +5145,45 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         
         <!-- Footer -->
         <footer class="footer">
-            <div class="footer-content">
-                <div class="footer-logo">
-                    <a href="/">
-                        <img src="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" height="40">
-                    </a>
-                    <p>Free development education for everyone.</p>
-                </div>
-                <div class="footer-links">
-                    <div class="footer-column">
-                        <h4>Learn</h4>
-                        <a href="/catalog">All Courses</a>
-                        <a href="/workshops">Workshops</a>
-                        <a href="/handouts">Handouts</a>
-                        <a href="/podcast">Podcast</a>
-                    </div>
-                    <div class="footer-column">
-                        <h4>Connect</h4>
-                        <a href="/about">About Us</a>
-                        <a href="/contact">Contact</a>
-                        <a href="/faq">FAQ</a>
-                        <a href="/blog">Blog</a>
-                    </div>
-                    <div class="footer-column">
-                        <h4>Support</h4>
-                        <a href="/premium">Premium</a>
-                        <a href="/premium">Support Us</a>
-                        <a href="/coaching">Coaching</a>
-                    </div>
-                </div>
+    <div class="footer-content">
+        <div class="footer-logo">
+            <a href="/">
+                <img src="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" height="40">
+            </a>
+            <p>Free development education for everyone.</p>
+        </div>
+        <div class="footer-links">
+            <div class="footer-column">
+                <h4>Learn</h4>
+                <a href="/catalog">All Courses</a>
+                <a href="/workshops">Workshops</a>
+                <a href="/handouts">Handouts</a>
+                <a href="/podcast">Podcast</a>
             </div>
-            <div class="footer-bottom">
-                <p>© 2026 ImpactMojo. Pay What You Think Is Fair.</p>
-                <div class="footer-legal">
-                    <a href="/privacy-policy">Privacy</a>
-                    <a href="/terms-of-service">Terms</a>
-                    <a href="/disclaimer">Disclaimer</a>
-                </div>
+            <div class="footer-column">
+                <h4>Connect</h4>
+                <a href="/about">About Us</a>
+                <a href="/contact">Contact</a>
+                <a href="/faq">FAQ</a>
+                <a href="/blog">Blog</a>
             </div>
-            <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Docs (GitBook)</a></p>
+            <div class="footer-column">
+                <h4>Support</h4>
+                <a href="/premium">Premium</a>
+                <a href="/premium">Support Us</a>
+                <a href="/coaching">Coaching</a>
+            </div>
+        </div>
+    </div>
+    <div class="footer-bottom">
+        <p>&copy; 2026 ImpactMojo. Pay What You Think Is Fair.</p>
+        <div class="footer-legal">
+            <a href="/privacy-policy">Privacy</a>
+            <a href="/terms-of-service">Terms</a>
+            <a href="/disclaimer">Disclaimer</a>
+        </div>
+    </div>
+    <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Docs (GitBook)</a></p>
 </footer>
         
         <!-- JavaScript -->

--- a/courses/pubpol/index.html
+++ b/courses/pubpol/index.html
@@ -1198,57 +1198,41 @@ body.dark-mode, [data-theme="dark"] {
 <footer class="footer">
     <div class="footer-content">
         <div class="footer-logo">
-            <img src="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo">
-            <p>Development Know-How for Social Impact</p>
+            <a href="/">
+                <img src="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" height="40">
+            </a>
+            <p>Free development education for everyone.</p>
         </div>
         <div class="footer-links">
             <div class="footer-column">
-                <h4>Courses</h4>
-                <a href="/courses/gandhi/">Gandhi Political Philosophy</a>
-                <a href="/courses/devecon/">Development Economics</a>
-                <a href="/courses/dataviz/">Data Visualization</a>
-                <a href="/courses/devai/">AI for Impact</a>
-                <a href="/courses/mel/">MEL</a>
+                <h4>Learn</h4>
+                <a href="/catalog">All Courses</a>
+                <a href="/workshops">Workshops</a>
+                <a href="/handouts">Handouts</a>
+                <a href="/podcast">Podcast</a>
             </div>
             <div class="footer-column">
-                <h4>Resources</h4>
-                <a href="/coaching">1:1 Coaching</a>
-                <a href="/#labs">Interactive Labs</a>
-                <a href="/catalog">Course Catalog</a>
+                <h4>Connect</h4>
+                <a href="/about">About Us</a>
+                <a href="/contact">Contact</a>
+                <a href="/faq">FAQ</a>
+                <a href="/blog">Blog</a>
+            </div>
+            <div class="footer-column">
+                <h4>Support</h4>
+                <a href="/premium">Premium</a>
+                <a href="/premium">Support Us</a>
+                <a href="/coaching">Coaching</a>
             </div>
         </div>
     </div>
     <div class="footer-bottom">
-        <p>&copy; 2026 ImpactMojo. Free for development professionals.</p>
+        <p>&copy; 2026 ImpactMojo. Pay What You Think Is Fair.</p>
         <div class="footer-legal">
-            <a href="/terms-of-service">Terms</a>
             <a href="/privacy-policy">Privacy</a>
+            <a href="/terms-of-service">Terms</a>
+            <a href="/disclaimer">Disclaimer</a>
         </div>
-    </div>
-    
-    <div class="v3-floating-elements" aria-hidden="true">
-        <div class="v3-sparkle v3-sparkle-1"><svg viewBox="0 0 24 24" width="1em" height="1em" fill="currentColor" style="display:inline-block;vertical-align:-0.15em" aria-hidden="true"><path d="M12 2l1.5 7.5L21 11l-7.5 1.5L12 20l-1.5-7.5L3 11l7.5-1.5z"/></svg></div>
-        <div class="v3-sparkle v3-sparkle-2"><svg viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" style="display:inline-block;vertical-align:-0.15em" aria-hidden="true"><path d="M12 2l1.5 7.5L21 11l-7.5 1.5L12 20l-1.5-7.5L3 11l7.5-1.5z"/></svg></div>
-        <div class="v3-sparkle v3-sparkle-3"><svg viewBox="0 0 24 24" width="1em" height="1em" fill="currentColor" style="display:inline-block;vertical-align:-0.15em" aria-hidden="true"><path d="M12 2l1.5 7.5L21 11l-7.5 1.5L12 20l-1.5-7.5L3 11l7.5-1.5z"/></svg></div>
-        
-        <!-- Additional floating planes -->
-        <svg class="v3-big-plane v3-big-plane-1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
-            <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#6366F1" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-            <path d="M80,130 L150,50" stroke="#0EA5E9" stroke-width="2" stroke-dasharray="4,4"/>
-            <circle cx="150" cy="50" r="4" fill="#10B981"/>
-        </svg>
-        
-        <svg class="v3-big-plane v3-big-plane-2" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
-            <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#10B981" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-            <path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/>
-            <circle cx="150" cy="50" r="4" fill="#0EA5E9"/>
-        </svg>
-        
-        <svg class="v3-big-plane v3-big-plane-3" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
-            <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#F59E0B" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-            <path d="M80,130 L150,50" stroke="#EF4444" stroke-width="2" stroke-dasharray="4,4"/>
-            <circle cx="150" cy="50" r="4" fill="#6366F1"/>
-        </svg>
     </div>
     <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Docs (GitBook)</a></p>
 </footer>


### PR DESCRIPTION
## Summary

Follow-up to your "courses look different from each other" feedback. Several pieces of chrome diverged across the 12 flagship courses:

**Footer** — used three different container/column class names and three different column structures:

| Pattern | Courses |
|---|---|
| 3 cols Learn/Connect/Support (`.footer-column`) | devecon (canonical) |
| 3 cols same content, different class names (`.footer-col`, `.footer-section`) | gender, gandhi |
| 2 cols Courses/Resources | SEL, pubpol |
| Other variants | media, mel, law, poa, pubchoice, dataviz, devai |

Plus **SEL had two duplicate `<footer class="footer">` blocks** in the same document.

**Sidebar drawer toggle** — 10 courses used `.sidebar.active`, but gandhi + devai used `.sidebar.open`. Both worked internally but were inconsistent with the fleet.

## Fix
1. **Footer**: Replace every non-devecon footer with devecon's exact markup — Learn / Connect / Support / legal links / Docs link. Each course keeps its color identity (accent comes from per-course CSS vars).
2. **SEL**: drop the duplicate footer block.
3. **Sidebar toggle class**: rename `.sidebar.open` → `.sidebar.active` in gandhi + devai (CSS selectors and the JS that toggles them).

## Verified at 1280px
- All 12 courses now render `1 <footer.footer>`, `3 columns`, headings `["Learn", "Connect", "Support"]`
- Sidebar drawer still opens on gandhi + devai

## Out of scope (separate work, can do later if you want)
- Gender's sidebar uses `.sidebar-link` instead of `.nav-link` — works fine, just inconsistent naming
- `.im-footer` CSS lives in 8 courses but no course renders an `.im-footer` element — dead CSS
- Coach-callout markup comes from Supabase via `course-loader.js`; gender's callouts arrive without action buttons — that's a content fix in the edge function, not the static HTML

https://claude.ai/code/session_012uCmAm56wSwFB5rTQSgacC

---
_Generated by [Claude Code](https://claude.ai/code/session_012uCmAm56wSwFB5rTQSgacC)_