### PR TITLE
fix: pa11y 13/13 green — fix last 2 failing pages

### DIFF
--- a/account.html
+++ b/account.html
@@ -943,7 +943,8 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .btn-primary {
-    background: var(--gradient-primary);
+    background-color: #4338CA;
+    background-image: var(--gradient-primary);
     color: white;
 }
 
@@ -1037,7 +1038,8 @@ h1, h2, h3, h4, h5, h6 {
 
 /* Upgrade banner */
 .upgrade-banner {
-    background: var(--gradient-primary);
+    background-color: #4338CA;
+    background-image: var(--gradient-primary);
     color: white;
     padding: 1.5rem;
     border-radius: 12px;
@@ -1061,7 +1063,7 @@ h1, h2, h3, h4, h5, h6 {
 
 .upgrade-btn {
     background: white;
-    color: var(--accent-color);
+    color: #0369A1;
     padding: 0.75rem 1.5rem;
     border-radius: 10px;
     font-weight: 600;
@@ -2232,7 +2234,7 @@ h1, h2, h3, h4, h5, h6 {
                         </div>
                         <div class="profile-detail-item" id="detailLinkedin" style="display:none;">
                             <svg viewBox="0 0 24 24" stroke-width="2"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/><rect x="2" y="9" width="4" height="12"/><circle cx="4" cy="4" r="2"/></svg>
-                            <a id="detailLinkedinLink" href="#" target="_blank" rel="noopener"></a>
+                            <a id="detailLinkedinLink" href="#" target="_blank" rel="noopener" aria-label="LinkedIn profile"></a>
                         </div>
                         <div class="profile-detail-item" id="detailBio" style="display:none; grid-column: 1 / -1;">
                             <svg viewBox="0 0 24 24" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
@@ -2651,7 +2653,7 @@ h1, h2, h3, h4, h5, h6 {
                             </label>
                             <div style="margin-top:0.5rem;">
                                 <label style="font-size:0.82rem; color:var(--text-secondary); font-weight:500;">Email Digest</label>
-                                <select id="prefDigestFreq" onchange="saveNotifPrefs()" style="margin-top:0.25rem; padding:0.4rem 0.6rem; border:1px solid var(--border-color); border-radius:6px; background:var(--primary-bg); color:var(--text-primary); font-size:0.82rem;">
+                                <select id="prefDigestFreq" aria-label="Email digest frequency" onchange="saveNotifPrefs()" style="margin-top:0.25rem; padding:0.4rem 0.6rem; border:1px solid var(--border-color); border-radius:6px; background:var(--primary-bg); color:var(--text-primary); font-size:0.82rem;">
                                     <option value="daily">Daily summary</option>
                                     <option value="weekly" selected>Weekly summary</option>
                                     <option value="never">No digest emails</option>
@@ -2900,7 +2902,7 @@ h1, h2, h3, h4, h5, h6 {
         <button class="chat-option" onclick="selectOption('feedback')"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Chat.svg" alt="" style="width:1em;height:1em;vertical-align:-0.15em;display:inline-block;" aria-hidden="true"> Feedback</button>
     </div>
     <div class="chat-input-area">
-        <input type="text" id="chatInput" placeholder="Type your message..." onkeypress="handleChatKeyPress(event)">
+        <input type="text" id="chatInput" aria-label="Chat message" placeholder="Type your message..." onkeypress="handleChatKeyPress(event)">
         <button class="chat-send" aria-label="Send message" onclick="sendChatMessage()">
             <svg viewBox="0 0 24 24"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
         </button>

--- a/handouts.html
+++ b/handouts.html
@@ -1692,7 +1692,7 @@ const TRACK_MAPPING = {
     'Cross Cutting Resources': {
         slug: 'cross-cutting',
         displayName: 'Cross-Cutting Resources',
-        color: '#64748B',
+        color: '#475569',
         order: 9
     },
     'Quick Reference Cards': {
@@ -1919,7 +1919,7 @@ async function loadHandouts() {
                 <line x1="12" y1="16" x2="12.01" y2="16"></line>
             </svg>
             <p>Error loading handouts: ${error.message}</p>
-            <p style="margin-top: 8px;"><a href="https://github.com/ImpactMojo/ImpactMojo/tree/main/Handouts" target="_blank" style="color: var(--accent-color);">View on GitHub directly &rarr;</a></p>
+            <p style="margin-top: 8px;"><a href="https://github.com/ImpactMojo/ImpactMojo/tree/main/Handouts" target="_blank" style="color: #0369A1;">View on GitHub directly &rarr;</a></p>
         `;
     }
 }


### PR DESCRIPTION
## Summary

Gets pa11y to **13/13 green** (was 11/13 after PR #447).

### Fixes

**handouts.html** (was 1 error → 0):
- JS category color `'#64748B'` → `'#475569'` for cross-cutting resources
- Inline link `color: var(--accent-color)` → `color: #0369A1` (sky-800, 7.0:1 on white)

**account.html** (was 8 errors → 0):
- `.upgrade-banner`: `background:` → `background-image:` so pa11y reads `background-color: #4338CA` (7.3:1) instead of transparent
- `.btn-primary`: same `background:` → `background-image:` + `background-color: #4338CA` fallback
- `.upgrade-btn`: `color: var(--accent-color)` → `color: #0369A1` (was resolving to sky-500 at 2.77:1)
- `#prefDigestFreq` select: added `aria-label="Email digest frequency"`
- `#chatInput` input: added `aria-label="Chat message"`
- `#detailLinkedinLink` empty anchor: added `aria-label="LinkedIn profile"`

### Verified locally

```
✔ 13/13 URLs passed
```

Using Playwright's Chromium (`/opt/pw-browsers/chromium-1194/chrome-linux/chrome`) with `--no-sandbox`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BeuCCodZutzv6wYFdZTsjb)_