### PR TITLE
chrome: add missing sidebar overlay + UserWay positioning + close audit gaps across 5 courses

### DIFF
--- a/courses/dataviz/index.html
+++ b/courses/dataviz/index.html
@@ -1348,7 +1348,7 @@
         .mobile-header {
             display: none;
             position: fixed;
-            top: 4px;
+            top: 0;
             left: 0;
             right: 0;
             height: 56px;
@@ -2409,6 +2409,18 @@
   .resource-card.handout .resource-card-eyebrow{color:#CBD5E1}
 }
 
+/* UserWay Widget Positioning - Small, Right Middle */
+.uwy.userway_p5 {
+    right: 10px !important;
+    left: auto !important;
+    top: 50% !important;
+    bottom: auto !important;
+    transform: translateY(-50%) !important;
+}
+.uwy .uai {
+    width: 40px !important;
+    height: 40px !important;
+}
 
 </style>
 <style>
@@ -2608,8 +2620,23 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     body { padding-top: 56px !important; }
     .mobile-header { z-index: 10000 !important; display: flex !important; }
     .mobile-menu-btn { display: flex !important; align-items: center; justify-content: center; }
-    /* If a sidebar-overlay element exists, ensure it sits above page content */
-    .sidebar-overlay { z-index: 9998; }
+    /* Sidebar overlay (mobile drawer backdrop) */
+    .sidebar-overlay {
+        display: none;
+        position: fixed;
+        top: 0; left: 0; right: 0; bottom: 0;
+        width: 100%; height: 100%;
+        background: rgba(0,0,0,0.6);
+        z-index: 9998;
+        pointer-events: none;
+        opacity: 0;
+        transition: opacity 0.3s ease;
+    }
+    .sidebar-overlay.active {
+        display: block;
+        pointer-events: auto;
+        opacity: 1;
+    }
 
     .v3-paper-plane, .v3-floating-elements, .v3-blob, .v3-big-plane,
     .v3-sparkle, .organic-blob, .floating-plane, .im-paper-plane {
@@ -2748,6 +2775,9 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             </svg>
         </button>
     </header>
+
+    <!-- Sidebar Overlay (for mobile) -->
+    <div class="sidebar-overlay" id="sidebar-overlay"></div>
 
     <!-- Navigation Sidebar -->
     <aside class="sidebar" id="sidebar">
@@ -3991,7 +4021,16 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         // Mobile sidebar toggle
         function toggleSidebar() {
             document.getElementById('sidebar').classList.toggle('active');
+            var ov = document.getElementById('sidebar-overlay');
+            if (ov) ov.classList.toggle('active');
         }
+        (function(){
+            var ov = document.getElementById('sidebar-overlay');
+            if (ov) ov.addEventListener('click', function() {
+                document.getElementById('sidebar').classList.remove('active');
+                ov.classList.remove('active');
+            });
+        })();
 
         // Chart Chooser Logic
         const chartRecommendations = {

--- a/courses/devai/index.html
+++ b/courses/devai/index.html
@@ -636,8 +636,23 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     body { padding-top: 56px !important; }
     .mobile-header { z-index: 10000 !important; display: flex !important; }
     .mobile-menu-btn { display: flex !important; align-items: center; justify-content: center; }
-    /* If a sidebar-overlay element exists, ensure it sits above page content */
-    .sidebar-overlay { z-index: 9998; }
+    /* Sidebar overlay (mobile drawer backdrop) */
+    .sidebar-overlay {
+        display: none;
+        position: fixed;
+        top: 0; left: 0; right: 0; bottom: 0;
+        width: 100%; height: 100%;
+        background: rgba(0,0,0,0.6);
+        z-index: 9998;
+        pointer-events: none;
+        opacity: 0;
+        transition: opacity 0.3s ease;
+    }
+    .sidebar-overlay.active {
+        display: block;
+        pointer-events: auto;
+        opacity: 1;
+    }
 
     .v3-paper-plane, .v3-floating-elements, .v3-blob, .v3-big-plane,
     .v3-sparkle, .organic-blob, .floating-plane, .im-paper-plane {
@@ -751,6 +766,9 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;z-index:9999;padding:8px 16px;background:#F59E0B;color:#0F172A;font-weight:600;font-size:0.9rem;text-decoration:none;border-radius:0 0 8px 0;" onfocus="this.style.cssText='position:fixed;left:0;top:0;z-index:9999;padding:8px 16px;background:#F59E0B;color:#0F172A;font-weight:600;font-size:0.9rem;text-decoration:none;border-radius:0 0 8px 0;'" onblur="this.style.cssText='position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;'">Skip to content</a>
     <div class="reading-progress" id="readingProgress"></div>
     
+    <!-- Sidebar Overlay (for mobile) -->
+    <div class="sidebar-overlay" id="sidebar-overlay"></div>
+
     <div class="page-container">
         <aside class="sidebar" id="sidebar" role="navigation" aria-label="Course navigation">
             <div class="sidebar-header">
@@ -1658,12 +1676,22 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             
             const mobileMenuBtn = document.getElementById('mobileMenuBtn');
             const sidebar = document.getElementById('sidebar');
+            var sidebarOverlay = document.getElementById('sidebar-overlay');
             if (mobileMenuBtn) {
-                mobileMenuBtn.addEventListener('click', function() { sidebar.classList.toggle('active'); });
+                mobileMenuBtn.addEventListener('click', function() {
+                    sidebar.classList.toggle('active');
+                    if (sidebarOverlay) sidebarOverlay.classList.toggle('active');
+                });
             }
-            
+            if (sidebarOverlay) {
+                sidebarOverlay.addEventListener('click', function() {
+                    sidebar.classList.remove('active');
+                    sidebarOverlay.classList.remove('active');
+                });
+            }
+
             // Coach Callout Popup Animation - initialized via IIFE below
-            
+
             // Update aria-expanded on mobile menu toggle
             if (mobileMenuBtn) {
                 mobileMenuBtn.addEventListener('click', function() {
@@ -1676,7 +1704,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 link.addEventListener('click', function(e) {
                     e.preventDefault();
                     const target = document.querySelector(this.getAttribute('href'));
-                    if (target) { target.scrollIntoView({ behavior: 'smooth' }); sidebar.classList.remove('active'); }
+                    if (target) {
+                        target.scrollIntoView({ behavior: 'smooth' });
+                        sidebar.classList.remove('active');
+                        if (sidebarOverlay) sidebarOverlay.classList.remove('active');
+                    }
                 });
             });
         });

--- a/courses/gandhi/index.html
+++ b/courses/gandhi/index.html
@@ -1161,7 +1161,7 @@
         .mobile-header {
             display: none;
             position: fixed;
-            top: 6px;
+            top: 0;
             left: 0;
             right: 0;
             height: 56px;
@@ -1931,6 +1931,18 @@
   .resource-card.handout .resource-card-eyebrow{color:#CBD5E1}
 }
 
+/* UserWay Widget Positioning - Small, Right Middle */
+.uwy.userway_p5 {
+    right: 10px !important;
+    left: auto !important;
+    top: 50% !important;
+    bottom: auto !important;
+    transform: translateY(-50%) !important;
+}
+.uwy .uai {
+    width: 40px !important;
+    height: 40px !important;
+}
 
 </style>
 <style>

--- a/courses/gender/index.html
+++ b/courses/gender/index.html
@@ -2349,5 +2349,31 @@ sections.forEach(section => {
 <script src="/js/pwa.js" defer></script>
 <script src="/js/offline.js" defer></script>
 <script defer src="../../js/auto-refresh.js"></script>
+
+<!-- UserWay Accessibility Widget - Position 5 = Right Middle, Small -->
+<script>
+    (function(d){
+        var s = d.createElement("script");
+        s.setAttribute("data-account", "EksmhlPg9k");
+        s.setAttribute("data-position", "5");
+        s.setAttribute("data-size", "small");
+        s.setAttribute("src", "https://cdn.userway.org/widget.js");
+        (d.body || d.head).appendChild(s);
+    })(document);
+</script>
+<style>
+/* UserWay Widget Positioning - Small, Right Middle */
+.uwy.userway_p5 {
+    right: 10px !important;
+    left: auto !important;
+    top: 50% !important;
+    bottom: auto !important;
+    transform: translateY(-50%) !important;
+}
+.uwy .uai {
+    width: 40px !important;
+    height: 40px !important;
+}
+</style>
 </body>
 </html>

--- a/courses/pubpol/index.html
+++ b/courses/pubpol/index.html
@@ -1505,5 +1505,31 @@ body.dark-mode, [data-theme="dark"] {
 <script src="/js/pwa.js" defer></script>
 <script src="/js/offline.js" defer></script>
 <script defer src="../../js/auto-refresh.js"></script>
+
+<!-- UserWay Accessibility Widget - Position 5 = Right Middle, Small -->
+<script>
+    (function(d){
+        var s = d.createElement("script");
+        s.setAttribute("data-account", "EksmhlPg9k");
+        s.setAttribute("data-position", "5");
+        s.setAttribute("data-size", "small");
+        s.setAttribute("src", "https://cdn.userway.org/widget.js");
+        (d.body || d.head).appendChild(s);
+    })(document);
+</script>
+<style>
+/* UserWay Widget Positioning - Small, Right Middle */
+.uwy.userway_p5 {
+    right: 10px !important;
+    left: auto !important;
+    top: 50% !important;
+    bottom: auto !important;
+    transform: translateY(-50%) !important;
+}
+.uwy .uai {
+    width: 40px !important;
+    height: 40px !important;
+}
+</style>
 </body>
 </html>


### PR DESCRIPTION
## Comprehensive 12-course audit + fixes

Line-by-line comparison of all 12 flagships against devecon (canonical) — checked mobile-header structure, sidebar structure, accessibility widget, theme system, topbar, viewport meta, course-loader integration, and CSS positioning.

## Real drift found and fixed

| Issue | Courses affected | Effect |
|---|---|---|
| Sidebar overlay element + CSS + JS missing | devai, dataviz | tapping outside open drawer didn't close it |
| UserWay loaded but no positioning CSS | dataviz, gandhi | widget rendered at default top-right as a dark/black box (this was the "black box top-right" you saw on dataviz) |
| UserWay completely missing | gender, pubpol | no accessibility help |
| Mobile-header `top: 4px/6px` offset | dataviz, gandhi | small visible gap above fixed header |

## Fixes

**devai** — added `<div class="sidebar-overlay">` element; replaced z-index-only CSS stub with canonical overlay (display/active states/rgba backdrop); wired hamburger + overlay click + in-sidebar nav-link clicks to toggle both elements.

**dataviz** — same overlay element + CSS + JS treatment; `top: 4px → 0` on mobile-header; added `.uwy.userway_p5` + `.uwy .uai` positioning CSS.

**gandhi** — `top: 6px → 0` on mobile-header; added UserWay positioning CSS.

**gender + pubpol** — added full canonical UserWay script (account=EksmhlPg9k, position=5, size=small) + positioning CSS.

## Verified

- **Audit script** (`/tmp/audit-all-12.py`): 12/12 now have UserWay configured, mh_top=0, sidebar-overlay element present
- **Visual** screenshots taken at 390px mobile and 1440px desktop for all 12 courses

## Still out of scope (next pass if you want)

- gender + SEL mobile-header has a 44px spacer instead of theme toggle (each uses `.im-theme-btn` with its own data-imtheme wiring — needs per-course glue layer)
- devai + SEL missing `.sidebar-collapse-btn` (the desktop chevron that shrinks the sidebar to icons)
- gender's mobile-header brand text is "Gender Studies" instead of "ImpactMojo" (might be intentional)

https://claude.ai/code/session_012uCmAm56wSwFB5rTQSgacC

---
_Generated by [Claude Code](https://claude.ai/code/session_012uCmAm56wSwFB5rTQSgacC)_