### PR TITLE
desktop: normalize sidebar width + hero h1 across all 12 courses

### DIFF
--- a/courses/dataviz/index.html
+++ b/courses/dataviz/index.html
@@ -197,7 +197,7 @@
             position: fixed;
             left: 0;
             top: 4px;
-            width: 280px;
+            width: 260px;
             height: calc(100vh - 4px);
             background: linear-gradient(180deg, #0F172A 0%, #1E293B 100%);
             color: #F1F5F9;
@@ -427,7 +427,7 @@
 
         .hero h1 {
             font-family: 'Inter', sans-serif;
-            font-size: 2.75rem;
+            font-size: clamp(2.5rem, 5vw, 3.5rem);
             font-weight: 700;
             line-height: 1.2;
             margin-bottom: 1rem;
@@ -1283,10 +1283,10 @@
         /* Responsive */
         @media (max-width: 1024px) {
             .sidebar {
-                width: 280px;
+                width: 260px;
             }
             .main-content {
-                margin-left: 280px;
+                margin-left: 260px;
             }
             .section {
                 padding: 2.5rem 2rem;
@@ -1301,10 +1301,12 @@
 
         @media (max-width: 768px) {
             .sidebar {
+                width: 280px;
+                max-width: 85vw;
                 transform: translateX(-100%);
                 transition: transform 0.3s ease;
             }
-            .sidebar.open {
+            .sidebar.active {
                 transform: translateX(0);
             }
             .main-content {
@@ -3992,7 +3994,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 
         // Mobile sidebar toggle
         function toggleSidebar() {
-            document.getElementById('sidebar').classList.toggle('open');
+            document.getElementById('sidebar').classList.toggle('active');
         }
 
         // Chart Chooser Logic
@@ -4110,7 +4112,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                     if (target) {
                         target.scrollIntoView({ behavior: 'smooth', block: 'start' });
                         // Close mobile sidebar
-                        document.getElementById('sidebar').classList.remove('open');
+                        document.getElementById('sidebar').classList.remove('active');
                     }
                 }
             });

--- a/courses/devai/index.html
+++ b/courses/devai/index.html
@@ -118,7 +118,7 @@
         
         .page-container { display: flex; min-height: 100vh; }
         
-        .sidebar { position: fixed; left: 0; top: 0; width: 280px; height: 100vh; background: linear-gradient(180deg, #1E1B4B 0%, #312E81 100%); color: #fff; overflow-y: auto; z-index: 100; display: flex; flex-direction: column; }
+        .sidebar { position: fixed; left: 0; top: 0; width: 260px; height: 100vh; background: linear-gradient(180deg, #1E1B4B 0%, #312E81 100%); color: #fff; overflow-y: auto; z-index: 100; display: flex; flex-direction: column; }
         .sidebar-header { padding: var(--spacing-lg); border-bottom: 1px solid rgba(255,255,255,0.1); }
         .sidebar-logo { display: flex; align-items: center; gap: var(--spacing-sm); color: #fff; font-family: var(--font-display); font-weight: 700; font-size: 1.1rem; }
         .sidebar-logo img { width: 32px; height: 32px; border-radius: 6px; }
@@ -141,7 +141,7 @@
         .hero::before { content: ''; position: absolute; top: 0; left: 0; right: 0; bottom: 0; background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.05'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E"); opacity: 0.5; }
         .hero-content { max-width: 900px; position: relative; z-index: 1; }
         .hero-badge { display: inline-flex; align-items: center; gap: var(--spacing-sm); background: rgba(255,255,255,0.2); padding: var(--spacing-xs) var(--spacing-md); border-radius: 20px; font-size: 0.8rem; font-weight: 600; margin-bottom: var(--spacing-lg); backdrop-filter: blur(10px); }
-        .hero h1 { font-family: var(--font-display); font-size: clamp(2rem, 5vw, 3rem); font-weight: 800; line-height: 1.2; margin-bottom: var(--spacing-sm); }
+        .hero h1 { font-family: var(--font-display); font-size: clamp(2.5rem, 5vw, 3.5rem); font-weight: 800; line-height: 1.2; margin-bottom: var(--spacing-sm); }
         .hero-tagline { font-size: 1.25rem; color: rgba(255,255,255,0.9); margin-bottom: var(--spacing-lg); font-weight: 500; }
         .hero-description { font-size: 1.1rem; color: rgba(255,255,255,0.85); line-height: 1.8; max-width: 700px; margin-bottom: var(--spacing-xl); }
         .hero-features { display: flex; flex-wrap: wrap; gap: var(--spacing-md); margin-bottom: var(--spacing-xl); }
@@ -343,7 +343,7 @@
         .stat-label { font-size: 0.85rem; color: var(--text-secondary); margin-top: var(--spacing-xs); }
         
         @media (max-width: 1024px) {
-            .sidebar { transform: translateX(-100%); transition: transform var(--transition-base); }
+            .sidebar { width: 280px; max-width: 85vw; transform: translateX(-100%); transition: transform var(--transition-base); }
             .sidebar.active { transform: translateX(0); }
             .main-content { margin-left: 0; }
             .mobile-header { display: flex; align-items: center; justify-content: space-between; padding: 0.75rem 1rem; height: 56px; box-sizing: border-box; background: var(--bg-primary); border-bottom: 1px solid var(--border-color); position: fixed; top: 0; left: 0; right: 0; z-index: 50; }

--- a/courses/gandhi/index.html
+++ b/courses/gandhi/index.html
@@ -218,7 +218,7 @@
             position: fixed;
             left: 0;
             top: 6px;
-            width: 280px;
+            width: 260px;
             height: calc(100vh - 6px);
             background: linear-gradient(180deg, var(--earth-deep) 0%, var(--earth-brown) 100%);
             color: var(--khadi-cream);
@@ -388,7 +388,7 @@
 
         .hero h1 {
             font-family: 'Inter', sans-serif;
-            font-size: 3rem;
+            font-size: clamp(2.5rem, 5vw, 3.5rem);
             font-weight: 600;
             line-height: 1.15;
             margin-bottom: 1.25rem;

--- a/courses/gender/index.html
+++ b/courses/gender/index.html
@@ -387,7 +387,7 @@ a:hover { text-decoration: underline; }
 .hero h1 {
   font-family: 'Inter', sans-serif;
   font-weight: 800;
-  font-size: 2.4rem;
+  font-size: clamp(2.5rem, 5vw, 3.5rem);
   color: #FFFFFF;
   line-height: 1.2;
   margin-bottom: 8px;

--- a/courses/pubpol/index.html
+++ b/courses/pubpol/index.html
@@ -62,7 +62,7 @@
             --hover-bg: #F1F5F9; --border-color: #E2E8F0;
             --gradient-primary:linear-gradient(135deg,#0EA5E9 0%,#6366F1 100%);
             --gradient-accent:linear-gradient(135deg,#0EA5E9 0%,#10B981 100%);
-            --sidebar-width:280px; --content-max-width:900px; --topbar-height:88px;
+            --sidebar-width:260px; --content-max-width:900px; --topbar-height:88px;
             --spacing-xs:0.25rem; --spacing-sm:0.5rem; --spacing-md:1rem;
             --spacing-lg:1.5rem; --spacing-xl:2rem; --spacing-2xl:3rem;
             --font-sans:'Amaranth',sans-serif; --font-heading:'Inter',sans-serif;
@@ -93,7 +93,7 @@
             --hover-bg:#334155; --border-color:#334155;
             --gradient-primary:linear-gradient(135deg,#0EA5E9 0%,#6366F1 100%);
             --gradient-accent:linear-gradient(135deg,#0EA5E9 0%,#10B981 100%);
-            --sidebar-width:280px; --content-max-width:900px; --topbar-height:88px;
+            --sidebar-width:260px; --content-max-width:900px; --topbar-height:88px;
             --spacing-xs:0.25rem; --spacing-sm:0.5rem; --spacing-md:1rem;
             --spacing-lg:1.5rem; --spacing-xl:2rem; --spacing-2xl:3rem;
             --font-sans:'Amaranth',sans-serif; --font-heading:'Inter',sans-serif;
@@ -124,7 +124,7 @@ body.light-mode, [data-theme="light"] {
             --hover-bg: #F1F5F9; --border-color: #E2E8F0;
             --gradient-primary:linear-gradient(135deg,#0EA5E9 0%,#6366F1 100%);
             --gradient-accent:linear-gradient(135deg,#0EA5E9 0%,#10B981 100%);
-            --sidebar-width:280px; --content-max-width:900px; --topbar-height:88px;
+            --sidebar-width:260px; --content-max-width:900px; --topbar-height:88px;
             --spacing-xs:0.25rem; --spacing-sm:0.5rem; --spacing-md:1rem;
             --spacing-lg:1.5rem; --spacing-xl:2rem; --spacing-2xl:3rem;
             --font-sans:'Amaranth',sans-serif; --font-heading:'Inter',sans-serif;
@@ -155,7 +155,7 @@ body.dark-mode, [data-theme="dark"] {
             --hover-bg:#334155; --border-color:#334155;
             --gradient-primary:linear-gradient(135deg,#0EA5E9 0%,#6366F1 100%);
             --gradient-accent:linear-gradient(135deg,#0EA5E9 0%,#10B981 100%);
-            --sidebar-width:280px; --content-max-width:900px; --topbar-height:88px;
+            --sidebar-width:260px; --content-max-width:900px; --topbar-height:88px;
             --spacing-xs:0.25rem; --spacing-sm:0.5rem; --spacing-md:1rem;
             --spacing-lg:1.5rem; --spacing-xl:2rem; --spacing-2xl:3rem;
             --font-sans:'Amaranth',sans-serif; --font-heading:'Inter',sans-serif;
@@ -378,7 +378,7 @@ body.dark-mode, [data-theme="dark"] {
         .hero{background:linear-gradient(135deg,#0c1445 0%,#1e3a8a 40%,#1d4ed8 70%,#0284c7 100%);color:white;padding:3rem 2rem 2.5rem;border-radius:16px;margin-bottom:2rem;position:relative;overflow:hidden;}
         .hero::before{content:'';position:absolute;inset:0;pointer-events:none;background:radial-gradient(ellipse 80% 60% at 20% 80%,rgba(99,102,241,0.2) 0%,transparent 60%),radial-gradient(ellipse 60% 50% at 80% 20%,rgba(14,165,233,0.25) 0%,transparent 60%);}
         .hero-badge{display:inline-flex;align-items:center;gap:8px;background:rgba(255,255,255,0.12);backdrop-filter:blur(8px);border:1px solid rgba(255,255,255,0.2);border-radius:20px;padding:5px 14px;font-size:0.75rem;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;margin-bottom:1.25rem;position:relative;font-family:var(--font-heading);}
-        .hero h1{font-size:clamp(1.8rem,4vw,2.8rem);font-weight:800;margin-bottom:0.5rem;color:white;position:relative;font-family:var(--font-heading);}
+        .hero h1{font-size:clamp(2.5rem,5vw,3.5rem);font-weight:800;margin-bottom:0.5rem;color:white;position:relative;font-family:var(--font-heading);}
         .hero-tagline{font-size:1.05rem;opacity:0.85;margin-bottom:0.75rem;position:relative;}
         .hero-subtitle{font-size:0.95rem;opacity:0.8;max-width:680px;margin-bottom:1.5rem;line-height:1.7;position:relative;}
         .feature-tags{display:flex;flex-wrap:wrap;gap:8px;margin-bottom:1.5rem;position:relative;}
@@ -516,7 +516,7 @@ body.dark-mode, [data-theme="dark"] {
         .footer-legal a:hover{color:var(--accent-color);}
         /* Responsive */
         @media(max-width:900px){
-            .sidebar{transform:translateX(-100%);transition:transform 0.3s ease;top:0;height:100vh;height:100dvh;}
+            .sidebar{width:280px;max-width:85vw;transform:translateX(-100%);transition:transform 0.3s ease;top:0;height:100vh;height:100dvh;}
             .sidebar.active{transform:translateX(0);}
             .main-content{margin-left:0!important;width:100%;}
             .footer{margin-left:0!important;}


### PR DESCRIPTION
## Summary

Follow-up to your "are you changing the desktop versions" concern. Honest audit + fix:

**What I was changing on desktop accidentally:**
- PR #422 changed pubpol's `--sidebar-width` root variable from 260 → 280, which affects all viewports. Reverted here.

**What was already drifting on desktop (pre-existing, you asked me to fix it):**
- Sidebar width: 8 courses at 260px, 4 at 280px (devai, dataviz, gandhi, pubpol)
- Hero H1 size: ranged from 38.4px → 56px across courses

## Canonical (devecon)

| Property | Desktop | Mobile drawer |
|---|---|---|
| Sidebar width | **260px** | 280px (override in media query) |
| Hero H1 | **`clamp(2.5rem, 5vw, 3.5rem)`** → 56px at 1440px | 25.35px (mobile media query) |

## Fixes (5 courses)

- **devai** — sidebar 280→260 base, mobile media query gains `width:280px; max-width:85vw`; H1 `clamp(2rem,5vw,3rem)` → `clamp(2.5rem,5vw,3.5rem)`
- **dataviz** — sidebar 280→260 base + tablet, mobile media query gains 280px width override; **also** finishes off the `.sidebar.open` → `.sidebar.active` migration from #421 (was internally consistent but using the old class name); H1 `2.75rem` → `clamp(2.5rem,5vw,3.5rem)`
- **gandhi** — sidebar 280→260 base (mobile already 280); H1 `3rem` → `clamp(2.5rem,5vw,3.5rem)`
- **pubpol** — `--sidebar-width` 280→260 (reverts #422 desktop drift, in all 4 theme variants); mobile media query gains explicit `width:280px`; H1 `clamp(1.8rem,4vw,2.8rem)` → `clamp(2.5rem,5vw,3.5rem)`
- **gender** — H1 `2.4rem` → `clamp(2.5rem,5vw,3.5rem)`

## Verified at both viewports

**Desktop 1440px, all 12:**
```
body=16px Amaranth · sidebar=260px · h1=56px Inter · footer=3 cols
```

**Mobile 390px, all 12:**
```
body=16px · sidebar drawer=280px · header=56px · h1=25.35px
```

https://claude.ai/code/session_012uCmAm56wSwFB5rTQSgacC

---
_Generated by [Claude Code](https://claude.ai/code/session_012uCmAm56wSwFB5rTQSgacC)_