### PR TITLE
fix: remove all emoji from every new page shipped this session

### DIFF
--- a/DeepDives/sel-evaluation-india.html
+++ b/DeepDives/sel-evaluation-india.html
@@ -356,7 +356,7 @@
 
 <footer class="im-footer" role="contentinfo">
   <div class="im-footer-content">
-    <p class="im-footer-made">Made with ❤ by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+    <p class="im-footer-made">Made with <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="vertical-align:-2px"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
     <div class="im-footer-grid">
       <div class="im-footer-section"><h4>About ImpactMojo</h4><ul>
         <li><a href="/about.html">About Us</a></li><li><a href="/contact.html">Contact</a></li>

--- a/Games/sel-simulation-game.html
+++ b/Games/sel-simulation-game.html
@@ -313,43 +313,43 @@ h1,h2,h3,h4{font-family:'Inter',sans-serif;line-height:1.3}
 
   <div class="modes-grid">
     <button class="mode-card teacher" onclick="startMode('teacher')">
-      <span class="mode-icon">🧑‍🏫</span>
+      <span class="mode-icon" style="font-family:Inter,sans-serif;font-size:1.4rem;font-weight:800;color:var(--pink)">T</span>
       <div class="mode-title">Teacher: Classroom Decisions</div>
       <div class="mode-subtitle">Six dilemmas. Real children. Hard tradeoffs.</div>
       <p class="mode-desc">A Class 6 in a government school. A withdrawn child, a fight between students, a parent who thinks SEL is "soft," a high-stakes exam week. Your choices show what happens to learning, wellbeing, equity, and trust.</p>
-      <div class="mode-meta"><span>🎯 6 rounds</span><span>⏱ ~7 min</span></div>
+      <div class="mode-meta"><span>6 rounds</span><span>~7 min</span></div>
     </button>
 
     <button class="mode-card designer" onclick="startMode('designer')">
-      <span class="mode-icon">🏗️</span>
+      <span class="mode-icon" style="font-family:Inter,sans-serif;font-size:1.4rem;font-weight:800;color:var(--indigo)">D</span>
       <div class="mode-title">Program Designer: ₹40 Lakh</div>
       <div class="mode-subtitle">One year. 12 schools. Limited budget.</div>
       <p class="mode-desc">You're designing an SEL program for a district. Curriculum, teacher training, measurement, parent engagement — every rupee allocated to one is a rupee not spent on another. The post-trial review shows what the evidence base actually predicts.</p>
-      <div class="mode-meta"><span>🎯 6 budget rounds</span><span>⏱ ~8 min</span></div>
+      <div class="mode-meta"><span>6 budget rounds</span><span>~8 min</span></div>
     </button>
 
     <button class="mode-card evaluator" onclick="startMode('evaluator')">
-      <span class="mode-icon">📐</span>
+      <span class="mode-icon" style="font-family:Inter,sans-serif;font-size:1.4rem;font-weight:800;color:var(--teal)">E</span>
       <div class="mode-title">Evaluator: What Can You Know?</div>
       <div class="mode-subtitle">A small NGO. A big claim. Your job: test it.</div>
       <p class="mode-desc">The NGO wants to prove SEL improves attendance, learning, and mental health. You pick the design — RCT, quasi-experimental, mixed-methods, developmental. The game shows what each design can and cannot tell you about cause, mechanism, and transfer.</p>
-      <div class="mode-meta"><span>🎯 6 design choices</span><span>⏱ ~7 min</span></div>
+      <div class="mode-meta"><span>6 design choices</span><span>~7 min</span></div>
     </button>
 
     <button class="mode-card student" onclick="startMode('student')">
-      <span class="mode-icon">🌱</span>
+      <span class="mode-icon" style="font-family:Inter,sans-serif;font-size:1.4rem;font-weight:800;color:var(--amber)">S</span>
       <div class="mode-title">Student: A Year in Class 7</div>
       <div class="mode-subtitle">Anika, 12. Migrant family. Hindi-medium school.</div>
       <p class="mode-desc">You play Anika across a school year — a friendship that breaks, an unfair teacher, an exam panic, a parent who doesn't speak the school's language. Strategies build the SEL competencies the field cares about (CASEL's five, SEE Learning's ethical dimension, WHO life skills) — or don't. See how childhood SEL is shaped less by curriculum than by daily moments.</p>
-      <div class="mode-meta"><span>🎯 6 episodes</span><span>⏱ ~6 min</span></div>
+      <div class="mode-meta"><span>6 episodes</span><span>~6 min</span></div>
     </button>
 
     <button class="mode-card parent" onclick="startMode('parent')">
-      <span class="mode-icon">🏠</span>
+      <span class="mode-icon" style="font-family:Inter,sans-serif;font-size:1.4rem;font-weight:800;color:var(--violet)">P</span>
       <div class="mode-title">Parent: Home Is the First Classroom</div>
       <div class="mode-subtitle">Your daughter is 11. Boards loom for her elder sister. You work.</div>
       <p class="mode-desc">A withdrawn child at dinner. A teacher complaint about your son. A daughter pressured by exams. A bad day where you snap. Indian SEL evidence consistently identifies <em>parent behaviour at home</em> as a larger predictor of child outcomes than any school programme. NEP 2020 explicitly invites parents into SEL — most parents are not sure how.</p>
-      <div class="mode-meta"><span>🎯 6 rounds</span><span>⏱ ~7 min</span></div>
+      <div class="mode-meta"><span>6 rounds</span><span>~7 min</span></div>
     </button>
   </div>
 
@@ -420,7 +420,7 @@ const MODES = {
     startScores: [50,50,50,50],
     rounds: [
       {
-        icon:'😔', title:'The child who stopped talking',
+        icon:'', title:'The child who stopped talking',
         context:'It is week 3. Rohan, 11, used to answer first. For five days he has not spoken once, not even at recess. His marks have not slipped. No teacher has flagged him. You notice during silent reading.',
         choices:[
           {label:'A) Call him out gently in class','sub':'Ask him a question warmly to show you see him.','impact':[+2,-4,-1,-3],
@@ -434,7 +434,7 @@ const MODES = {
         ]
       },
       {
-        icon:'💢', title:'The fight at lunch',
+        icon:'', title:'The fight at lunch',
         context:'Two boys, both Class 6, both your students. Arman pushed Vikram. Vikram fell. Both are now in your room with the head teacher. Arman is from a Muslim family in a school where 90% of children are Hindu. Vikram\'s family is a major school donor.',
         choices:[
           {label:'A) Punish both equally','sub':'Same detention. Stay neutral. Don\'t take sides.','impact':[-2,-4,-6,-3],
@@ -448,7 +448,7 @@ const MODES = {
         ]
       },
       {
-        icon:'📞', title:'The parent who thinks SEL is "wasted time"',
+        icon:'', title:'The parent who thinks SEL is "wasted time"',
         context:'Rohan\'s father comes to school. "Why is my son drawing feelings instead of doing maths? This soft-skill nonsense — my child needs marks, not therapy." He is angry, polite, and not entirely wrong about the pressure.',
         choices:[
           {label:'A) Defend SEL — show him the research','sub':'Pull out the NEP 2020 page. Cite CASEL. Be firm.','impact':[0,-1,-2,-4],
@@ -462,7 +462,7 @@ const MODES = {
         ]
       },
       {
-        icon:'📚', title:'Exam week — the system bears down',
+        icon:'', title:'Exam week — the system bears down',
         context:'Board prep starts Monday. Headmaster sends a circular: "All co-curricular activities — including SEL period — suspended till exams." Your Class 6 has not done SEL for three weeks already. Two children have been visibly more anxious. You have one period.',
         choices:[
           {label:'A) Comply. Use the period for revision.','sub':'Pick your battles. The exam matters most.','impact':[+2,-5,-2,-1],
@@ -476,7 +476,7 @@ const MODES = {
         ]
       },
       {
-        icon:'🎒', title:'The new girl from the migrant family',
+        icon:'', title:'The new girl from the migrant family',
         context:'Mid-term, Anika joins. Father works construction; family moved from rural Bihar. She speaks halting Hindi (her first language is Bhojpuri), no English. Class 6 has already formed friend groups. Three girls have begun mimicking her accent.',
         choices:[
           {label:'A) Pair her with the top student as buddy','sub':'Smart kid will catch her up academically.','impact':[+1,-1,-1,0],
@@ -490,7 +490,7 @@ const MODES = {
         ]
       },
       {
-        icon:'🌧️', title:'The school year ends',
+        icon:'', title:'The school year ends',
         context:'It is May. Final week. The exam results are mixed — your class did marginally better than last year on board prep, slightly worse than the class next door (which had no SEL period). The headmaster asks: "Was it worth it?"',
         choices:[
           {label:'A) Cite the marginal gain — claim the win','sub':'"Yes — see, we did slightly better than last year."','impact':[+1,0,0,+1],
@@ -531,7 +531,7 @@ const MODES = {
     startScores: [0,0,0,0],
     rounds: [
       {
-        icon:'💰', title:'Year 1 budget: ₹40 lakh, 12 schools',
+        icon:'', title:'Year 1 budget: ₹40 lakh, 12 schools',
         context:'The state government has offered to co-fund SEL in 12 government schools (~3,000 children). You have ₹40 lakh from a foundation and one school year. First call: how to split the budget.',
         choices:[
           {label:'A) Heavy on curriculum (₹20L) + light training','sub':'Buy/adapt a known curriculum. Quick teacher orientation.','impact':[+8,+3,-3,+2],
@@ -545,7 +545,7 @@ const MODES = {
         ]
       },
       {
-        icon:'📘', title:'Build, buy, or adapt curriculum?',
+        icon:'', title:'Build, buy, or adapt curriculum?',
         context:'Four options on the table: build from scratch (12 months), license a CASEL-aligned global curriculum (immediate, ~₹4L), bring in SEE Learning materials from Emory/Dalai Lama Centre (immediate, modest cost, India-translated), or adapt the SCERT well-being modules / NCERT Adolescence Education Programme already approved by the state (free, lower quality, government-aligned).',
         choices:[
           {label:'A) Build from scratch — contextual','sub':'Hire 2 writers. 12 months. Bespoke for your kids.','impact':[-3,+5,-2,+1],
@@ -559,7 +559,7 @@ const MODES = {
         ]
       },
       {
-        icon:'👩‍🏫', title:'Who delivers SEL? The teacher question.',
+        icon:'', title:'Who delivers SEL? The teacher question.',
         context:'Three delivery models being considered: (1) train existing class teachers to deliver SEL during a dedicated period, (2) hire external SEL facilitators who rotate across schools, (3) train one teacher per school as "SEL champion."',
         choices:[
           {label:'A) Train ALL class teachers','sub':'Deep training for ~40 teachers across 12 schools.','impact':[+5,+7,+8,+5],
@@ -573,7 +573,7 @@ const MODES = {
         ]
       },
       {
-        icon:'📊', title:'How will you know it worked?',
+        icon:'', title:'How will you know it worked?',
         context:'The funder wants evidence of impact at year-end. You have ~₹5L for measurement. Choose your design.',
         choices:[
           {label:'A) RCT with control schools','sub':'12 treatment, 12 control. Pre-post measures. Independent evaluator.','impact':[-2,+2,-1,+9],
@@ -587,7 +587,7 @@ const MODES = {
         ]
       },
       {
-        icon:'👨‍👩‍👧', title:'Parent and community engagement?',
+        icon:'', title:'Parent and community engagement?',
         context:'You have ₹3L left. Parent engagement is recommended by every SEL framework. But Indian parent-engagement in government schools has poor attendance rates and limited evidence base. What do you fund?',
         choices:[
           {label:'A) Skip it — focus budget on school','sub':'Parent engagement is hard to do well; redirect funds.','impact':[+2,+1,-2,0],
@@ -601,7 +601,7 @@ const MODES = {
         ]
       },
       {
-        icon:'🔭', title:'Year 2 question — what would you scale?',
+        icon:'', title:'Year 2 question — what would you scale?',
         context:'End of year 1. The state government is interested in scaling — but they will only fund what\'s working. Where do you point them?',
         choices:[
           {label:'A) Scale the curriculum and program brand','sub':'"Take our model to 200 schools."','impact':[+9,+1,-3,+2],
@@ -641,7 +641,7 @@ const MODES = {
     startScores: [0,0,0,0],
     rounds: [
       {
-        icon:'❓', title:'The brief: "Prove our SEL program works"',
+        icon:'', title:'The brief: "Prove our SEL program works"',
         context:'A medium-sized NGO runs an SEL program in 30 government schools across two districts in Karnataka. Three years in. Funder needs evidence for renewal. They have ₹15 lakh and 9 months. First decision: what is the question?',
         choices:[
           {label:'A) "Does the program improve learning outcomes?"','sub':'Test scores. Reading. Math. Boards.','impact':[+5,+2,+5,+1],
@@ -655,7 +655,7 @@ const MODES = {
         ]
       },
       {
-        icon:'🎲', title:'Design: counterfactual question',
+        icon:'', title:'Design: counterfactual question',
         context:'You\'ve picked your question. Now: what comparison? The program is already running in 30 schools. The challenge of evaluation: what would have happened without it.',
         choices:[
           {label:'A) Cluster RCT — randomise schools','sub':'Half schools get program, half wait-listed.','impact':[+9,+4,-4,+5],
@@ -669,7 +669,7 @@ const MODES = {
         ]
       },
       {
-        icon:'📏', title:'What do you measure?',
+        icon:'', title:'What do you measure?',
         context:'You need instruments. The team is debating: standardized scales (CASEL-aligned, validated), India-adapted scales (ACER, NCERT), program-developed scales (closely matched to curriculum), or behavioral observations.',
         choices:[
           {label:'A) Standardized CASEL-aligned scales','sub':'Global validity. Comparability to other studies.','impact':[+7,+3,+4,+4],
@@ -683,7 +683,7 @@ const MODES = {
         ]
       },
       {
-        icon:'👂', title:'Who do you listen to?',
+        icon:'', title:'Who do you listen to?',
         context:'The quantitative measurement plan is set. The mixed-methods strand: who do you interview, observe, and listen to?',
         choices:[
           {label:'A) Teachers only — they implement','sub':'Focus groups with program teachers across schools.','impact':[+4,+4,+7,+3],
@@ -697,7 +697,7 @@ const MODES = {
         ]
       },
       {
-        icon:'⚖️', title:'When the finding is mixed',
+        icon:'', title:'When the finding is mixed',
         context:'Your data is back. Quantitative: weak positive on self-awareness (p=0.09); null on regulation; positive trend on peer relationships. Qualitative: rich stories of individual transformation; weaker stories of class-level change. The funder wants a one-page summary.',
         choices:[
           {label:'A) Lead with the positive quantitative + the strong stories','sub':'Headline: "Promising effects on social-emotional competencies"','impact':[-3,-1,+5,-3],
@@ -711,7 +711,7 @@ const MODES = {
         ]
       },
       {
-        icon:'🔁', title:'The renewal conversation',
+        icon:'', title:'The renewal conversation',
         context:'Six weeks after submission. The funder calls. "We\'re considering not renewing. Your findings weren\'t strong enough." You know — based on the implementation findings — that with two more years the effects would compound. What do you say?',
         choices:[
           {label:'A) Defend the findings — push back','sub':'"You\'re reading them wrong. Here\'s why."','impact':[+3,+1,-2,+1],
@@ -751,7 +751,7 @@ const MODES = {
     startScores: [40,40,40,40],
     rounds: [
       {
-        icon:'😶', title:'Episode 1 — The first week',
+        icon:'', title:'Episode 1 — The first week',
         context:'You\'re Anika, 12. New school. The girls in your class are speaking faster than you understand. One of them, Priya, repeated something you said in Hindi and the others laughed. You don\'t know if they were laughing at you or with you.',
         choices:[
           {label:'A) Smile and laugh along','sub':'Don\'t make a scene. Fit in.','impact':[-3,+1,+1,-2],
@@ -765,7 +765,7 @@ const MODES = {
         ]
       },
       {
-        icon:'📝', title:'Episode 2 — The unfair grade',
+        icon:'', title:'Episode 2 — The unfair grade',
         context:'You wrote a story for class. You\'re proud of it. The teacher returned it: 6/10, no comments. Vikram, who copied half his story from a movie scene, got 8/10. You feel something hot in your chest.',
         choices:[
           {label:'A) Tell everyone — protest loudly','sub':'The injustice is the point.','impact':[+2,-3,-1,0],
@@ -779,7 +779,7 @@ const MODES = {
         ]
       },
       {
-        icon:'💔', title:'Episode 3 — The friendship that broke',
+        icon:'', title:'Episode 3 — The friendship that broke',
         context:'Reena was your first friend in this school. Today she said in front of three others, "Anika is weird, na?" and they all laughed. After class she came to you and said, "I was joking. Don\'t take it seriously."',
         choices:[
           {label:'A) Accept the apology — move on','sub':'Don\'t lose the friendship. It\'s the only one you have.','impact':[+1,+2,+2,-1],
@@ -793,7 +793,7 @@ const MODES = {
         ]
       },
       {
-        icon:'😰', title:'Episode 4 — Exam panic',
+        icon:'', title:'Episode 4 — Exam panic',
         context:'Maths exam tomorrow. You\'ve studied, but your stomach is in knots. Your hands keep shaking. Your mother says, "You\'re being dramatic. Just sleep." You don\'t know how to sleep when your heart is racing.',
         choices:[
           {label:'A) Force yourself to sleep — try to ignore the feeling','sub':'Mother knows best. Just push through.','impact':[-1,-3,-1,0],
@@ -807,7 +807,7 @@ const MODES = {
         ]
       },
       {
-        icon:'👨‍👩', title:'Episode 5 — The conversation with your father',
+        icon:'', title:'Episode 5 — The conversation with your father',
         context:'Your father came home tired. He saw your maths score (62/100) and said, "You\'re wasting our money. Your brother got 80 at your age." You worked harder than your brother. The unfairness sits in your throat.',
         choices:[
           {label:'A) Stay quiet — accept the comparison','sub':'Don\'t fight back. He\'s tired.','impact':[-3,-1,0,-2],
@@ -821,7 +821,7 @@ const MODES = {
         ]
       },
       {
-        icon:'🌅', title:'Episode 6 — Year-end',
+        icon:'', title:'Episode 6 — Year-end',
         context:'It\'s May. School year ends next week. You sit on the steps of your building. You think about everything that happened. Priya stopped laughing at you somewhere around January. Reena and you are friends, real ones now, after a hard conversation. Your father said "well done" twice this year. You don\'t feel the same as you did in June.',
         choices:[
           {label:'A) Write it all down — keep a record','sub':'Process by reflecting on the year.','impact':[+7,+4,+2,+5],
@@ -861,7 +861,7 @@ const MODES = {
     startScores: [50,50,50,50],
     rounds: [
       {
-        icon:'🍽️', title:'Round 1 — The dinner that went quiet',
+        icon:'', title:'Round 1 — The dinner that went quiet',
         context:'Your daughter, Meera (11), used to chatter through dinner. For six evenings she has been monosyllabic. Her marks are fine. No teacher has called. You don\'t know why. Tonight she sat down, ate quickly, asked to leave.',
         choices:[
           {label:'A) Ask her directly: "What is going on with you?"','sub':'Warm, but interrogating. You want answers.','impact':[-2,-1,-3,-1],
@@ -875,7 +875,7 @@ const MODES = {
         ]
       },
       {
-        icon:'📞', title:'Round 2 — The teacher complaint',
+        icon:'', title:'Round 2 — The teacher complaint',
         context:'Class teacher of your son Arjun (8) calls. "He won\'t sit still, he interrupts, he draws when I\'m teaching. I\'ve warned him three times this week. You need to do something at home."',
         choices:[
           {label:'A) Punish him at home — be consistent with school','sub':'Take away screen time. Lecture him. School must be respected.','impact':[-3,-3,-4,-2],
@@ -889,7 +889,7 @@ const MODES = {
         ]
       },
       {
-        icon:'💔', title:'Round 3 — The friend who turned',
+        icon:'', title:'Round 3 — The friend who turned',
         context:'Meera comes home crying. Her best friend Riya, with whom she has played for three years, has started excluding her at recess and mocking her clothes ("village style"). Meera says, "I don\'t want to go to school tomorrow."',
         choices:[
           {label:'A) Tell her to find new friends — Riya isn\'t worth it','sub':'Move on. There are other girls.','impact':[-2,-3,-3,-2],
@@ -903,7 +903,7 @@ const MODES = {
         ]
       },
       {
-        icon:'😤', title:'Round 4 — The day you snapped',
+        icon:'', title:'Round 4 — The day you snapped',
         context:'You came home from work after a brutal day. The kids are loud. The kitchen is a mess. You snap — "Can you ALL just be quiet for ONE minute?" Both children go silent. Meera puts her head down. Arjun looks scared. You realise they are watching you.',
         choices:[
           {label:'A) Carry on as if nothing happened','sub':'They\'ll forget. Move on.','impact':[-3,-2,-3,-5],
@@ -917,7 +917,7 @@ const MODES = {
         ]
       },
       {
-        icon:'🏫', title:'Round 5 — The school SEL programme arrives',
+        icon:'', title:'Round 5 — The school SEL programme arrives',
         context:'Meera\'s school has started a daily 30-minute "social-emotional learning" period under NEP 2020. The first parent-engagement note has arrived: it asks families to share feelings at dinner using a "feelings wheel." Your husband mutters "wasted time." Meera says she likes it. You\'re not sure.',
         choices:[
           {label:'A) Skip it — it\'s not your style, not your culture','sub':'The school can do its job. We have our way.','impact':[-1,-2,-1,-2],
@@ -931,7 +931,7 @@ const MODES = {
         ]
       },
       {
-        icon:'📚', title:'Round 6 — Boards. Your elder daughter.',
+        icon:'', title:'Round 6 — Boards. Your elder daughter.',
         context:'Your elder daughter Tara (15) is in Class 10. Board exams are 4 months away. She\'s been crying at night about pressure. Last night she mentioned that a girl in her class has been cutting herself. She said "I don\'t know how she does it." You don\'t know what she meant.',
         choices:[
           {label:'A) Reduce pressure: "Beta, marks don\'t define you. Just do your best."','sub':'Take the heat off. She knows you love her.','impact':[+3,+3,+4,+2],

--- a/Labs/teacher-evidence-lab.html
+++ b/Labs/teacher-evidence-lab.html
@@ -129,7 +129,7 @@ body{font-family:var(--font-sans);background:var(--primary-bg);color:var(--text-
 <a href="/Labs/" class="back-link">← All Labs</a>
 
 <div class="header">
-  <span class="header-badge">📊 Evidence Lab · Education</span>
+  <span class="header-badge"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align:-2px;margin-right:3px"><path d="M18 20V10M12 20V4M6 20v-6"/></svg>Evidence Lab · Education</span>
   <h1>Teacher Evidence Explorer</h1>
   <p>Filter teacher-effectiveness interventions by what the evidence actually says — quality, cost, India relevance, and outcome. Built from rigorous evaluations 2000–2024 across India and comparable contexts.</p>
 </div>

--- a/blog/writing-a-tor-for-research.html
+++ b/blog/writing-a-tor-for-research.html
@@ -242,7 +242,7 @@ body {
 .checklist-card ul { list-style: none; margin: 0; padding: 0; }
 .checklist-card li { padding: 0.5rem 0; padding-left: 1.8rem; position: relative; font-size: 0.95rem; line-height: 1.65; color: var(--text-secondary); }
 .checklist-card li:before {
-    content: "☐";
+    content: "<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align:-2px"><rect x="3" y="3" width="18" height="18" rx="2"/></svg>";
     position: absolute; left: 0; top: 0.4rem;
     color: var(--accent-color); font-size: 1.1rem;
     font-weight: 700;

--- a/courses/livelihoods/index.html
+++ b/courses/livelihoods/index.html
@@ -287,10 +287,10 @@ body{padding-top:56px}
     <h1>Livelihoods in India: Rural, Urban, and Skills</h1>
     <p class="hero-tagline">A comprehensive flagship course on the institutions, instruments, and evidence that shape work and incomes in India today. Built for practitioners, evaluators, and policy actors who need both the policy landscape and the methodological rigour to read the field critically.</p>
     <div class="hero-meta">
-        <span>📚 3 modules · 15 topics</span>
-        <span>⏱ ~18 hours estimated</span>
-        <span>🎯 Practitioner level</span>
-        <span>🇮🇳 India-centred</span>
+        <span><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align:-2px;margin-right:2px"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>3 modules · 15 topics</span>
+        <span><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align:-2px;margin-right:2px"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>~18 hours estimated</span>
+        <span><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align:-2px;margin-right:2px"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/></svg>Practitioner level</span>
+        <span>India · India-centred</span>
     </div>
     <div class="stat-grid">
         <div class="stat-card"><span class="stat-num">~67%</span><div class="stat-label">Indian workforce in informal employment (PLFS 2022–23)</div></div>
@@ -408,7 +408,7 @@ body{padding-top:56px}
     <p>This is the same observation evaluators make of TaRL, JEEViKA, and most other Indian programmes that scale: <em>implementation architecture matters more than programme design</em>.</p>
 
     <div class="reading-list">
-        <h4>📖 Core readings for this section</h4>
+        <h4><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align:-2px;margin-right:2px"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>Core readings for this section</h4>
         <ul>
             <li><strong>Hoffmann, Rao, Surendra & Datta (2018).</strong> "Relief from usury: Impact of a self-help group lending program in rural India" — <em>Journal of Development Economics</em>. The single most rigorous evaluation of NRLM-style SHG federations.</li>
             <li><strong>Kumar, Nair, Parsons & others (multiple).</strong> Various JEEViKA / Bihar Rural Livelihoods evaluations — useful for understanding state-specific implementation.</li>
@@ -485,7 +485,7 @@ body{padding-top:56px}
     <p>For NGOs working on rural livelihoods, MGNREGA is rarely the direct intervention — but it is almost always the background condition. A programme that ignores MGNREGA is missing a substantial share of the household income story.</p>
 
     <div class="reading-list">
-        <h4>📖 Core MGNREGA readings</h4>
+        <h4><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align:-2px;margin-right:2px"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>Core MGNREGA readings</h4>
         <ul>
             <li><strong>Imbert & Papp (2015).</strong> "Labour market effects of social programs" — <em>AEJ: Applied</em>.</li>
             <li><strong>Klonner & Oh (2019).</strong> "Labor market effects of a government-guaranteed employment program" — <em>Journal of Development Economics</em>.</li>
@@ -661,7 +661,7 @@ body{padding-top:56px}
     <p>The Indian domestic-workers' movement — National Domestic Workers' Movement (NDWM), Jagori, SEWA, and others — has nonetheless made meaningful progress on registration, identity cards, and welfare board enrollment, though structural protection remains elusive.</p>
 
     <div class="reading-list">
-        <h4>📖 Urban informal work — core readings</h4>
+        <h4><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align:-2px;margin-right:2px"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>Urban informal work — core readings</h4>
         <ul>
             <li><strong>Breman, Jan (multiple).</strong> Five-decade body of work on Indian informal labour. <em>Footloose Labour</em>, <em>Wage Hunters and Gatherers</em>, others.</li>
             <li><strong>Agarwala, Rina (2013).</strong> <em>Informal Labour, Formal Politics, and Dignified Discontent in India</em> — best single book on informal-sector political organisation.</li>
@@ -976,7 +976,7 @@ body{padding-top:56px}
 
 <footer class="im-footer" role="contentinfo">
     <div class="im-footer-content">
-        <p class="im-footer-made">Made with ❤ by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+        <p class="im-footer-made">Made with <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="vertical-align:-2px"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
         <div class="im-footer-grid">
             <div class="im-footer-section"><h4>About ImpactMojo</h4><ul>
                 <li><a href="/about.html">About Us</a></li>


### PR DESCRIPTION
## Summary

Removes all emoji from every new page shipped this session — SEL game, teacher lab, livelihoods course, deep dive, and ToR blog. Follows the same Sargam-icon pattern applied to Practice Packs in PR #440.

### Changes by file

| File | Emoji removed | Replacement |
|---|---|---|
| SEL Simulation Game | 186 | Mode icons → styled letter initials (T/D/E/S/P in brand colors); all 30 scenario round-icon emoji removed (title carries the weight); hero-meta → plain text |
| Livelihoods Course | 8 | Hero-meta → Sargam SVGs; reading-list → SVG book; footer heart → SVG |
| Teacher Evidence Lab | 1 | Header badge → SVG chart |
| SEL Eval Deep Dive | 1 | Footer heart → SVG |
| ToR Blog | 1 | Checklist checkbox → SVG rect |

**All 9 session files at zero emoji.** Sargam-style inline SVGs (viewBox 0 0 24, stroke 1.5–2px, currentColor) used throughout.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BeuCCodZutzv6wYFdZTsjb)_