### PR TITLE
Puzzle Library: 117 puzzles (≥3 per course) + redesigned hub

### DIFF
--- a/data/puzzles.json
+++ b/data/puzzles.json
@@ -2675,6 +2675,3752 @@
           "r": "The networks and trust that help people act collectively"
         }
       ]
+    },
+    {
+      "id": "econ-101-wordsearch",
+      "title": "Economic Indicators",
+      "course": "Economics 101",
+      "track": "policy-economics",
+      "type": "wordsearch",
+      "difficulty": "Easy",
+      "blurb": "Find the metrics economists watch.",
+      "size": 15,
+      "words": [
+        {
+          "w": "INFLATION",
+          "h": "Rising general price level"
+        },
+        {
+          "w": "RECESSION",
+          "h": "Two quarters of shrinking output"
+        },
+        {
+          "w": "UNEMPLOYMENT",
+          "h": "Share of jobseekers without work"
+        },
+        {
+          "w": "PRODUCTIVITY",
+          "h": "Output per worker or hour"
+        },
+        {
+          "w": "INTERESTRATE",
+          "h": "Price of borrowing money"
+        },
+        {
+          "w": "EXCHANGERATE",
+          "h": "Value of one currency in another"
+        },
+        {
+          "w": "DEFICIT",
+          "h": "Spending beyond revenue"
+        },
+        {
+          "w": "SUPPLY",
+          "h": "Paired with demand"
+        },
+        {
+          "w": "DEMAND",
+          "h": "Willingness to buy at a price"
+        },
+        {
+          "w": "ELASTICITY",
+          "h": "Responsiveness to price"
+        },
+        {
+          "w": "MONOPOLY",
+          "h": "Single seller market"
+        },
+        {
+          "w": "SUBSIDY",
+          "h": "Payment that lowers a price"
+        },
+        {
+          "w": "SURPLUS",
+          "h": "Excess of supply over demand"
+        },
+        {
+          "w": "EQUILIBRIUM",
+          "h": "Where supply meets demand"
+        }
+      ]
+    },
+    {
+      "id": "inequality-wordsearch",
+      "title": "Redistribution Tools",
+      "course": "Inequality Basics",
+      "track": "policy-economics",
+      "type": "wordsearch",
+      "difficulty": "Medium",
+      "blurb": "Find policies that narrow the gap.",
+      "size": 15,
+      "words": [
+        {
+          "w": "PROGRESSIVETAX",
+          "h": "Rate rises with income"
+        },
+        {
+          "w": "WEALTHTAX",
+          "h": "Levy on accumulated assets"
+        },
+        {
+          "w": "MINIMUMWAGE",
+          "h": "Legal pay floor"
+        },
+        {
+          "w": "LIVINGWAGE",
+          "h": "Pay covering basic needs"
+        },
+        {
+          "w": "TRANSFERS",
+          "h": "Cash or in-kind support"
+        },
+        {
+          "w": "INHERITANCE",
+          "h": "Wealth passed at death"
+        },
+        {
+          "w": "ESTATETAX",
+          "h": "Tax on bequests"
+        },
+        {
+          "w": "LANDREFORM",
+          "h": "Redistributing farmland"
+        },
+        {
+          "w": "UNIONS",
+          "h": "Workers bargaining collectively"
+        },
+        {
+          "w": "SUBSIDIES",
+          "h": "Price support for the poor"
+        },
+        {
+          "w": "MOBILITY",
+          "h": "Movement between income classes"
+        },
+        {
+          "w": "PALMA",
+          "h": "Top 10% over bottom 40%"
+        },
+        {
+          "w": "GINI",
+          "h": "0-to-1 inequality index"
+        },
+        {
+          "w": "REDISTRIBUTION",
+          "h": "Shifting resources to reduce gaps"
+        }
+      ]
+    },
+    {
+      "id": "livelihood-wordsearch",
+      "title": "Livelihoods & Markets",
+      "course": "Livelihood Basics",
+      "track": "policy-economics",
+      "type": "wordsearch",
+      "difficulty": "Medium",
+      "blurb": "Find elements of rural and urban livelihoods.",
+      "size": 15,
+      "words": [
+        {
+          "w": "SUBSISTENCE",
+          "h": "Farming mainly to eat"
+        },
+        {
+          "w": "CASHCROP",
+          "h": "Grown to sell"
+        },
+        {
+          "w": "VALUECHAIN",
+          "h": "Steps from farm to market"
+        },
+        {
+          "w": "COOPERATIVE",
+          "h": "Member-owned enterprise"
+        },
+        {
+          "w": "EXTENSION",
+          "h": "Agricultural advisory service"
+        },
+        {
+          "w": "IRRIGATION",
+          "h": "Supplying water to crops"
+        },
+        {
+          "w": "MICROFINANCE",
+          "h": "Small-scale lending"
+        },
+        {
+          "w": "REMITTANCE",
+          "h": "Money sent home by migrants"
+        },
+        {
+          "w": "DIVERSIFICATION",
+          "h": "Spreading income sources"
+        },
+        {
+          "w": "RESILIENCE",
+          "h": "Coping with shocks"
+        },
+        {
+          "w": "INFORMAL",
+          "h": "Unregulated sector"
+        },
+        {
+          "w": "MARKETACCESS",
+          "h": "Reaching buyers"
+        },
+        {
+          "w": "PASTORALIST",
+          "h": "Livestock-herding livelihood"
+        },
+        {
+          "w": "POSTHARVEST",
+          "h": "After-crop handling"
+        }
+      ]
+    },
+    {
+      "id": "cost-effectiveness-wordsearch",
+      "title": "Economic Evaluation",
+      "course": "Cost Effectiveness 101",
+      "track": "policy-economics",
+      "type": "wordsearch",
+      "difficulty": "Medium",
+      "blurb": "Find terms from cost-effectiveness analysis.",
+      "size": 16,
+      "words": [
+        {
+          "w": "COSTEFFECTIVENESS",
+          "h": "Cost per unit of effect"
+        },
+        {
+          "w": "COSTBENEFIT",
+          "h": "Both sides in money"
+        },
+        {
+          "w": "ICER",
+          "h": "Incremental cost-effectiveness ratio"
+        },
+        {
+          "w": "DALY",
+          "h": "Disability-adjusted life year"
+        },
+        {
+          "w": "QALY",
+          "h": "Quality-adjusted life year"
+        },
+        {
+          "w": "DISCOUNTING",
+          "h": "Future values to present"
+        },
+        {
+          "w": "THRESHOLD",
+          "h": "Value-for-money cut-off"
+        },
+        {
+          "w": "SENSITIVITY",
+          "h": "Testing assumptions"
+        },
+        {
+          "w": "PERSPECTIVE",
+          "h": "Whose costs count"
+        },
+        {
+          "w": "COMPARATOR",
+          "h": "The alternative compared"
+        },
+        {
+          "w": "OVERHEAD",
+          "h": "Indirect running costs"
+        },
+        {
+          "w": "MARGINAL",
+          "h": "Cost of one more unit"
+        },
+        {
+          "w": "DOMINANCE",
+          "h": "Cheaper and more effective"
+        },
+        {
+          "w": "EFFICIENCY",
+          "h": "Best use of resources"
+        }
+      ]
+    },
+    {
+      "id": "decent-work-wordsearch",
+      "title": "Labour Standards",
+      "course": "Decent Work 101",
+      "track": "policy-economics",
+      "type": "wordsearch",
+      "difficulty": "Medium",
+      "blurb": "Find ILO decent-work concepts.",
+      "size": 16,
+      "words": [
+        {
+          "w": "DECENTWORK",
+          "h": "Productive work in dignity"
+        },
+        {
+          "w": "LIVINGWAGE",
+          "h": "Pay meeting basic needs"
+        },
+        {
+          "w": "FORCEDLABOUR",
+          "h": "Work under coercion"
+        },
+        {
+          "w": "CHILDLABOUR",
+          "h": "Work harming children"
+        },
+        {
+          "w": "DISCRIMINATION",
+          "h": "Unfair treatment at work"
+        },
+        {
+          "w": "SAFETY",
+          "h": "Occupational health and ____"
+        },
+        {
+          "w": "INFORMAL",
+          "h": "Outside legal protection"
+        },
+        {
+          "w": "PRECARIOUS",
+          "h": "Insecure employment"
+        },
+        {
+          "w": "GIGECONOMY",
+          "h": "Platform-mediated work"
+        },
+        {
+          "w": "TRADEUNION",
+          "h": "Workers' organisation"
+        },
+        {
+          "w": "TRIPARTISM",
+          "h": "State, employers, workers"
+        },
+        {
+          "w": "BARGAINING",
+          "h": "Negotiating conditions"
+        },
+        {
+          "w": "PROTECTION",
+          "h": "Social safety coverage"
+        },
+        {
+          "w": "ASSOCIATION",
+          "h": "Freedom to organise"
+        }
+      ]
+    },
+    {
+      "id": "safety-nets-wordsearch",
+      "title": "Social Protection",
+      "course": "Social Safety Nets",
+      "track": "policy-economics",
+      "type": "wordsearch",
+      "difficulty": "Easy",
+      "blurb": "Find social-protection instruments.",
+      "size": 16,
+      "words": [
+        {
+          "w": "CASHTRANSFER",
+          "h": "Direct payment to households"
+        },
+        {
+          "w": "CONDITIONAL",
+          "h": "Tied to behaviours"
+        },
+        {
+          "w": "PENSION",
+          "h": "Income in old age"
+        },
+        {
+          "w": "CHILDGRANT",
+          "h": "Support for children"
+        },
+        {
+          "w": "PUBLICWORKS",
+          "h": "Workfare employment"
+        },
+        {
+          "w": "SCHOOLFEEDING",
+          "h": "Meals at school"
+        },
+        {
+          "w": "INSURANCE",
+          "h": "Contributory protection"
+        },
+        {
+          "w": "ASSISTANCE",
+          "h": "Non-contributory support"
+        },
+        {
+          "w": "TARGETING",
+          "h": "Selecting beneficiaries"
+        },
+        {
+          "w": "GRADUATION",
+          "h": "Moving out of poverty"
+        },
+        {
+          "w": "RESILIENCE",
+          "h": "Withstanding shocks"
+        },
+        {
+          "w": "UNIVERSAL",
+          "h": "Benefits for all"
+        },
+        {
+          "w": "MEANSTEST",
+          "h": "Income-based eligibility"
+        },
+        {
+          "w": "FLOOR",
+          "h": "Basic protection guarantee"
+        }
+      ]
+    },
+    {
+      "id": "fundraising-wordsearch",
+      "title": "Fundraising & Grants",
+      "course": "Fundraising Basics",
+      "track": "policy-economics",
+      "type": "wordsearch",
+      "difficulty": "Easy",
+      "blurb": "Find resource-mobilisation terms.",
+      "size": 15,
+      "words": [
+        {
+          "w": "FUNDRAISING",
+          "h": "Mobilising resources"
+        },
+        {
+          "w": "GRANT",
+          "h": "Awarded funding"
+        },
+        {
+          "w": "DONOR",
+          "h": "Source of funds"
+        },
+        {
+          "w": "FOUNDATION",
+          "h": "Philanthropic funder"
+        },
+        {
+          "w": "CONCEPTNOTE",
+          "h": "Short funding pitch"
+        },
+        {
+          "w": "PROPOSAL",
+          "h": "Full funding application"
+        },
+        {
+          "w": "BUDGET",
+          "h": "Costed plan"
+        },
+        {
+          "w": "REPORTING",
+          "h": "Accounting to donors"
+        },
+        {
+          "w": "STEWARDSHIP",
+          "h": "Nurturing donor ties"
+        },
+        {
+          "w": "BILATERAL",
+          "h": "Country-to-country donor"
+        },
+        {
+          "w": "MULTILATERAL",
+          "h": "Many-country donor"
+        },
+        {
+          "w": "RESTRICTED",
+          "h": "Earmarked funds"
+        },
+        {
+          "w": "CORE",
+          "h": "Unrestricted funding"
+        },
+        {
+          "w": "DIVERSIFICATION",
+          "h": "Spreading funding sources"
+        }
+      ]
+    },
+    {
+      "id": "care-economy-wordsearch",
+      "title": "The Care Economy",
+      "course": "Care Economy 101",
+      "track": "gender-equity",
+      "type": "wordsearch",
+      "difficulty": "Easy",
+      "blurb": "Find care-economy concepts.",
+      "size": 16,
+      "words": [
+        {
+          "w": "CHILDCARE",
+          "h": "Caring for children"
+        },
+        {
+          "w": "ELDERCARE",
+          "h": "Caring for older people"
+        },
+        {
+          "w": "UNPAIDWORK",
+          "h": "Care without pay"
+        },
+        {
+          "w": "REPRODUCTION",
+          "h": "Sustaining people and labour"
+        },
+        {
+          "w": "CAREDIAMOND",
+          "h": "Family-state-market-NGO mix"
+        },
+        {
+          "w": "TIMEUSE",
+          "h": "Survey of hours spent"
+        },
+        {
+          "w": "PARENTALLEAVE",
+          "h": "Time off for new parents"
+        },
+        {
+          "w": "FEMINIZATION",
+          "h": "Gendering of care work"
+        },
+        {
+          "w": "DEVALUATION",
+          "h": "Undervaluing care"
+        },
+        {
+          "w": "RECOGNISE",
+          "h": "First of the 3 Rs"
+        },
+        {
+          "w": "REDISTRIBUTE",
+          "h": "Sharing care more fairly"
+        },
+        {
+          "w": "CARECHAINS",
+          "h": "Care labour across borders"
+        },
+        {
+          "w": "INFRASTRUCTURE",
+          "h": "Public care services"
+        },
+        {
+          "w": "INVISIBLE",
+          "h": "Care missing from GDP"
+        }
+      ]
+    },
+    {
+      "id": "wee-wordsearch",
+      "title": "Women's Economic Rights",
+      "course": "WEE Studies",
+      "track": "gender-equity",
+      "type": "wordsearch",
+      "difficulty": "Medium",
+      "blurb": "Find barriers to and enablers of women's economic power.",
+      "size": 16,
+      "words": [
+        {
+          "w": "PROPERTYRIGHTS",
+          "h": "Owning and controlling assets"
+        },
+        {
+          "w": "INHERITANCE",
+          "h": "Passing on wealth"
+        },
+        {
+          "w": "LANDTENURE",
+          "h": "Secure rights to land"
+        },
+        {
+          "w": "CREDITACCESS",
+          "h": "Reaching finance"
+        },
+        {
+          "w": "ENTREPRENEUR",
+          "h": "Running a business"
+        },
+        {
+          "w": "WAGEGAP",
+          "h": "Pay difference by gender"
+        },
+        {
+          "w": "GLASSCEILING",
+          "h": "Barrier to top jobs"
+        },
+        {
+          "w": "MOTHERHOOD",
+          "h": "Earnings penalty"
+        },
+        {
+          "w": "UNPAIDCARE",
+          "h": "Unrewarded domestic work"
+        },
+        {
+          "w": "CHILDCARE",
+          "h": "Support enabling work"
+        },
+        {
+          "w": "FINANCIAL",
+          "h": "____ inclusion"
+        },
+        {
+          "w": "DISCRIMINATION",
+          "h": "Unequal treatment"
+        },
+        {
+          "w": "AGENCY",
+          "h": "Power to choose and act"
+        },
+        {
+          "w": "EMPOWERMENT",
+          "h": "Expanding choices"
+        }
+      ]
+    },
+    {
+      "id": "social-margins-wordsearch",
+      "title": "Rights & Inclusion",
+      "course": "Social Margins",
+      "track": "gender-equity",
+      "type": "wordsearch",
+      "difficulty": "Medium",
+      "blurb": "Find terms for understanding exclusion.",
+      "size": 16,
+      "words": [
+        {
+          "w": "INTERSECTIONALITY",
+          "h": "Overlapping oppressions"
+        },
+        {
+          "w": "MARGINALISATION",
+          "h": "Pushed to the edges"
+        },
+        {
+          "w": "DISCRIMINATION",
+          "h": "Unfair treatment"
+        },
+        {
+          "w": "EXCLUSION",
+          "h": "Shut out of society"
+        },
+        {
+          "w": "STIGMA",
+          "h": "Discrediting mark"
+        },
+        {
+          "w": "PREJUDICE",
+          "h": "Prejudgement of a group"
+        },
+        {
+          "w": "ACCESSIBILITY",
+          "h": "Usable by disabled people"
+        },
+        {
+          "w": "INCLUSION",
+          "h": "Full participation"
+        },
+        {
+          "w": "ACCOMMODATION",
+          "h": "Reasonable adjustment"
+        },
+        {
+          "w": "AFFIRMATIVE",
+          "h": "____ action"
+        },
+        {
+          "w": "INDIGENOUS",
+          "h": "First peoples' rights"
+        },
+        {
+          "w": "DISABILITY",
+          "h": "____ rights (CRPD)"
+        },
+        {
+          "w": "RECOGNITION",
+          "h": "Valuing identity"
+        },
+        {
+          "w": "REPRESENTATION",
+          "h": "Having a voice"
+        }
+      ]
+    },
+    {
+      "id": "qual-methods-wordsearch",
+      "title": "Qualitative Research",
+      "course": "Qualitative Methods",
+      "track": "mel-research",
+      "type": "wordsearch",
+      "difficulty": "Medium",
+      "blurb": "Find qualitative research vocabulary.",
+      "size": 16,
+      "words": [
+        {
+          "w": "ETHNOGRAPHY",
+          "h": "Immersive cultural study"
+        },
+        {
+          "w": "PHENOMENOLOGY",
+          "h": "Study of lived experience"
+        },
+        {
+          "w": "GROUNDEDTHEORY",
+          "h": "Theory built from data"
+        },
+        {
+          "w": "INTERVIEW",
+          "h": "One-to-one conversation"
+        },
+        {
+          "w": "FOCUSGROUP",
+          "h": "Group discussion"
+        },
+        {
+          "w": "OBSERVATION",
+          "h": "Watching in context"
+        },
+        {
+          "w": "CODING",
+          "h": "Tagging data segments"
+        },
+        {
+          "w": "THEMATIC",
+          "h": "____ analysis"
+        },
+        {
+          "w": "SATURATION",
+          "h": "No new themes emerge"
+        },
+        {
+          "w": "TRIANGULATION",
+          "h": "Multiple sources"
+        },
+        {
+          "w": "REFLEXIVITY",
+          "h": "Examining your own role"
+        },
+        {
+          "w": "CREDIBILITY",
+          "h": "Trustworthiness of findings"
+        },
+        {
+          "w": "PURPOSIVE",
+          "h": "Deliberate sampling"
+        },
+        {
+          "w": "SNOWBALL",
+          "h": "Referral sampling"
+        }
+      ]
+    },
+    {
+      "id": "econometrics-wordsearch",
+      "title": "Causal Inference",
+      "course": "Econometrics 101",
+      "track": "mel-research",
+      "type": "wordsearch",
+      "difficulty": "Medium",
+      "blurb": "Find methods for establishing causality.",
+      "size": 17,
+      "words": [
+        {
+          "w": "RANDOMISATION",
+          "h": "Random assignment"
+        },
+        {
+          "w": "DIFFERENCE",
+          "h": "____-in-differences"
+        },
+        {
+          "w": "PROPENSITY",
+          "h": "____ score matching"
+        },
+        {
+          "w": "INSTRUMENTAL",
+          "h": "____ variables"
+        },
+        {
+          "w": "DISCONTINUITY",
+          "h": "Regression ____ design"
+        },
+        {
+          "w": "COUNTERFACTUAL",
+          "h": "The 'what if not'"
+        },
+        {
+          "w": "SELECTIONBIAS",
+          "h": "Non-random differences"
+        },
+        {
+          "w": "ENDOGENEITY",
+          "h": "Predictor linked to error"
+        },
+        {
+          "w": "ATTRITION",
+          "h": "Dropout from a study"
+        },
+        {
+          "w": "SPILLOVER",
+          "h": "Effects on non-participants"
+        },
+        {
+          "w": "VALIDITY",
+          "h": "Internal and external ____"
+        },
+        {
+          "w": "CLUSTERED",
+          "h": "____ standard errors"
+        },
+        {
+          "w": "PLACEBO",
+          "h": "Control comparison"
+        },
+        {
+          "w": "BASELINE",
+          "h": "Pre-treatment measure"
+        }
+      ]
+    },
+    {
+      "id": "bivariate-wordsearch",
+      "title": "Two-Variable Statistics",
+      "course": "Bivariate Analysis 101",
+      "track": "mel-research",
+      "type": "wordsearch",
+      "difficulty": "Medium",
+      "blurb": "Find bivariate methods and concepts.",
+      "size": 15,
+      "words": [
+        {
+          "w": "CORRELATION",
+          "h": "Linear association strength"
+        },
+        {
+          "w": "CAUSATION",
+          "h": "Cause-and-effect"
+        },
+        {
+          "w": "PEARSON",
+          "h": "Correlation for continuous data"
+        },
+        {
+          "w": "SPEARMAN",
+          "h": "Rank correlation"
+        },
+        {
+          "w": "CHISQUARE",
+          "h": "Test for categorical data"
+        },
+        {
+          "w": "TTEST",
+          "h": "Compares two means"
+        },
+        {
+          "w": "SCATTERPLOT",
+          "h": "Points for two variables"
+        },
+        {
+          "w": "CONTINGENCY",
+          "h": "Cross-tabulation table"
+        },
+        {
+          "w": "PVALUE",
+          "h": "Significance measure"
+        },
+        {
+          "w": "CONFIDENCE",
+          "h": "____ interval"
+        },
+        {
+          "w": "EFFECTSIZE",
+          "h": "Magnitude of a result"
+        },
+        {
+          "w": "SIGNIFICANCE",
+          "h": "Unlikely by chance"
+        },
+        {
+          "w": "SPURIOUS",
+          "h": "False correlation"
+        },
+        {
+          "w": "CONFOUNDING",
+          "h": "Hidden third factor"
+        }
+      ]
+    },
+    {
+      "id": "multivariate-wordsearch",
+      "title": "Multivariate Methods",
+      "course": "Multivariate Analysis Basics",
+      "track": "mel-research",
+      "type": "wordsearch",
+      "difficulty": "Advanced",
+      "blurb": "Find techniques for many variables.",
+      "size": 17,
+      "words": [
+        {
+          "w": "REGRESSION",
+          "h": "Multiple ____"
+        },
+        {
+          "w": "LOGISTIC",
+          "h": "For binary outcomes"
+        },
+        {
+          "w": "FACTORANALYSIS",
+          "h": "Finding latent dimensions"
+        },
+        {
+          "w": "COMPONENT",
+          "h": "Principal ____ analysis"
+        },
+        {
+          "w": "CLUSTERING",
+          "h": "Grouping similar cases"
+        },
+        {
+          "w": "DISCRIMINANT",
+          "h": "Classifying groups"
+        },
+        {
+          "w": "MANOVA",
+          "h": "Multivariate ANOVA"
+        },
+        {
+          "w": "PATHANALYSIS",
+          "h": "Modelling causal paths"
+        },
+        {
+          "w": "MEDIATION",
+          "h": "Indirect effects"
+        },
+        {
+          "w": "MODERATION",
+          "h": "Interaction effects"
+        },
+        {
+          "w": "EIGENVALUE",
+          "h": "Variance per factor"
+        },
+        {
+          "w": "LOADING",
+          "h": "Factor ____"
+        },
+        {
+          "w": "HIERARCHICAL",
+          "h": "Stepwise model building"
+        },
+        {
+          "w": "COLLINEARITY",
+          "h": "Correlated predictors"
+        }
+      ]
+    },
+    {
+      "id": "irt-wordsearch",
+      "title": "Measurement Theory",
+      "course": "IRT Basics",
+      "track": "mel-research",
+      "type": "wordsearch",
+      "difficulty": "Advanced",
+      "blurb": "Find psychometric concepts.",
+      "size": 17,
+      "words": [
+        {
+          "w": "LATENTTRAIT",
+          "h": "Unobserved ability"
+        },
+        {
+          "w": "RASCHMODEL",
+          "h": "One-parameter IRT"
+        },
+        {
+          "w": "DIFFICULTY",
+          "h": "Item parameter"
+        },
+        {
+          "w": "DISCRIMINATION",
+          "h": "How sharply an item separates"
+        },
+        {
+          "w": "GUESSING",
+          "h": "Third IRT parameter"
+        },
+        {
+          "w": "INFORMATION",
+          "h": "Test ____ function"
+        },
+        {
+          "w": "EQUATING",
+          "h": "Linking test forms"
+        },
+        {
+          "w": "INVARIANCE",
+          "h": "Stable across groups"
+        },
+        {
+          "w": "THETA",
+          "h": "Ability estimate"
+        },
+        {
+          "w": "UNIDIMENSIONAL",
+          "h": "One trait measured"
+        },
+        {
+          "w": "ADAPTIVE",
+          "h": "Computerised ____ testing"
+        },
+        {
+          "w": "PERSONFIT",
+          "h": "Respondent consistency"
+        },
+        {
+          "w": "ITEMFIT",
+          "h": "Item-model agreement"
+        },
+        {
+          "w": "RELIABILITY",
+          "h": "Consistency of measurement"
+        }
+      ]
+    },
+    {
+      "id": "eda-wordsearch",
+      "title": "Data Visualisation",
+      "course": "EDA for HH Surveys",
+      "track": "mel-research",
+      "type": "wordsearch",
+      "difficulty": "Easy",
+      "blurb": "Find charts and descriptive statistics.",
+      "size": 15,
+      "words": [
+        {
+          "w": "HISTOGRAM",
+          "h": "Distribution bars"
+        },
+        {
+          "w": "BOXPLOT",
+          "h": "Quartiles and outliers"
+        },
+        {
+          "w": "SCATTERPLOT",
+          "h": "Two-variable points"
+        },
+        {
+          "w": "BARCHART",
+          "h": "Categorical comparison"
+        },
+        {
+          "w": "LINEGRAPH",
+          "h": "Trend over time"
+        },
+        {
+          "w": "HEATMAP",
+          "h": "Colour-coded matrix"
+        },
+        {
+          "w": "MEAN",
+          "h": "Arithmetic average"
+        },
+        {
+          "w": "MEDIAN",
+          "h": "Middle value"
+        },
+        {
+          "w": "MODE",
+          "h": "Most frequent value"
+        },
+        {
+          "w": "OUTLIER",
+          "h": "Extreme observation"
+        },
+        {
+          "w": "SKEWNESS",
+          "h": "Asymmetry of a distribution"
+        },
+        {
+          "w": "QUARTILE",
+          "h": "Quarter of the data"
+        },
+        {
+          "w": "PERCENTILE",
+          "h": "Rank position"
+        },
+        {
+          "w": "VARIANCE",
+          "h": "Spread measure"
+        }
+      ]
+    },
+    {
+      "id": "obs2insight-wordsearch",
+      "title": "Field Observation",
+      "course": "Obs2Insight",
+      "track": "mel-research",
+      "type": "wordsearch",
+      "difficulty": "Easy",
+      "blurb": "Find systematic-observation terms.",
+      "size": 16,
+      "words": [
+        {
+          "w": "OBSERVATION",
+          "h": "Watching systematically"
+        },
+        {
+          "w": "FIELDNOTES",
+          "h": "Written records"
+        },
+        {
+          "w": "PARTICIPANT",
+          "h": "____ observation"
+        },
+        {
+          "w": "REFLEXIVE",
+          "h": "Self-aware notes"
+        },
+        {
+          "w": "THICKDESCRIPTION",
+          "h": "Rich contextual detail"
+        },
+        {
+          "w": "HAWTHORNE",
+          "h": "Effect of being watched"
+        },
+        {
+          "w": "EMIC",
+          "h": "Insider perspective"
+        },
+        {
+          "w": "ETIC",
+          "h": "Outsider perspective"
+        },
+        {
+          "w": "JOTTINGS",
+          "h": "Quick field scribbles"
+        },
+        {
+          "w": "MEMOING",
+          "h": "Analytic notes"
+        },
+        {
+          "w": "TRIANGULATION",
+          "h": "Multiple sources"
+        },
+        {
+          "w": "BRACKETING",
+          "h": "Setting aside assumptions"
+        },
+        {
+          "w": "PATTERN",
+          "h": "Recurring regularity"
+        },
+        {
+          "w": "CONTEXT",
+          "h": "The surrounding setting"
+        }
+      ]
+    },
+    {
+      "id": "visual-ethnography-wordsearch",
+      "title": "Visual Methods",
+      "course": "Visual Ethnography 101",
+      "track": "mel-research",
+      "type": "wordsearch",
+      "difficulty": "Easy",
+      "blurb": "Find visual-research vocabulary.",
+      "size": 16,
+      "words": [
+        {
+          "w": "PHOTOVOICE",
+          "h": "Participant photography"
+        },
+        {
+          "w": "ELICITATION",
+          "h": "Photo ____ in interviews"
+        },
+        {
+          "w": "DOCUMENTARY",
+          "h": "Real-world photography"
+        },
+        {
+          "w": "VISUALNARRATIVE",
+          "h": "Story told in images"
+        },
+        {
+          "w": "SEMIOTICS",
+          "h": "Study of signs"
+        },
+        {
+          "w": "ICONOGRAPHY",
+          "h": "Meaning of images"
+        },
+        {
+          "w": "REPRESENTATION",
+          "h": "Depicting people fairly"
+        },
+        {
+          "w": "FRAMING",
+          "h": "What's in the shot"
+        },
+        {
+          "w": "COMPOSITION",
+          "h": "Arrangement of an image"
+        },
+        {
+          "w": "MULTIMODAL",
+          "h": "Text, image and sound"
+        },
+        {
+          "w": "CONSENT",
+          "h": "Permission to photograph"
+        },
+        {
+          "w": "ANONYMITY",
+          "h": "Hiding identities"
+        },
+        {
+          "w": "GAZE",
+          "h": "Who is looking"
+        },
+        {
+          "w": "ETHICS",
+          "h": "Respectful representation"
+        }
+      ]
+    },
+    {
+      "id": "education-wordsearch",
+      "title": "Learning Theories",
+      "course": "Education & Pedagogy 101",
+      "track": "mel-research",
+      "type": "wordsearch",
+      "difficulty": "Easy",
+      "blurb": "Find pedagogies and learning ideas.",
+      "size": 16,
+      "words": [
+        {
+          "w": "BEHAVIORISM",
+          "h": "Learning via reinforcement"
+        },
+        {
+          "w": "CONSTRUCTIVISM",
+          "h": "Learners build knowledge"
+        },
+        {
+          "w": "CONNECTIVISM",
+          "h": "Learning through networks"
+        },
+        {
+          "w": "SCAFFOLDING",
+          "h": "Graduated support"
+        },
+        {
+          "w": "METACOGNITION",
+          "h": "Thinking about thinking"
+        },
+        {
+          "w": "FORMATIVE",
+          "h": "Ongoing assessment"
+        },
+        {
+          "w": "SUMMATIVE",
+          "h": "End-point assessment"
+        },
+        {
+          "w": "INQUIRY",
+          "h": "____-based learning"
+        },
+        {
+          "w": "EXPERIENTIAL",
+          "h": "Learning by doing"
+        },
+        {
+          "w": "DIFFERENTIATED",
+          "h": "Tailored instruction"
+        },
+        {
+          "w": "BLOOMS",
+          "h": "Taxonomy of objectives"
+        },
+        {
+          "w": "FREIRE",
+          "h": "Critical pedagogy thinker"
+        },
+        {
+          "w": "VYGOTSKY",
+          "h": "Zone of proximal development"
+        },
+        {
+          "w": "PIAGET",
+          "h": "Stages of development"
+        }
+      ]
+    },
+    {
+      "id": "english-dev-wordsearch",
+      "title": "Development Sector Terms",
+      "course": "English for Development Professionals",
+      "track": "mel-research",
+      "type": "wordsearch",
+      "difficulty": "Easy",
+      "blurb": "Find common development vocabulary.",
+      "size": 16,
+      "words": [
+        {
+          "w": "BENEFICIARY",
+          "h": "Person a programme serves"
+        },
+        {
+          "w": "STAKEHOLDER",
+          "h": "Affected or interested party"
+        },
+        {
+          "w": "SUSTAINABILITY",
+          "h": "Lasting beyond funding"
+        },
+        {
+          "w": "SCALABILITY",
+          "h": "Potential to expand"
+        },
+        {
+          "w": "CAPACITY",
+          "h": "____ building"
+        },
+        {
+          "w": "BASELINE",
+          "h": "Starting measurement"
+        },
+        {
+          "w": "BESTPRACTICE",
+          "h": "Proven approach"
+        },
+        {
+          "w": "CASESTUDY",
+          "h": "Detailed example"
+        },
+        {
+          "w": "PROCUREMENT",
+          "h": "Buying goods and services"
+        },
+        {
+          "w": "CONSORTIUM",
+          "h": "Partner alliance"
+        },
+        {
+          "w": "PARTNERSHIP",
+          "h": "Working together"
+        },
+        {
+          "w": "ALIGNMENT",
+          "h": "Fitting country systems"
+        },
+        {
+          "w": "HARMONISATION",
+          "h": "Donors coordinating"
+        },
+        {
+          "w": "DISSEMINATION",
+          "h": "Sharing findings"
+        }
+      ]
+    },
+    {
+      "id": "digital-ethics-wordsearch",
+      "title": "Technology Ethics",
+      "course": "Digital Ethics 101",
+      "track": "data-tech",
+      "type": "wordsearch",
+      "difficulty": "Medium",
+      "blurb": "Find digital-ethics concepts.",
+      "size": 17,
+      "words": [
+        {
+          "w": "PRIVACY",
+          "h": "Control over personal data"
+        },
+        {
+          "w": "SURVEILLANCE",
+          "h": "Monitoring of people"
+        },
+        {
+          "w": "ALGORITHMIC",
+          "h": "____ accountability"
+        },
+        {
+          "w": "TRANSPARENCY",
+          "h": "Openness about systems"
+        },
+        {
+          "w": "EXPLAINABILITY",
+          "h": "Understandable decisions"
+        },
+        {
+          "w": "BIAS",
+          "h": "Systematic unfairness"
+        },
+        {
+          "w": "DISCRIMINATION",
+          "h": "Unequal treatment"
+        },
+        {
+          "w": "GDPR",
+          "h": "EU data-protection law"
+        },
+        {
+          "w": "BIOMETRIC",
+          "h": "Body-based identifiers"
+        },
+        {
+          "w": "CONSENT",
+          "h": "Permission to use data"
+        },
+        {
+          "w": "PROFILING",
+          "h": "Inferring traits from data"
+        },
+        {
+          "w": "MINIMISATION",
+          "h": "Collect only what's needed"
+        },
+        {
+          "w": "ANONYMISATION",
+          "h": "Stripping identifiers"
+        },
+        {
+          "w": "SURVEILLANCECAPITALISM",
+          "h": "Profiting from behaviour"
+        }
+      ]
+    },
+    {
+      "id": "data-literacy-wordsearch",
+      "title": "Data Basics",
+      "course": "Data Literacy 101",
+      "track": "data-tech",
+      "type": "wordsearch",
+      "difficulty": "Easy",
+      "blurb": "Find fundamental data concepts.",
+      "size": 15,
+      "words": [
+        {
+          "w": "DATA",
+          "h": "Recorded values"
+        },
+        {
+          "w": "DATASET",
+          "h": "A collection of data"
+        },
+        {
+          "w": "VARIABLE",
+          "h": "A measured attribute"
+        },
+        {
+          "w": "QUANTITATIVE",
+          "h": "Numeric data"
+        },
+        {
+          "w": "QUALITATIVE",
+          "h": "Non-numeric data"
+        },
+        {
+          "w": "CATEGORICAL",
+          "h": "Group-based data"
+        },
+        {
+          "w": "CONTINUOUS",
+          "h": "Any value in a range"
+        },
+        {
+          "w": "MEAN",
+          "h": "Average value"
+        },
+        {
+          "w": "MEDIAN",
+          "h": "Middle value"
+        },
+        {
+          "w": "PERCENTAGE",
+          "h": "Out of a hundred"
+        },
+        {
+          "w": "CORRELATION",
+          "h": "Things moving together"
+        },
+        {
+          "w": "CAUSATION",
+          "h": "One thing causing another"
+        },
+        {
+          "w": "MISLEADING",
+          "h": "Deceptive presentation"
+        },
+        {
+          "w": "VISUALISATION",
+          "h": "Charts and graphs"
+        }
+      ]
+    },
+    {
+      "id": "public-health-wordsearch",
+      "title": "Public Health Interventions",
+      "course": "Public Health Basics",
+      "track": "health-comms",
+      "type": "wordsearch",
+      "difficulty": "Medium",
+      "blurb": "Find public-health programmes and concepts.",
+      "size": 16,
+      "words": [
+        {
+          "w": "IMMUNISATION",
+          "h": "Building population immunity"
+        },
+        {
+          "w": "VACCINATION",
+          "h": "Protective injection"
+        },
+        {
+          "w": "SANITATION",
+          "h": "Safe waste disposal"
+        },
+        {
+          "w": "HYGIENE",
+          "h": "Cleanliness practices"
+        },
+        {
+          "w": "SURVEILLANCE",
+          "h": "Tracking disease"
+        },
+        {
+          "w": "QUARANTINE",
+          "h": "Separating the exposed"
+        },
+        {
+          "w": "SCREENING",
+          "h": "Early detection"
+        },
+        {
+          "w": "PREVENTION",
+          "h": "Stopping disease"
+        },
+        {
+          "w": "MATERNAL",
+          "h": "____ and child health"
+        },
+        {
+          "w": "NUTRITION",
+          "h": "Food and health"
+        },
+        {
+          "w": "EPIDEMIOLOGY",
+          "h": "Study of disease patterns"
+        },
+        {
+          "w": "HERDIMMUNITY",
+          "h": "Indirect protection"
+        },
+        {
+          "w": "INCIDENCE",
+          "h": "Rate of new cases"
+        },
+        {
+          "w": "PREVALENCE",
+          "h": "Existing cases"
+        }
+      ]
+    },
+    {
+      "id": "srhr-wordsearch",
+      "title": "Family Planning & SRHR",
+      "course": "SRHR Basics",
+      "track": "health-comms",
+      "type": "wordsearch",
+      "difficulty": "Easy",
+      "blurb": "Find SRHR methods and concepts.",
+      "size": 16,
+      "words": [
+        {
+          "w": "FAMILYPLANNING",
+          "h": "Choosing if and when"
+        },
+        {
+          "w": "CONTRACEPTION",
+          "h": "Preventing pregnancy"
+        },
+        {
+          "w": "CONDOM",
+          "h": "Barrier method"
+        },
+        {
+          "w": "IMPLANT",
+          "h": "Long-acting method"
+        },
+        {
+          "w": "INJECTABLE",
+          "h": "Hormonal method"
+        },
+        {
+          "w": "EMERGENCY",
+          "h": "Post-coital contraception"
+        },
+        {
+          "w": "ANTENATAL",
+          "h": "Pregnancy care"
+        },
+        {
+          "w": "POSTNATAL",
+          "h": "Post-birth care"
+        },
+        {
+          "w": "SAFEABORTION",
+          "h": "Legal, safe termination"
+        },
+        {
+          "w": "BODILYAUTONOMY",
+          "h": "Control over one's body"
+        },
+        {
+          "w": "CONSENT",
+          "h": "Voluntary agreement"
+        },
+        {
+          "w": "YOUTHFRIENDLY",
+          "h": "Accessible to young people"
+        },
+        {
+          "w": "MATERNALHEALTH",
+          "h": "Health in pregnancy"
+        },
+        {
+          "w": "INFORMEDCHOICE",
+          "h": "Decision with full information"
+        }
+      ]
+    },
+    {
+      "id": "bcc-wordsearch",
+      "title": "Behaviour Change",
+      "course": "BCC Comms",
+      "track": "health-comms",
+      "type": "wordsearch",
+      "difficulty": "Medium",
+      "blurb": "Find behaviour-change communication terms.",
+      "size": 17,
+      "words": [
+        {
+          "w": "HEALTHBELIEF",
+          "h": "____ Model"
+        },
+        {
+          "w": "PLANNEDBEHAVIOUR",
+          "h": "Theory of ____"
+        },
+        {
+          "w": "TRANSTHEORETICAL",
+          "h": "Stages-of-change model"
+        },
+        {
+          "w": "DIFFUSION",
+          "h": "____ of innovations"
+        },
+        {
+          "w": "SELFEFFICACY",
+          "h": "Belief in one's ability"
+        },
+        {
+          "w": "SOCIALNORMS",
+          "h": "What others do"
+        },
+        {
+          "w": "MASSMEDIA",
+          "h": "Broadcast channels"
+        },
+        {
+          "w": "EDUTAINMENT",
+          "h": "Entertainment plus education"
+        },
+        {
+          "w": "PEEREDUCATION",
+          "h": "Learning from peers"
+        },
+        {
+          "w": "FRAMING",
+          "h": "How a message is cast"
+        },
+        {
+          "w": "FORMATIVE",
+          "h": "____ research"
+        },
+        {
+          "w": "SEGMENTATION",
+          "h": "Dividing the audience"
+        },
+        {
+          "w": "PRETESTING",
+          "h": "Trying out materials"
+        },
+        {
+          "w": "NUDGE",
+          "h": "Subtle behavioural prompt"
+        }
+      ]
+    },
+    {
+      "id": "sel-wordsearch",
+      "title": "Social-Emotional Skills",
+      "course": "SEL Basics",
+      "track": "health-comms",
+      "type": "wordsearch",
+      "difficulty": "Easy",
+      "blurb": "Find SEL competencies and skills.",
+      "size": 16,
+      "words": [
+        {
+          "w": "SELFAWARENESS",
+          "h": "Knowing your emotions"
+        },
+        {
+          "w": "SELFMANAGEMENT",
+          "h": "Regulating yourself"
+        },
+        {
+          "w": "SOCIALAWARENESS",
+          "h": "Understanding others"
+        },
+        {
+          "w": "RELATIONSHIP",
+          "h": "____ skills"
+        },
+        {
+          "w": "DECISIONMAKING",
+          "h": "Responsible ____"
+        },
+        {
+          "w": "EMPATHY",
+          "h": "Sharing others' feelings"
+        },
+        {
+          "w": "RESILIENCE",
+          "h": "Bouncing back"
+        },
+        {
+          "w": "MINDFULNESS",
+          "h": "Present-moment attention"
+        },
+        {
+          "w": "COOPERATION",
+          "h": "Working together"
+        },
+        {
+          "w": "CONFLICT",
+          "h": "____ resolution"
+        },
+        {
+          "w": "REGULATION",
+          "h": "Managing emotions"
+        },
+        {
+          "w": "GROWTHMINDSET",
+          "h": "Belief in improvement"
+        },
+        {
+          "w": "PROSOCIAL",
+          "h": "Helping behaviour"
+        },
+        {
+          "w": "GOALSETTING",
+          "h": "Planning ahead"
+        }
+      ]
+    },
+    {
+      "id": "env-justice-wordsearch",
+      "title": "Environmental Justice",
+      "course": "Environmental Justice 101",
+      "track": "climate-env",
+      "type": "wordsearch",
+      "difficulty": "Medium",
+      "blurb": "Find environmental-justice concepts.",
+      "size": 18,
+      "words": [
+        {
+          "w": "ENVIRONMENTALRACISM",
+          "h": "Racialised harm"
+        },
+        {
+          "w": "CLIMATEJUSTICE",
+          "h": "Fairness in climate burdens"
+        },
+        {
+          "w": "TOXICEXPOSURE",
+          "h": "Contact with pollutants"
+        },
+        {
+          "w": "POLLUTION",
+          "h": "Contamination of environment"
+        },
+        {
+          "w": "DISTRIBUTIVE",
+          "h": "____ justice"
+        },
+        {
+          "w": "PROCEDURAL",
+          "h": "____ justice"
+        },
+        {
+          "w": "RECOGNITION",
+          "h": "Valuing affected groups"
+        },
+        {
+          "w": "FRONTLINE",
+          "h": "First and worst hit"
+        },
+        {
+          "w": "PRECAUTIONARY",
+          "h": "____ principle"
+        },
+        {
+          "w": "POLLUTERPAYS",
+          "h": "Cost borne by polluter"
+        },
+        {
+          "w": "FPIC",
+          "h": "Free, prior, informed consent"
+        },
+        {
+          "w": "LANDDEFENDERS",
+          "h": "Protectors of territory"
+        },
+        {
+          "w": "VULNERABILITY",
+          "h": "Exposure to harm"
+        },
+        {
+          "w": "EQUITY",
+          "h": "Fairness"
+        }
+      ]
+    },
+    {
+      "id": "political-economy-wordsearch",
+      "title": "Political Economy",
+      "course": "Political Economy",
+      "track": "governance",
+      "type": "wordsearch",
+      "difficulty": "Medium",
+      "blurb": "Find political-economy concepts.",
+      "size": 18,
+      "words": [
+        {
+          "w": "RENTSEEKING",
+          "h": "Profit by manipulating policy"
+        },
+        {
+          "w": "STATECAPACITY",
+          "h": "Ability to govern"
+        },
+        {
+          "w": "ELITECAPTURE",
+          "h": "Benefits seized by elites"
+        },
+        {
+          "w": "CLIENTELISM",
+          "h": "Benefits for support"
+        },
+        {
+          "w": "PATRONAGE",
+          "h": "Favours for loyalty"
+        },
+        {
+          "w": "CORRUPTION",
+          "h": "Abuse of public office"
+        },
+        {
+          "w": "LEGITIMACY",
+          "h": "Accepted right to rule"
+        },
+        {
+          "w": "ACCOUNTABILITY",
+          "h": "Answerability of power"
+        },
+        {
+          "w": "TRANSPARENCY",
+          "h": "Openness of decisions"
+        },
+        {
+          "w": "INSTITUTIONS",
+          "h": "Rules of the game"
+        },
+        {
+          "w": "GOVERNANCE",
+          "h": "How power is exercised"
+        },
+        {
+          "w": "COLLECTIVEACTION",
+          "h": "Organising shared interests"
+        },
+        {
+          "w": "REGULATORYCAPTURE",
+          "h": "Regulators serving industry"
+        },
+        {
+          "w": "PATHDEPENDENCE",
+          "h": "History shaping options"
+        }
+      ]
+    },
+    {
+      "id": "post-truth-wordsearch",
+      "title": "Information Disorder",
+      "course": "Post-Truth Politics 101",
+      "track": "governance",
+      "type": "wordsearch",
+      "difficulty": "Medium",
+      "blurb": "Find post-truth and media-literacy terms.",
+      "size": 18,
+      "words": [
+        {
+          "w": "MISINFORMATION",
+          "h": "False, not intended to harm"
+        },
+        {
+          "w": "DISINFORMATION",
+          "h": "Deliberately deceptive"
+        },
+        {
+          "w": "MALINFORMATION",
+          "h": "True but weaponised"
+        },
+        {
+          "w": "FAKENEWS",
+          "h": "Fabricated stories"
+        },
+        {
+          "w": "DEEPFAKE",
+          "h": "Synthetic media"
+        },
+        {
+          "w": "CONSPIRACY",
+          "h": "____ theory"
+        },
+        {
+          "w": "ECHOCHAMBER",
+          "h": "Belief-reinforcing space"
+        },
+        {
+          "w": "FILTERBUBBLE",
+          "h": "Algorithmic isolation"
+        },
+        {
+          "w": "FACTCHECKING",
+          "h": "Verifying claims"
+        },
+        {
+          "w": "MEDIALITERACY",
+          "h": "Critical media skills"
+        },
+        {
+          "w": "PREBUNKING",
+          "h": "Pre-emptive inoculation"
+        },
+        {
+          "w": "LATERALREADING",
+          "h": "Checking other sources"
+        },
+        {
+          "w": "POLARISATION",
+          "h": "Growing division"
+        },
+        {
+          "w": "PROPAGANDA",
+          "h": "Manipulative messaging"
+        }
+      ]
+    },
+    {
+      "id": "indian-constitution-wordsearch",
+      "title": "Constitution of India",
+      "course": "Indian Constitution 101",
+      "track": "governance",
+      "type": "wordsearch",
+      "difficulty": "Medium",
+      "blurb": "Find key constitutional concepts.",
+      "size": 16,
+      "words": [
+        {
+          "w": "PREAMBLE",
+          "h": "Opening statement of values"
+        },
+        {
+          "w": "SOVEREIGN",
+          "h": "Self-governing"
+        },
+        {
+          "w": "SECULAR",
+          "h": "No state religion"
+        },
+        {
+          "w": "DEMOCRATIC",
+          "h": "Rule by the people"
+        },
+        {
+          "w": "REPUBLIC",
+          "h": "Elected head of state"
+        },
+        {
+          "w": "FUNDAMENTAL",
+          "h": "____ rights"
+        },
+        {
+          "w": "DIRECTIVE",
+          "h": "____ principles"
+        },
+        {
+          "w": "EQUALITY",
+          "h": "Article 14 value"
+        },
+        {
+          "w": "LIBERTY",
+          "h": "Freedom protected by law"
+        },
+        {
+          "w": "PARLIAMENT",
+          "h": "Union legislature"
+        },
+        {
+          "w": "LOKSABHA",
+          "h": "House of the People"
+        },
+        {
+          "w": "RAJYASABHA",
+          "h": "Council of States"
+        },
+        {
+          "w": "FEDERALISM",
+          "h": "Power shared with states"
+        },
+        {
+          "w": "RESERVATION",
+          "h": "Affirmative quotas"
+        }
+      ]
+    },
+    {
+      "id": "global-dev-arch-wordsearch",
+      "title": "Development Institutions",
+      "course": "Global Development Architecture 101",
+      "track": "governance",
+      "type": "wordsearch",
+      "difficulty": "Medium",
+      "blurb": "Find actors in international development.",
+      "size": 17,
+      "words": [
+        {
+          "w": "UNDP",
+          "h": "UN Development Programme"
+        },
+        {
+          "w": "UNICEF",
+          "h": "UN Children's Fund"
+        },
+        {
+          "w": "WHO",
+          "h": "World Health Organization"
+        },
+        {
+          "w": "FAO",
+          "h": "Food and Agriculture Org"
+        },
+        {
+          "w": "WORLDBANK",
+          "h": "Major development lender"
+        },
+        {
+          "w": "IMF",
+          "h": "International Monetary Fund"
+        },
+        {
+          "w": "USAID",
+          "h": "US aid agency"
+        },
+        {
+          "w": "GAVI",
+          "h": "Vaccine alliance"
+        },
+        {
+          "w": "GLOBALFUND",
+          "h": "AIDS, TB and malaria fund"
+        },
+        {
+          "w": "BILATERAL",
+          "h": "Country-to-country aid"
+        },
+        {
+          "w": "MULTILATERAL",
+          "h": "Pooled multi-country aid"
+        },
+        {
+          "w": "ODA",
+          "h": "Official development assistance"
+        },
+        {
+          "w": "AIDEFFECTIVENESS",
+          "h": "Making aid work better"
+        },
+        {
+          "w": "PARISDECLARATION",
+          "h": "2005 aid principles"
+        }
+      ]
+    },
+    {
+      "id": "research-ethics-wordsearch",
+      "title": "Research Ethics",
+      "course": "Research Ethics 101",
+      "track": "mel-research",
+      "type": "wordsearch",
+      "difficulty": "Medium",
+      "blurb": "Find research-ethics frameworks and principles.",
+      "size": 16,
+      "words": [
+        {
+          "w": "BELMONT",
+          "h": "1979 ethics report"
+        },
+        {
+          "w": "NUREMBERG",
+          "h": "Post-war ethics code"
+        },
+        {
+          "w": "HELSINKI",
+          "h": "Declaration on medical research"
+        },
+        {
+          "w": "BENEFICENCE",
+          "h": "Do good, minimise harm"
+        },
+        {
+          "w": "AUTONOMY",
+          "h": "Respect for self-determination"
+        },
+        {
+          "w": "JUSTICE",
+          "h": "Fair distribution of risk"
+        },
+        {
+          "w": "CONSENT",
+          "h": "Informed agreement"
+        },
+        {
+          "w": "CONFIDENTIALITY",
+          "h": "Protecting identities"
+        },
+        {
+          "w": "ANONYMITY",
+          "h": "No identifiers collected"
+        },
+        {
+          "w": "VULNERABLE",
+          "h": "Groups needing protection"
+        },
+        {
+          "w": "IRB",
+          "h": "Institutional Review Board"
+        },
+        {
+          "w": "PROTOCOL",
+          "h": "Approved study plan"
+        },
+        {
+          "w": "RISKBENEFIT",
+          "h": "Weighing harms and gains"
+        },
+        {
+          "w": "ASSENT",
+          "h": "A child's agreement"
+        }
+      ]
+    },
+    {
+      "id": "community-dev-wordsearch",
+      "title": "Community Development",
+      "course": "Community Development 101",
+      "track": "governance",
+      "type": "wordsearch",
+      "difficulty": "Easy",
+      "blurb": "Find community-development methods.",
+      "size": 16,
+      "words": [
+        {
+          "w": "ASSETBASED",
+          "h": "Starting from strengths"
+        },
+        {
+          "w": "PARTICIPATORY",
+          "h": "Community-led"
+        },
+        {
+          "w": "MOBILISATION",
+          "h": "Rallying people to act"
+        },
+        {
+          "w": "EMPOWERMENT",
+          "h": "Building people's power"
+        },
+        {
+          "w": "OWNERSHIP",
+          "h": "Local control"
+        },
+        {
+          "w": "SOCIALCAPITAL",
+          "h": "Networks and trust"
+        },
+        {
+          "w": "TRANSECTWALK",
+          "h": "Observational walk"
+        },
+        {
+          "w": "WEALTHRANKING",
+          "h": "Sorting by well-being"
+        },
+        {
+          "w": "MAPPING",
+          "h": "Community ____"
+        },
+        {
+          "w": "FACILITATION",
+          "h": "Guiding group process"
+        },
+        {
+          "w": "INCLUSIVITY",
+          "h": "Leaving no one out"
+        },
+        {
+          "w": "GRASSROOTS",
+          "h": "Bottom-up action"
+        },
+        {
+          "w": "COLLECTIVE",
+          "h": "____ action"
+        },
+        {
+          "w": "SELFDETERMINATION",
+          "h": "Communities deciding"
+        }
+      ]
+    },
+    {
+      "id": "advocacy-wordsearch",
+      "title": "Advocacy & Campaigning",
+      "course": "Advocacy Basics",
+      "track": "governance",
+      "type": "wordsearch",
+      "difficulty": "Medium",
+      "blurb": "Find advocacy strategy and tactics.",
+      "size": 16,
+      "words": [
+        {
+          "w": "ADVOCACY",
+          "h": "Influencing policy"
+        },
+        {
+          "w": "LOBBYING",
+          "h": "Direct persuasion of decision-makers"
+        },
+        {
+          "w": "COALITION",
+          "h": "Alliance of actors"
+        },
+        {
+          "w": "GRASSROOTS",
+          "h": "Base mobilisation"
+        },
+        {
+          "w": "MEDIAADVOCACY",
+          "h": "Using media to influence"
+        },
+        {
+          "w": "POLICYBRIEF",
+          "h": "Short evidence summary"
+        },
+        {
+          "w": "STAKEHOLDER",
+          "h": "____ mapping"
+        },
+        {
+          "w": "POWERANALYSIS",
+          "h": "Mapping influence"
+        },
+        {
+          "w": "POLICYWINDOW",
+          "h": "Moment of opportunity"
+        },
+        {
+          "w": "FRAMING",
+          "h": "Shaping the issue"
+        },
+        {
+          "w": "MESSAGING",
+          "h": "Crafting the ask"
+        },
+        {
+          "w": "CHAMPION",
+          "h": "Inside supporter"
+        },
+        {
+          "w": "NEGOTIATION",
+          "h": "Bargaining for change"
+        },
+        {
+          "w": "OUTCOMEMAPPING",
+          "h": "Tracking influence"
+        }
+      ]
+    },
+    {
+      "id": "data-feminism-wordsearch",
+      "title": "Critical Data Studies",
+      "course": "Data Feminism",
+      "track": "gender-equity",
+      "type": "wordsearch",
+      "difficulty": "Medium",
+      "blurb": "Find data-justice vocabulary.",
+      "size": 17,
+      "words": [
+        {
+          "w": "ALGORITHMICBIAS",
+          "h": "Unfairness in models"
+        },
+        {
+          "w": "DATACOLONIALISM",
+          "h": "Extraction of human life"
+        },
+        {
+          "w": "SURVEILLANCE",
+          "h": "Watching populations"
+        },
+        {
+          "w": "MISSINGDATA",
+          "h": "What isn't counted"
+        },
+        {
+          "w": "PARTICIPATORY",
+          "h": "Community-led data"
+        },
+        {
+          "w": "SOVEREIGNTY",
+          "h": "Data ____"
+        },
+        {
+          "w": "COUNTERDATA",
+          "h": "Data from the margins"
+        },
+        {
+          "w": "THICKDATA",
+          "h": "Rich qualitative context"
+        },
+        {
+          "w": "STANDPOINT",
+          "h": "Situated knowledge"
+        },
+        {
+          "w": "EMBODIMENT",
+          "h": "Knowledge in bodies"
+        },
+        {
+          "w": "INTERSECTIONAL",
+          "h": "Overlapping identities"
+        },
+        {
+          "w": "PROXY",
+          "h": "____ discrimination"
+        },
+        {
+          "w": "FACIALRECOGNITION",
+          "h": "Biased identification tech"
+        },
+        {
+          "w": "JUSTICE",
+          "h": "Data ____"
+        }
+      ]
+    },
+    {
+      "id": "advocacy-matching",
+      "title": "Advocacy Toolkit",
+      "course": "Advocacy Basics",
+      "track": "governance",
+      "type": "matching",
+      "difficulty": "Medium",
+      "blurb": "Match each advocacy tool to its purpose.",
+      "pairs": [
+        {
+          "l": "Power analysis",
+          "r": "Mapping who holds influence over a decision"
+        },
+        {
+          "l": "Stakeholder mapping",
+          "r": "Plotting actors by interest and power"
+        },
+        {
+          "l": "Policy window",
+          "r": "A moment when change becomes possible"
+        },
+        {
+          "l": "Coalition",
+          "r": "An alliance that amplifies a shared demand"
+        },
+        {
+          "l": "Policy brief",
+          "r": "A short, evidence-based case for change"
+        },
+        {
+          "l": "Outcome mapping",
+          "r": "Tracking changes in actors' behaviour"
+        }
+      ]
+    },
+    {
+      "id": "bivariate-matching",
+      "title": "Reading Relationships",
+      "course": "Bivariate Analysis 101",
+      "track": "mel-research",
+      "type": "matching",
+      "difficulty": "Medium",
+      "blurb": "Match each statistic to what it tells you.",
+      "pairs": [
+        {
+          "l": "Pearson's r",
+          "r": "Strength and direction of a linear link"
+        },
+        {
+          "l": "Chi-square",
+          "r": "Whether two categorical variables are associated"
+        },
+        {
+          "l": "p-value",
+          "r": "Probability of a result if there were no real effect"
+        },
+        {
+          "l": "Confidence interval",
+          "r": "A plausible range for the true value"
+        },
+        {
+          "l": "Effect size",
+          "r": "How large a difference or relationship is"
+        },
+        {
+          "l": "Confounder",
+          "r": "A hidden variable that distorts a relationship"
+        }
+      ]
+    },
+    {
+      "id": "cost-effectiveness-matching",
+      "title": "Costing Concepts",
+      "course": "Cost Effectiveness 101",
+      "track": "policy-economics",
+      "type": "matching",
+      "difficulty": "Medium",
+      "blurb": "Match each costing term to its meaning.",
+      "pairs": [
+        {
+          "l": "Direct cost",
+          "r": "Resource used directly to deliver the service"
+        },
+        {
+          "l": "Indirect cost",
+          "r": "Productivity or time losses borne by participants"
+        },
+        {
+          "l": "Fixed cost",
+          "r": "Cost that doesn't change with output"
+        },
+        {
+          "l": "Marginal cost",
+          "r": "Cost of producing one more unit"
+        },
+        {
+          "l": "Ingredients approach",
+          "r": "Costing each input used by a programme"
+        },
+        {
+          "l": "Budget impact",
+          "r": "Total affordability for the payer"
+        }
+      ]
+    },
+    {
+      "id": "data-literacy-matching",
+      "title": "Data Vocabulary",
+      "course": "Data Literacy 101",
+      "track": "data-tech",
+      "type": "matching",
+      "difficulty": "Easy",
+      "blurb": "Match each term to its meaning.",
+      "pairs": [
+        {
+          "l": "Variable",
+          "r": "A characteristic that can take different values"
+        },
+        {
+          "l": "Categorical",
+          "r": "Data in groups, like region or sex"
+        },
+        {
+          "l": "Continuous",
+          "r": "Numeric data that can take any value in a range"
+        },
+        {
+          "l": "Median",
+          "r": "The middle value when data is ordered"
+        },
+        {
+          "l": "Outlier",
+          "r": "A value far from the rest"
+        },
+        {
+          "l": "Sample",
+          "r": "A subset drawn from a population"
+        }
+      ]
+    },
+    {
+      "id": "fundraising-matching",
+      "title": "Donor Relations",
+      "course": "Fundraising Basics",
+      "track": "policy-economics",
+      "type": "matching",
+      "difficulty": "Medium",
+      "blurb": "Match each fundraising term to its meaning.",
+      "pairs": [
+        {
+          "l": "Cultivation",
+          "r": "Building a relationship before asking"
+        },
+        {
+          "l": "Stewardship",
+          "r": "Caring for donors after a gift"
+        },
+        {
+          "l": "Restricted funds",
+          "r": "Money earmarked for a specific use"
+        },
+        {
+          "l": "Core funding",
+          "r": "Flexible, unrestricted support"
+        },
+        {
+          "l": "Concept note",
+          "r": "A brief pitch before a full proposal"
+        },
+        {
+          "l": "Cost recovery",
+          "r": "Recouping indirect and overhead costs"
+        }
+      ]
+    },
+    {
+      "id": "irt-matching",
+      "title": "Psychometric Terms",
+      "course": "IRT Basics",
+      "track": "mel-research",
+      "type": "matching",
+      "difficulty": "Advanced",
+      "blurb": "Match each IRT term to its meaning.",
+      "pairs": [
+        {
+          "l": "Latent trait",
+          "r": "The unobserved ability being measured"
+        },
+        {
+          "l": "Item difficulty",
+          "r": "Trait level where half answer correctly"
+        },
+        {
+          "l": "Discrimination",
+          "r": "How sharply an item separates ability levels"
+        },
+        {
+          "l": "DIF",
+          "r": "Items behaving differently across equal-ability groups"
+        },
+        {
+          "l": "Test information",
+          "r": "Where the test measures most precisely"
+        },
+        {
+          "l": "Rasch model",
+          "r": "One-parameter model with difficulty only"
+        }
+      ]
+    },
+    {
+      "id": "livelihood-matching",
+      "title": "Livelihood Interventions",
+      "course": "Livelihood Basics",
+      "track": "policy-economics",
+      "type": "matching",
+      "difficulty": "Medium",
+      "blurb": "Match each intervention to its aim.",
+      "pairs": [
+        {
+          "l": "Value chain development",
+          "r": "Improving links from producer to market"
+        },
+        {
+          "l": "Savings group",
+          "r": "Pooling savings and small loans locally"
+        },
+        {
+          "l": "Graduation approach",
+          "r": "Moving the ultra-poor to sustainable livelihoods"
+        },
+        {
+          "l": "Agricultural extension",
+          "r": "Bringing know-how to farmers"
+        },
+        {
+          "l": "Skills training",
+          "r": "Building employable capabilities"
+        },
+        {
+          "l": "Market linkage",
+          "r": "Connecting producers to buyers"
+        }
+      ]
+    },
+    {
+      "id": "obs2insight-matching",
+      "title": "Observation Concepts",
+      "course": "Obs2Insight",
+      "track": "mel-research",
+      "type": "matching",
+      "difficulty": "Easy",
+      "blurb": "Match each observation term to its meaning.",
+      "pairs": [
+        {
+          "l": "Participant observation",
+          "r": "Joining in while observing"
+        },
+        {
+          "l": "Field notes",
+          "r": "Detailed written records of observation"
+        },
+        {
+          "l": "Hawthorne effect",
+          "r": "People changing behaviour when watched"
+        },
+        {
+          "l": "Emic",
+          "r": "The insider's point of view"
+        },
+        {
+          "l": "Etic",
+          "r": "The outsider's analytical view"
+        },
+        {
+          "l": "Triangulation",
+          "r": "Cross-checking with other methods"
+        }
+      ]
+    },
+    {
+      "id": "research-ethics-matching",
+      "title": "Ethical Principles",
+      "course": "Research Ethics 101",
+      "track": "mel-research",
+      "type": "matching",
+      "difficulty": "Medium",
+      "blurb": "Match each principle or term to its meaning.",
+      "pairs": [
+        {
+          "l": "Respect for persons",
+          "r": "Honouring autonomy and informed consent"
+        },
+        {
+          "l": "Beneficence",
+          "r": "Maximising benefit, minimising harm"
+        },
+        {
+          "l": "Justice",
+          "r": "Fair distribution of risks and benefits"
+        },
+        {
+          "l": "Confidentiality",
+          "r": "Protecting identifiable information"
+        },
+        {
+          "l": "Assent",
+          "r": "A child's agreement alongside parental consent"
+        },
+        {
+          "l": "IRB",
+          "r": "Body that reviews studies to protect participants"
+        }
+      ]
+    },
+    {
+      "id": "sel-matching",
+      "title": "SEL Concepts",
+      "course": "SEL Basics",
+      "track": "health-comms",
+      "type": "matching",
+      "difficulty": "Easy",
+      "blurb": "Match each SEL idea to its meaning.",
+      "pairs": [
+        {
+          "l": "Self-awareness",
+          "r": "Recognising one's emotions and values"
+        },
+        {
+          "l": "Self-management",
+          "r": "Regulating emotions and impulses"
+        },
+        {
+          "l": "Social awareness",
+          "r": "Empathy and perspective-taking"
+        },
+        {
+          "l": "Growth mindset",
+          "r": "Believing abilities can be developed"
+        },
+        {
+          "l": "Restorative practice",
+          "r": "Repairing harm and relationships"
+        },
+        {
+          "l": "Trauma-informed",
+          "r": "Sensitive to the effects of adversity"
+        }
+      ]
+    },
+    {
+      "id": "social-margins-matching",
+      "title": "Inclusion Concepts",
+      "course": "Social Margins",
+      "track": "gender-equity",
+      "type": "matching",
+      "difficulty": "Medium",
+      "blurb": "Match each term to its meaning.",
+      "pairs": [
+        {
+          "l": "Intersectionality",
+          "r": "Overlapping identities compounding disadvantage"
+        },
+        {
+          "l": "Stigma",
+          "r": "A discrediting social mark"
+        },
+        {
+          "l": "Reasonable accommodation",
+          "r": "Adjustments enabling disabled people to participate"
+        },
+        {
+          "l": "Universal design",
+          "r": "Designing for the widest range of users"
+        },
+        {
+          "l": "Affirmative action",
+          "r": "Measures favouring under-represented groups"
+        },
+        {
+          "l": "Matrix of domination",
+          "r": "Interlocking systems of power"
+        }
+      ]
+    },
+    {
+      "id": "safety-nets-matching",
+      "title": "Programme Design",
+      "course": "Social Safety Nets",
+      "track": "policy-economics",
+      "type": "matching",
+      "difficulty": "Medium",
+      "blurb": "Match each safety-net concept to its meaning.",
+      "pairs": [
+        {
+          "l": "Proxy means test",
+          "r": "Estimating need from observable assets"
+        },
+        {
+          "l": "Conditional transfer",
+          "r": "Payment tied to behaviours"
+        },
+        {
+          "l": "Shock-responsive",
+          "r": "Scalable in crises"
+        },
+        {
+          "l": "Social protection floor",
+          "r": "Basic guarantees for all"
+        },
+        {
+          "l": "Self-targeting",
+          "r": "Design that mainly attracts the poor"
+        },
+        {
+          "l": "Consumption smoothing",
+          "r": "Stabilising spending across time"
+        }
+      ]
+    },
+    {
+      "id": "care-economy-cloze",
+      "title": "Care Economy: Fill the Gaps",
+      "course": "Care Economy 101",
+      "track": "gender-equity",
+      "type": "cloze",
+      "difficulty": "Medium",
+      "blurb": "Complete each statement about care work.",
+      "bank": [
+        "unpaid",
+        "redistribute",
+        "reproduction",
+        "time",
+        "satellite",
+        "diamond"
+      ],
+      "items": [
+        {
+          "text": "Most care work is {} and falls disproportionately on women.",
+          "answer": "unpaid"
+        },
+        {
+          "text": "Care is part of social {}, the work of sustaining people day to day.",
+          "answer": "reproduction"
+        },
+        {
+          "text": "Heavy care duties create {} poverty, leaving little for paid work or rest.",
+          "answer": "time"
+        },
+        {
+          "text": "The third 'R' urges us to {} care more fairly between women, men and the state.",
+          "answer": "redistribute"
+        },
+        {
+          "text": "Unpaid work can be valued in a {} account alongside GDP.",
+          "answer": "satellite"
+        },
+        {
+          "text": "The care {} describes the mix of family, state, market and non-profit provision.",
+          "answer": "diamond"
+        }
+      ]
+    },
+    {
+      "id": "decent-work-cloze",
+      "title": "Decent Work: Fill the Gaps",
+      "course": "Decent Work 101",
+      "track": "policy-economics",
+      "type": "cloze",
+      "difficulty": "Medium",
+      "blurb": "Complete each statement about labour rights.",
+      "bank": [
+        "association",
+        "bargaining",
+        "living",
+        "informal",
+        "forced",
+        "tripartite"
+      ],
+      "items": [
+        {
+          "text": "Freedom of {} is the right to form and join trade unions.",
+          "answer": "association"
+        },
+        {
+          "text": "Through collective {}, workers negotiate pay and conditions as a group.",
+          "answer": "bargaining"
+        },
+        {
+          "text": "A {} wage covers a worker and family's basic needs.",
+          "answer": "living"
+        },
+        {
+          "text": "Most workers in poor economies are in {} employment, outside legal protection.",
+          "answer": "informal"
+        },
+        {
+          "text": "Work exacted under threat and not offered voluntarily is {} labour.",
+          "answer": "forced"
+        },
+        {
+          "text": "The ILO works through {} dialogue among governments, employers and workers.",
+          "answer": "tripartite"
+        }
+      ]
+    },
+    {
+      "id": "english-dev-cloze",
+      "title": "Development Writing: Fill the Gaps",
+      "course": "English for Development Professionals",
+      "track": "mel-research",
+      "type": "cloze",
+      "difficulty": "Easy",
+      "blurb": "Complete each sentence with the right term.",
+      "bank": [
+        "beneficiaries",
+        "baseline",
+        "sustainability",
+        "stakeholders",
+        "deliverables",
+        "scalable"
+      ],
+      "items": [
+        {
+          "text": "The people a programme serves are its {}.",
+          "answer": "beneficiaries"
+        },
+        {
+          "text": "All affected and interested parties are {}.",
+          "answer": "stakeholders"
+        },
+        {
+          "text": "A {} survey captures conditions before the programme starts.",
+          "answer": "baseline"
+        },
+        {
+          "text": "If results last after funding ends, the programme has {}.",
+          "answer": "sustainability"
+        },
+        {
+          "text": "Contractual outputs a consultant must produce are {}.",
+          "answer": "deliverables"
+        },
+        {
+          "text": "An approach that can expand to reach many more people is {}.",
+          "answer": "scalable"
+        }
+      ]
+    },
+    {
+      "id": "env-justice-cloze",
+      "title": "Environmental Justice: Fill the Gaps",
+      "course": "Environmental Justice 101",
+      "track": "climate-env",
+      "type": "cloze",
+      "difficulty": "Medium",
+      "blurb": "Complete each statement.",
+      "bank": [
+        "distributive",
+        "procedural",
+        "frontline",
+        "polluter",
+        "precautionary",
+        "recognition"
+      ],
+      "items": [
+        {
+          "text": "{} justice concerns the fair sharing of environmental burdens and benefits.",
+          "answer": "distributive"
+        },
+        {
+          "text": "{} justice concerns fair, inclusive decision-making processes.",
+          "answer": "procedural"
+        },
+        {
+          "text": "Communities first and worst hit by harm are {} communities.",
+          "answer": "frontline"
+        },
+        {
+          "text": "The {} pays principle says those causing pollution should bear its cost.",
+          "answer": "polluter"
+        },
+        {
+          "text": "The {} principle favours caution when harm is uncertain but serious.",
+          "answer": "precautionary"
+        },
+        {
+          "text": "{} justice means valuing the identities and knowledge of affected groups.",
+          "answer": "recognition"
+        }
+      ]
+    },
+    {
+      "id": "multivariate-cloze",
+      "title": "Multivariate Analysis: Fill the Gaps",
+      "course": "Multivariate Analysis Basics",
+      "track": "mel-research",
+      "type": "cloze",
+      "difficulty": "Advanced",
+      "blurb": "Complete each statement.",
+      "bank": [
+        "logistic",
+        "multicollinearity",
+        "mediation",
+        "factor",
+        "interaction",
+        "standardised"
+      ],
+      "items": [
+        {
+          "text": "{} regression models the probability of a binary outcome.",
+          "answer": "logistic"
+        },
+        {
+          "text": "When predictors are highly correlated, {} makes their effects hard to separate.",
+          "answer": "multicollinearity"
+        },
+        {
+          "text": "{} analysis tests whether one variable carries another's effect.",
+          "answer": "mediation"
+        },
+        {
+          "text": "{} analysis uncovers latent dimensions behind many items.",
+          "answer": "factor"
+        },
+        {
+          "text": "An {} term lets one predictor's effect depend on another.",
+          "answer": "interaction"
+        },
+        {
+          "text": "{} coefficients let you compare predictors on a common scale.",
+          "answer": "standardised"
+        }
+      ]
+    },
+    {
+      "id": "post-truth-cloze",
+      "title": "Information Disorder: Fill the Gaps",
+      "course": "Post-Truth Politics 101",
+      "track": "governance",
+      "type": "cloze",
+      "difficulty": "Medium",
+      "blurb": "Complete each statement.",
+      "bank": [
+        "disinformation",
+        "misinformation",
+        "prebunking",
+        "lateral",
+        "echo",
+        "deepfake"
+      ],
+      "items": [
+        {
+          "text": "False content spread without intent to harm is {}.",
+          "answer": "misinformation"
+        },
+        {
+          "text": "False content created and spread to deceive is {}.",
+          "answer": "disinformation"
+        },
+        {
+          "text": "Building resistance to false claims before exposure is {}.",
+          "answer": "prebunking"
+        },
+        {
+          "text": "Checking a source by leaving it to see what others say is {} reading.",
+          "answer": "lateral"
+        },
+        {
+          "text": "A belief-reinforcing media environment is an {} chamber.",
+          "answer": "echo"
+        },
+        {
+          "text": "AI-fabricated, realistic video or audio is a {}.",
+          "answer": "deepfake"
+        }
+      ]
+    },
+    {
+      "id": "srhr-cloze",
+      "title": "SRHR: Fill the Gaps",
+      "course": "SRHR Basics",
+      "track": "health-comms",
+      "type": "cloze",
+      "difficulty": "Medium",
+      "blurb": "Complete each statement.",
+      "bank": [
+        "autonomy",
+        "contraception",
+        "antenatal",
+        "consent",
+        "unmet",
+        "comprehensive"
+      ],
+      "items": [
+        {
+          "text": "Bodily {} is the right to make decisions about one's own body.",
+          "answer": "autonomy"
+        },
+        {
+          "text": "Methods used to prevent pregnancy are {}.",
+          "answer": "contraception"
+        },
+        {
+          "text": "Care during pregnancy is {} care.",
+          "answer": "antenatal"
+        },
+        {
+          "text": "Care should be confidential and based on informed {}.",
+          "answer": "consent"
+        },
+        {
+          "text": "Wanting to avoid pregnancy but using no method is {} need.",
+          "answer": "unmet"
+        },
+        {
+          "text": "Age-appropriate teaching on bodies and rights is {} sexuality education.",
+          "answer": "comprehensive"
+        }
+      ]
+    },
+    {
+      "id": "visual-ethnography-cloze",
+      "title": "Visual Methods: Fill the Gaps",
+      "course": "Visual Ethnography 101",
+      "track": "mel-research",
+      "type": "cloze",
+      "difficulty": "Easy",
+      "blurb": "Complete each statement.",
+      "bank": [
+        "photovoice",
+        "semiotics",
+        "consent",
+        "representation",
+        "elicitation",
+        "multimodal"
+      ],
+      "items": [
+        {
+          "text": "In {}, participants take and discuss their own photographs.",
+          "answer": "photovoice"
+        },
+        {
+          "text": "Using images to deepen interview responses is photo {}.",
+          "answer": "elicitation"
+        },
+        {
+          "text": "The study of signs and how images mean is {}.",
+          "answer": "semiotics"
+        },
+        {
+          "text": "Depicting people fairly and with dignity is about {}.",
+          "answer": "representation"
+        },
+        {
+          "text": "Photographing identifiable people requires informed {}.",
+          "answer": "consent"
+        },
+        {
+          "text": "Analysing text, image and sound together is {} analysis.",
+          "answer": "multimodal"
+        }
+      ]
+    },
+    {
+      "id": "wee-cloze",
+      "title": "Women's Economic Empowerment: Fill the Gaps",
+      "course": "WEE Studies",
+      "track": "gender-equity",
+      "type": "cloze",
+      "difficulty": "Medium",
+      "blurb": "Complete each statement.",
+      "bank": [
+        "agency",
+        "segregation",
+        "motherhood",
+        "tenure",
+        "inclusion",
+        "unpaid"
+      ],
+      "items": [
+        {
+          "text": "A woman's power to set goals and act on them is {}.",
+          "answer": "agency"
+        },
+        {
+          "text": "The earnings drop women face after having children is the {} penalty.",
+          "answer": "motherhood"
+        },
+        {
+          "text": "Women's concentration in particular jobs is occupational {}.",
+          "answer": "segregation"
+        },
+        {
+          "text": "Secure rights to land are land {}.",
+          "answer": "tenure"
+        },
+        {
+          "text": "Access to and use of financial services is financial {}.",
+          "answer": "inclusion"
+        },
+        {
+          "text": "Care done without pay, limiting paid work, is {} care.",
+          "answer": "unpaid"
+        }
+      ]
+    },
+    {
+      "id": "community-dev-sequence",
+      "title": "Community Action Planning",
+      "course": "Community Development 101",
+      "track": "governance",
+      "type": "sequence",
+      "difficulty": "Easy",
+      "blurb": "",
+      "prompt": "Order the steps of a participatory community process.",
+      "items": [
+        "Build trust and enter the community respectfully",
+        "Facilitate a participatory needs and asset assessment",
+        "Prioritise issues together with the community",
+        "Develop a community action plan",
+        "Implement with local ownership",
+        "Reflect, learn and sustain the initiative"
+      ]
+    },
+    {
+      "id": "qual-methods-sequence",
+      "title": "The Qualitative Research Process",
+      "course": "Qualitative Methods",
+      "track": "mel-research",
+      "type": "sequence",
+      "difficulty": "Medium",
+      "blurb": "",
+      "prompt": "Order the stages of a qualitative study.",
+      "items": [
+        "Define the research question",
+        "Choose an approach and sampling strategy",
+        "Collect data through interviews or observation",
+        "Transcribe and code the data",
+        "Develop themes through analysis",
+        "Write up with thick description and reflexivity"
+      ]
+    },
+    {
+      "id": "eda-categorize",
+      "title": "Choosing the Right Chart",
+      "course": "EDA for HH Surveys",
+      "track": "mel-research",
+      "type": "categorize",
+      "difficulty": "Medium",
+      "blurb": "Sort each task under the chart that fits best.",
+      "categories": [
+        "Histogram",
+        "Bar chart",
+        "Scatter plot"
+      ],
+      "items": [
+        {
+          "t": "Show the distribution of household income",
+          "c": 0
+        },
+        {
+          "t": "See the shape and spread of ages",
+          "c": 0
+        },
+        {
+          "t": "Compare counts across regions",
+          "c": 1
+        },
+        {
+          "t": "Show frequency of each caste category",
+          "c": 1
+        },
+        {
+          "t": "Explore income versus years of schooling",
+          "c": 2
+        },
+        {
+          "t": "Check the relationship between two continuous variables",
+          "c": 2
+        }
+      ]
+    },
+    {
+      "id": "economics-101-crossword",
+      "title": "Microeconomics Foundations",
+      "course": "Economics 101",
+      "track": "policy-economics",
+      "type": "crossword",
+      "difficulty": "Easy",
+      "blurb": "Key ideas from introductory microeconomics.",
+      "entries": [
+        {
+          "a": "DEMAND",
+          "c": "Quantity buyers will purchase at each price"
+        },
+        {
+          "a": "SUPPLY",
+          "c": "Quantity sellers offer at each price"
+        },
+        {
+          "a": "ELASTICITY",
+          "c": "Responsiveness of quantity to price change"
+        },
+        {
+          "a": "MONOPOLY",
+          "c": "Market with a single seller"
+        },
+        {
+          "a": "OLIGOPOLY",
+          "c": "Market dominated by a few firms"
+        },
+        {
+          "a": "UTILITY",
+          "c": "Satisfaction a consumer gets from a good"
+        },
+        {
+          "a": "SURPLUS",
+          "c": "Gap between value and price, for buyer or seller"
+        },
+        {
+          "a": "EXTERNALITY",
+          "c": "Cost or benefit falling on a third party"
+        },
+        {
+          "a": "MARGINAL",
+          "c": "____ cost: the cost of one more unit"
+        },
+        {
+          "a": "SCARCITY",
+          "c": "The basic economic problem of limited resources"
+        }
+      ]
+    },
+    {
+      "id": "data-feminism-crossword",
+      "title": "Data Power & Justice",
+      "course": "Data Feminism",
+      "track": "gender-equity",
+      "type": "crossword",
+      "difficulty": "Advanced",
+      "blurb": "Concepts from feminist and critical data studies.",
+      "entries": [
+        {
+          "a": "POWER",
+          "c": "Data feminism begins by examining ____"
+        },
+        {
+          "a": "BIAS",
+          "c": "Systematic unfairness baked into a model"
+        },
+        {
+          "a": "COLONIALISM",
+          "c": "Data ____: extraction of human life as raw material"
+        },
+        {
+          "a": "MISSING",
+          "c": "____ data: what goes uncounted and unseen"
+        },
+        {
+          "a": "STANDPOINT",
+          "c": "Situated, partial knowledge from a social position"
+        },
+        {
+          "a": "SURVEILLANCE",
+          "c": "Pervasive monitoring, often for profit"
+        },
+        {
+          "a": "EMBODIMENT",
+          "c": "Feminist data work values emotion and ____"
+        },
+        {
+          "a": "COUNTERDATA",
+          "c": "Community-produced data exposing injustice"
+        },
+        {
+          "a": "PLURALISM",
+          "c": "Embracing many ways of knowing"
+        },
+        {
+          "a": "CONTEXT",
+          "c": "Data is never raw; always consider its ____"
+        }
+      ]
+    },
+    {
+      "id": "political-economy-crossword",
+      "title": "Institutions & Power",
+      "course": "Political Economy",
+      "track": "governance",
+      "type": "crossword",
+      "difficulty": "Advanced",
+      "blurb": "The political economy of development.",
+      "entries": [
+        {
+          "a": "INSTITUTIONS",
+          "c": "The rules of the game shaping incentives"
+        },
+        {
+          "a": "RENTSEEKING",
+          "c": "Pursuing income by manipulating policy"
+        },
+        {
+          "a": "CLIENTELISM",
+          "c": "Trading benefits for political support"
+        },
+        {
+          "a": "CORRUPTION",
+          "c": "Abuse of public office for private gain"
+        },
+        {
+          "a": "CAPTURE",
+          "c": "When regulators serve the regulated"
+        },
+        {
+          "a": "LEGITIMACY",
+          "c": "Accepted right of an authority to rule"
+        },
+        {
+          "a": "ACCOUNTABILITY",
+          "c": "Answerability of power-holders to citizens"
+        },
+        {
+          "a": "PATRONAGE",
+          "c": "Distributing favours for loyalty"
+        },
+        {
+          "a": "EXTRACTIVE",
+          "c": "Institutions that concentrate power and wealth"
+        },
+        {
+          "a": "SETTLEMENT",
+          "c": "Political ____: the balance of power among elites"
+        }
+      ]
+    },
+    {
+      "id": "bcc-quiz",
+      "title": "Designing Behaviour Change",
+      "course": "BCC Comms",
+      "track": "health-comms",
+      "type": "quiz",
+      "difficulty": "Intermediate",
+      "blurb": "Test your grasp of behaviour-change communication.",
+      "questions": [
+        {
+          "q": "In the Health Belief Model, action is most likely when a person perceives:",
+          "options": [
+            "Low risk and high cost",
+            "High susceptibility and high benefits of acting",
+            "No threat at all",
+            "Only social pressure"
+          ],
+          "answer": 1,
+          "explanation": "The Health Belief Model predicts action when perceived susceptibility and severity are high and the perceived benefits of acting outweigh the barriers."
+        },
+        {
+          "q": "'Formative research' in a BCC campaign is conducted:",
+          "options": [
+            "After the campaign ends",
+            "Before designing messages, to understand the audience",
+            "Only by donors",
+            "To replace evaluation"
+          ],
+          "answer": 1,
+          "explanation": "Formative research explores audience knowledge, attitudes, barriers and channels up front, so messages and materials are grounded in evidence."
+        },
+        {
+          "q": "Entertainment-education (edutainment) works mainly by:",
+          "options": [
+            "Forcing behaviour through penalties",
+            "Modelling behaviours and norms through engaging stories",
+            "Banning media",
+            "Paying audiences"
+          ],
+          "answer": 1,
+          "explanation": "Edutainment embeds messages in compelling narratives, letting audiences learn vicariously from role models and shifting perceived norms."
+        },
+        {
+          "q": "A 'social norms' approach assumes behaviour is shaped by:",
+          "options": [
+            "Only personal attitudes",
+            "Beliefs about what others do and approve of",
+            "Random chance",
+            "Government rules alone"
+          ],
+          "answer": 1,
+          "explanation": "Norms-based campaigns correct misperceptions about what is common or acceptable, since people often act on what they think others do."
+        },
+        {
+          "q": "Pre-testing materials before launch helps to:",
+          "options": [
+            "Save money by skipping research",
+            "Check that messages are clear, acceptable and persuasive to the audience",
+            "Guarantee behaviour change",
+            "Avoid working with communities"
+          ],
+          "answer": 1,
+          "explanation": "Pre-testing with the intended audience catches confusing, offensive or ineffective content before scarce resources are spent on rollout."
+        }
+      ]
+    },
+    {
+      "id": "digital-ethics-quiz",
+      "title": "Privacy & Data Protection",
+      "course": "Digital Ethics 101",
+      "track": "data-tech",
+      "type": "quiz",
+      "difficulty": "Intermediate",
+      "blurb": "Test your knowledge of data privacy.",
+      "questions": [
+        {
+          "q": "'Data minimisation' means:",
+          "options": [
+            "Collecting as much data as possible",
+            "Collecting only the data needed for a stated purpose",
+            "Deleting all data",
+            "Encrypting everything"
+          ],
+          "answer": 1,
+          "explanation": "Data minimisation, a core privacy principle, limits collection to what is strictly necessary for a specified, legitimate purpose."
+        },
+        {
+          "q": "Anonymisation differs from pseudonymisation because anonymised data:",
+          "options": [
+            "Can always be re-identified",
+            "Cannot be linked back to an individual even with extra information",
+            "Uses real names",
+            "Is never useful"
+          ],
+          "answer": 1,
+          "explanation": "True anonymisation removes the possibility of re-identification; pseudonymisation merely replaces identifiers that could be restored with a key."
+        },
+        {
+          "q": "'Purpose limitation' requires that personal data is:",
+          "options": [
+            "Used for any future purpose",
+            "Used only for the purposes for which it was collected",
+            "Sold to third parties",
+            "Kept forever"
+          ],
+          "answer": 1,
+          "explanation": "Purpose limitation means data gathered for one stated purpose should not be repurposed incompatibly without a fresh lawful basis."
+        },
+        {
+          "q": "Under the GDPR, the 'right to be forgotten' lets a person:",
+          "options": [
+            "Demand deletion of certain personal data",
+            "Avoid all taxes",
+            "Access any company's files",
+            "Delete other people's data"
+          ],
+          "answer": 0,
+          "explanation": "The right to erasure allows individuals, in defined circumstances, to have their personal data deleted by the controller."
+        },
+        {
+          "q": "A privacy impact assessment is best done:",
+          "options": [
+            "After a breach",
+            "Before launching a data-processing project, to identify and reduce risks",
+            "Only if regulators ask",
+            "Never"
+          ],
+          "answer": 1,
+          "explanation": "A PIA/DPIA is a proactive tool to surface and mitigate privacy risks during design, not a reactive clean-up after problems occur."
+        }
+      ]
+    },
+    {
+      "id": "econometrics-quiz",
+      "title": "Interpreting Regression",
+      "course": "Econometrics 101",
+      "track": "mel-research",
+      "type": "quiz",
+      "difficulty": "Advanced",
+      "blurb": "Test your understanding of regression in evaluation.",
+      "questions": [
+        {
+          "q": "An OLS coefficient on a binary 'treatment' variable estimates:",
+          "options": [
+            "The correlation only",
+            "The average difference in outcome associated with treatment, holding other regressors fixed",
+            "The R-squared",
+            "The sample size"
+          ],
+          "answer": 1,
+          "explanation": "The coefficient gives the estimated change in the outcome for treated vs untreated units, conditional on the other variables in the model."
+        },
+        {
+          "q": "A statistically significant result with a tiny effect size means:",
+          "options": [
+            "The effect is large and important",
+            "The effect is precisely estimated but may be practically trivial",
+            "The model is wrong",
+            "Causation is proven"
+          ],
+          "answer": 1,
+          "explanation": "Significance is about precision/chance, not importance. With large samples even trivial effects can be 'significant', so report effect sizes too."
+        },
+        {
+          "q": "Clustered standard errors are used when:",
+          "options": [
+            "Observations are fully independent",
+            "Observations are correlated within groups, e.g. pupils within schools",
+            "There is no variation",
+            "The sample is tiny"
+          ],
+          "answer": 1,
+          "explanation": "Clustering corrects standard errors for within-group correlation; ignoring it understates uncertainty and overstates significance."
+        },
+        {
+          "q": "In difference-in-differences, the key identifying assumption is:",
+          "options": [
+            "Random assignment",
+            "Parallel trends: groups would have moved together absent treatment",
+            "No control group",
+            "Perfect data"
+          ],
+          "answer": 1,
+          "explanation": "DID attributes the divergence after treatment to the programme only if the treated and comparison groups would otherwise have followed parallel paths."
+        },
+        {
+          "q": "An instrumental variable must be:",
+          "options": [
+            "Correlated with treatment and affect the outcome only through treatment",
+            "Random noise",
+            "The outcome itself",
+            "A perfect predictor of the outcome"
+          ],
+          "answer": 0,
+          "explanation": "A valid instrument is relevant (predicts treatment) and satisfies the exclusion restriction (affects the outcome only via treatment)."
+        }
+      ]
+    },
+    {
+      "id": "education-quiz",
+      "title": "Effective Teaching",
+      "course": "Education & Pedagogy 101",
+      "track": "mel-research",
+      "type": "quiz",
+      "difficulty": "Intermediate",
+      "blurb": "Test your knowledge of pedagogy.",
+      "questions": [
+        {
+          "q": "Vygotsky's 'zone of proximal development' is the gap between what a learner can do:",
+          "options": [
+            "With no help and with no help",
+            "Alone and with guidance from a more capable other",
+            "Yesterday and today",
+            "In two subjects"
+          ],
+          "answer": 1,
+          "explanation": "The ZPD is the range of tasks a learner can accomplish with support but not yet independently — the sweet spot for scaffolded teaching."
+        },
+        {
+          "q": "Formative assessment is primarily used to:",
+          "options": [
+            "Rank and grade at the end",
+            "Give feedback during learning to improve it",
+            "Replace teaching",
+            "Punish errors"
+          ],
+          "answer": 1,
+          "explanation": "Formative assessment informs ongoing teaching and learning with timely feedback; summative assessment judges achievement at the end."
+        },
+        {
+          "q": "'Scaffolding' refers to:",
+          "options": [
+            "Permanent support that is never removed",
+            "Temporary support gradually withdrawn as competence grows",
+            "Physical classroom structures",
+            "Standardised testing"
+          ],
+          "answer": 1,
+          "explanation": "Scaffolding provides structured help that is faded over time, transferring responsibility to the learner as they become able."
+        },
+        {
+          "q": "Bloom's taxonomy orders cognitive skills from:",
+          "options": [
+            "Creating down to remembering",
+            "Remembering up to higher-order skills like analysing and creating",
+            "Easy to expensive",
+            "Cheap to hard"
+          ],
+          "answer": 1,
+          "explanation": "Bloom's taxonomy moves from lower-order (remember, understand) to higher-order thinking (apply, analyse, evaluate, create)."
+        },
+        {
+          "q": "Freire's critical pedagogy emphasises:",
+          "options": [
+            "Rote memorisation",
+            "Dialogue and learners' critical consciousness for liberation",
+            "Silent obedience",
+            "Teaching only elites"
+          ],
+          "answer": 1,
+          "explanation": "Freire critiqued the 'banking' model and championed dialogic education that raises critical consciousness (conscientização)."
+        }
+      ]
+    },
+    {
+      "id": "global-dev-arch-quiz",
+      "title": "Aid Effectiveness",
+      "course": "Global Development Architecture 101",
+      "track": "governance",
+      "type": "quiz",
+      "difficulty": "Intermediate",
+      "blurb": "Test your knowledge of the aid system.",
+      "questions": [
+        {
+          "q": "'Ownership' in the Paris Declaration means:",
+          "options": [
+            "Donors own the projects",
+            "Partner countries lead their own development strategies",
+            "NGOs own the funds",
+            "No one is responsible"
+          ],
+          "answer": 1,
+          "explanation": "Ownership is the principle that developing countries set their own strategies and donors align behind them, rather than imposing priorities."
+        },
+        {
+          "q": "'Tied aid' refers to assistance that:",
+          "options": [
+            "Comes with no conditions",
+            "Must be spent on goods or services from the donor country",
+            "Is always cash",
+            "Is provided by NGOs"
+          ],
+          "answer": 1,
+          "explanation": "Tied aid requires procurement from the donor, which can raise costs and reduce value for the recipient compared with untied aid."
+        },
+        {
+          "q": "Official Development Assistance (ODA) is defined by the:",
+          "options": [
+            "UN Security Council",
+            "OECD Development Assistance Committee",
+            "World Trade Organization",
+            "G20"
+          ],
+          "answer": 1,
+          "explanation": "The OECD DAC sets the definition of ODA — concessional flows to eligible countries for development and welfare."
+        },
+        {
+          "q": "Budget support differs from project aid because it:",
+          "options": [
+            "Funds a single project",
+            "Channels funds through the partner government's own budget and systems",
+            "Bypasses governments",
+            "Is only humanitarian"
+          ],
+          "answer": 1,
+          "explanation": "Budget support provides funds through national systems, strengthening alignment and ownership but raising fiduciary and accountability questions."
+        },
+        {
+          "q": "'South-South cooperation' describes:",
+          "options": [
+            "Aid only from the Global North",
+            "Development cooperation among developing countries",
+            "Military alliances",
+            "Private philanthropy"
+          ],
+          "answer": 1,
+          "explanation": "South-South cooperation is exchange of resources, technology and knowledge between developing countries, complementing traditional North-South aid."
+        }
+      ]
     }
   ]
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,13 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.32.0 — May 31, 2026 (Puzzle Library: 117 puzzles + redesigned hub)
+
+### For Learners
+
+- **The Puzzle Library now has 117 puzzles — at least three per course**, so every one of the 39 ImpactMojo courses offers real variety: a word search plus a mix of crosswords, quizzes, matching, fill-in-the-blank, sorting, and sequencing.
+- **Redesigned puzzle hub** — puzzles are now grouped into colour-coded learning tracks (each with its folk-art accent), with a sticky track/format filter bar, at-a-glance stats, per-track progress, and refined cards that show a completion tick once you finish a puzzle.
+
 ## v10.31.0 — May 31, 2026 (Puzzle Library expands to all 39 courses)
 
 ### For Learners

--- a/index.html
+++ b/index.html
@@ -2356,11 +2356,11 @@ window.addEventListener('authStateChanged', function(e) {
                             </span>
 <span class="learner-badge">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Activity"/></svg>
-                                50 puzzles
+                                117 puzzles
                             </span>
 </div>
 <h3 class="card-title">Puzzle Library</h3>
-<p class="card-description">Seven formats — crosswords, quizzes, word searches, matching, sequencing, sorting and fill-in-the-blank — covering all 39 ImpactMojo courses. Free, in-browser, with progress saved on your device.</p>
+<p class="card-description">117 puzzles in seven formats — crosswords, quizzes, word searches, matching, sequencing, sorting and fill-in-the-blank — with at least three per course across all 39 ImpactMojo courses. Free, in-browser, progress saved on your device.</p>
 </a>
 </div>
 </div>

--- a/puzzle-library.html
+++ b/puzzle-library.html
@@ -113,54 +113,86 @@ a { color: var(--color-primary); }
 
 .hero {
   background: var(--color-primary-gradient); color: #fff;
-  padding: 3rem 1.25rem 2.5rem; text-align: center; position: relative; overflow: hidden;
+  padding: 3.5rem 1.25rem 3rem; text-align: center; position: relative; overflow: hidden;
 }
-.hero h1 { font-size: clamp(1.8rem, 4vw, 2.8rem); margin: 0 0 0.6rem; color: #fff; }
+.hero-inner { position: relative; z-index: 1; }
+.hero-deco {
+  position: absolute; inset: 0; z-index: 0; opacity: 0.5; pointer-events: none;
+  background-image: radial-gradient(circle at 12% 20%, rgba(255,255,255,0.18) 0 2px, transparent 3px),
+    radial-gradient(circle at 82% 30%, rgba(255,255,255,0.14) 0 2px, transparent 3px),
+    radial-gradient(circle at 28% 78%, rgba(255,255,255,0.12) 0 2px, transparent 3px),
+    radial-gradient(circle at 68% 82%, rgba(255,255,255,0.16) 0 2px, transparent 3px);
+  background-size: 220px 220px, 260px 260px, 300px 300px, 240px 240px;
+}
+.hero h1 { font-size: clamp(1.9rem, 4vw, 3rem); margin: 0 0 0.6rem; color: #fff; letter-spacing: -0.02em; }
 .hero p { max-width: 640px; margin: 0 auto; font-size: 1.05rem; opacity: 0.95; }
-.hero .kicker { text-transform: uppercase; letter-spacing: 0.12em; font-size: 0.8rem; font-weight: 700; opacity: 0.9; font-family: var(--font-heading); }
-.progress-wrap { max-width: 420px; margin: 1.4rem auto 0; }
+.hero .kicker { text-transform: uppercase; letter-spacing: 0.14em; font-size: 0.8rem; font-weight: 700; opacity: 0.92; font-family: var(--font-heading); margin-bottom: 0.4rem; }
+.hero-stats { display: flex; flex-wrap: wrap; justify-content: center; gap: 0.75rem; margin: 1.6rem auto 0; }
+.hstat { background: rgba(255,255,255,0.14); border: 1px solid rgba(255,255,255,0.25); border-radius: 12px; padding: 0.55rem 1rem; min-width: 84px; backdrop-filter: blur(4px); }
+.hstat-n { display: block; font-family: var(--font-heading); font-weight: 800; font-size: 1.5rem; line-height: 1; }
+.hstat-l { display: block; font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; opacity: 0.9; margin-top: 0.2rem; }
+.progress-wrap { max-width: 420px; margin: 1.5rem auto 0; }
 .progress-bar { height: 10px; background: rgba(255,255,255,0.28); border-radius: 999px; overflow: hidden; }
 .progress-bar > span { display: block; height: 100%; width: 0%; background: #fff; border-radius: 999px; transition: width 0.4s ease; }
 .progress-label { font-size: 0.85rem; margin-top: 0.5rem; font-family: var(--font-mono); opacity: 0.95; }
 
-section.section { padding: 2.5rem 0; }
-.section-title { font-size: 1.6rem; margin: 0 0 0.3rem; }
-.section-sub { color: var(--color-text-muted); margin: 0 0 1.5rem; }
+section.section { padding: 1.5rem 0 2.5rem; }
 
-/* ---------- Filters ---------- */
-.filters { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 1.5rem; }
+/* ---------- Sticky filter bar ---------- */
+.filterbar { position: sticky; top: 52px; z-index: 50; background: var(--color-bg); border-bottom: 1px solid var(--border); }
+.filterbar-inner { display: flex; flex-wrap: wrap; align-items: center; gap: 0.4rem; padding-top: 0.7rem; padding-bottom: 0.7rem; }
+.filter-divider { width: 1px; align-self: stretch; background: var(--border); margin: 0.1rem 0.35rem; }
 .filter-group { display: flex; flex-wrap: wrap; gap: 0.4rem; align-items: center; }
 .chip {
   font-family: var(--font-heading); font-weight: 600; font-size: 0.82rem;
   border: 1px solid var(--border); background: var(--color-bg-card); color: var(--color-text);
-  padding: 0.4rem 0.85rem; border-radius: 999px; cursor: pointer; transition: all 0.15s; min-height: 36px;
+  padding: 0.4rem 0.8rem; border-radius: 999px; cursor: pointer; transition: all 0.15s; min-height: 36px;
+  display: inline-flex; align-items: center; gap: 0.4rem;
 }
+.chip svg { width: 15px; height: 15px; }
+.chip .dot { width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0; }
+.chip b { font-family: var(--font-mono); font-weight: 500; font-size: 0.72rem; opacity: 0.7; }
 .chip:hover { border-color: var(--color-primary); }
 .chip.active { background: var(--color-primary); color: #fff; border-color: var(--color-primary); }
+.chip.active b { opacity: 0.85; }
+
+/* ---------- Track sections ---------- */
+.track-section { margin: 0 0 2.75rem; }
+.track-head { display: flex; align-items: center; gap: 0.8rem; margin-bottom: 1.1rem; }
+.th-dot { width: 14px; height: 14px; border-radius: 4px; background: var(--track); flex-shrink: 0; box-shadow: 0 0 0 4px color-mix(in srgb, var(--track) 22%, transparent); }
+.th-text { display: flex; flex-direction: column; }
+.th-art { font-family: var(--font-mono); font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--track); }
+.track-head h3 { margin: 0; font-size: 1.3rem; }
+.th-count { margin-left: auto; font-family: var(--font-mono); font-size: 0.8rem; color: var(--color-text-muted); background: var(--color-bg-card); border: 1px solid var(--border); padding: 0.25rem 0.7rem; border-radius: 999px; }
 
 /* ---------- Cards ---------- */
-.cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(290px, 1fr)); gap: 1.25rem; }
+.cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(270px, 1fr)); gap: 1.1rem; }
 .pcard {
   background: var(--color-bg-card); border: 1px solid var(--border); border-radius: 16px;
-  box-shadow: var(--shadow); padding: 1.25rem; cursor: pointer; position: relative;
-  border-top: 4px solid var(--track, var(--color-primary)); transition: transform 0.15s, box-shadow 0.15s; text-align: left;
-  display: flex; flex-direction: column; gap: 0.5rem; width: 100%; font: inherit; color: inherit;
+  box-shadow: var(--shadow); padding: 1.2rem 1.25rem; cursor: pointer; position: relative; overflow: hidden;
+  transition: transform 0.15s, box-shadow 0.15s, border-color 0.15s; text-align: left;
+  display: flex; flex-direction: column; gap: 0.45rem; width: 100%; font: inherit; color: inherit;
 }
-.pcard:hover { transform: translateY(-3px); box-shadow: var(--shadow-lg); }
-.pcard:focus-visible { outline: 3px solid var(--color-primary); outline-offset: 2px; }
-.pcard-top { display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; }
-.ptype { display: inline-flex; align-items: center; gap: 0.35rem; font-family: var(--font-heading); font-weight: 700; font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--track, var(--color-primary)); }
-.ptype svg { width: 16px; height: 16px; }
-.pcard h3 { font-size: 1.1rem; margin: 0.1rem 0; }
-.pcard .pcourse { font-size: 0.8rem; color: var(--color-text-muted); font-family: var(--font-mono); }
-.pcard .pblurb { font-size: 0.92rem; color: var(--color-text-muted); margin: 0.2rem 0 0; }
-.pcard-foot { display: flex; align-items: center; justify-content: space-between; margin-top: auto; padding-top: 0.6rem; }
-.pdiff { font-size: 0.75rem; font-family: var(--font-mono); color: var(--color-text-muted); }
-.pdone { display: none; align-items: center; gap: 0.3rem; color: var(--color-success); font-size: 0.78rem; font-weight: 700; font-family: var(--font-heading); }
-.pdone svg { width: 16px; height: 16px; }
-.pcard.is-done .pdone { display: inline-flex; }
-.track-tag { font-size: 0.7rem; font-family: var(--font-heading); font-weight: 700; padding: 0.15rem 0.5rem; border-radius: 6px; color: #fff; background: var(--track, var(--color-primary)); }
-.no-results { color: var(--color-text-muted); padding: 2rem 0; text-align: center; grid-column: 1/-1; }
+.pcard::before { content: ""; position: absolute; top: 0; left: 0; right: 0; height: 4px; background: var(--track, var(--color-primary)); }
+.pcard:hover { transform: translateY(-4px); box-shadow: var(--shadow-lg); border-color: var(--track, var(--color-primary)); }
+.pcard:focus-visible { outline: 3px solid var(--track, var(--color-primary)); outline-offset: 2px; }
+.pcard-top { display: flex; align-items: center; gap: 0.6rem; }
+.ptype-badge { width: 38px; height: 38px; border-radius: 11px; display: inline-flex; align-items: center; justify-content: center; background: var(--track, var(--color-primary)); color: #fff; flex-shrink: 0; }
+.ptype-badge svg { width: 20px; height: 20px; }
+.ptype-label { font-family: var(--font-heading); font-weight: 700; font-size: 0.74rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--track, var(--color-primary)); }
+.pcard h3 { font-size: 1.08rem; margin: 0.15rem 0 0; line-height: 1.3; }
+.pcard .pcourse { font-size: 0.78rem; color: var(--color-text-muted); font-family: var(--font-mono); }
+.pcard .pblurb { font-size: 0.9rem; color: var(--color-text-muted); margin: 0.15rem 0 0; }
+.pcard-foot { display: flex; align-items: center; justify-content: space-between; margin-top: auto; padding-top: 0.7rem; }
+.pdiff { font-size: 0.72rem; font-family: var(--font-mono); color: var(--color-text-muted); border: 1px solid var(--border); border-radius: 999px; padding: 0.15rem 0.6rem; }
+.pgo { display: inline-flex; align-items: center; gap: 0.25rem; font-family: var(--font-heading); font-weight: 700; font-size: 0.78rem; color: var(--track, var(--color-primary)); opacity: 0; transform: translateX(-4px); transition: all 0.15s; }
+.pgo svg { width: 15px; height: 15px; }
+.pcard:hover .pgo { opacity: 1; transform: translateX(0); }
+.pcheck { position: absolute; top: 0.7rem; right: 0.7rem; color: var(--color-success); display: none; }
+.pcheck svg { width: 20px; height: 20px; }
+.pcard.is-done { border-color: var(--color-success); }
+.pcard.is-done .pcheck { display: block; }
+.no-results { color: var(--color-text-muted); padding: 2rem 0; text-align: center; }
 
 /* ---------- Play overlay ---------- */
 .overlay { position: fixed; inset: 0; z-index: 10001; background: var(--color-bg); display: none; overflow-y: auto; }
@@ -309,6 +341,10 @@ section.section { padding: 2.5rem 0; }
 @media (max-width: 520px) {
   .footer-grid { grid-template-columns: 1fr; }
   .ws-words { columns: 1; }
+  .match-grid { grid-template-columns: 1fr; }
+}
+@media (hover: none) {
+  .pgo { opacity: 1; transform: none; }
 }
 @media (prefers-reduced-motion: reduce) {
   .paper-plane { animation: none; }
@@ -350,31 +386,32 @@ section.section { padding: 2.5rem 0; }
 
 <!-- Hero -->
 <header class="hero">
-  <div class="kicker">ImpactMojo Puzzle Library</div>
-  <h1>Learn development by playing</h1>
-  <p>Free, in-browser crosswords, quizzes and word searches drawn from ImpactMojo's courses — economics, gender, research methods, public health and climate. No sign-up, no downloads.</p>
-  <div class="progress-wrap">
-    <div class="progress-bar"><span id="progressFill"></span></div>
-    <div class="progress-label" id="progressLabel">0 of 0 puzzles completed</div>
+  <div class="hero-deco" aria-hidden="true"></div>
+  <div class="hero-inner">
+    <div class="kicker">ImpactMojo Puzzle Library</div>
+    <h1>Learn development by playing</h1>
+    <p>Free, in-browser puzzles drawn from ImpactMojo's courses — seven formats spanning economics, gender, research methods, data, health, climate and governance. No sign-up, no downloads.</p>
+    <div class="hero-stats" id="heroStats"></div>
+    <div class="progress-wrap">
+      <div class="progress-bar"><span id="progressFill"></span></div>
+      <div class="progress-label" id="progressLabel">0 of 0 puzzles completed</div>
+    </div>
   </div>
 </header>
 
 <main id="main-content">
-<section class="section">
-  <div class="wrap">
-    <h2 class="section-title">Browse puzzles</h2>
-    <p class="section-sub">Pick a track and a format, then dive in. Your progress is saved on this device.</p>
-
-    <div class="filters">
+  <div class="filterbar" id="filterbar">
+    <div class="wrap filterbar-inner">
       <div class="filter-group" id="trackFilters" role="group" aria-label="Filter by track"></div>
-    </div>
-    <div class="filters">
+      <div class="filter-divider" aria-hidden="true"></div>
       <div class="filter-group" id="typeFilters" role="group" aria-label="Filter by puzzle type"></div>
     </div>
-
-    <div class="cards" id="cardGrid" aria-live="polite"></div>
   </div>
-</section>
+  <section class="section">
+    <div class="wrap">
+      <div id="trackSections" aria-live="polite"></div>
+    </div>
+  </section>
 </main>
 
 <!-- Play overlay -->
@@ -483,6 +520,7 @@ section.section { padding: 2.5rem 0; }
     categorize: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="7" height="16" rx="1"/><rect x="14" y="4" width="7" height="16" rx="1"/></svg>',
     cloze: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 7h16M4 12h7M4 17h13"/><path d="M14 11l3 3 4-5"/></svg>',
     check: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg>',
+    go: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M13 6l6 6-6 6"/></svg>',
     done: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="12" cy="12" r="10"/><path d="M8 12l3 3 5-6"/></svg>'
   };
   var TYPE_LABEL = { crossword: 'Crossword', wordsearch: 'Word Search', quiz: 'Quiz', matching: 'Matching', sequence: 'Sequence', categorize: 'Sort', cloze: 'Fill-in' };
@@ -1068,15 +1106,28 @@ section.section { padding: 2.5rem 0; }
     if (card && PROGRESS[id] && PROGRESS[id].done) card.classList.add('is-done');
   }
 
+  function fillHeroStats() {
+    var formats = {}; PUZZLES.forEach(function (p) { formats[p.type] = 1; });
+    var courses = {}; PUZZLES.forEach(function (p) { courses[p.course] = 1; });
+    var stats = [[PUZZLES.length, 'puzzles'], [Object.keys(formats).length, 'formats'], [Object.keys(courses).length, 'courses'], [Object.keys(TRACKS).length, 'tracks']];
+    document.getElementById('heroStats').innerHTML = stats.map(function (s) {
+      return '<div class="hstat"><span class="hstat-n">' + s[0] + '</span><span class="hstat-l">' + s[1] + '</span></div>';
+    }).join('');
+  }
+
   function buildFilters() {
     var tf = document.getElementById('trackFilters');
-    var chips = '<button class="chip active" data-track="all">All tracks</button>';
+    var chips = '<button class="chip chip-track active" data-track="all">All tracks <b>' + PUZZLES.length + '</b></button>';
     Object.keys(TRACKS).forEach(function (k) {
-      chips += '<button class="chip" data-track="' + k + '" style="border-left:4px solid ' + TRACKS[k].color + ';">' + esc(TRACKS[k].name) + '</button>';
+      var n = PUZZLES.filter(function (p) { return p.track === k; }).length;
+      chips += '<button class="chip chip-track" data-track="' + k + '"><span class="dot" style="background:' + TRACKS[k].color + ';"></span>' + esc(TRACKS[k].name) + ' <b>' + n + '</b></button>';
     });
     tf.innerHTML = chips;
     var typeChips = '<button class="chip active" data-type="all">All formats</button>';
-    TYPE_ORDER.forEach(function (t) { typeChips += '<button class="chip" data-type="' + t + '">' + TYPE_LABEL[t] + '</button>'; });
+    TYPE_ORDER.forEach(function (t) {
+      var n = PUZZLES.filter(function (p) { return p.type === t; }).length;
+      if (n) typeChips += '<button class="chip" data-type="' + t + '">' + ICONS[t] + TYPE_LABEL[t] + ' <b>' + n + '</b></button>';
+    });
     document.getElementById('typeFilters').innerHTML = typeChips;
 
     tf.addEventListener('click', function (e) {
@@ -1091,24 +1142,36 @@ section.section { padding: 2.5rem 0; }
     });
   }
 
+  function cardHTML(p) {
+    var tr = TRACKS[p.track] || { name: 'General', color: '#667eea' };
+    var done = PROGRESS[p.id] && PROGRESS[p.id].done;
+    return '<button class="pcard' + (done ? ' is-done' : '') + '" data-id="' + p.id + '" style="--track:' + tr.color + ';">' +
+      '<span class="pcheck" title="Completed">' + ICONS.done + '</span>' +
+      '<div class="pcard-top"><span class="ptype-badge">' + ICONS[p.type] + '</span><span class="ptype-label">' + TYPE_LABEL[p.type] + '</span></div>' +
+      '<h3>' + esc(p.title) + '</h3>' +
+      '<div class="pcourse">' + esc(p.course) + '</div>' +
+      '<p class="pblurb">' + esc(p.blurb || '') + '</p>' +
+      '<div class="pcard-foot"><span class="pdiff">' + esc(p.difficulty || '') + '</span><span class="pgo">Play ' + ICONS.go + '</span></div>' +
+      '</button>';
+  }
+
   function renderCards() {
-    var grid = document.getElementById('cardGrid');
-    var list = PUZZLES.filter(function (p) {
-      return (activeTrack === 'all' || p.track === activeTrack) && (activeType === 'all' || p.type === activeType);
+    var root = document.getElementById('trackSections');
+    var trackKeys = Object.keys(TRACKS).filter(function (k) { return activeTrack === 'all' || k === activeTrack; });
+    var html = '', shown = 0;
+    trackKeys.forEach(function (k) {
+      var tr = TRACKS[k];
+      var list = PUZZLES.filter(function (p) { return p.track === k && (activeType === 'all' || p.type === activeType); });
+      if (!list.length) return;
+      shown += list.length;
+      var done = list.filter(function (p) { return PROGRESS[p.id] && PROGRESS[p.id].done; }).length;
+      html += '<section class="track-section" style="--track:' + tr.color + ';">' +
+        '<div class="track-head"><span class="th-dot"></span><div class="th-text"><div class="th-art">' + esc(tr.art || '') + ' folk art</div><h3>' + esc(tr.name) + '</h3></div>' +
+        '<span class="th-count">' + done + ' / ' + list.length + ' done</span></div>' +
+        '<div class="cards">' + list.map(cardHTML).join('') + '</div></section>';
     });
-    if (!list.length) { grid.innerHTML = '<p class="no-results">No puzzles match those filters yet — more are on the way.</p>'; return; }
-    grid.innerHTML = list.map(function (p) {
-      var tr = TRACKS[p.track] || { name: 'General', color: '#667eea' };
-      var done = PROGRESS[p.id] && PROGRESS[p.id].done;
-      return '<button class="pcard' + (done ? ' is-done' : '') + '" data-id="' + p.id + '" style="--track:' + tr.color + ';">' +
-        '<div class="pcard-top"><span class="ptype">' + ICONS[p.type] + TYPE_LABEL[p.type] + '</span><span class="track-tag" style="--track:' + tr.color + ';">' + esc(tr.name) + '</span></div>' +
-        '<h3>' + esc(p.title) + '</h3>' +
-        '<div class="pcourse">' + esc(p.course) + '</div>' +
-        '<p class="pblurb">' + esc(p.blurb || '') + '</p>' +
-        '<div class="pcard-foot"><span class="pdiff">' + esc(p.difficulty || '') + '</span><span class="pdone">' + ICONS.done + 'Completed</span></div>' +
-        '</button>';
-    }).join('');
-    grid.querySelectorAll('.pcard').forEach(function (card) {
+    root.innerHTML = shown ? html : '<p class="no-results">No puzzles match those filters yet — more are on the way.</p>';
+    root.querySelectorAll('.pcard').forEach(function (card) {
       card.addEventListener('click', function () { openPuzzle(card.dataset.id); });
     });
   }
@@ -1146,7 +1209,7 @@ section.section { padding: 2.5rem 0; }
     .then(function (res) { if (!res.ok) throw new Error('HTTP ' + res.status); return res.json(); })
     .then(function (data) {
       DATA = data; TRACKS = data.tracks || {}; PUZZLES = data.puzzles || [];
-      buildFilters(); renderCards(); renderProgress();
+      buildFilters(); fillHeroStats(); renderCards(); renderProgress();
       if (location.hash) { var id = location.hash.slice(1); if (PUZZLES.some(function (p) { return p.id === id; })) openPuzzle(id); }
     })
     .catch(function (err) {


### PR DESCRIPTION
## Summary
Expands the self-hosted Puzzle Library and redesigns its hub.

### Content — variety, ≥3 per course
- Every one of the **39 ImpactMojo courses now has at least 3 puzzles** with real format variety.
- `data/puzzles.json` grows **50 → 117**: a word search for every course, plus a second interactive format each (matching, fill-in-the-blank, sort, sequence, quiz, or crossword).
- Format mix: word search 39 · matching 31 · quiz 15 · fill-in 13 · crossword 9 · sort 5 · sequence 5.

### Design — prettier hub
- Flat card grid → **track-grouped sections** with folk-art colour accents and per-track progress.
- **Sticky filter bar** (track + format) with live counts, hero **stat tiles**, and refined cards (icon badge, difficulty pill, hover "Play" cue, completion tick).

### Engine (shipped earlier in this branch)
- Seven runtime renderers: auto-laid-out crosswords, interactive word searches, scored quizzes, matching, sequencing, sorting, fill-in-the-blank. Progress saved in `localStorage`; deep-linkable via `#id`.

## Verification
- All 39 courses ≥3 puzzles; no course is single-format; no duplicate IDs; all structures valid (matching pairs, categorize indices in range, cloze answers in their banks, quiz indices valid).
- All 9 crosswords lay out and read correctly; all 39 word searches place every word reliably (tested headless).
- All inline JS passes `node --check`.

Also updates the homepage card and `docs/changelog.md`.

https://claude.ai/code/session_01AydWEVNYYD2jZkaxND6TDz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AydWEVNYYD2jZkaxND6TDz)_