### PR TITLE
Fix dark mode CSS variables in Policy Lab

### DIFF
--- a/Labs/policy-analysis-lab.html
+++ b/Labs/policy-analysis-lab.html
@@ -37,7 +37,8 @@
 }}
 [data-theme="light"]{--primary-bg:#FFFFFF;--secondary-bg:#F8FAFC;--text-primary:#0F172A;--text-secondary:#475569;--text-muted:#64748B;--card-bg:#FFFFFF;--hover-bg:#F1F5F9;--border:#E2E8F0;
   --im-primary-bg:#F8FAFC;--im-secondary-bg:#FFFFFF;--im-accent:#0284C7;--im-text-primary:#0F172A;--im-text-secondary:#475569;--im-text-muted:#64748B;--im-card-bg:#FFFFFF;--im-hover-bg:#F1F5F9;--im-border:#E2E8F0;--im-nav-bg:rgba(248,250,252,0.95);}
-[data-theme="dark"]{--primary-bg:#0F172A;--secondary-bg:#1E293B;--text-primary:#F1F5F9;--text-secondary:#CBD5E1;--text-muted:#94A3B8;--card-bg:#1E293B;--hover-bg:#334155;--border:#334155;}
+[data-theme="dark"]{--primary-bg:#0F172A;--secondary-bg:#1E293B;--text-primary:#F1F5F9;--text-secondary:#CBD5E1;--text-muted:#94A3B8;--card-bg:#1E293B;--hover-bg:#334155;--border:#334155;
+  --im-primary-bg:#0F172A;--im-secondary-bg:#1E293B;--im-accent:#0EA5E9;--im-text-primary:#F1F5F9;--im-text-secondary:#94A3B8;--im-text-muted:#64748B;--im-card-bg:#1E293B;--im-hover-bg:#334155;--im-border:#334155;--im-nav-bg:rgba(15,23,42,0.95);}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 html{scroll-behavior:smooth}
 body{font-family:var(--font-sans);background:var(--primary-bg);color:var(--text-primary);line-height:1.65;min-height:100vh;padding-top:52px}


### PR DESCRIPTION
Add missing --im-* variable overrides to [data-theme=dark] so topbar and footer theme correctly in dark mode.

https://claude.ai/code/session_01DWuFTbqMvHvijjtSJT2mkz