### PR TITLE
mobile: normalize body font-size, sidebar width, mobile-header height

### DIFF
--- a/courses/dataviz/index.html
+++ b/courses/dataviz/index.html
@@ -1283,10 +1283,10 @@
         /* Responsive */
         @media (max-width: 1024px) {
             .sidebar {
-                width: 240px;
+                width: 280px;
             }
             .main-content {
-                margin-left: 240px;
+                margin-left: 280px;
             }
             .section {
                 padding: 2.5rem 2rem;

--- a/courses/devai/index.html
+++ b/courses/devai/index.html
@@ -346,7 +346,7 @@
             .sidebar { transform: translateX(-100%); transition: transform var(--transition-base); }
             .sidebar.active { transform: translateX(0); }
             .main-content { margin-left: 0; }
-            .mobile-header { display: flex; align-items: center; justify-content: space-between; padding: var(--spacing-md) var(--spacing-lg); background: var(--bg-primary); border-bottom: 1px solid var(--border-color); position: fixed; top: 0; left: 0; right: 0; z-index: 50; }
+            .mobile-header { display: flex; align-items: center; justify-content: space-between; padding: 0.75rem 1rem; height: 56px; box-sizing: border-box; background: var(--bg-primary); border-bottom: 1px solid var(--border-color); position: fixed; top: 0; left: 0; right: 0; z-index: 50; }
             .mobile-menu-btn { background: none; border: none; padding: var(--spacing-sm); cursor: pointer; }
             .mobile-menu-btn span { display: block; width: 24px; height: 2px; background: var(--text-primary); margin: 5px 0; transition: all var(--transition-fast); }
         }
@@ -389,7 +389,7 @@
 .v3-big-plane-2 { bottom: 20%; right: 10%; animation-delay: -10s; }
 .v3-big-plane-3 { top: 70%; left: 70%; animation-delay: -20s; }
 @keyframes v3-plane-float { 0%, 100% { transform: translate(0, 0) rotate(0deg); } 25% { transform: translate(50px, -30px) rotate(10deg); } 50% { transform: translate(80px, 40px) rotate(-5deg); } 75% { transform: translate(-20px, 60px) rotate(8deg); } }
-@media (max-width: 768px) { .v3-paper-plane, .v3-floating-elements, .v3-blob, .v3-big-plane { display: none !important; } .main-content { padding: 1rem; } body { font-size: 15px; } }
+@media (max-width: 768px) { .v3-paper-plane, .v3-floating-elements, .v3-blob, .v3-big-plane { display: none !important; } .main-content { padding: 1rem; } }
 @media (max-width: 480px) { .main-content { padding: 0.75rem; } h2 { font-size: 1.3rem; } h3 { font-size: 1.1rem; } }
 @media (prefers-reduced-motion: reduce) { .v3-paper-plane, .v3-blob, .v3-sparkle, .v3-big-plane { animation: none !important; } }
 

--- a/courses/gandhi/index.html
+++ b/courses/gandhi/index.html
@@ -145,7 +145,7 @@
             background: var(--bg-primary);
             color: var(--text-primary);
             line-height: 1.8;
-            font-size: 17px;
+            font-size: 16px;
             min-height: 100vh;
             transition: background 0.3s ease, color 0.3s ease;
             padding-top: 48px;

--- a/courses/gender/index.html
+++ b/courses/gender/index.html
@@ -1454,7 +1454,6 @@ section, .module, .lexicon-section, .founders-section {
 @media (max-width: 768px) {
     .v3-paper-plane, .v3-floating-elements, .v3-blob, .v3-big-plane { display: none !important; }
     .main-content { padding: 1rem; }
-    body { font-size: 15px; }
 }
 @media (max-width: 480px) {
     .main-content { padding: 0.75rem; }

--- a/courses/pubpol/index.html
+++ b/courses/pubpol/index.html
@@ -62,7 +62,7 @@
             --hover-bg: #F1F5F9; --border-color: #E2E8F0;
             --gradient-primary:linear-gradient(135deg,#0EA5E9 0%,#6366F1 100%);
             --gradient-accent:linear-gradient(135deg,#0EA5E9 0%,#10B981 100%);
-            --sidebar-width:260px; --content-max-width:900px; --topbar-height:88px;
+            --sidebar-width:280px; --content-max-width:900px; --topbar-height:88px;
             --spacing-xs:0.25rem; --spacing-sm:0.5rem; --spacing-md:1rem;
             --spacing-lg:1.5rem; --spacing-xl:2rem; --spacing-2xl:3rem;
             --font-sans:'Amaranth',sans-serif; --font-heading:'Inter',sans-serif;
@@ -93,7 +93,7 @@
             --hover-bg:#334155; --border-color:#334155;
             --gradient-primary:linear-gradient(135deg,#0EA5E9 0%,#6366F1 100%);
             --gradient-accent:linear-gradient(135deg,#0EA5E9 0%,#10B981 100%);
-            --sidebar-width:260px; --content-max-width:900px; --topbar-height:88px;
+            --sidebar-width:280px; --content-max-width:900px; --topbar-height:88px;
             --spacing-xs:0.25rem; --spacing-sm:0.5rem; --spacing-md:1rem;
             --spacing-lg:1.5rem; --spacing-xl:2rem; --spacing-2xl:3rem;
             --font-sans:'Amaranth',sans-serif; --font-heading:'Inter',sans-serif;
@@ -124,7 +124,7 @@ body.light-mode, [data-theme="light"] {
             --hover-bg: #F1F5F9; --border-color: #E2E8F0;
             --gradient-primary:linear-gradient(135deg,#0EA5E9 0%,#6366F1 100%);
             --gradient-accent:linear-gradient(135deg,#0EA5E9 0%,#10B981 100%);
-            --sidebar-width:260px; --content-max-width:900px; --topbar-height:88px;
+            --sidebar-width:280px; --content-max-width:900px; --topbar-height:88px;
             --spacing-xs:0.25rem; --spacing-sm:0.5rem; --spacing-md:1rem;
             --spacing-lg:1.5rem; --spacing-xl:2rem; --spacing-2xl:3rem;
             --font-sans:'Amaranth',sans-serif; --font-heading:'Inter',sans-serif;
@@ -155,7 +155,7 @@ body.dark-mode, [data-theme="dark"] {
             --hover-bg:#334155; --border-color:#334155;
             --gradient-primary:linear-gradient(135deg,#0EA5E9 0%,#6366F1 100%);
             --gradient-accent:linear-gradient(135deg,#0EA5E9 0%,#10B981 100%);
-            --sidebar-width:260px; --content-max-width:900px; --topbar-height:88px;
+            --sidebar-width:280px; --content-max-width:900px; --topbar-height:88px;
             --spacing-xs:0.25rem; --spacing-sm:0.5rem; --spacing-md:1rem;
             --spacing-lg:1.5rem; --spacing-xl:2rem; --spacing-2xl:3rem;
             --font-sans:'Amaranth',sans-serif; --font-heading:'Inter',sans-serif;
@@ -544,7 +544,7 @@ body.dark-mode, [data-theme="dark"] {
         .im-theme-btn:hover{background:var(--im-hover-bg,#334155);color:var(--im-text-primary,#F1F5F9);}
         .im-theme-btn.active{background:var(--im-accent,#0EA5E9);color:#fff;}
         .im-theme-btn svg{width:15px;height:15px;}
-        @media(max-width:768px){.im-topbar{padding:0.4rem 0.75rem;gap:0.5rem;}.im-premium-btn{padding:0.3rem 0.6rem;font-size:0.75rem;}.im-theme-btn{width:26px;height:26px;padding:4px;}.im-theme-btn svg{width:13px;height:13px;}.main-content{padding:1rem;}body{font-size:15px;}}
+        @media(max-width:768px){.im-topbar{padding:0.4rem 0.75rem;gap:0.5rem;}.im-premium-btn{padding:0.3rem 0.6rem;font-size:0.75rem;}.im-theme-btn{width:26px;height:26px;padding:4px;}.im-theme-btn svg{width:13px;height:13px;}.main-content{padding:1rem;}}
         @media(max-width:480px){.main-content{padding:0.75rem;}h2{font-size:1.3rem;}h3{font-size:1.1rem;}}
         /* Font overrides - exact DevEcon pattern */
         body{font-family:'Amaranth',sans-serif!important;}


### PR DESCRIPTION
## Summary

Follow-up to your "fonts are different or maybe sizes" feedback. A 390px-viewport audit on all 12 courses found three real divergences:

| What | Canonical | Outliers |
|---|---|---|
| Body font-size on mobile | **16px** | gandhi 17px · devai/gender/pubpol 15px |
| Sidebar drawer width | **280px** | dataviz 240px · pubpol 260px |
| Mobile-header height | **56px** | devai ~66px |

## Fixes

- **devai/gender/pubpol** — drop the `body { font-size: 15px }` override inside the `@media (max-width: 768px)` block
- **gandhi** — base body `font-size: 17px` → `16px`
- **dataviz** — tablet sidebar width 240 → 280
- **pubpol** — `--sidebar-width: 260px` → `280px` (set in all 4 theme variant blocks)
- **devai** — `.mobile-header` was using `--spacing-md/--spacing-lg` padding tokens that resolved bigger; pin to `padding: 0.75rem 1rem; height: 56px` like the others

## Verified at 390×844 mobile viewport

```
course       body_fs  sidebar_w   header_h   hamburger
-------------------------------------------------------
devecon      16px     280px       56px       True
devai        16px     280px       56px       True
dataviz      16px     280px       56px       True
gandhi       16px     280px       56px       True
gender       16px     280px       56px       True
law          16px     280px       56px       True
media        16px     280px       56px       True
mel          16px     280px       56px       True
poa          16px     280px       56px       True
pubchoice    16px     280px       56px       True
pubpol       16px     280px       56px       True
SEL          16px     280px       56px       True
```

## Note on the hamburger complaint

You said "all don't have hamburger for the side panel". The audit script clicked the hamburger on each course and confirmed the drawer opens on **all 12** — `.sidebar` transform goes from `translateX(-280px)` to `translateX(0)`. Best guess: you were testing the live site before #421 had finished deploying. Test after this PR ships and let me know if any course still hides it.

https://claude.ai/code/session_012uCmAm56wSwFB5rTQSgacC

---
_Generated by [Claude Code](https://claude.ai/code/session_012uCmAm56wSwFB5rTQSgacC)_