### PR TITLE
fix: wire up all new session content across homepage and catalog

### DIFF
--- a/catalog.html
+++ b/catalog.html
@@ -2074,15 +2074,15 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         
         <div class="stats-bar">
             <div class="stat-item">
-                <div class="stat-number">48</div>
+                <div class="stat-number">53</div>
                 <div class="stat-label">Courses</div>
             </div>
             <div class="stat-item">
-                <div class="stat-number">11</div>
+                <div class="stat-number">12</div>
                 <div class="stat-label">Labs</div>
             </div>
             <div class="stat-item">
-                <div class="stat-number">16</div>
+                <div class="stat-number">17</div>
                 <div class="stat-label">Games</div>
             </div>
             <div class="stat-item">
@@ -2297,6 +2297,7 @@ const allContent = [
     { id: 'f10', type: 'flagship', title: 'Public Policy: Process, Design & Governance', description: "How policy gets made, implemented, and why it often doesn't work. From the Planning Commission to NITI Aayog, fiscal federalism to GST, regulatory governance to social sector delivery. 16 modules.", track: 'policy', rating: 4.9, users: '1.4K', url: '/courses/pubpol/' },
     { id: 'f11', type: 'flagship', title: 'Gender Studies: Feminisms, Power & Social Change', description: 'A rigorous introduction to feminist theory, the political economy of gender, care work, law and rights, caste-gender intersections, and development practice — anchored in South Asian scholarship. 16 modules with AI study companion.', track: 'gender', rating: 4.9, users: '1.6K', url: '/courses/gender/' },
     { id: 'f12', type: 'flagship', title: 'Public Choice: Decisions, Incentives & Institutions', description: 'Mechanics, incentives, and institutional design. From voting paradoxes and rent-seeking to bureaucratic capture and federal bargaining, with South Asian cases throughout. 13 modules with 83-term interactive lexicon.', track: 'policy', rating: 4.9, users: 'New', url: '/courses/pubchoice/' },
+    { id: 'f13', type: 'flagship', title: 'Livelihoods in India: Rural, Urban & Skills', description: 'Comprehensive flagship across three modules — rural (NRLM, SHGs, MGNREGA, agriculture), urban (informal sector, gig economy, vendors, domestic workers), and skills (Skill India, apprenticeships, FLFPR, returns to training). Evidence-driven, India-centred, ~15,000 words.', track: 'policy', rating: 4.9, users: 'New', url: '/courses/livelihoods/' },
 
     // FOUNDATIONAL COURSES (38)
     { id: 'c1', type: 'course', title: 'MEL Basics 101', description: 'Master the fundamentals of Monitoring, Evaluation, and Learning for development projects.', track: 'mel', rating: 4.8, users: '2.5K', url: '/101-courses/mel-basics.html' },
@@ -2352,6 +2353,7 @@ const allContent = [
     { id: 'l9', type: 'lab', title: 'Resource and Sustainability Lab', description: 'Analyze resource flows and develop sustainability plans.', track: 'mel', rating: 4.8, users: '490', url: '/Labs/resource-sustainability-lab.html' },
     { id: 'l10', type: 'lab', title: 'Impact and Partnerships Lab', description: 'Map partnership ecosystems and design collaboration frameworks.', track: 'mel', rating: 4.8, users: '450', url: '/Labs/impact-partnerships-lab.html' },
     { id: 'l11', type: 'lab', title: 'Gender Analysis Lab', description: 'Apply gender frameworks, assess intersectionality, design gender-responsive programmes, and plan inclusive interventions.', track: 'gender', rating: 4.8, users: '420', url: '/Labs/gender-studies-lab.html' },
+    { id: 'l12', type: 'lab', title: 'Teacher Evidence Explorer', description: 'Filter 30+ teacher-effectiveness interventions by evidence quality, cost, type, outcome, and India relevance. Built from rigorous evaluations 2000–2024 — TaRL, contract teachers, mentoring, Mindspark, pay-for-performance, and more.', track: 'health', rating: 4.9, users: 'New', url: '/Labs/teacher-evidence-lab.html' },
     
     // GAMES (16)
     { id: 'g1', type: 'game', title: 'The Real Middle', description: 'Understand who the middle-class really is in India through wealth inequality dynamics.', track: 'policy', rating: 4.0, users: '850', url: '/Games/real-middle-india.html' },
@@ -2370,7 +2372,8 @@ const allContent = [
     { id: 'g14', type: 'game', title: 'Epidemic Response Challenge', description: 'Manage a public health crisis: balance containment, communication, equity, and economic costs in real time.', track: 'health', rating: 4.7, users: '380', url: '/Games/public-health-game.html' },
     { id: 'g15', type: 'game', title: 'Climate Action Challenge', description: 'Make climate policy trade-offs: mitigation vs. adaptation, equity vs. speed, energy transition under constraints.', track: 'policy', rating: 4.7, users: '410', url: '/Games/climate-action-game.html' },
     { id: 'g16', type: 'game', title: 'The Care Economy Challenge', description: 'Confront the invisibilised work of care — design recognition, redistribution, and reward into policy systems.', track: 'gender', rating: 4.8, users: '350', url: '/Games/gender-equity-game.html' },
-    
+    { id: 'g17', type: 'game', title: 'SEL Simulation: Four Lenses', description: 'Step into Social-Emotional Learning from four sides — teacher, program designer, evaluator, or student. 24 evidence-grounded scenarios from NEP 2020, CASEL, and Indian SEL research.', track: 'health', rating: 4.9, users: 'New', url: '/Games/sel-simulation-game.html' },
+
     // PREMIUM (9)
     { id: 'p1', type: 'premium', title: 'Field Notes from a Development Economist', description: 'Behind-the-scenes analysis of real programs, procurement dynamics, and implementation trade-offs across South Asia.', track: 'policy', rating: 5.0, users: '450', url: 'https://impactmojo-field-notes-pro.netlify.app/' },
     { id: 'p2', type: 'premium', title: 'Qualitative Insights Lab Pro', description: 'AI-assisted thematic coding, memo generation, and pattern identification for interview and FGD transcripts. Built for researchers without NVivo licensing.', track: 'mel', rating: 4.5, users: '680', url: '/premium-tools/qual-insights-lab.html' },

--- a/index.html
+++ b/index.html
@@ -226,16 +226,16 @@ window.addEventListener('click', function(e) {
 })();
 </script>
 
-<meta name="description" content="Free development economics education: 12 flagship courses covering MEAL, data visualization, AI for impact, Gandhian philosophy, political economy and more. Development Know-How at zero cost for practitioners across South Asia."/>
+<meta name="description" content="Free development economics education: 13 flagship courses covering MEAL, data visualization, AI for impact, Gandhian philosophy, political economy and more. Development Know-How at zero cost for practitioners across South Asia."/>
 <meta property="og:title" content="ImpactMojo | Free Development Economics & Policy Education">
-<meta property="og:description" content="Free development economics education: 12 flagship courses covering MEAL, data visualization, AI for impact, Gandhian philosophy, political economy and more. Development Know-How at zero cost.">
+<meta property="og:description" content="Free development economics education: 13 flagship courses covering MEAL, data visualization, AI for impact, Gandhian philosophy, political economy and more. Development Know-How at zero cost.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://www.impactmojo.in/">
 <meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
 <meta property="og:site_name" content="ImpactMojo">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="ImpactMojo | Free Development Economics & Policy Education">
-<meta name="twitter:description" content="Free development economics education: 12 flagship courses covering MEAL, data visualization, AI for impact, Gandhian philosophy, political economy and more.">
+<meta name="twitter:description" content="Free development economics education: 13 flagship courses covering MEAL, data visualization, AI for impact, Gandhian philosophy, political economy and more.">
 <meta name="twitter:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
 <link rel="canonical" href="https://www.impactmojo.in/">
 <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large">
@@ -2389,6 +2389,16 @@ window.addEventListener('authStateChanged', function(e) {
 <p class="card-description">Reading climate change as a development question — equity, energy, and the politics of transition. Curated by Sukhmeet Bedi.</p>
 </a>
 </div>
+<div class="card">
+<a href="/DeepDives/sel-evaluation-india.html">
+<div class="card-header">
+<span class="card-number"><svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Library_books"/></svg> DD6</span>
+<span class="learner-badge">28 readings · New</span>
+</div>
+<h3 class="card-title">SEL Evaluation in India: What Works, What Doesn't, &amp; How</h3>
+<p class="card-description">Working syllabus on Social-Emotional Learning evaluation in Indian school contexts — methods, measures, and the critical scholarship on both. Curated by the ImpactMojo Editorial team.</p>
+</a>
+</div>
 </div>
 <div class="action-buttons">
 <a class="btn btn-primary" href="/DeepDives/">
@@ -3256,7 +3266,7 @@ window.addEventListener('authStateChanged', function(e) {
 <circle cx="12" cy="12" r="2"></circle>
 <circle cx="12" cy="19" r="2"></circle>
 </svg>
-                        All Labs <span id="labsCount"></span>
+                        All Labs <span id="labsCount">(12)</span>
                     </h2>
 <span class="close" onclick="closeModal('labsModal')">×</span>
 </div>
@@ -3482,6 +3492,20 @@ window.addEventListener('authStateChanged', function(e) {
 </a>
 </div>
 </div>
+<div class="modal-item">
+<div class="modal-item-icon"><svg fill="none" stroke="white" stroke-width="2" viewbox="0 0 24 24"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg></div>
+<div class="modal-item-content">
+<a href="/Labs/teacher-evidence-lab.html" target="_blank" rel="noopener noreferrer">
+<div class="modal-item-title">Teacher Evidence Explorer
+<span style="background: #0EA5E9; color: white; font-size: 0.6rem; padding: 0.15rem 0.5rem; border-radius: 4px; margin-left: 0.5rem; text-transform: uppercase; letter-spacing: 0.05em;">New</span>
+</div>
+<p class="modal-item-description">Filter 30+ teacher-effectiveness interventions by evidence quality, cost (₹/teacher/year), type, outcome, and India relevance. TaRL, contract teachers, mentoring, Mindspark, pay-for-performance, and more. Honest summaries including null and weak findings.</p>
+<div class="modal-item-meta">
+<span class="modal-item-link">Open -></span>
+</div>
+</a>
+</div>
+</div>
 
 </div>
 </div>
@@ -3498,7 +3522,7 @@ window.addEventListener('authStateChanged', function(e) {
 <rect height="14" rx="2" ry="2" width="20" x="2" y="7"></rect>
 <path d="M16 7V4a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v3"></path>
 </svg>
-                        All Interactive Games (16)
+                        All Interactive Games (17)
                     </h2>
 <span class="close" onclick="closeModal('gamesModal')">×</span>
 </div>
@@ -3830,6 +3854,23 @@ window.addEventListener('authStateChanged', function(e) {
 <span class="imx-star-text">4.9</span>
 </div></div>
 <p class="modal-item-description">Design AI systems across 8 real-world scenarios — facial recognition, credit scoring, predictive policing, and hiring algorithms. Navigate tradeoffs between efficiency, fairness, privacy, and public trust.</p>
+<div class="modal-item-meta"><span class="modal-item-link">Open -></span></div>
+</a></div></div>
+<div class="modal-item">
+<div class="modal-item-icon"><svg fill="none" stroke="white" stroke-width="2" viewbox="0 0 24 24"><path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2z"/><circle cx="12" cy="12" r="3"/><path d="M2 12h4M18 12h4M12 2v4M12 18v4"/></svg></div>
+<div class="modal-item-content">
+<a href="/Games/sel-simulation-game.html" target="_blank" rel="noopener noreferrer">
+<div class="modal-item-title">SEL Simulation: Four Lenses
+<span style="background: #EC4899; color: white; font-size: 0.6rem; padding: 0.15rem 0.5rem; border-radius: 4px; margin-left: 0.5rem; text-transform: uppercase; letter-spacing: 0.05em;">New</span>
+<div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
+<svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
+<svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
+<svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
+<svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
+<svg class="star-icon" style="opacity:.6" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
+<span class="imx-star-text">New</span>
+</div></div>
+<p class="modal-item-description">Step into Social-Emotional Learning from four sides — teacher facing classroom dilemmas, program designer with ₹40L, evaluator deciding what can be known, or student (Anika, 12) across a school year. 24 evidence-grounded scenarios from NEP 2020, CASEL, and Indian SEL research.</p>
 <div class="modal-item-meta"><span class="modal-item-link">Open -></span></div>
 </a></div></div>
 
@@ -4416,7 +4457,7 @@ window.addEventListener('authStateChanged', function(e) {
 <path d="M12 14l9-5-9-5-9 5z"></path>
 <path d="M12 14l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z"></path>
 </svg>
-                        All Courses (52)
+                        All Courses (53)
                     </h2>
 <span class="close" onclick="closeModal('coursesModal')">×</span>
 </div>
@@ -4692,6 +4733,30 @@ window.addEventListener('authStateChanged', function(e) {
 </div>
 </div>
 <p class="modal-item-description">A rigorous introduction to feminist theory, the political economy of gender, care work, law and rights, caste-gender intersections, and development practice — anchored in South Asian scholarship and global feminist thought. 75-term interactive lexicon across 5 thematic categories.</p>
+<div class="modal-item-meta">
+<span class="modal-item-link">Open -></span>
+</div>
+</a>
+</div>
+</div>
+<div class="modal-item" style="border: 2px solid #F59E0B; background: linear-gradient(135deg, rgba(245, 158, 11, 0.05) 0%, rgba(217, 119, 6, 0.05) 100%);">
+<div class="modal-item-icon" style="background: linear-gradient(135deg, #F59E0B 0%, #D97706 100%);"><svg fill="none" stroke="white" stroke-width="2" viewBox="0 0 24 24"><path d="M3 21h18M5 21V7l8-4 8 4v14M9 9h.01M9 12h.01M9 15h.01M9 18h.01M13 9h.01M13 12h.01M13 15h.01M13 18h.01"/></svg></div>
+<div class="modal-item-content">
+<a href="/courses/livelihoods/">
+<div class="modal-item-title">
+                        <span style="background: #F59E0B; color: white; font-size: 0.6rem; padding: 0.15rem 0.5rem; border-radius: 4px; margin-right: 0.5rem; text-transform: uppercase; letter-spacing: 0.05em;">Flagship</span>
+                        <span style="background: #EC4899; color: white; font-size: 0.6rem; padding: 0.15rem 0.5rem; border-radius: 4px; margin-right: 0.5rem; text-transform: uppercase; letter-spacing: 0.05em;">New</span>
+                        Livelihoods in India: Rural, Urban &amp; Skills
+                        <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
+<svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
+<svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
+<svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
+<svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
+<svg class="star-icon" style="opacity:.6" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
+<span class="imx-star-text">New</span>
+</div>
+</div>
+<p class="modal-item-description">Comprehensive flagship across three modules — rural (NRLM, SHGs, MGNREGA, agriculture, financial inclusion), urban (informal sector, gig economy, vendors, domestic workers, urban policy), and skills (Skill India, apprenticeships, FLFPR, job matching, returns to training). Evidence-driven, India-centred, ~15,000 words for practitioners on both sides of the commissioning table.</p>
 <div class="modal-item-meta">
 <span class="modal-item-link">Open -></span>
 </div>


### PR DESCRIPTION
## Summary

The 6 pieces shipped earlier this session (#428–#431) existed in `search-index.json`, `sitemap.xml`, `data/deep-dives.json`, `catalog_data.json`, and `blog.html` — but **were not linked from `index.html`'s modals or `catalog.html`'s hardcoded arrays**. Visitors browsing the homepage or catalog wouldn't see the new content. This PR fixes that.

### Added to index.html

| What | Where |
|---|---|
| **SEL Simulation: Four Lenses** | `gamesModal` (with "New" badge) |
| **Teacher Evidence Explorer** | `labsModal` (with "New" badge) |
| **Livelihoods in India: Rural, Urban & Skills** | `coursesModal` as flagship card after Gender Studies (with "Flagship" + "New" badges) |
| **SEL Evaluation in India** | Deep Dives homepage section as 4th card |

Counts updated:
- gamesModal `(16)` → `(17)`
- coursesModal `(52)` → `(53)`
- labsCount span filled with `(12)`
- Meta description: "12 flagship courses" → "13 flagship courses"

### Added to catalog.html

- `f13` Livelihoods flagship entry to courses array
- `g17` SEL Simulation entry to games array
- `l12` Teacher Evidence Explorer entry to labs array
- Stat bar updated: 48 → 53 courses, 11 → 12 labs, 16 → 17 games (closing prior count drift)

### Not changed

- **Blog posts** (`knowing-what-you-want`, `writing-a-tor-for-research`) remain linked from `blog.html` (their cards were added in earlier PRs) and from the nav. Homepage has no featured-blog section, so no additional wiring needed.
- **Deep Dives landing page** (`/DeepDives/`) renders dynamically from `data/deep-dives.json` which was updated in #428 — no static edits needed.

## Test plan

- [ ] Open `https://www.impactmojo.in/` → click "All Interactive Games" → SEL Simulation appears
- [ ] Click "All Labs" → Teacher Evidence Explorer appears
- [ ] Click "All Courses" → Livelihoods appears in Flagship section
- [ ] Scroll to Deep Dives section → SEL Evaluation card visible
- [ ] Open `/catalog.html` → all 3 new content pieces appear in their filterable grids; stat bar shows 53/12/17
- [ ] Open `/DeepDives/` → SEL Evaluation in India card appears (already dynamic)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BeuCCodZutzv6wYFdZTsjb)_