### PR TITLE
feat: launch Practice Packs series + first pack (SEL Evaluation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to ImpactMojo are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.26.0] - 2026-05-23
+
+### Added — Practice Packs series launched
+
+**New content type**: ImpactMojo Practice Packs — short, focused 3-hour sprints that take practitioners from a job-to-be-done to a finished artefact. Sits between blog posts (one-shot read) and flagship courses (multi-week commitment). The format contract:
+
+- 4 modules, ~25 min each
+- ~2 hours reading + 1 hour exercise = ~3 hour total commitment
+- Each module: short read + worked example + exercise + downloadable template
+- Capstone: produce one concrete artefact (a ToR, drafted survey, logframe, eval design, etc.)
+- Take-home pack of all templates
+
+**New section**: `/practice-packs/` — landing page lists all packs (1 live, 9 upcoming).
+
+**First Practice Pack**: `/practice-packs/sel-evaluation/` — "SEL Evaluation: Design & Instruments" (PP01).
+- Module 1: What kind of evaluation do you actually need? (3 dimensions)
+- Module 2: Choosing your measurement approach (CASEL / SEE Learning / WHO Life Skills / NCERT AEP / ACER India / behavioural / direct assessment)
+- Module 3: Designing the data collection (sample sizes, per-unit costs in 2026 ₹, consent architecture)
+- Module 4: Analysis, reporting, and the honest framing
+- Capstone: 1-page SEL Evaluation Design Brief
+- 5 downloadable copy-to-clipboard templates throughout
+
+**Upcoming Practice Packs** (listed on landing page):
+PP02 ToR Writing · PP03 Survey Instrument · PP04 Logframe · PP05 Costing · PP06 FGD · PP07 Critiquing Evidence · PP08 Stakeholder Mapping · PP09 Donor Reporting · PP10 MEL from Scratch
+
+**Cross-references**: `data/search-index.json` (PP-LANDING + PP01, new type `practice-pack`), `sitemap.xml` (2 URLs), `index.html` (nav link with "New" badge).
+
 ## [10.25.5] - 2026-05-23
 
 ### Added — Framework diversity propagated to SEL Course and SEL Eval Deep Dive

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -7493,5 +7493,41 @@
       "process tracing",
       "mixed methods"
     ]
+  },
+  {
+    "id": "PP-LANDING",
+    "title": "Practice Packs — Job-to-be-Done Sprints",
+    "description": "ImpactMojo Practice Packs — short, focused 3-hour sprints that take you from a job-to-be-done to a finished artefact. 4 modules + a take-home pack. Free.",
+    "type": "landing-page",
+    "category": "Practice Packs",
+    "url": "/practice-packs/",
+    "tags": [
+      "practice packs",
+      "sprints",
+      "mini courses",
+      "templates",
+      "ImpactMojo"
+    ]
+  },
+  {
+    "id": "PP01",
+    "title": "SEL Evaluation: Design & Instruments — Practice Pack 01",
+    "description": "A 3-hour Practice Pack that takes you from an SEL programme to a drafted evaluation design — research question, sample, instruments (CASEL, SEE Learning, NCERT AEP, ACER India), data collection plan with realistic India costs, analysis approach, reporting outline. 4 modules + capstone + downloadable templates.",
+    "type": "practice-pack",
+    "category": "SEL · Evaluation",
+    "url": "/practice-packs/sel-evaluation/",
+    "tags": [
+      "practice pack",
+      "SEL",
+      "evaluation",
+      "design",
+      "instruments",
+      "CASEL",
+      "SEE Learning",
+      "NCERT AEP",
+      "ACER India",
+      "India",
+      "mixed methods"
+    ]
   }
 ]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,20 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.26.0 — May 23, 2026 (Practice Packs series launched)
+
+A new content type on ImpactMojo: **Practice Packs**. Short, focused 3-hour sprints that take a practitioner from a job-to-be-done to a finished artefact. Sits between blog posts (read in 10 min) and flagship courses (multi-week commitment) — designed for the working practitioner with a real project waiting on a defensible artefact.
+
+### For Learners
+
+- **New section**: `/practice-packs/` — landing page listing the series (1 live, 9 upcoming)
+- **First Practice Pack — SEL Evaluation: Design & Instruments** (PP01). 4 modules + capstone. Walk in with an SEL programme; walk out with a drafted evaluation design (research question, instruments, data plan, reporting outline). Includes 5 copy-to-clipboard templates.
+- Nav link added to homepage; "New" badge.
+
+### Roadmap (visible on landing page)
+
+PP02 ToR Writing · PP03 Survey Instrument Design · PP04 Logframe Building · PP05 Activity-Based Costing · PP06 Focus Group Discussion · PP07 Critiquing Evidence Papers · PP08 Stakeholder Mapping · PP09 Donor Reporting · PP10 Building an MEL System from Scratch
+
 ## v10.25.5 — May 23, 2026 (Framework diversity propagated to SEL Course + Deep Dive)
 
 After adding framework plurality to the SEL Simulation Game (v10.25.4), audited the SEL flagship course and the SEL Evaluation Deep Dive. Both had the same gaps. This release closes them.

--- a/index.html
+++ b/index.html
@@ -513,6 +513,7 @@ window.addEventListener('click', function(e) {
   <ul class="dropdown-section-items">
     <li id="nav-booksummaries"><a href='/BookSummaries/' style='color: #D97706; font-weight: 600;'><svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Book"/></svg> Book Companions</a></li>
     <li id="nav-deepdives"><a href='/DeepDives/' style='color: #C8910A; font-weight: 600;'><svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Library_books"/></svg> Deep Dives</a></li>
+    <li id="nav-practicepacks"><a href='/practice-packs/' style='color: #0EA5E9; font-weight: 600;'><svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Flare"/></svg> Practice Packs <span style="background:#0EA5E9;color:#fff;font-size:0.55rem;padding:0.1rem 0.35rem;border-radius:4px;margin-left:0.3rem;text-transform:uppercase;letter-spacing:0.5px;vertical-align:middle">New</span></a></li>
     <li id="nav-timelines"><a href='/timelines/' style='color: #6366F1; font-weight: 600;'><svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Activity"/></svg> Timelines</a></li>
   </ul>
 </li>

--- a/practice-packs/index.html
+++ b/practice-packs/index.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<script>(function(){try{var k='impactmojo-theme';var s=localStorage.getItem(k);var r=s;if(!s||s==='system'){r=(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)?'dark':'light';}document.documentElement.setAttribute('data-theme',r);}catch(e){}})();</script>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
+<meta name="theme-color" content="#0F172A">
+<title>Practice Packs — Job-to-be-Done Sprints | ImpactMojo</title>
+<meta name="description" content="ImpactMojo Practice Packs — short, focused 3-hour sprints that take you from a job-to-be-done to a finished artefact. 4 modules + a take-home pack. Free.">
+<meta name="keywords" content="practice packs, sprints, mini courses, MEL, SEL evaluation, ToR, logframe, India, ImpactMojo">
+<link rel="canonical" href="https://www.impactmojo.in/practice-packs/">
+<meta property="og:title" content="Practice Packs — Job-to-be-Done Sprints | ImpactMojo">
+<meta property="og:description" content="Short, focused 3-hour sprints. 4 modules. One artefact. Take-home pack.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://www.impactmojo.in/practice-packs/">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-JRCMEB9TBW');</script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+:root{
+  --primary-bg:#FFFFFF;--secondary-bg:#F8FAFC;
+  --accent:#0EA5E9;--accent-hover:#0284C7;
+  --secondary-accent:#6366F1;
+  --success:#10B981;--warning:#F59E0B;--danger:#EF4444;
+  --text-primary:#0F172A;--text-secondary:#475569;--text-muted:#52627A;--text-faint:#94A3B8;
+  --card-bg:#FFFFFF;--hover-bg:#F1F5F9;--border:#E2E8F0;
+  --gradient:linear-gradient(135deg,#0EA5E9 0%,#6366F1 100%);
+  --font-sans:'Amaranth',sans-serif;--font-heading:'Inter',sans-serif;--font-mono:'JetBrains Mono',monospace;
+}
+[data-theme="dark"]{
+  --primary-bg:#0F172A;--secondary-bg:#1E293B;
+  --text-primary:#F1F5F9;--text-secondary:#CBD5E1;--text-muted:#94A3B8;--text-faint:#64748B;
+  --card-bg:#1E293B;--hover-bg:#334155;--border:#334155;
+}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+html{scroll-behavior:smooth}
+body{font-family:var(--font-sans);background:var(--primary-bg);color:var(--text-primary);line-height:1.7;min-height:100vh}
+h1,h2,h3,h4{font-family:var(--font-heading);line-height:1.3}
+a{color:var(--accent);text-decoration:none}
+a:hover{color:var(--accent-hover);text-decoration:underline}
+
+/* Topbar */
+.topbar{position:fixed;top:0;left:0;right:0;z-index:100;background:rgba(255,255,255,.95);backdrop-filter:blur(20px);border-bottom:1px solid var(--border);padding:.6rem 1rem;display:flex;align-items:center;justify-content:space-between;gap:.75rem;flex-wrap:wrap;font-family:var(--font-heading)}
+[data-theme="dark"] .topbar{background:rgba(15,23,42,.95)}
+.topbar-home{display:flex;align-items:center;gap:.5rem;color:var(--text-primary);font-weight:700;font-size:1rem;background:var(--gradient);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
+.topbar-home svg{width:22px;height:22px;stroke:var(--accent);flex-shrink:0}
+.topbar-right{display:flex;align-items:center;gap:.5rem}
+.topbar-btn{display:inline-flex;align-items:center;gap:.35rem;padding:.4rem .8rem;border-radius:8px;font-size:.8rem;font-weight:600;color:var(--text-secondary);background:var(--secondary-bg);border:1px solid var(--border);text-decoration:none}
+.topbar-btn:hover{transform:translateY(-1px);text-decoration:none}
+.theme-sel{display:flex;gap:2px;background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:3px}
+.theme-btn{background:transparent;border:none;color:var(--text-secondary);padding:5px;border-radius:5px;cursor:pointer;width:28px;height:28px;display:flex;align-items:center;justify-content:center}
+.theme-btn:hover{background:var(--hover-bg);color:var(--text-primary)}
+.theme-btn svg{width:14px;height:14px;fill:none;stroke:currentColor;stroke-width:2}
+
+body{padding-top:60px}
+.container{max-width:1100px;margin:0 auto;padding:1.5rem}
+
+/* Hero */
+.hero{padding:3rem 0 2rem;text-align:center;border-bottom:1px solid var(--border);margin-bottom:2rem}
+.hero-eyebrow{display:inline-block;padding:.3rem 1rem;background:rgba(14,165,233,.15);color:var(--accent);border-radius:20px;font-size:.78rem;font-weight:700;text-transform:uppercase;letter-spacing:.6px;margin-bottom:1rem;font-family:var(--font-heading)}
+.hero h1{font-size:clamp(2rem,5vw,3rem);font-weight:800;margin-bottom:1rem;background:var(--gradient);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
+.hero-tagline{font-size:1.1rem;color:var(--text-secondary);max-width:680px;margin:0 auto 1.5rem;line-height:1.7}
+
+/* Format card */
+.format-card{background:var(--card-bg);border:1px solid var(--border);border-left:4px solid var(--accent);border-radius:12px;padding:1.75rem;margin-bottom:2.5rem}
+.format-card h2{font-size:1.2rem;margin-bottom:.7rem;color:var(--text-primary)}
+.format-card p{color:var(--text-secondary);margin-bottom:.7rem;font-size:.97rem}
+.format-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:1rem;margin-top:1.2rem}
+.format-item{padding:.85rem;background:var(--secondary-bg);border-radius:8px}
+.format-item-num{font-size:.7rem;color:var(--accent);font-weight:700;text-transform:uppercase;letter-spacing:.6px;margin-bottom:.25rem;font-family:var(--font-heading)}
+.format-item-title{font-size:.95rem;font-weight:700;color:var(--text-primary);margin-bottom:.25rem}
+.format-item-desc{font-size:.83rem;color:var(--text-muted);line-height:1.55}
+
+/* Packs grid */
+.section-title{font-size:1.4rem;font-weight:700;color:var(--text-primary);margin-bottom:1.5rem;font-family:var(--font-heading)}
+.packs-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(290px,1fr));gap:1.25rem}
+.pack-card{background:var(--card-bg);border:1px solid var(--border);border-radius:12px;padding:1.5rem;display:flex;flex-direction:column;transition:all .25s;text-decoration:none;color:inherit}
+.pack-card:hover{transform:translateY(-3px);box-shadow:0 8px 24px rgba(14,165,233,.1);border-color:var(--accent);text-decoration:none}
+.pack-card.live{cursor:pointer}
+.pack-card.upcoming{opacity:.65}
+.pack-card.upcoming:hover{transform:none;box-shadow:none;border-color:var(--border);cursor:default}
+.pack-num{font-size:.7rem;color:var(--accent);font-weight:700;text-transform:uppercase;letter-spacing:.6px;font-family:var(--font-heading);margin-bottom:.25rem;display:flex;justify-content:space-between;align-items:center}
+.pack-badge{padding:.18rem .5rem;border-radius:5px;font-size:.62rem;font-weight:700;text-transform:uppercase}
+.pack-badge.live{background:rgba(16,185,129,.15);color:var(--success)}
+.pack-badge.soon{background:rgba(148,163,184,.18);color:var(--text-muted)}
+.pack-title{font-size:1.05rem;font-weight:700;color:var(--text-primary);margin-bottom:.4rem;font-family:var(--font-heading);line-height:1.3}
+.pack-capstone{font-size:.85rem;color:var(--text-secondary);margin-bottom:.7rem;line-height:1.55;flex:1}
+.pack-capstone strong{color:var(--text-primary);font-weight:600}
+.pack-meta{display:flex;gap:.85rem;font-size:.78rem;color:var(--text-muted);padding-top:.7rem;border-top:1px solid var(--border)}
+.pack-meta span{display:inline-flex;align-items:center;gap:.3rem}
+
+/* Why packs */
+.why-section{background:var(--secondary-bg);border-radius:12px;padding:2rem;margin:3rem 0 2rem}
+.why-section h2{font-size:1.3rem;margin-bottom:1rem;color:var(--text-primary)}
+.why-section p{color:var(--text-secondary);margin-bottom:.9rem;line-height:1.75;font-size:.97rem}
+.why-section ul{padding-left:1.4rem;color:var(--text-secondary);margin-top:.6rem}
+.why-section li{margin-bottom:.5rem;line-height:1.7;font-size:.95rem}
+
+/* Footer */
+.im-footer{background:var(--secondary-bg);border-top:1px solid var(--border);padding:2rem 1rem;margin-top:3rem;font-family:var(--font-heading);color:var(--text-muted);text-align:center;font-size:.85rem}
+.im-footer a{color:var(--accent);text-decoration:none}
+
+@media (max-width:768px){
+  .container{padding:1rem}
+  .hero{padding:2rem 0 1.5rem}
+  .topbar-home span{display:none}
+}
+</style>
+</head>
+<body>
+
+<header class="topbar" role="banner">
+  <a href="/" class="topbar-home">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+    <span>ImpactMojo</span>
+  </a>
+  <div class="topbar-right">
+    <a href="/catalog.html" class="topbar-btn">Browse</a>
+    <a href="/premium.html" class="topbar-btn" style="color:var(--accent)">Premium</a>
+    <div class="theme-sel">
+      <button class="theme-btn" data-theme-set="light" aria-label="Light"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/></svg></button>
+      <button class="theme-btn" data-theme-set="dark" aria-label="Dark"><svg viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+    </div>
+  </div>
+</header>
+
+<div class="container">
+
+  <section class="hero">
+    <span class="hero-eyebrow">New · Practice Packs</span>
+    <h1>Job-to-be-Done Sprints</h1>
+    <p class="hero-tagline">Short, focused, take-an-artefact-home practice sets for development practitioners. <strong>4 modules. ~3 hours. One concrete deliverable.</strong> Sits between blog-post depth and flagship-course commitment.</p>
+  </section>
+
+  <div class="format-card">
+    <h2>The Practice Pack contract</h2>
+    <p>Every pack follows the same structure so you know what you're getting before you commit.</p>
+    <div class="format-grid">
+      <div class="format-item">
+        <div class="format-item-num">① 4 Modules</div>
+        <div class="format-item-title">~25 min each</div>
+        <div class="format-item-desc">Short read, one worked example, one exercise prompt, one downloadable template per module.</div>
+      </div>
+      <div class="format-item">
+        <div class="format-item-num">② ~3 Hours Total</div>
+        <div class="format-item-title">2h reading + 1h exercise</div>
+        <div class="format-item-desc">Designed to fit a single afternoon, or four short sittings across a week.</div>
+      </div>
+      <div class="format-item">
+        <div class="format-item-num">③ One Capstone Artefact</div>
+        <div class="format-item-title">You finish with a deliverable</div>
+        <div class="format-item-desc">A ToR. A drafted survey. A logframe. A workshop plan. Something you can actually use Monday morning.</div>
+      </div>
+      <div class="format-item">
+        <div class="format-item-num">④ Take-Home Pack</div>
+        <div class="format-item-title">Templates + checklists</div>
+        <div class="format-item-desc">Everything you build during the pack — exportable and printable. Yours to keep.</div>
+      </div>
+    </div>
+  </div>
+
+  <h2 class="section-title">All Practice Packs</h2>
+  <div class="packs-grid">
+
+    <a class="pack-card live" href="/practice-packs/sel-evaluation/">
+      <div class="pack-num"><span>PP01</span><span class="pack-badge live">Live</span></div>
+      <div class="pack-title">SEL Evaluation: Design &amp; Instruments</div>
+      <div class="pack-capstone">Walk in with an SEL programme. Walk out with a <strong>drafted evaluation design</strong> — research question, sample, instruments, analysis plan, reporting outline.</div>
+      <div class="pack-meta"><span>📚 4 modules</span><span>⏱ ~3 hours</span></div>
+    </a>
+
+    <div class="pack-card upcoming">
+      <div class="pack-num"><span>PP02</span><span class="pack-badge soon">Soon</span></div>
+      <div class="pack-title">Writing a ToR That Gets You Useful Research</div>
+      <div class="pack-capstone">Walk in with a research need. Walk out with a <strong>polished ToR + costing sheet</strong> ready to circulate to agencies.</div>
+      <div class="pack-meta"><span>📚 4 modules</span><span>⏱ ~3 hours</span></div>
+    </div>
+
+    <div class="pack-card upcoming">
+      <div class="pack-num"><span>PP03</span><span class="pack-badge soon">Soon</span></div>
+      <div class="pack-title">Designing a Survey Instrument</div>
+      <div class="pack-capstone">From research question to a <strong>drafted, pre-tested 30-item instrument</strong> — including pilot protocol and revision plan.</div>
+      <div class="pack-meta"><span>📚 4 modules</span><span>⏱ ~3 hours</span></div>
+    </div>
+
+    <div class="pack-card upcoming">
+      <div class="pack-num"><span>PP04</span><span class="pack-badge soon">Soon</span></div>
+      <div class="pack-title">Building a Logframe That Actually Tracks</div>
+      <div class="pack-capstone">A complete <strong>DAC-compatible logframe</strong> for your programme — with testable indicators and an honest assumption list.</div>
+      <div class="pack-meta"><span>📚 4 modules</span><span>⏱ ~3 hours</span></div>
+    </div>
+
+    <div class="pack-card upcoming">
+      <div class="pack-num"><span>PP05</span><span class="pack-badge soon">Soon</span></div>
+      <div class="pack-title">Costing a Programme from Activities Up</div>
+      <div class="pack-capstone">A defensible <strong>activity-based budget</strong> with realistic salary tables, overhead, and contingency.</div>
+      <div class="pack-meta"><span>📚 4 modules</span><span>⏱ ~3 hours</span></div>
+    </div>
+
+    <div class="pack-card upcoming">
+      <div class="pack-num"><span>PP06</span><span class="pack-badge soon">Soon</span></div>
+      <div class="pack-title">Running a Real Focus Group Discussion</div>
+      <div class="pack-capstone">A complete <strong>FGD facilitator's guide</strong> — recruitment, group composition, prompts, recording plan, analysis approach.</div>
+      <div class="pack-meta"><span>📚 4 modules</span><span>⏱ ~3 hours</span></div>
+    </div>
+
+    <div class="pack-card upcoming">
+      <div class="pack-num"><span>PP07</span><span class="pack-badge soon">Soon</span></div>
+      <div class="pack-title">Reading &amp; Critiquing an Evidence Paper</div>
+      <div class="pack-capstone">A <strong>1-page critique</strong> of an evaluation paper of your choice — what's solid, what's overclaimed, what to discount.</div>
+      <div class="pack-meta"><span>📚 4 modules</span><span>⏱ ~3 hours</span></div>
+    </div>
+
+    <div class="pack-card upcoming">
+      <div class="pack-num"><span>PP08</span><span class="pack-badge soon">Soon</span></div>
+      <div class="pack-title">Stakeholder Mapping for Influence</div>
+      <div class="pack-capstone">A <strong>power-interest-alignment map</strong> for your project + a stakeholder engagement strategy you can defend.</div>
+      <div class="pack-meta"><span>📚 4 modules</span><span>⏱ ~3 hours</span></div>
+    </div>
+
+    <div class="pack-card upcoming">
+      <div class="pack-num"><span>PP09</span><span class="pack-badge soon">Soon</span></div>
+      <div class="pack-title">Donor Reporting That Funders Read</div>
+      <div class="pack-capstone">A <strong>4-page report skeleton</strong> with a strong exec summary, honest framing, and the right balance of numbers and narrative.</div>
+      <div class="pack-meta"><span>📚 4 modules</span><span>⏱ ~3 hours</span></div>
+    </div>
+
+    <div class="pack-card upcoming">
+      <div class="pack-num"><span>PP10</span><span class="pack-badge soon">Soon</span></div>
+      <div class="pack-title">Building an MEL System from Scratch</div>
+      <div class="pack-capstone">A <strong>90-day MEL setup plan</strong> — what to do in months 1, 3, 6 when you've just been handed MEL responsibility at a new org.</div>
+      <div class="pack-meta"><span>📚 4 modules</span><span>⏱ ~3 hours</span></div>
+    </div>
+
+  </div>
+
+  <div class="why-section">
+    <h2>Why Practice Packs?</h2>
+    <p>Most practitioner training in India sits at two extremes: a one-hour workshop that's too thin to produce anything, or a multi-week course that asks for commitment most practitioners can't make. Practice Packs are designed for the middle — focused enough to finish in a working day, deep enough to leave you with something usable.</p>
+    <p>Each pack assumes you are a practitioner with limited time and a real project waiting. The capstone isn't a quiz — it's the thing your programme actually needs.</p>
+    <ul>
+      <li><strong>Pairs with existing ImpactMojo content</strong> — labs for hands-on tool use, deep dives for evidence, flagship courses for full breadth, blog posts for opinion.</li>
+      <li><strong>Free, no login required</strong> — like everything else on ImpactMojo.</li>
+      <li><strong>Living documents</strong> — updated as practice evolves and reader feedback arrives.</li>
+    </ul>
+    <p style="margin-top:1rem;font-size:.92rem;color:var(--text-muted)"><em>Suggest a Practice Pack topic, or volunteer to co-author one, at <a href="/contact.html?topic=PracticePacks">/contact</a>.</em></p>
+  </div>
+
+</div>
+
+<footer class="im-footer" role="contentinfo">
+  <p>© 2026 ImpactMojo. Free development education for South Asia.</p>
+  <p><a href="/about.html">About</a> · <a href="/catalog.html">Catalog</a> · <a href="/blog.html">Blog</a> · <a href="/contact.html">Contact</a></p>
+</footer>
+
+<script>
+document.querySelectorAll('.theme-btn').forEach(b=>b.addEventListener('click',()=>{
+  const t=b.dataset.themeSet;
+  document.documentElement.setAttribute('data-theme',t);
+  try{localStorage.setItem('impactmojo-theme',t);}catch(e){}
+}));
+</script>
+
+</body>
+</html>

--- a/practice-packs/sel-evaluation/index.html
+++ b/practice-packs/sel-evaluation/index.html
@@ -1,0 +1,896 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<script>(function(){try{var k='impactmojo-theme';var s=localStorage.getItem(k);var r=s;if(!s||s==='system'){r=(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)?'dark':'light';}document.documentElement.setAttribute('data-theme',r);}catch(e){}})();</script>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
+<meta name="theme-color" content="#0F172A">
+<title>SEL Evaluation: Design &amp; Instruments — Practice Pack 01 | ImpactMojo</title>
+<meta name="description" content="A 3-hour Practice Pack that takes you from an SEL programme to a drafted evaluation design — research question, sample, instruments (CASEL, SEE Learning, NCERT, behavioural), analysis plan, reporting outline. 4 modules + capstone + take-home templates.">
+<meta name="keywords" content="SEL evaluation, practice pack, India, NCERT AEP, CASEL, SEE Learning, Happiness Curriculum, evaluation design, instrument selection, mixed methods, ImpactMojo">
+<link rel="canonical" href="https://www.impactmojo.in/practice-packs/sel-evaluation/">
+<meta property="og:title" content="SEL Evaluation: Design &amp; Instruments — Practice Pack 01">
+<meta property="og:description" content="3 hours. 4 modules. Walk in with an SEL programme. Walk out with a drafted evaluation design.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://www.impactmojo.in/practice-packs/sel-evaluation/">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-JRCMEB9TBW');</script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+:root{
+  --primary-bg:#FFFFFF;--secondary-bg:#F8FAFC;
+  --accent:#0EA5E9;--accent-hover:#0284C7;
+  --secondary-accent:#6366F1;
+  --success:#10B981;--warning:#F59E0B;--danger:#EF4444;--violet:#8B5CF6;
+  --text-primary:#0F172A;--text-secondary:#475569;--text-muted:#52627A;--text-faint:#94A3B8;
+  --card-bg:#FFFFFF;--hover-bg:#F1F5F9;--border:#E2E8F0;
+  --gradient:linear-gradient(135deg,#0EA5E9 0%,#6366F1 100%);
+  --font-sans:'Amaranth',sans-serif;--font-heading:'Inter',sans-serif;--font-mono:'JetBrains Mono',monospace;
+}
+[data-theme="dark"]{
+  --primary-bg:#0F172A;--secondary-bg:#1E293B;
+  --text-primary:#F1F5F9;--text-secondary:#CBD5E1;--text-muted:#94A3B8;--text-faint:#64748B;
+  --card-bg:#1E293B;--hover-bg:#334155;--border:#334155;
+}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+html{scroll-behavior:smooth}
+body{font-family:var(--font-sans);background:var(--primary-bg);color:var(--text-primary);line-height:1.7;min-height:100vh}
+h1,h2,h3,h4{font-family:var(--font-heading);line-height:1.3}
+a{color:var(--accent);text-decoration:underline;text-underline-offset:.15em}
+a:hover{color:var(--accent-hover)}
+strong{color:var(--text-primary);font-weight:700}
+
+/* Topbar */
+.topbar{position:fixed;top:0;left:0;right:0;z-index:100;background:rgba(255,255,255,.95);backdrop-filter:blur(20px);border-bottom:1px solid var(--border);padding:.6rem 1rem;display:flex;align-items:center;justify-content:space-between;gap:.75rem;flex-wrap:wrap;font-family:var(--font-heading)}
+[data-theme="dark"] .topbar{background:rgba(15,23,42,.95)}
+.topbar-left{display:flex;align-items:center;gap:.75rem}
+.topbar-home{display:flex;align-items:center;gap:.5rem;color:var(--text-primary);font-weight:700;font-size:.95rem;background:var(--gradient);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;text-decoration:none}
+.topbar-home svg{width:20px;height:20px;stroke:var(--accent);flex-shrink:0}
+.topbar-crumb{font-size:.78rem;color:var(--text-muted);text-decoration:none}
+.topbar-crumb:hover{color:var(--accent);text-decoration:none}
+.topbar-right{display:flex;align-items:center;gap:.5rem}
+.topbar-btn{display:inline-flex;align-items:center;gap:.35rem;padding:.4rem .8rem;border-radius:8px;font-size:.8rem;font-weight:600;color:var(--text-secondary);background:var(--secondary-bg);border:1px solid var(--border);text-decoration:none}
+.topbar-btn:hover{transform:translateY(-1px);text-decoration:none}
+.theme-sel{display:flex;gap:2px;background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:3px}
+.theme-btn{background:transparent;border:none;color:var(--text-secondary);padding:5px;border-radius:5px;cursor:pointer;width:28px;height:28px;display:flex;align-items:center;justify-content:center}
+.theme-btn:hover{background:var(--hover-bg);color:var(--text-primary)}
+.theme-btn svg{width:14px;height:14px;fill:none;stroke:currentColor;stroke-width:2}
+
+body{padding-top:60px}
+.container{max-width:840px;margin:0 auto;padding:1.5rem}
+
+/* Hero */
+.hero{padding:2.5rem 0 2rem;text-align:center;border-bottom:1px solid var(--border);margin-bottom:2rem}
+.hero-eyebrow{display:inline-block;padding:.3rem 1rem;background:rgba(14,165,233,.15);color:var(--accent);border-radius:20px;font-size:.78rem;font-weight:700;text-transform:uppercase;letter-spacing:.6px;margin-bottom:1rem;font-family:var(--font-heading)}
+.hero h1{font-size:clamp(1.8rem,4vw,2.6rem);font-weight:800;margin-bottom:.7rem;background:var(--gradient);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;line-height:1.2}
+.hero-tagline{font-size:1.05rem;color:var(--text-secondary);max-width:680px;margin:0 auto 1.5rem;line-height:1.7}
+.hero-meta{display:flex;justify-content:center;gap:1.25rem;flex-wrap:wrap;font-size:.85rem;color:var(--text-muted)}
+.hero-meta span{display:inline-flex;align-items:center;gap:.3rem}
+
+/* Capstone callout */
+.capstone-card{background:linear-gradient(135deg,rgba(14,165,233,.04),rgba(99,102,241,.04));border:1px solid var(--border);border-left:4px solid var(--accent);border-radius:12px;padding:1.5rem;margin-bottom:2.5rem}
+.capstone-card .eyebrow{font-size:.75rem;color:var(--accent);font-weight:700;text-transform:uppercase;letter-spacing:.6px;margin-bottom:.5rem;font-family:var(--font-heading)}
+.capstone-card h2{font-size:1.2rem;margin-bottom:.5rem;color:var(--text-primary)}
+.capstone-card p{color:var(--text-secondary);margin-bottom:0;font-size:.97rem;line-height:1.7}
+
+/* Module nav (tabs) */
+.module-tabs{display:flex;gap:.5rem;margin-bottom:1.5rem;border-bottom:2px solid var(--border);overflow-x:auto;-webkit-overflow-scrolling:touch}
+.module-tab{padding:.7rem 1rem;background:none;border:none;border-bottom:3px solid transparent;margin-bottom:-2px;color:var(--text-muted);font-family:var(--font-heading);font-size:.85rem;font-weight:600;cursor:pointer;white-space:nowrap;display:flex;align-items:center;gap:.4rem;transition:all .2s}
+.module-tab:hover{color:var(--text-secondary)}
+.module-tab.active{color:var(--accent);border-bottom-color:var(--accent)}
+.module-tab.done{color:var(--success)}
+.module-tab .tab-num{display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;border-radius:50%;background:var(--border);font-size:.72rem;font-weight:700}
+.module-tab.active .tab-num{background:var(--accent);color:#fff}
+.module-tab.done .tab-num{background:var(--success);color:#fff}
+
+/* Module panels */
+.module-panel{display:none;animation:fadeIn .3s ease}
+.module-panel.active{display:block}
+@keyframes fadeIn{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:translateY(0)}}
+.module-panel h2{font-size:1.6rem;color:var(--text-primary);margin-bottom:.6rem}
+.module-panel h3{font-size:1.2rem;color:var(--text-primary);margin:1.8rem 0 .6rem;font-weight:700}
+.module-panel p{color:var(--text-secondary);margin-bottom:1rem;line-height:1.85;font-size:1rem}
+.module-panel ul,.module-panel ol{margin:.7rem 0 1.2rem 1.5rem;color:var(--text-secondary);line-height:1.8;font-size:.97rem}
+.module-panel li{margin-bottom:.45rem}
+.module-panel blockquote{border-left:4px solid var(--accent);padding:.8rem 1.3rem;margin:1.4rem 0;background:var(--secondary-bg);border-radius:0 8px 8px 0;font-style:italic;color:var(--text-secondary);font-size:1rem}
+
+.module-eyebrow{font-size:.75rem;color:var(--accent);text-transform:uppercase;letter-spacing:.7px;font-weight:700;margin-bottom:.5rem;font-family:var(--font-heading)}
+
+.example-box{background:var(--secondary-bg);border-radius:10px;border-left:4px solid var(--secondary-accent);padding:1.2rem 1.4rem;margin:1.5rem 0}
+.example-box .e-label{font-size:.72rem;color:var(--secondary-accent);font-weight:700;text-transform:uppercase;letter-spacing:.6px;margin-bottom:.4rem;font-family:var(--font-heading)}
+.example-box p{margin-bottom:.5rem;font-size:.93rem;color:var(--text-secondary)}
+.example-box p:last-child{margin-bottom:0}
+
+.exercise-box{background:linear-gradient(135deg,rgba(245,158,11,.05),rgba(236,72,153,.05));border:1px solid var(--border);border-left:4px solid var(--warning);border-radius:10px;padding:1.3rem 1.4rem;margin:1.8rem 0}
+.exercise-box .ex-label{font-size:.75rem;color:var(--warning);font-weight:700;text-transform:uppercase;letter-spacing:.6px;margin-bottom:.4rem;font-family:var(--font-heading)}
+.exercise-box h4{font-size:1.05rem;margin-bottom:.55rem;color:var(--text-primary);font-weight:700}
+.exercise-box ol{margin-bottom:.5rem;color:var(--text-secondary);font-size:.95rem;padding-left:1.4rem}
+.exercise-box li{margin-bottom:.4rem}
+
+/* Template card */
+.template-card{background:var(--card-bg);border:2px solid var(--accent);border-radius:12px;padding:1.4rem;margin:2rem 0}
+.template-card .t-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:1rem;gap:.7rem;flex-wrap:wrap}
+.template-card h4{font-size:1.05rem;color:var(--accent);font-family:var(--font-heading);font-weight:700;margin:0;display:flex;align-items:center;gap:.5rem}
+.template-card h4::before{content:'📥';font-size:1.2rem}
+.template-card .copy-btn{padding:.45rem .9rem;background:var(--accent);color:#fff;border:none;border-radius:6px;font-size:.78rem;font-weight:600;cursor:pointer;font-family:var(--font-sans);transition:all .2s}
+.template-card .copy-btn:hover{background:var(--accent-hover)}
+.template-card .copy-btn.copied{background:var(--success)}
+.template-card pre{background:var(--secondary-bg);padding:1rem 1.2rem;border-radius:8px;font-family:var(--font-mono);font-size:.84rem;line-height:1.7;color:var(--text-primary);white-space:pre-wrap;overflow-x:auto;max-height:480px;border:1px solid var(--border)}
+
+/* Module nav buttons */
+.module-nav{display:flex;justify-content:space-between;gap:.7rem;margin-top:2.5rem;padding-top:1.5rem;border-top:1px solid var(--border);flex-wrap:wrap}
+.nav-btn{padding:.7rem 1.2rem;background:var(--secondary-bg);border:1px solid var(--border);border-radius:8px;color:var(--text-primary);font-family:var(--font-sans);font-size:.92rem;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:.4rem;transition:all .2s;text-decoration:none}
+.nav-btn:hover{border-color:var(--accent);background:var(--hover-bg);text-decoration:none}
+.nav-btn.primary{background:var(--accent);color:#fff;border-color:var(--accent)}
+.nav-btn.primary:hover{background:var(--accent-hover)}
+
+/* Resources box */
+.resources-section{background:var(--secondary-bg);border-radius:12px;padding:1.5rem;margin-top:2.5rem}
+.resources-section h3{font-size:1rem;margin-bottom:.8rem;font-family:var(--font-heading);color:var(--text-primary)}
+.resources-section ul{list-style:none;padding:0;margin:0}
+.resources-section li{padding:.45rem 0;border-bottom:1px solid var(--border);font-size:.92rem}
+.resources-section li:last-child{border-bottom:none}
+
+.callout{background:var(--secondary-bg);border-left:4px solid var(--violet);padding:1rem 1.3rem;border-radius:0 8px 8px 0;margin:1.5rem 0}
+.callout .c-label{font-size:.72rem;color:var(--violet);font-weight:700;text-transform:uppercase;letter-spacing:.6px;margin-bottom:.3rem;font-family:var(--font-heading)}
+.callout p{font-size:.93rem;color:var(--text-secondary);line-height:1.75;margin-bottom:.4rem}
+.callout p:last-child{margin-bottom:0}
+
+.framework-table{width:100%;border-collapse:collapse;margin:1.3rem 0;font-size:.88rem}
+.framework-table th,.framework-table td{padding:.65rem .85rem;text-align:left;border-bottom:1px solid var(--border);vertical-align:top}
+.framework-table th{background:var(--secondary-bg);font-family:var(--font-heading);font-size:.78rem;font-weight:700;text-transform:uppercase;letter-spacing:.5px;color:var(--text-primary)}
+.framework-table tr:hover td{background:var(--hover-bg)}
+.framework-table strong{color:var(--text-primary)}
+
+/* Capstone screen */
+.capstone-final{background:linear-gradient(135deg,rgba(16,185,129,.05),rgba(14,165,233,.05));border:2px solid var(--success);border-radius:12px;padding:2rem;margin-top:1.5rem}
+.capstone-final h3{color:var(--success);font-size:1.3rem;margin-bottom:.7rem}
+.capstone-final p{color:var(--text-secondary);font-size:.97rem;line-height:1.75;margin-bottom:1rem}
+
+/* Footer */
+.im-footer{background:var(--secondary-bg);border-top:1px solid var(--border);padding:2rem 1rem;margin-top:3rem;font-family:var(--font-heading);color:var(--text-muted);text-align:center;font-size:.85rem}
+.im-footer a{color:var(--accent);text-decoration:none}
+
+@media (max-width:768px){
+  .container{padding:1rem}
+  .topbar-crumb{display:none}
+  .module-tab{padding:.55rem .65rem;font-size:.78rem}
+  .module-tab .tab-text{display:none}
+  .module-panel h2{font-size:1.35rem}
+  .module-panel h3{font-size:1.1rem}
+  .framework-table{font-size:.78rem;display:block;overflow-x:auto}
+  .framework-table th,.framework-table td{padding:.45rem .55rem}
+}
+</style>
+</head>
+<body>
+
+<header class="topbar" role="banner">
+  <div class="topbar-left">
+    <a href="/" class="topbar-home">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+      <span>ImpactMojo</span>
+    </a>
+    <a href="/practice-packs/" class="topbar-crumb">← Practice Packs</a>
+  </div>
+  <div class="topbar-right">
+    <a href="/catalog.html" class="topbar-btn">Browse</a>
+    <a href="/premium.html" class="topbar-btn" style="color:var(--accent)">Premium</a>
+    <div class="theme-sel">
+      <button class="theme-btn" data-theme-set="light" aria-label="Light"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/></svg></button>
+      <button class="theme-btn" data-theme-set="dark" aria-label="Dark"><svg viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+    </div>
+  </div>
+</header>
+
+<div class="container">
+
+  <section class="hero">
+    <span class="hero-eyebrow">Practice Pack 01 · Live</span>
+    <h1>SEL Evaluation: Design &amp; Instruments</h1>
+    <p class="hero-tagline">A 3-hour Practice Pack that takes you from an SEL programme you care about to a defensible, drafted evaluation design — covering the design choice, instrument selection, data collection plan, and reporting outline.</p>
+    <div class="hero-meta">
+      <span>📚 4 modules</span>
+      <span>⏱ ~3 hours</span>
+      <span>🎯 Practitioner level</span>
+      <span>🇮🇳 India-context</span>
+    </div>
+  </section>
+
+  <div class="capstone-card">
+    <div class="eyebrow">Your Capstone</div>
+    <h2>What you'll have when you finish</h2>
+    <p>A one-page <strong>SEL Evaluation Design Brief</strong> for your real programme — a clear research question, sample frame, selected instruments with justification, data collection plan and budget sketch, mixed-methods integration approach, and a one-page reporting outline. Defensible to a funder. Achievable on a real budget.</p>
+  </div>
+
+  <!-- Module tabs -->
+  <div class="module-tabs" role="tablist">
+    <button class="module-tab active" data-tab="0" role="tab"><span class="tab-num">1</span><span class="tab-text">Design Choice</span></button>
+    <button class="module-tab" data-tab="1" role="tab"><span class="tab-num">2</span><span class="tab-text">Instruments</span></button>
+    <button class="module-tab" data-tab="2" role="tab"><span class="tab-num">3</span><span class="tab-text">Data Collection</span></button>
+    <button class="module-tab" data-tab="3" role="tab"><span class="tab-num">4</span><span class="tab-text">Analysis &amp; Reporting</span></button>
+    <button class="module-tab" data-tab="4" role="tab"><span class="tab-num">★</span><span class="tab-text">Capstone</span></button>
+  </div>
+
+  <!-- ============================================================ -->
+  <!-- MODULE 1: DESIGN CHOICE                                       -->
+  <!-- ============================================================ -->
+  <div class="module-panel active" id="module-0" role="tabpanel">
+    <div class="module-eyebrow">Module 1 · ~25 min</div>
+    <h2>What kind of evaluation do you actually need?</h2>
+
+    <p>The number-one reason SEL evaluations disappoint is that the design choice happens implicitly. The team picks the method they've used before. The funder asks for "impact." Someone says "mixed-methods" without specifying what is mixed with what. Six months later, the data answers a question nobody quite asked.</p>
+
+    <p>Before any instrument selection, before any sampling, walk through three dimensions explicitly.</p>
+
+    <h3>Dimension 1 — What is the question, really?</h3>
+    <p>Three options, each implying a different design:</p>
+    <ul>
+      <li><strong>Outcome evaluation</strong> — "Did it work? What was the effect?" Needs a comparison group and measurable outcomes. Tells you whether to scale.</li>
+      <li><strong>Process tracing</strong> — "Why did it happen? What was the mechanism?" Needs detailed, time-ordered evidence. Tells you how to redesign.</li>
+      <li><strong>Theory-based evaluation</strong> — combines both. Tests the causal links inside a theory of change. Most demanding; most informative.</li>
+    </ul>
+
+    <p>For SEL specifically, the most common mismatch is wanting to know <em>why</em> the programme works (a process question) but writing the ToR for an outcome evaluation. The resulting effect-size estimate cannot tell you why.</p>
+
+    <h3>Dimension 2 — What evidence will be persuasive?</h3>
+    <ul>
+      <li><strong>Quantitative</strong> — for representativeness, scale, effect sizes. Needs adequate sample. For SEL: hard because most validated quant instruments are CASEL-aligned and US-developed.</li>
+      <li><strong>Qualitative</strong> — for depth, mechanism, lived experience. Needs careful case selection. For SEL: especially powerful with children and teachers.</li>
+      <li><strong>Mixed-methods</strong> — most common for SEL because both kinds of evidence are usually needed. Consistently under-budgeted: clients pay for the quant strand and the qual strand but not for the integration time.</li>
+    </ul>
+
+    <h3>Dimension 3 — Snapshot or change?</h3>
+    <ul>
+      <li><strong>Cross-sectional</strong> — one point in time. Cannot support change claims.</li>
+      <li><strong>Pre-post</strong> — minimum credible change design. Needs baseline <em>before</em> the intervention.</li>
+      <li><strong>Longitudinal</strong> — same units across multiple rounds. Strongest for causality, hardest operationally.</li>
+      <li><strong>Retrospective</strong> — relies on recall. Cheaper, weaker, use only when no alternative.</li>
+    </ul>
+
+    <p>SEL effects are real but small in any single year (CASEL Durlak meta-analysis ~11 percentile points, cumulative). A one-year cross-sectional study is structurally tilted toward null findings.</p>
+
+    <div class="example-box">
+      <div class="e-label">Worked example</div>
+      <p><strong>NGO</strong>: Sangati programme runs in 40 Mumbai government schools, three years in. Funder wants evidence for renewal. Budget: ₹15 lakh, 9 months.</p>
+      <p><strong>Dimension 1</strong>: Outcome ("did it improve SEL competencies?") + process ("which programme features explain success?"). Pick a primary — outcome — and a secondary — process.</p>
+      <p><strong>Dimension 2</strong>: Mixed-methods. Quantitative competency measurement primary; qualitative case studies secondary. <em>Budget 30% for integration time, not just the two strands.</em></p>
+      <p><strong>Dimension 3</strong>: Quasi-experimental matched comparison. No baseline data — but matched control schools provide a counterfactual. Honest about the limits this places on causal claims.</p>
+    </div>
+
+    <div class="exercise-box">
+      <div class="ex-label">Exercise 1 (15 min)</div>
+      <h4>State your design across all three dimensions</h4>
+      <p>For your real SEL programme, write one sentence per dimension. If you cannot write a clean sentence, you do not yet have a defensible design — keep iterating.</p>
+      <ol>
+        <li>The question is primarily ____________ (outcome / process / theory-based) with a secondary focus on ____________</li>
+        <li>The evidence will be primarily ____________ (quant / qual / mixed) with the rationale that ____________</li>
+        <li>The time dimension is ____________ (cross-sectional / pre-post / longitudinal / retrospective) because ____________</li>
+      </ol>
+    </div>
+
+    <div class="template-card">
+      <div class="t-header">
+        <h4>Template — SEL Eval Design Decision Sheet</h4>
+        <button class="copy-btn" data-copy="template-1">Copy</button>
+      </div>
+<pre id="template-1">SEL EVALUATION DESIGN DECISION SHEET
+====================================
+
+Programme: __________________________________________
+Date:       __________________________________________
+Author:     __________________________________________
+
+1. THE QUESTION (Dimension 1)
+   Primary question type:
+   [ ] Outcome evaluation — "Did it work? What effect?"
+   [ ] Process tracing — "Why? What mechanism?"
+   [ ] Theory-based — both, testing the ToC
+
+   Write the central research question as ONE sentence:
+   _____________________________________________________
+
+   The decision this will inform:
+   _____________________________________________________
+
+2. THE EVIDENCE (Dimension 2)
+   Primary evidence type:
+   [ ] Quantitative — needs adequate sample size
+   [ ] Qualitative — needs careful case selection
+   [ ] Mixed — REMINDER: budget 25-30% for integration
+
+   Audience(s) for the output (often >1):
+   - Funder:           Needs: ___________________________
+   - Programme team:   Needs: ___________________________
+   - Community:        Needs: ___________________________
+   - Other:            Needs: ___________________________
+
+3. THE TIME DIMENSION (Dimension 3)
+   [ ] Cross-sectional — single snapshot
+   [ ] Pre-post        — minimum for change claims
+   [ ] Longitudinal    — strongest, most expensive
+   [ ] Retrospective   — last-resort, weaker
+
+   Baseline data available? Y / N
+   If no baseline, what counterfactual is feasible?
+   _____________________________________________________
+
+4. RED FLAGS — write down anything that concerns you
+   _____________________________________________________
+   _____________________________________________________
+
+5. WHAT YOU CANNOT ANSWER WITH THIS DESIGN
+   _____________________________________________________
+   _____________________________________________________
+
+Sign off with one honest sentence: "This design will tell us..."
+_______________________________________________________</pre>
+    </div>
+
+    <div class="module-nav">
+      <span></span>
+      <button class="nav-btn primary" onclick="goTab(1)">Module 2: Instruments →</button>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <!-- MODULE 2: INSTRUMENTS                                         -->
+  <!-- ============================================================ -->
+  <div class="module-panel" id="module-1" role="tabpanel">
+    <div class="module-eyebrow">Module 2 · ~30 min</div>
+    <h2>Choosing your measurement approach</h2>
+
+    <p>Instrument selection is where most SEL evaluations quietly go wrong. Three persistent failure modes:</p>
+    <ol>
+      <li><strong>Imported instruments</strong> used without cultural adaptation — Indian children interpret items differently than the US/UK populations the instruments were validated on.</li>
+      <li><strong>Programme-developed instruments</strong> that measure exposure to the programme rather than the underlying competency.</li>
+      <li><strong>Self-report scales</strong> used as the sole measure with younger children, where social-desirability bias dominates.</li>
+    </ol>
+
+    <p>The good news: the field has matured. There are now real options across frameworks.</p>
+
+    <h3>Available instruments by framework</h3>
+
+    <table class="framework-table">
+      <thead><tr><th>Framework</th><th>Sample instruments</th><th>India status</th></tr></thead>
+      <tbody>
+        <tr><td><strong>CASEL</strong></td><td>SECA (Social-Emotional Composite Assessment), DESSA, SSIS-SEL</td><td>Translated; partial India validation (Tandon 2020); item-level cultural-validity concerns persist</td></tr>
+        <tr><td><strong>SEE Learning</strong></td><td>Embedded reflection rubrics; observational checklists from the Dalai Lama Centre toolkit</td><td>Used in Indian pilot schools; not yet rigorously validated</td></tr>
+        <tr><td><strong>WHO Life Skills / NCERT AEP</strong></td><td>NCERT AEP self-rating; SCERT well-being modules; ACER India SEL skills assessment</td><td><strong>Most aligned with government schools.</strong> ACER India scales are the strongest validated option</td></tr>
+        <tr><td><strong>Direct assessment</strong></td><td>Head-Toes-Knees-Shoulders (self-regulation); Dimensional Change Card Sort</td><td>Implementable; bypasses self-report bias; narrower constructs</td></tr>
+        <tr><td><strong>Behavioural observation</strong></td><td>CLASS (Classroom Assessment Scoring System); structured peer-interaction logs</td><td>Highest validity; highest cost; needs trained observers</td></tr>
+        <tr><td><strong>Adult report</strong></td><td>Teacher rating scales; parent report (PHQ-A adapted; SDQ India)</td><td>Operationally easy; rater-bias concerns; useful in mixed-methods designs</td></tr>
+      </tbody>
+    </table>
+
+    <h3>How to choose</h3>
+    <ul>
+      <li><strong>Government-school context?</strong> Start with NCERT AEP and ACER India scales — they fit the curricular ground the schools already work on.</li>
+      <li><strong>Younger children (Grade 5 or below)?</strong> De-emphasise self-report. Prioritise behavioural observation or adult report.</li>
+      <li><strong>Budget under ₹10L?</strong> One quant instrument + qualitative case studies. Skip behavioural observation; it breaks the budget.</li>
+      <li><strong>Multi-stakeholder triangulation desired?</strong> Pair child self-report with teacher report and brief parent report.</li>
+    </ul>
+
+    <div class="example-box">
+      <div class="e-label">Worked example</div>
+      <p>Sangati's Mumbai eval (Class 4–6, government schools, ₹15L budget): primary instrument = ACER India SEL skills assessment (200 children, pre-post). Secondary = teacher report on classroom climate (CLASS subscales, 40 classrooms). Qualitative = 30 child interviews + 20 teacher interviews. Behavioural observation deliberately skipped — would have added ₹6L the budget cannot absorb.</p>
+    </div>
+
+    <div class="callout">
+      <div class="c-label">Note on instrument adaptation</div>
+      <p>Indian cultural validation is not the same as translation. Translation handles language; adaptation handles whether the underlying construct (e.g., "self-regulation") means the same thing in a Mumbai government school as in a Boston suburb. ACER India and Tandon et al. (2020) document specific items that do not transfer well. Budget at least one cognitive-pretesting round per instrument.</p>
+    </div>
+
+    <div class="exercise-box">
+      <div class="ex-label">Exercise 2 (20 min)</div>
+      <h4>Select 2–3 instruments and justify</h4>
+      <ol>
+        <li>From the table above, pick a primary quant instrument and a secondary triangulation source.</li>
+        <li>For each, write one sentence on why it fits your context (school type, child age, budget).</li>
+        <li>For each, write one sentence on its limits (what it under-measures, what bias it carries).</li>
+      </ol>
+    </div>
+
+    <div class="template-card">
+      <div class="t-header">
+        <h4>Template — Instrument Selection Matrix</h4>
+        <button class="copy-btn" data-copy="template-2">Copy</button>
+      </div>
+<pre id="template-2">INSTRUMENT SELECTION MATRIX
+===========================
+
+Programme:    _______________________________________
+Child age:    _______________________________________
+School type:  Government / Private / NGO-run / Mixed
+Budget tier:  Rapid (₹2L) / Standard (₹10L) / Flagship (₹40L+)
+
+PRIMARY INSTRUMENT (quantitative)
+  Name:        _______________________________________
+  Framework:   _______________________________________
+  Construct:   _______________________________________
+  Cost:        ₹__________ per child  Total: ₹________
+  India validation status: _________________________
+  Fit rationale: ___________________________________
+  ____________________________________________________
+  Known limits: ____________________________________
+  ____________________________________________________
+
+SECONDARY TRIANGULATION SOURCE (qual or adult report)
+  Name:        _______________________________________
+  Type:        Interview / FGD / Teacher report / Parent / Observation
+  Sample size: ______________________________________
+  Cost:        ₹____________
+  Fit rationale: ___________________________________
+  Known limits: ____________________________________
+
+OPTIONAL THIRD SOURCE (only if budget permits)
+  Name:        _______________________________________
+  Purpose in design: _______________________________
+  Cost:        ₹____________
+
+ADAPTATION BUDGET
+  Cognitive pretesting (per instrument): ₹___________
+  Translation (₹2–4 per source word):    ₹___________
+  Pilot + revision round:                ₹___________
+  TOTAL adaptation cost:                 ₹___________
+
+DECISION: Will this set of instruments answer the
+research question stated in the Design Decision Sheet?
+[ ] Yes — proceed
+[ ] No — return to Module 1 and refine question</pre>
+    </div>
+
+    <div class="module-nav">
+      <button class="nav-btn" onclick="goTab(0)">← Module 1</button>
+      <button class="nav-btn primary" onclick="goTab(2)">Module 3: Data Collection →</button>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <!-- MODULE 3: DATA COLLECTION                                    -->
+  <!-- ============================================================ -->
+  <div class="module-panel" id="module-2" role="tabpanel">
+    <div class="module-eyebrow">Module 3 · ~30 min</div>
+    <h2>Designing the data collection (without breaking the budget)</h2>
+
+    <p>Three operational realities define what Indian SEL data collection looks like:</p>
+    <ol>
+      <li><strong>School-year calendar</strong> — June–April is workable; May, October (festivals), and exam weeks are not. You have roughly 5–6 months of clean fieldwork per academic year.</li>
+      <li><strong>Consent architecture</strong> — School management committee (SMC) approval, parent informed consent, child assent. All three. Plan a 6-week consent window minimum.</li>
+      <li><strong>Field team composition</strong> — for child-facing SEL data collection, you need women enumerators, ideally local-language native, trained in child-rapport protocols. This is a real constraint, not a checkbox.</li>
+    </ol>
+
+    <h3>Sample size — without illusions</h3>
+
+    <p>The "how many" question is rarely as scientific as the power calculation suggests. For SEL specifically:</p>
+    <ul>
+      <li><strong>Single-arm pre-post:</strong> 200–300 children minimum to detect moderate effect (~0.3 SD). Below 100, power is too weak to interpret.</li>
+      <li><strong>Two-arm quasi-experimental:</strong> 400–600 children minimum across treatment and control. Cluster effects (children within schools) reduce effective sample by 30–50%.</li>
+      <li><strong>RCT at the school level:</strong> ~12+ schools per arm for credible inference. Below this, group-level comparisons are unstable.</li>
+      <li><strong>Qualitative depth:</strong> 25–40 interviews + 4–8 FGDs typically reaches thematic saturation for a single-context SEL question. More is not better; more often dilutes.</li>
+    </ul>
+
+    <h3>Cost realities (₹ per data point, 2026)</h3>
+    <ul>
+      <li><strong>Survey administration</strong> (in-school, supervised, ~40 min): ₹350–₹600 per child including enumerator time, supervision, transit, materials.</li>
+      <li><strong>Qualitative interview</strong> (45–60 min, with transcription): ₹2,500–₹4,500 each (₹800/day enumerator + ₹60/min transcription + supervisor time).</li>
+      <li><strong>Focus group</strong> (90 min, 6–8 participants, with transcription): ₹6,000–₹10,000 each.</li>
+      <li><strong>Behavioural observation</strong> (1 classroom, ~3 hours, 2 trained observers, inter-rater reliability): ₹4,000–₹7,000 per observation session.</li>
+      <li><strong>Teacher/parent report instrument</strong> (mail/digital, follow-up): ₹150–₹300 per respondent at scale.</li>
+    </ul>
+
+    <div class="example-box">
+      <div class="e-label">Worked example</div>
+      <p>₹15L Sangati evaluation: 200 children × ACER quant (₹500 × 2 rounds = ₹2L), 30 child interviews (₹3,000 each = ₹90K), 20 teacher interviews (₹4,000 = ₹80K), 6 FGDs (₹8,000 = ₹48K), CLASS observations on 20 classrooms × 1 round (₹5,000 = ₹1L), instrument adaptation + pilot (₹1.5L), team training (₹1L), project management 15% (~₹2.3L), travel/logistics (₹1.5L), analysis + reporting (₹3L), contingency 8% (₹1.2L). Total ≈ ₹15L.</p>
+    </div>
+
+    <div class="callout">
+      <div class="c-label">The integration line item</div>
+      <p>Mixed-methods studies in India routinely under-budget the work of integrating quant and qual findings into a coherent narrative. Budget at minimum 10–15 days of senior researcher time post-fieldwork specifically for integration meetings, joint coding, and contradictory-finding resolution. Without it, you produce two parallel reports instead of one integrated study.</p>
+    </div>
+
+    <div class="exercise-box">
+      <div class="ex-label">Exercise 3 (20 min)</div>
+      <h4>Sketch your data collection plan against your budget</h4>
+      <ol>
+        <li>Take your instrument selection from Module 2. Multiply each by realistic per-unit cost.</li>
+        <li>Add adaptation, training, travel, PM (10–15%), analysis (~20%), reporting, contingency (8%).</li>
+        <li>Compare the total to your actual budget. If over: cut sample size, drop a method, or descope.</li>
+        <li>Identify your one biggest risk to fieldwork (timing, consent, team, season).</li>
+      </ol>
+    </div>
+
+    <div class="template-card">
+      <div class="t-header">
+        <h4>Template — Data Collection Plan &amp; Budget Sketch</h4>
+        <button class="copy-btn" data-copy="template-3">Copy</button>
+      </div>
+<pre id="template-3">DATA COLLECTION PLAN &amp; BUDGET SKETCH
+=====================================
+
+Programme:    _______________________________________
+Total budget: ₹_____________________________________
+Timeline:     ______ months total, fieldwork in months ___ to ___
+
+A. QUANTITATIVE DATA COLLECTION
+   Instrument:        _______________________________
+   Sample size:       _____ children (across ___ schools)
+   Rounds:            Baseline / Endline / Midline
+   Per-child cost:    ₹________
+   Total quant cost:  ₹________
+
+B. QUALITATIVE DATA COLLECTION
+   Child interviews:   ___ @ ₹________ = ₹_________
+   Teacher interviews: ___ @ ₹________ = ₹_________
+   Parent interviews:  ___ @ ₹________ = ₹_________
+   FGDs:               ___ @ ₹________ = ₹_________
+   Total qual cost:    ₹_________
+
+C. BEHAVIOURAL / ADULT REPORT (if applicable)
+   Type:               _____________________________
+   Sample:             _____________________________
+   Total cost:         ₹_________
+
+D. OTHER COST LINES (apply realistic % to subtotal)
+   Instrument adaptation + pilot:  ₹_________
+   Team training:                  ₹_________
+   Travel + logistics:             ₹_________ (~10%)
+   Project management overhead:    ₹_________ (~12%)
+   Analysis (incl. integration):   ₹_________ (~20%)
+   Reporting + revision rounds:    ₹_________ (~10%)
+   Contingency:                    ₹_________ (~8%)
+
+E. TOTAL: ₹_________
+   Budget available: ₹_________
+   Variance: ₹_________
+
+   If over budget — what to cut (in priority order):
+   1. _____________________________________________
+   2. _____________________________________________
+   3. _____________________________________________
+
+F. SEASONAL FEASIBILITY MAP
+   Baseline window:  Month ___ to ___ (avoid: ____________)
+   Intervention:     Month ___ to ___
+   Endline window:   Month ___ to ___ (avoid: ____________)
+
+G. BIGGEST FIELDWORK RISK
+   _____________________________________________________
+   Mitigation: ________________________________________
+
+H. CONSENT ARCHITECTURE
+   [ ] SMC approval — by Month ___
+   [ ] Parent informed consent — by Month ___
+   [ ] Child assent — at point of data collection
+   [ ] Ethics committee clearance — by Month ___</pre>
+    </div>
+
+    <div class="module-nav">
+      <button class="nav-btn" onclick="goTab(1)">← Module 2</button>
+      <button class="nav-btn primary" onclick="goTab(3)">Module 4: Analysis &amp; Reporting →</button>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <!-- MODULE 4: ANALYSIS & REPORTING                                -->
+  <!-- ============================================================ -->
+  <div class="module-panel" id="module-3" role="tabpanel">
+    <div class="module-eyebrow">Module 4 · ~25 min</div>
+    <h2>Analysis, reporting, and the honest framing</h2>
+
+    <p>The reporting stage is where SEL evaluations earn or lose trust. Two patterns recur:</p>
+    <ol>
+      <li><strong>Over-claim from underpowered data</strong> — small effect, marginal significance, headline as if causal. Funders who've seen this once stop reading the next report.</li>
+      <li><strong>Under-claim from mixed findings</strong> — the report buries the real signal because the team is afraid to commit. Programme teams stop fighting for further funding.</li>
+    </ol>
+
+    <p>The honest middle is harder and more valuable.</p>
+
+    <h3>What to expect from SEL analysis</h3>
+    <ul>
+      <li><strong>Effect sizes will be small.</strong> Kraft (2020) calibrates the "typical" effect size for cost-effective school interventions at 0.05–0.20 SD — not the 0.30+ that marketing language suggests. SEL effects sit in this range.</li>
+      <li><strong>Statistical significance is not the same as meaningful change.</strong> With 500 children, very small effects become "significant" without being interpretively important.</li>
+      <li><strong>Subgroup analyses are exploratory.</strong> If you did not pre-register them, treat as hypothesis-generating, not confirming.</li>
+      <li><strong>Mixed findings are the rule.</strong> One competency improves, another doesn't. One school sub-group benefits, another doesn't. Report all of it.</li>
+    </ul>
+
+    <h3>The integration discipline</h3>
+    <p>Mixed-methods studies typically run quant and qual analyses in parallel. The genuine work is at integration:</p>
+    <ul>
+      <li>Where do the two strands <strong>agree</strong>? That's your strongest finding.</li>
+      <li>Where do they <strong>disagree</strong>? That's the most interesting question — neither strand alone could surface it.</li>
+      <li>Where does one strand <strong>fill a hole</strong> the other strand opens? Effect estimates without mechanism explanations need the qual to make them usable.</li>
+    </ul>
+
+    <h3>Reporting that funders read</h3>
+    <p>The structure that works:</p>
+    <ol>
+      <li><strong>1-page executive summary</strong> — what we asked, what we found (with honest framing), what we recommend.</li>
+      <li><strong>2-page methods note</strong> — design, sample, instruments, key limitations.</li>
+      <li><strong>3–5 page findings section</strong> — organised by research question, not by data type.</li>
+      <li><strong>2-page implications</strong> — what should the programme do; what should be evaluated next.</li>
+      <li><strong>Appendices</strong> — full results, instruments, sample characteristics, qualitative quotes.</li>
+    </ol>
+
+    <p>Total: 15–25 pages of main report + appendices. Anything longer goes unread.</p>
+
+    <div class="callout">
+      <div class="c-label">The honesty test</div>
+      <p>Before submitting your report, run the honesty test: hand it to a colleague unfamiliar with the programme and ask them to summarise the headline finding in one sentence. If their sentence overstates the evidence, your framing was too strong. If they cannot find the signal at all, your framing was too weak. Iterate.</p>
+    </div>
+
+    <div class="example-box">
+      <div class="e-label">Worked example — Sangati exec summary</div>
+      <p><strong>What we asked:</strong> Does the Sangati SEL programme improve social-emotional competencies, classroom climate, and child-reported wellbeing in Mumbai Grade 4–6 government schools?</p>
+      <p><strong>What we found:</strong> Modest positive effects on self-awareness (ACER scales, +0.18 SD, p=0.04) and classroom climate (CLASS subscales, teacher-rated, +0.22 SD, p=0.01). No detectable effect on self-management or peer relationships in this period. Qualitative interviews surfaced a consistent theme of programme fatigue in higher-implementation schools, suggesting the dose-response relationship is non-linear.</p>
+      <p><strong>What we recommend:</strong> Continue Sangati with a revised implementation cadence (4 sessions/week, not 5) and an explicit teacher-load review. Re-evaluate at 24 months with longitudinal design to capture the slower-emerging competencies. Do not scale further without addressing the fatigue finding.</p>
+    </div>
+
+    <div class="exercise-box">
+      <div class="ex-label">Exercise 4 (15 min)</div>
+      <h4>Draft your one-page exec summary template</h4>
+      <ol>
+        <li>Write the "what we asked" sentence — paraphrase of your research question.</li>
+        <li>Write three "what we might find" sentences — your range from strongest plausible finding to weakest. Be honest.</li>
+        <li>Write a "what we recommend" structure — programme implications + next-evaluation suggestions.</li>
+      </ol>
+    </div>
+
+    <div class="template-card">
+      <div class="t-header">
+        <h4>Template — One-Page Executive Summary Outline</h4>
+        <button class="copy-btn" data-copy="template-4">Copy</button>
+      </div>
+<pre id="template-4">EXECUTIVE SUMMARY — ONE-PAGE OUTLINE
+=====================================
+
+Programme: _________________________________________
+Evaluation period: _________________________________
+Lead evaluator: ____________________________________
+Funder: ____________________________________________
+
+WHAT WE ASKED (1-2 sentences)
+The central research question was:
+____________________________________________________
+____________________________________________________
+
+WHAT WE DID (3-4 sentences)
+Design: _________________________ (outcome/process/theory-based)
+Sample: ___________ children across ___ schools, in ____________
+Instruments: ______________________________________________
+Comparison strategy: _____________________________________
+
+WHAT WE FOUND
+Headline finding (1 sentence, honest):
+____________________________________________________
+
+Specific results:
+- Competency 1: ____________________________________
+- Competency 2: ____________________________________
+- Competency 3: ____________________________________
+
+Qualitative themes that complicate or extend the quant:
+- ___________________________________________________
+- ___________________________________________________
+
+What we cannot conclude with this design:
+____________________________________________________
+
+WHAT WE RECOMMEND
+For the programme:
+1. _________________________________________________
+2. _________________________________________________
+
+For the next evaluation:
+1. _________________________________________________
+2. _________________________________________________
+
+KEY LIMITATIONS (be honest)
+- ___________________________________________________
+- ___________________________________________________
+
+THE HONESTY-TEST SENTENCE
+"If a colleague reads only this page, the most accurate summary
+of what this evaluation tells us is:"
+____________________________________________________
+____________________________________________________</pre>
+    </div>
+
+    <div class="module-nav">
+      <button class="nav-btn" onclick="goTab(2)">← Module 3</button>
+      <button class="nav-btn primary" onclick="goTab(4)">★ Capstone →</button>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <!-- CAPSTONE                                                      -->
+  <!-- ============================================================ -->
+  <div class="module-panel" id="module-4" role="tabpanel">
+    <div class="module-eyebrow">Capstone · 30–60 min</div>
+    <h2>Your SEL Evaluation Design Brief</h2>
+
+    <p>You now have outputs from all four modules. Pull them together into a single one-page brief you can share with your team, funder, or evaluation agency.</p>
+
+    <div class="capstone-final">
+      <h3>The deliverable</h3>
+      <p>A <strong>1–2 page SEL Evaluation Design Brief</strong> covering:</p>
+      <ol style="color:var(--text-secondary);padding-left:1.4rem">
+        <li>Programme + context (3 lines)</li>
+        <li>Research question (one sentence)</li>
+        <li>Design choice across all three dimensions</li>
+        <li>Primary + secondary instruments with adaptation plan</li>
+        <li>Data collection plan + total budget</li>
+        <li>Analysis approach + integration strategy</li>
+        <li>Reporting outline + audience map</li>
+        <li>Top three limitations</li>
+        <li>One honesty-test sentence</li>
+      </ol>
+      <p>Use the template below as your scaffold. Pull values directly from the four module templates you completed.</p>
+    </div>
+
+    <div class="template-card">
+      <div class="t-header">
+        <h4>Capstone — SEL Evaluation Design Brief</h4>
+        <button class="copy-btn" data-copy="template-capstone">Copy full brief</button>
+      </div>
+<pre id="template-capstone">SEL EVALUATION DESIGN BRIEF
+===========================
+
+Programme:           _____________________________________
+Implementing org:    _____________________________________
+Geography:           _____________________________________
+Grades:              _____________________________________
+Years running:       _____________________________________
+Author:              _____________________________________
+Date:                _____________________________________
+
+1. PROGRAMME &amp; CONTEXT (3 lines)
+___________________________________________________________
+___________________________________________________________
+___________________________________________________________
+
+2. RESEARCH QUESTION (one sentence)
+___________________________________________________________
+___________________________________________________________
+
+The decision this will inform: ___________________________
+___________________________________________________________
+
+3. DESIGN
+   Question type (D1):    Outcome / Process / Theory-based
+   Evidence type (D2):    Quant / Qual / Mixed-methods
+   Time dimension (D3):   Cross-section / Pre-post / Longitudinal
+   Counterfactual:        ___________________________________
+
+4. INSTRUMENTS
+   Primary:        ________________________________________
+                   (Framework: ________________)
+   Secondary:      ________________________________________
+   Adaptation:     ________________________________________
+
+5. DATA COLLECTION
+   Quant sample:           ______ children, ____ schools
+   Qual sample:            ______ interviews + ____ FGDs
+   Other:                  __________________________________
+   Total budget:           ₹ _____________________________
+   Timeline:               _______________________________
+   Biggest risk:           _______________________________
+
+6. ANALYSIS APPROACH
+   Quant analysis plan:    _______________________________
+                           _______________________________
+   Qual coding approach:   _______________________________
+   Integration strategy:   _______________________________
+                           _______________________________
+
+7. REPORTING
+   Audiences (and what each needs):
+   - Funder:               _______________________________
+   - Programme team:       _______________________________
+   - Community:            _______________________________
+   - Other:                _______________________________
+   Lead deliverable:       _______________________________
+   Supplementary outputs:  _______________________________
+
+8. TOP THREE LIMITATIONS
+   1. ______________________________________________________
+   2. ______________________________________________________
+   3. ______________________________________________________
+
+9. HONESTY-TEST SENTENCE
+   "This evaluation will tell us _________________________
+   _______________________________________________________
+   and it will not tell us ______________________________
+   _____________________________________________________."
+
+SIGNED OFF BY:
+___________________________________________________________
+                          Date: ________________</pre>
+    </div>
+
+    <div class="resources-section">
+      <h3>Where to go next on ImpactMojo</h3>
+      <ul>
+        <li><a href="/DeepDives/sel-evaluation-india.html">Deep Dive: SEL Evaluation in India</a> — 32 readings across foundations, India evidence base, measurement, design choices, operational wisdom, critiques</li>
+        <li><a href="/Games/sel-simulation-game.html">SEL Simulation Game (Five Lenses)</a> — especially the Evaluator mode for hands-on design tradeoffs</li>
+        <li><a href="/Labs/teacher-evidence-lab.html">Teacher Evidence Lab</a> — adjacent evidence base showing what rigorous evaluation evidence looks like in one sector</li>
+        <li><a href="/Labs/mel-design-lab.html">MEL Design Lab</a> — build a structured evaluation plan with prompts</li>
+        <li><a href="/courses/SEL/">SEL Flagship Course</a> — the comprehensive 13-module SEL course</li>
+        <li><a href="/courses/mel/">MEL Flagship Course</a> — foundations of monitoring, evaluation &amp; learning</li>
+        <li><a href="/blog/writing-a-tor-for-research.html">Blog: How to Write a ToR That Gets You Useful Research</a> — once your design is ready, you'll need a ToR</li>
+      </ul>
+    </div>
+
+    <div class="callout" style="margin-top:2rem">
+      <div class="c-label">Done?</div>
+      <p>If you've completed all four modules and drafted your capstone brief — well done. Share it with one colleague before circulating widely. Their first reaction is the most accurate signal you'll get on whether the framing lands.</p>
+      <p style="margin-top:.7rem">Help us improve this pack: <a href="/contact.html?topic=PracticePack01">feedback form</a>.</p>
+    </div>
+
+    <div class="module-nav">
+      <button class="nav-btn" onclick="goTab(3)">← Module 4</button>
+      <a class="nav-btn" href="/practice-packs/">All Practice Packs →</a>
+    </div>
+  </div>
+
+</div>
+
+<footer class="im-footer" role="contentinfo">
+  <p>© 2026 ImpactMojo. Free development education for South Asia.</p>
+  <p><a href="/about.html">About</a> · <a href="/practice-packs/">Practice Packs</a> · <a href="/catalog.html">Catalog</a> · <a href="/contact.html">Contact</a></p>
+</footer>
+
+<script>
+// Tab navigation
+const tabs = document.querySelectorAll('.module-tab');
+const panels = document.querySelectorAll('.module-panel');
+
+function goTab(idx){
+  tabs.forEach((t, i) => {
+    t.classList.toggle('active', i === idx);
+    if (i < idx) t.classList.add('done');
+  });
+  panels.forEach((p, i) => p.classList.toggle('active', i === idx));
+  window.scrollTo({top: 0, behavior: 'smooth'});
+}
+
+tabs.forEach((t, i) => t.addEventListener('click', () => goTab(i)));
+
+// Copy buttons
+document.querySelectorAll('.copy-btn').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const id = btn.dataset.copy;
+    const text = document.getElementById(id).textContent;
+    navigator.clipboard.writeText(text).then(() => {
+      const orig = btn.textContent;
+      btn.textContent = '✓ Copied';
+      btn.classList.add('copied');
+      setTimeout(() => {
+        btn.textContent = orig;
+        btn.classList.remove('copied');
+      }, 1800);
+    }).catch(() => {
+      // Fallback: select the pre element
+      const range = document.createRange();
+      range.selectNode(document.getElementById(id));
+      window.getSelection().removeAllRanges();
+      window.getSelection().addRange(range);
+      btn.textContent = '↑ Select + Copy';
+    });
+  });
+});
+
+// Theme
+document.querySelectorAll('.theme-btn').forEach(b => b.addEventListener('click', () => {
+  const t = b.dataset.themeSet;
+  document.documentElement.setAttribute('data-theme', t);
+  try { localStorage.setItem('impactmojo-theme', t); } catch(e){}
+}));
+</script>
+
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1225,5 +1225,17 @@
         <changefreq>monthly</changefreq>
         <priority>0.8</priority>
     </url>
+    <url>
+        <loc>https://www.impactmojo.in/practice-packs/</loc>
+        <lastmod>2026-05-23</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.9</priority>
+    </url>
+    <url>
+        <loc>https://www.impactmojo.in/practice-packs/sel-evaluation/</loc>
+        <lastmod>2026-05-23</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.85</priority>
+    </url>
 
 </urlset>


### PR DESCRIPTION
## Summary

Launches the **Practice Packs** series — a new content type on ImpactMojo. Short, focused 3-hour sprints from job-to-be-done to a finished artefact. Sits between blog posts (one-shot read) and flagship courses (multi-week commitment) — designed for the working practitioner with a real project waiting on a defensible artefact.

## Format contract

| Element | Spec |
|---|---|
| Modules | 4, ~25 min each |
| Total time | ~2h reading + 1h exercise = ~3h |
| Per module | Short read + worked example + exercise + downloadable template |
| Capstone | One concrete artefact (ToR, drafted survey, logframe, eval design, etc.) |
| Take-home pack | All templates copyable to clipboard |

## What ships in this PR

### Landing page: `/practice-packs/`
Lists the full 10-pack roadmap with capstone deliverable shown for each. PP01 marked Live, PP02–PP10 marked Soon.

### First Pack: `/practice-packs/sel-evaluation/` (PP01)

**SEL Evaluation: Design & Instruments**

| Module | Topic | Output |
|---|---|---|
| 1 | What kind of evaluation do you actually need? | Design Decision Sheet (3 dimensions) |
| 2 | Choosing your measurement approach | Instrument Selection Matrix (CASEL/SEE/WHO/NCERT/ACER/observation/direct, with India validation status) |
| 3 | Designing data collection without breaking the budget | Data Collection Plan + Budget Sketch (real 2026 ₹ per-unit costs) |
| 4 | Analysis, reporting, and the honest framing | One-Page Exec Summary Outline |
| Capstone | SEL Evaluation Design Brief | 1-page deliverable combining all 4 |

5 copy-to-clipboard templates throughout, with India-context defaults.

## Roadmap (visible on landing page as "Soon")

PP02 Writing a ToR · PP03 Survey Instrument · PP04 Logframe · PP05 Costing · PP06 FGD · PP07 Critiquing Evidence · PP08 Stakeholder Mapping · PP09 Donor Reporting · PP10 MEL from Scratch

## Cross-references

- `data/search-index.json` — PP-LANDING + PP01 (new type `practice-pack`)
- `sitemap.xml` — 2 new URLs
- `index.html` — nav link added with "New" badge
- `CHANGELOG.md` + `docs/changelog.md` — v10.26.0

## Test plan

- [ ] `/practice-packs/` lists all 10 packs; PP01 has "Live" badge, others "Soon"
- [ ] Click PP01 → 4 module tabs + Capstone tab visible
- [ ] Module navigation works (tabs + prev/next buttons)
- [ ] Copy-to-clipboard buttons work on all 5 templates
- [ ] Cross-links to SEL game, deep dive, lab, course all resolve
- [ ] Homepage nav now shows Practice Packs link with "New" badge

---
_Generated by [Claude Code](https://claude.ai/code/session_01BeuCCodZutzv6wYFdZTsjb)_