### PR TITLE
chrome: close deferred items — gender brand text + gender/SEL mobile theme toggle

### DIFF
--- a/courses/SEL/index.html
+++ b/courses/SEL/index.html
@@ -3070,7 +3070,19 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         </svg>
     </button>
     <a href="/" style="font-weight: 600; color: var(--color-text); text-decoration: none; font-size: 1rem;">ImpactMojo</a>
-    <span style="width:44px"></span>
+    <button class="mobile-menu-btn" id="theme-toggle-mobile" aria-label="Toggle theme" type="button" style="background: transparent; border: none;">
+        <svg width="20" height="20" style="pointer-events: none;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="5"></circle>
+            <line x1="12" y1="1" x2="12" y2="3"></line>
+            <line x1="12" y1="21" x2="12" y2="23"></line>
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+            <line x1="1" y1="12" x2="3" y2="12"></line>
+            <line x1="21" y1="12" x2="23" y2="12"></line>
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+        </svg>
+    </button>
 </header>
 <div class="sidebar-overlay" id="sidebar-overlay"></div>
 

--- a/courses/gender/index.html
+++ b/courses/gender/index.html
@@ -1619,8 +1619,20 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
             <line x1="3" y1="18" x2="21" y2="18"></line>
         </svg>
     </button>
-    <a href="../../index.html" class="mobile-header-brand">Gender Studies</a>
-    <span style="width:44px"></span>
+    <a href="/" class="mobile-header-brand" style="font-weight: 600; color: var(--color-text, var(--text-primary)); text-decoration: none; font-size: 1rem;">ImpactMojo</a>
+    <button class="mobile-menu-btn" id="theme-toggle-mobile" aria-label="Toggle theme" type="button" style="background: transparent; border: none; pointer-events: auto;" onclick="(function(){var c=document.documentElement.getAttribute('data-theme');var n=c==='dark'?'light':'dark';document.documentElement.setAttribute('data-theme',n);document.body.classList.remove('dark-mode','light-mode');document.body.classList.add(n+'-mode');localStorage.setItem('impactmojo-theme',n);document.querySelectorAll('.im-theme-btn').forEach(function(b){b.classList.toggle('active',b.getAttribute('data-imtheme')===n);});})()">
+        <svg width="20" height="20" style="pointer-events: none;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="5"></circle>
+            <line x1="12" y1="1" x2="12" y2="3"></line>
+            <line x1="12" y1="21" x2="12" y2="23"></line>
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+            <line x1="1" y1="12" x2="3" y2="12"></line>
+            <line x1="21" y1="12" x2="23" y2="12"></line>
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+        </svg>
+    </button>
 </header>
 <div class="sidebar-overlay" id="sidebar-overlay"></div>
 


### PR DESCRIPTION
## Closes 2 of the 3 deferred items from the chrome normalization session

| # | Item | Status |
|---|---|---|
| 1 | gender mobile-header brand "Gender Studies" → "ImpactMojo" | ✅ Closed |
| 2 | gender + SEL mobile-header spacer → theme toggle button | ✅ Closed |
| 3 | devai + SEL missing `.sidebar-collapse-btn` (desktop chevron) | Honestly deferred — see below |

## Implementation notes

**SEL** — the page already had a `themeToggleMobile.addEventListener('click', toggleTheme)` IIFE at line 3447, but no button in the DOM for it to bind to. Adding the button HTML hooks into the existing handler. (An earlier attempt with a duplicate inline onclick made the toggle cancel itself: light → dark → light. Caught via Playwright test.)

**gender** — no pre-existing handler. Used inline `onclick` that toggles `data-theme`, writes to the canonical `impactmojo-theme` localStorage key, and syncs the desktop `.im-theme-btn` indicators.

**Verified at 390px mobile:** clicking the sun icon toggles theme on both. Visual screenshots match the canonical HAM | ImpactMojo | sun-icon layout from the other 10.

## Why I didn't close #3

Adding the desktop `.sidebar-collapse-btn` chevron to devai + SEL needs ~100 lines of CSS for the `.sidebar.collapsed` icon-only state + JS for localStorage persistence. Adding just the button HTML produces a visible chevron that does nothing when clicked — worse UX than no button. Honestly deferring until a dedicated pass.

https://claude.ai/code/session_012uCmAm56wSwFB5rTQSgacC

---
_Generated by [Claude Code](https://claude.ai/code/session_012uCmAm56wSwFB5rTQSgacC)_