### PR TITLE
feat: propagate SEL framework diversity to course + deep dive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to ImpactMojo are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.25.5] - 2026-05-23
+
+### Added — Framework diversity propagated to SEL Course and SEL Eval Deep Dive
+
+After bringing framework plurality to the SEL Simulation Game (#433), audited the SEL Course and SEL Evaluation Deep Dive — both had the same CASEL-heavy, NEP-child-only gaps. This PR fixes both.
+
+**SEL Flagship Course (`/courses/SEL/`)**:
+- Hero subtitle now names CASEL, SEE Learning, WHO Life Skills, Delhi Happiness Curriculum + EMC, Indian indigenous traditions (Tagore, Krishnamurti, Aurobindo, Nai Talim), and NEP 2020 teacher-side provisions (NPST, CPD, B.Ed., teacher autonomy)
+- New static "Frameworks We Draw From" section inserted between hero and Module 1, explicitly mapping each framework's relevance with India-context notes
+- Sidebar nav updated with link to the new section
+- Meta description, keywords, OG description updated for SEO
+- *Note*: Course module content itself is dynamically loaded from Supabase edge function; this PR updates only the static shell. Full integration of framework references into individual module bodies would require database updates outside this repo.
+
+**SEL Evaluation in India Deep Dive (`/DeepDives/sel-evaluation-india.html`)**:
+- Section 01 (Foundations) — added 4 new entries:
+  - SEE Learning (Emory + Dalai Lama Centre)
+  - NCERT Adolescence Education Programme (AEP) — the framework Indian government schools actually run
+  - Indian indigenous educational traditions (Tagore, Krishnamurti, Aurobindo, Nai Talim)
+  - Expanded NEP 2020 entry to explicitly include teacher-side provisions (NPST, 50-hr CPD, 4-yr integrated B.Ed., teacher autonomy)
+- Section 02 (India Evidence Base) — added entry for Delhi's Entrepreneurship Mindset Curriculum (EMC) alongside the existing Happiness Curriculum entry; deepened the Happiness Curriculum annotation
+- Reading count updated 28 → 32 (in HTML, `data/deep-dives.json`, and the homepage Deep Dives card)
+
 ## [10.25.4] - 2026-05-23
 
 ### Added

--- a/DeepDives/sel-evaluation-india.html
+++ b/DeepDives/sel-evaluation-india.html
@@ -47,7 +47,7 @@
     <span class="dd-chip">SEL</span>
     <span class="dd-chip">India context</span>
     <span class="dd-chip">Methods</span>
-    <span class="dd-chip dd-chip-teal">28 readings</span>
+    <span class="dd-chip dd-chip-teal">32 readings</span>
   </div>
 
   <div class="dd-curator">
@@ -89,8 +89,23 @@
     </article>
 
     <article class="dd-item">
-      <div class="dd-item-head"><span class="dd-type" data-t="report">Report</span><span class="dd-cite"><a href="https://www.education.gov.in/sites/upload_files/mhrd/files/NEP_Final_English_0.pdf" target="_blank" rel="noopener">Government of India, <em>National Education Policy 2020</em> (specifically Sections 4.6, 4.7, 5.7 on SEL/life skills)</a></span></div>
-      <p class="dd-annot">The policy text that opened the door to large-scale SEL investment in Indian government schools. Cites "holistic development of all faculties" repeatedly; explicit on life skills, social-emotional development, mental health. Evaluators working with state systems should know exactly what NEP language enables; it is the warrant for investment.</p>
+      <div class="dd-item-head"><span class="dd-type" data-t="web">Web</span><span class="dd-cite"><a href="https://seelearning.emory.edu/" target="_blank" rel="noopener">Emory University &amp; the Dalai Lama Center, "SEE Learning: Social, Emotional &amp; Ethical Learning" (2019, with India-translated materials)</a></span></div>
+      <p class="dd-annot">The most important non-CASEL global SEL framework. SEE Learning extends CASEL's five competencies with an explicit <em>ethical</em> dimension grounded in compassion, interdependence, and systems-awareness — drawing on contemplative traditions, neuroscience, and developmental science. India translations and pilots are run by the Dalai Lama Center, Vidya &amp; Child schools, and several urban progressive schools. The ethical dimension tends to travel better cross-culturally than the CASEL frame; evaluators commissioning SEL in Indian contexts should know it exists.</p>
+    </article>
+
+    <article class="dd-item">
+      <div class="dd-item-head"><span class="dd-type" data-t="report">Report</span><span class="dd-cite">NCERT, <em>Adolescence Education Programme (AEP) — Source Book</em> and life-skills curricular materials</span></div>
+      <p class="dd-annot">The framework Indian government schools actually run. AEP is built on the WHO Life Skills 10-skill model; it is operationalised through state SCERTs, teacher handbooks, and the Adolescence Education Programme module of CBSE/state curricula. For evaluators working with government schools, this is the curricular ground truth — not CASEL, not SEE Learning. Engaging with NCERT's own measurement instruments (which are increasingly developed but under-published) is essential for state-system-integrated evaluation.</p>
+    </article>
+
+    <article class="dd-item">
+      <div class="dd-item-head"><span class="dd-type" data-t="book">Book</span><span class="dd-cite">Indian indigenous educational traditions — Rabindranath Tagore (Santiniketan), J. Krishnamurti (Foundation schools), Sri Aurobindo &amp; The Mother (Integral Education), M.K. Gandhi (Nai Talim / Basic Education)</span></div>
+      <p class="dd-annot">Predating SEL by a century, India's indigenous educational philosophies all centred what would now be called social-emotional and ethical development. Tagore's Santiniketan integrated art, nature, and the inner life; Krishnamurti emphasised freedom from conditioning and self-knowledge; Aurobindo's Integral Education named five dimensions (physical, vital, mental, psychic, spiritual); Gandhi's Nai Talim treated work, community, and character as inseparable from learning. Modern Indian SEL implementations rarely cite these traditions explicitly — and lose conceptual ground when they don't. The most thoughtful Indian SEL practice draws from both global frameworks and indigenous traditions.</p>
+    </article>
+
+    <article class="dd-item">
+      <div class="dd-item-head"><span class="dd-type" data-t="report">Report</span><span class="dd-cite"><a href="https://www.education.gov.in/sites/upload_files/mhrd/files/NEP_Final_English_0.pdf" target="_blank" rel="noopener">Government of India, <em>National Education Policy 2020</em> (Sections 4.6, 4.7, 5.7 on SEL/life skills; Sections 5.4–5.15 on teacher development; Section 5.20 on NPST)</a></span></div>
+      <p class="dd-annot">The policy text that opened the door to large-scale SEL investment in Indian government schools. Cites "holistic development of all faculties" repeatedly; explicit on life skills, social-emotional development, mental health. <strong>Evaluators should read both halves</strong>: the child-facing provisions (Sections 4.6–4.7) <em>and</em> the teacher-development provisions — National Professional Standards for Teachers (NPST), mandatory 50-hour annual CPD, 4-year integrated B.Ed., teacher autonomy in classroom decisions. The teacher-side architecture is what determines whether SEL programmes have skilled adults to actually deliver them. Most published SEL evaluations under-attend to this side; that is a methodological gap as much as a policy one.</p>
     </article>
 
     <article class="dd-item">
@@ -121,7 +136,12 @@
 
     <article class="dd-item">
       <div class="dd-item-head"><span class="dd-type" data-t="report">Report</span><span class="dd-cite">Delhi Government and SCERT Delhi, "Happiness Curriculum Implementation Reports" (2018–2023)</span></div>
-      <p class="dd-annot">India's largest public-sector SEL implementation — the Delhi government's Happiness Curriculum covers ~800,000 children daily across 1,000+ government schools. The evaluations published to date have methodological limits (no counterfactual; outcome measures predominantly survey-based), but the operational learnings are unmatched. Required reading for anyone designing SEL at state scale.</p>
+      <p class="dd-annot">India's largest public-sector SEL implementation — the Delhi government's Happiness Curriculum covers ~800,000 children daily across 1,000+ government schools (classes Nursery–8). Focus: mindfulness, gratitude, reflection, and "happiness as a skill." The evaluations published to date have methodological limits (no counterfactual; outcome measures predominantly survey-based), but the operational learnings are unmatched. Required reading for anyone designing SEL at state scale.</p>
+    </article>
+
+    <article class="dd-item">
+      <div class="dd-item-head"><span class="dd-type" data-t="report">Report</span><span class="dd-cite">Delhi Government and SCERT Delhi, "Entrepreneurship Mindset Curriculum (EMC) Implementation Reports" (2019 onwards)</span></div>
+      <p class="dd-annot">The companion to the Happiness Curriculum, for classes 9–12. EMC targets agency, problem-solving, self-confidence, risk-taking, and entrepreneurial thinking — overlapping with the CASEL "responsible decision-making" and "self-management" competencies but framed in market-oriented language that resonates with adolescents and parents in ways the "happiness" framing does not. Operationally distinct from Happiness Curriculum but designed as the senior-grade continuation. Together they form the largest functioning state-system SEL programme in India. Evaluators should note: the two curricula are evaluated separately, mostly through implementation studies rather than impact evaluation, and the cross-grade developmental story has not yet been built.</p>
     </article>
 
     <article class="dd-item">

--- a/courses/SEL/index.html
+++ b/courses/SEL/index.html
@@ -34,12 +34,12 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <link rel="manifest" href="/manifest.json">
     <title>Social-Emotional Learning for Development Practice | ImpactMojo</title>
-    <meta name="description" content="How social-emotional competencies shape effective development practice. A rigorous course connecting SEL research from CASEL, WHO life skills, and Indian educational frameworks with the daily realities of practitioners working in high-stress, resource-constrained environments across South Asia.">
-    <meta name="keywords" content="social emotional learning, SEL, practitioner wellbeing, facilitation skills, conflict resolution, burnout, trauma-informed, NEP 2020, CASEL, development practice, ImpactMojo">
+    <meta name="description" content="How social-emotional competencies shape effective development practice. A rigorous course drawing on multiple SEL frameworks — CASEL, SEE Learning (Emory/Dalai Lama Centre), WHO Life Skills, Delhi's Happiness Curriculum and Entrepreneurship Mindset Curriculum (EMC), Indian indigenous traditions (Tagore, Krishnamurti, Aurobindo, Nai Talim), and NEP 2020 (including teacher-side provisions: NPST, 50-hr CPD mandate, 4-yr B.Ed.) — connected with daily realities for practitioners across South Asia.">
+    <meta name="keywords" content="social emotional learning, SEL, SEE Learning, WHO Life Skills, Happiness Curriculum, EMC, NPST, CPD, NEP 2020, practitioner wellbeing, facilitation skills, conflict resolution, burnout, trauma-informed, CASEL, Tagore, Krishnamurti, Nai Talim, development practice, ImpactMojo">
     <meta name="author" content="ImpactMojo">
     <link rel="canonical" href="https://www.impactmojo.in/courses/sel/">
     <meta property="og:title" content="Social-Emotional Learning for Development Practice | ImpactMojo">
-    <meta property="og:description" content="How social-emotional competencies shape effective development practice. A rigorous course connecting SEL research from CASEL, WHO life skills, and Indian educational frameworks with the daily realities of practitioners working in high-stress, resource-constrained environments across South Asia.">
+    <meta property="og:description" content="How social-emotional competencies shape effective development practice. Draws on multiple SEL frameworks (CASEL, SEE Learning, WHO Life Skills, Delhi Happiness Curriculum + EMC, Indian indigenous traditions, NEP 2020 teacher-side provisions) connected with daily practitioner realities across South Asia.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://www.impactmojo.in/courses/sel/">
     <meta property="og:site_name" content="ImpactMojo">
@@ -3101,6 +3101,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 <div class="nav-section">
                     <div class="nav-section-title">Overview</div>
                     <a href="#hero" class="nav-link active"><span class="nav-link-number">&rarr;</span>Course Introduction</a>
+                    <a href="#frameworks" class="nav-link"><span class="nav-link-number"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Flare.svg" alt="" class="nav-icon"></span>Frameworks We Draw From</a>
                     <a href="#lexicon" class="nav-link"><span class="nav-link-number"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Book.svg" alt="" class="nav-icon"></span>Papers & Resources</a>
                     <a href="#lexicon" class="nav-link"><span class="nav-link-number"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Flare.svg" alt="" class="nav-icon"></span>Lexicon (60 Terms)</a>
                 </div>
@@ -3136,7 +3137,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                     <div class="hero-badge"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_User_alt_4.svg" alt="" style="width:16px;height:16px;">Flagship Course &bull; Free Forever</div>
                     <h1>Social-Emotional Learning for Development Practice</h1>
                     <p class="hero-tagline">Wellbeing, Facilitation & Resilience for Practitioners</p>
-                    <p class="hero-subtitle">How social-emotional competencies shape effective development practice. A rigorous course connecting SEL research from CASEL, WHO life skills, and Indian educational frameworks with the daily realities of practitioners working in high-stress, resource-constrained environments across <a href="../../blog/south-asia-development-landscape.html" style="color: rgba(255,255,255,0.95); text-decoration: underline;">South Asia</a>. Complements our <a href="../mel/index.html" style="color: rgba(255,255,255,0.95); text-decoration: underline;">MEL</a> and <a href="../gender/index.html" style="color: rgba(255,255,255,0.95); text-decoration: underline;">Gender Studies</a> courses for holistic practitioner development.</p>
+                    <p class="hero-subtitle">How social-emotional competencies shape effective development practice. A rigorous course drawing on <strong>multiple frameworks</strong> — CASEL, <strong>SEE Learning</strong> (Emory + Dalai Lama Centre), <strong>WHO Life Skills</strong>, Delhi's <strong>Happiness Curriculum &amp; EMC</strong>, Indian indigenous traditions (Tagore, Krishnamurti, Aurobindo, Nai Talim), and <strong>NEP 2020</strong> (including teacher-side provisions: NPST, 50-hour CPD, 4-year B.Ed., teacher autonomy) — connected with daily realities for practitioners in high-stress, resource-constrained environments across <a href="../../blog/south-asia-development-landscape.html" style="color: rgba(255,255,255,0.95); text-decoration: underline;">South Asia</a>. Complements our <a href="../mel/index.html" style="color: rgba(255,255,255,0.95); text-decoration: underline;">MEL</a> and <a href="../gender/index.html" style="color: rgba(255,255,255,0.95); text-decoration: underline;">Gender Studies</a> courses for holistic practitioner development.</p>
                     <div class="feature-tags">
 <span class="feature-tag data"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Heart.svg" alt="">Practitioner Wellbeing</span>
 <span class="feature-tag data"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_User_alt_4.svg" alt="">Facilitation Skills</span>
@@ -3153,6 +3154,24 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                         <a href="https://notebooklm.google.com/notebook/e11569c6-2dcd-4750-b627-a84378f90d0b" target="_blank" class="hero-resource-btn"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_AI.svg" alt="" style="width:16px;height:16px;">AI Study Companion</a>
                         <span class="hero-resource-btn" style="opacity: 0.5; cursor: default;" title="Coming soon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Download.svg" alt="" style="width:16px;height:16px;">Excel Lexicon (Coming Soon)</span>
                     </div></section><div class="divider"></div>
+
+<section class="section reveal" id="frameworks" style="max-width:900px;margin:0 auto;padding:2.5rem 1.5rem;">
+  <div style="background:var(--secondary-bg);border:1px solid var(--border-color);border-left:4px solid var(--accent-color);border-radius:12px;padding:1.75rem 1.75rem 1.25rem;">
+    <div style="font-family:'Inter',sans-serif;font-size:0.78rem;text-transform:uppercase;letter-spacing:0.7px;color:var(--accent-color);font-weight:700;margin-bottom:0.5rem;">A Note on Frameworks</div>
+    <h3 style="font-family:'Inter',sans-serif;font-size:1.35rem;font-weight:700;margin:0 0 0.85rem;color:var(--text-primary);">SEL is not one framework. We draw on several.</h3>
+    <p style="color:var(--text-secondary);line-height:1.75;margin-bottom:0.9rem;">Most Indian SEL training collapses the field into <strong>CASEL's five competencies</strong>. That framing is well-validated globally, but it is one framework among several — and the others matter especially in Indian contexts.</p>
+    <ul style="color:var(--text-secondary);line-height:1.75;padding-left:1.25rem;margin-bottom:0.9rem;">
+      <li><strong>CASEL</strong> — Collaborative for Academic, Social &amp; Emotional Learning. Five competencies: self-awareness, self-management, social awareness, relationship skills, responsible decision-making. The dominant US framework; most cited in global research.</li>
+      <li><strong>SEE Learning</strong> (Social, Emotional &amp; Ethical Learning) — Emory University + Dalai Lama Center. Extends CASEL with an explicit <em>ethical</em> dimension grounded in compassion, interdependence, and systems-awareness. India-translated; used in several urban progressive schools. Travels better cross-culturally than pure CASEL.</li>
+      <li><strong>WHO Life Skills (1997)</strong> — Ten core skills (decision-making, problem-solving, creative + critical thinking, communication, interpersonal, self-awareness, empathy, coping with emotions, coping with stress). This is the framework <em>NCERT's Adolescence Education Programme</em> and most state-board life-skills curricula are actually built on.</li>
+      <li><strong>Delhi Happiness Curriculum</strong> (classes Nursery–8) + <strong>Entrepreneurship Mindset Curriculum / EMC</strong> (classes 9–12) — India's largest functioning state-system SEL programmes, reaching ~800K children daily across 1,000+ government schools. The Happiness Curriculum centres mindfulness, gratitude, and reflection; EMC centres agency, problem-solving, and self-confidence.</li>
+      <li><strong>Indian indigenous traditions</strong> — Tagore's Santiniketan (art, nature, the inner life), J. Krishnamurti (freedom from conditioning, self-knowledge), Sri Aurobindo &amp; The Mother (Integral Education: physical, vital, mental, psychic, spiritual), M.K. Gandhi's Nai Talim (work, community, character as inseparable from learning). Predate "SEL" by a century; rarely cited in modern Indian SEL programming but conceptually richer.</li>
+      <li><strong>NEP 2020</strong> — both halves matter: the child-facing provisions (Sections 4.6, 4.7, 5.7 on SEL/life skills/mental health) <em>and</em> the teacher-development provisions (NPST — National Professional Standards for Teachers; mandatory 50-hour annual CPD; 4-year integrated B.Ed.; teacher autonomy in classroom decisions). SEL programmes without the teacher-development half do not have the skilled adults to actually deliver the child-facing half.</li>
+    </ul>
+    <p style="color:var(--text-secondary);line-height:1.75;margin-bottom:0;font-size:0.95rem;">This course's stance: <em>frame-pluralism</em>. Each module draws on whichever framework illuminates the question best. The strongest practitioners we know hold all of these lightly, choose what fits, and build their own integration.</p>
+    <p style="color:var(--text-muted);font-size:0.85rem;font-style:italic;margin-top:0.7rem;border-top:1px dashed var(--border-color);padding-top:0.7rem;">See also: <a href="/Games/sel-simulation-game.html">SEL Simulation Game (Five Lenses)</a> · <a href="/DeepDives/sel-evaluation-india.html">Deep Dive: SEL Evaluation in India</a></p>
+  </div>
+</section>
 
 <section class="section reveal" id="module1">
                     

--- a/data/deep-dives.json
+++ b/data/deep-dives.json
@@ -137,7 +137,7 @@
             "curator": "ImpactMojo Editorial",
             "curator_role": "Curated with input from SEL practitioners",
             "curator_type": "Editorial Curation",
-            "reading_count": 28,
+            "reading_count": 32,
             "sections": [
                 "Foundations",
                 "India SEL Evidence Base",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,15 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.25.5 — May 23, 2026 (Framework diversity propagated to SEL Course + Deep Dive)
+
+After adding framework plurality to the SEL Simulation Game (v10.25.4), audited the SEL flagship course and the SEL Evaluation Deep Dive. Both had the same gaps. This release closes them.
+
+### For Learners
+
+- **SEL Course** now opens with an explicit "Frameworks We Draw From" section explaining how the course integrates CASEL, SEE Learning, WHO Life Skills, Delhi's Happiness Curriculum + EMC, Indian indigenous traditions (Tagore, Krishnamurti, Aurobindo, Nai Talim), and NEP 2020's full provisions (including teacher-side: NPST, 50-hr CPD, 4-yr B.Ed., teacher autonomy).
+- **SEL Eval Deep Dive** expanded from 28 to 32 readings: added SEE Learning, NCERT AEP, Indian indigenous traditions, Delhi EMC; expanded NEP entry to surface teacher-side provisions.
+
 ## v10.25.4 — May 23, 2026 (SEL Simulation — Parent mode + framework diversity)
 
 Addresses two cofounder feedback items: the game was missing a Parent perspective, and it framed NEP 2020 almost entirely from the child-facing side while leaning heavily on CASEL.

--- a/index.html
+++ b/index.html
@@ -2393,7 +2393,7 @@ window.addEventListener('authStateChanged', function(e) {
 <a href="/DeepDives/sel-evaluation-india.html">
 <div class="card-header">
 <span class="card-number"><svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Library_books"/></svg> DD6</span>
-<span class="learner-badge">28 readings · New</span>
+<span class="learner-badge">32 readings · New</span>
 </div>
 <h3 class="card-title">SEL Evaluation in India: What Works, What Doesn't, &amp; How</h3>
 <p class="card-description">Working syllabus on Social-Emotional Learning evaluation in Indian school contexts — methods, measures, and the critical scholarship on both. Curated by the ImpactMojo Editorial team.</p>


### PR DESCRIPTION
## Summary

After the SEL Simulation Game's framework-diversity fix (#433), you asked whether the SEL Course and SEL Eval Deep Dive had the same gaps. Audit results:

| Framework | SEL Course | Deep Dive |
|---|---|---|
| SEE Learning | ❌ 0 | ❌ 0 |
| Happiness Curriculum | ❌ 0 | ⚠ 2 (passing) |
| EMC | ❌ 0 | ❌ 0 |
| NPST | ❌ 0 | ❌ 0 |
| CPD (NEP 50-hr mandate) | ❌ 0 | ❌ 0 |
| Tagore / Krishnamurti / Aurobindo / Nai Talim | ❌ 0 | ⚠ 1-2 (passing) |

Confirmed: both files had the same CASEL-heavy / NEP-child-only gaps. This PR closes them.

### SEL Course (`/courses/SEL/`)

- **Hero subtitle** rewritten to explicitly name all six framework traditions
- **New static "Frameworks We Draw From" section** inserted between hero and Module 1 — explicit one-paragraph treatment of each framework with India-context notes and a closing statement of the course's frame-pluralist stance
- **Sidebar nav** updated with link to the new section
- **Meta description, keywords, OG description** updated for SEO

> **Important note:** The SEL course module content (modules 1–13) is dynamically loaded from a Supabase edge function — the static HTML contains only structure, not body text. This PR updates the static shell (hero + new Frameworks section + nav). Full integration of framework references into individual module bodies (e.g., Module 2 self-awareness drawing explicitly on SEE Learning's compassion frame, or Module 12 NEP-policy module covering NPST/CPD) would require **separate database content updates** outside this repo. Flagged in the changelog as a known follow-up.

### SEL Evaluation Deep Dive

- **Section 01 (Foundations)** — added 4 new entries:
  - **SEE Learning** (Emory + Dalai Lama Center, India-translated)
  - **NCERT Adolescence Education Programme** (AEP) — the framework Indian government schools *actually* run, often missed by evaluators
  - **Indian indigenous educational traditions** — Tagore (Santiniketan), Krishnamurti, Aurobindo (Integral Education), Gandhi (Nai Talim)
  - Expanded the **NEP 2020 entry** to surface teacher-side provisions (NPST, 50-hr annual CPD mandate, 4-yr integrated B.Ed., teacher autonomy)
- **Section 02 (India Evidence Base)** — added entry for **Delhi EMC** (Entrepreneurship Mindset Curriculum, classes 9–12) alongside the existing Happiness Curriculum entry, and deepened the Happiness Curriculum annotation
- **Reading count** 28 → 32 updated in HTML chip, `data/deep-dives.json`, and homepage Deep Dives card

## Audit confirmation (after edits)

| Framework | SEL Course | Deep Dive |
|---|---|---|
| SEE Learning | ✅ 5 | ✅ 3 |
| Happiness Curriculum | ✅ 5 | ✅ 3 |
| EMC | ✅ 5 | ✅ 2 |
| NPST | ✅ 4 | ✅ 2 |
| CPD | ✅ 4 | ✅ 1 |
| Indigenous traditions | ✅ 4 | ✅ 4 |

## Test plan

- [ ] Open `/courses/SEL/` — "Frameworks We Draw From" section visible between hero and Module 1
- [ ] Sidebar shows new link to #frameworks
- [ ] Open `/DeepDives/sel-evaluation-india.html` — Section 01 now has 9 entries (was 5), Section 02 has new EMC entry, reading count chip shows 32
- [ ] Open `/DeepDives/` landing — SEL Evaluation card shows "32 readings"
- [ ] Open homepage `/` — Deep Dives section card shows "32 readings · New"

---
_Generated by [Claude Code](https://claude.ai/code/session_01BeuCCodZutzv6wYFdZTsjb)_