### PR TITLE
Practice Packs go premium (freemium paywall after first 2 modules)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to ImpactMojo are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.34.0] - 2026-06-02
+
+### Added — Practice Packs premium (freemium paywall)
+
+Practice Packs move from fully free to a freemium model: the first two modules
+of every pack remain a free preview; modules 3–4 plus the capstone builder
+require access.
+
+- **`js/practice-pack-gate.js`** (new) — reusable client-side freemium gate.
+  Wraps the shared `goTab(idx)` entry point so every tab and nav button is
+  gated with one drop-in. Themed paywall modal offers three paths: Practitioner
+  subscription (₹399/mo, all 18 packs), standalone single pack (₹299), and an
+  optional expert review (₹999). Config per pack via `window.IM_PACK`.
+- **All 18 packs** wired with the gate (`freeModules: 2`).
+- **Standalone purchase support** — `profiles.resource_grants TEXT[]` column
+  (migration `20260602_add_resource_grants.sql`, GIN-indexed). `auth.js` selects
+  it and exposes `ImpactMojoAuth.hasResourceAccess(slug)`; `state-manager.js`
+  caches it; the gate unlocks a pack if the user's tier qualifies OR the slug is
+  in `resource_grants`. Admin grants the slug after UPI, matching the existing
+  manual registration flow.
+- **`premium.html`** — Practice Packs added to the Practitioner tier card and
+  detail; registration form gains "Practice Pack (single) – ₹299", "Practice
+  Pack + Expert Review – ₹1,298", and "Practice Pack Expert Review – ₹999"
+  options plus a conditional pack-name field; `?pack=<slug>` deep link
+  preselects the standalone option and prefills the pack; new FAQ entry.
+- **`upgrade.html`** — Practice Packs added to the Practitioner offer.
+- **`practice-packs/index.html`** — reframed from "Free" to free-preview +
+  premium; **search-index** landing description updated.
+
 ## [10.28.0] - 2026-05-23
 
 ### Added — Complete Practice Packs series (16 new) + blog rewrite

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -7497,7 +7497,7 @@
   {
     "id": "PP-LANDING",
     "title": "Practice Packs — Job-to-be-Done Sprints",
-    "description": "ImpactMojo Practice Packs — short, focused 3-hour sprints that take you from a job-to-be-done to a finished artefact. 4 modules + a take-home pack. Free.",
+    "description": "ImpactMojo Practice Packs — short, focused 3-hour sprints that take you from a job-to-be-done to a finished artefact. 4 modules + a take-home pack. First 2 modules free; full pack with Premium (₹399/mo) or ₹299 per pack.",
     "type": "landing-page",
     "category": "Practice Packs",
     "url": "/practice-packs/",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,15 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.34.0 — June 2, 2026 (Practice Packs go premium)
+
+### For Learners
+
+- **Practice Packs now have a free preview** — the first two modules of every one of the 18 packs are open to all, no login, so you can try the format before you commit.
+- **Unlock the full pack with Premium** — a Practitioner membership (₹399/month) unlocks all modules and the auto-built capstone across all 18 Practice Packs, alongside Research Question Builder Pro, Theory of Change Workbench Pro, and certificates.
+- **Buy a single pack for ₹299** — if you only need one, you can unlock a single Practice Pack on its own.
+- **Optional expert review (₹999)** — get written feedback on the artefact you build in any pack — your ToR, logframe, evaluation design, and more.
+
 ## v10.33.0 — May 31, 2026 (Games & Puzzles navigation)
 
 ### For Learners

--- a/js/auth.js
+++ b/js/auth.js
@@ -439,7 +439,7 @@ const ImpactMojoAuth = {
 
                 var profilePromise = supabaseClient
                     .from('profiles')
-                    .select('id, display_name, full_name, email, avatar_url, subscription_tier, subscription_status, organization, role')
+                    .select('id, display_name, full_name, email, avatar_url, subscription_tier, subscription_status, organization, role, resource_grants')
                     .eq('id', this.user.id)
                     .single();
 
@@ -1082,6 +1082,17 @@ const ImpactMojoAuth = {
         const userTierIndex = tierHierarchy.indexOf(this.profile?.subscription_tier || 'explorer');
         const requiredTierIndex = tierHierarchy.indexOf(requiredTier);
         return userTierIndex >= requiredTierIndex;
+    },
+
+    // Check standalone per-resource access (e.g. a single Practice Pack
+    // bought for a one-time fee). Granted via the profile's resource_grants
+    // column — an array of resource slugs, or an object keyed by slug.
+    hasResourceAccess(slug) {
+        const grants = this.profile?.resource_grants;
+        if (!grants || !slug) return false;
+        if (Array.isArray(grants)) return grants.indexOf(slug) !== -1;
+        if (typeof grants === 'object') return !!grants[slug];
+        return false;
     },
 
     // Get subscription tier display name

--- a/js/practice-pack-gate.js
+++ b/js/practice-pack-gate.js
@@ -1,0 +1,239 @@
+/**
+ * ImpactMojo Practice Pack Paywall Gate
+ * Version: 1.0.0
+ *
+ * Freemium gate for Practice Packs. The first N modules of every pack stay
+ * free (the preview / hook); the remaining modules + the auto-built capstone
+ * require access. Access is granted by EITHER:
+ *
+ *   1. A subscription tier at or above `requiredTier` (default: practitioner),
+ *      i.e. the existing platform-wide tier gating, OR
+ *   2. A standalone per-pack purchase recorded in the profile's
+ *      `resource_grants` array (slug match).
+ *
+ * This is a CLIENT-SIDE freemium teaser gate, not a hard paywall. It reads the
+ * cached Supabase profile written by js/auth.js (`impactmojo_cached_profile`)
+ * so it works without loading the full auth stack into every pack. Modules 3-4
+ * carry little value without the user's own Module 1-2 inputs (which never
+ * leave their browser), so casual bypass is low-risk — the real value is the
+ * personalised capstone, the subscription, and the optional expert review.
+ *
+ * USAGE — add to a pack page, AFTER the pack's inline <script> that defines
+ * goTab():
+ *
+ *   <script>window.IM_PACK = {
+ *       slug:        'tor-writing',
+ *       title:       'Writing a ToR That Gets You Useful Research',
+ *       artefact:    'ToR + costing sheet',
+ *       freeModules: 2,            // modules 0..1 free; 2+ gated
+ *       price:       '₹299',       // standalone per-pack price
+ *       requiredTier:'practitioner'
+ *   };</script>
+ *   <script src="/js/practice-pack-gate.js"></script>
+ */
+(function () {
+  'use strict';
+
+  var PACK = window.IM_PACK || {};
+  var CFG = {
+    slug:         PACK.slug || (location.pathname.split('/').filter(Boolean).pop() || 'practice-pack'),
+    title:        PACK.title || document.title.split('—')[0].split('|')[0].trim() || 'this Practice Pack',
+    artefact:     PACK.artefact || 'capstone artefact',
+    freeModules:  typeof PACK.freeModules === 'number' ? PACK.freeModules : 2,
+    price:        PACK.price || '₹299',
+    requiredTier: PACK.requiredTier || 'practitioner',
+    tierPrice:    PACK.tierPrice || '₹399/mo',
+    review:       PACK.review || '₹999'
+  };
+
+  var TIERS = ['explorer', 'practitioner', 'professional', 'organization'];
+
+  // ── Access check ────────────────────────────────────────────────────
+  // Reads the cached profile + session that js/auth.js persists on login.
+  function hasSession() {
+    try {
+      var keys = Object.keys(localStorage);
+      for (var i = 0; i < keys.length; i++) {
+        var k = keys[i];
+        if (k.indexOf('impactmojo-auth') !== -1 ||
+            k.indexOf('supabase.auth.token') !== -1 ||
+            (k.indexOf('sb-') !== -1 && k.indexOf('-auth-token') !== -1)) {
+          var v = JSON.parse(localStorage.getItem(k));
+          if (v && (v.access_token || (v.currentSession && v.currentSession.access_token))) return true;
+        }
+      }
+    } catch (e) { /* ignore */ }
+    return false;
+  }
+
+  function cachedProfile() {
+    try { return JSON.parse(localStorage.getItem('impactmojo_cached_profile')) || null; }
+    catch (e) { return null; }
+  }
+
+  function hasAccess() {
+    // Live auth, if the full stack happens to be loaded, wins.
+    if (window.ImpactMojoAuth && window.ImpactMojoAuth.profile) {
+      return evaluate(window.ImpactMojoAuth.profile);
+    }
+    if (!hasSession()) return false;
+    return evaluate(cachedProfile());
+  }
+
+  function evaluate(profile) {
+    if (!profile) return false;
+    var status = profile.subscription_status;
+    // Tier path — block only if subscription is explicitly cancelled/expired.
+    if (!(status && status !== 'active' && status !== 'trialing')) {
+      var have = TIERS.indexOf(profile.subscription_tier || 'explorer');
+      var need = TIERS.indexOf(CFG.requiredTier);
+      if (need >= 0 && have >= need) return true;
+    }
+    // Standalone per-pack grant path.
+    var grants = profile.resource_grants;
+    if (Array.isArray(grants) && grants.indexOf(CFG.slug) !== -1) return true;
+    if (grants && typeof grants === 'object' && grants[CFG.slug]) return true;
+    return false;
+  }
+
+  // ── Styles (uses the pack's own CSS variables so it themes correctly) ─
+  function injectStyles() {
+    if (document.getElementById('pp-gate-styles')) return;
+    var s = document.createElement('style');
+    s.id = 'pp-gate-styles';
+    s.textContent = [
+      '.pp-lock-pill{display:inline-flex;align-items:center;gap:.25rem;margin-left:.35rem;padding:.05rem .35rem;border-radius:6px;font-size:.6rem;font-weight:700;letter-spacing:.3px;text-transform:uppercase;background:rgba(245,158,11,.18);color:var(--warning,#F59E0B);font-family:var(--font-heading,sans-serif)}',
+      '.pp-lock-pill svg{width:10px;height:10px}',
+      '.pp-gate-backdrop{position:fixed;inset:0;z-index:9998;background:rgba(15,23,42,.72);backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);opacity:0;visibility:hidden;transition:opacity .25s;display:flex;align-items:center;justify-content:center;padding:1rem}',
+      '.pp-gate-backdrop.open{opacity:1;visibility:visible}',
+      '.pp-gate-modal{background:var(--card-bg,#fff);color:var(--text-primary,#0F172A);border:1px solid var(--border,#E2E8F0);border-radius:16px;max-width:480px;width:100%;max-height:92vh;overflow-y:auto;box-shadow:0 25px 60px rgba(0,0,0,.35);transform:translateY(16px) scale(.98);transition:transform .25s;font-family:var(--font-sans,sans-serif)}',
+      '.pp-gate-backdrop.open .pp-gate-modal{transform:none}',
+      '.pp-gate-head{padding:1.6rem 1.6rem 1rem;text-align:center;border-bottom:1px solid var(--border,#E2E8F0)}',
+      '.pp-gate-badge{display:inline-flex;align-items:center;gap:.35rem;padding:.3rem .8rem;border-radius:20px;background:rgba(14,165,233,.14);color:var(--accent,#0EA5E9);font-size:.72rem;font-weight:700;text-transform:uppercase;letter-spacing:.5px;margin-bottom:.8rem;font-family:var(--font-heading,sans-serif)}',
+      '.pp-gate-head h3{font-family:var(--font-heading,sans-serif);font-size:1.3rem;margin:0 0 .5rem;color:var(--text-primary,#0F172A)}',
+      '.pp-gate-head p{margin:0;color:var(--text-secondary,#475569);font-size:.95rem;line-height:1.65}',
+      '.pp-gate-body{padding:1.3rem 1.6rem}',
+      '.pp-offer{display:block;text-decoration:none;border:1px solid var(--border,#E2E8F0);border-radius:12px;padding:1rem 1.1rem;margin-bottom:.85rem;transition:all .2s;background:var(--secondary-bg,#F8FAFC)}',
+      '.pp-offer:hover{transform:translateY(-2px);border-color:var(--accent,#0EA5E9);text-decoration:none;box-shadow:0 8px 22px rgba(14,165,233,.12)}',
+      '.pp-offer.primary{border-color:var(--accent,#0EA5E9);background:linear-gradient(135deg,rgba(14,165,233,.08),rgba(99,102,241,.08))}',
+      '.pp-offer-row{display:flex;align-items:baseline;justify-content:space-between;gap:.6rem}',
+      '.pp-offer-name{font-family:var(--font-heading,sans-serif);font-weight:700;font-size:1rem;color:var(--text-primary,#0F172A)}',
+      '.pp-offer-price{font-family:var(--font-heading,sans-serif);font-weight:800;font-size:1.05rem;color:var(--accent,#0EA5E9);white-space:nowrap}',
+      '.pp-offer-desc{margin:.3rem 0 0;font-size:.82rem;color:var(--text-muted,#52627A);line-height:1.5}',
+      '.pp-gate-foot{padding:0 1.6rem 1.4rem;text-align:center}',
+      '.pp-gate-foot a{color:var(--accent,#0EA5E9);font-size:.85rem;font-weight:600}',
+      '.pp-gate-close{position:absolute;top:.9rem;right:.9rem;width:34px;height:34px;border:none;border-radius:50%;background:var(--hover-bg,#F1F5F9);color:var(--text-secondary,#475569);cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:1.1rem;line-height:1}',
+      '.pp-gate-modal{position:relative}'
+    ].join('');
+    document.head.appendChild(s);
+  }
+
+  var LOCK_SVG = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>';
+
+  // ── Lock the gated tabs visually ─────────────────────────────────────
+  function lockTabs() {
+    document.querySelectorAll('.module-tab').forEach(function (tab) {
+      var idx = parseInt(tab.getAttribute('data-tab'), 10);
+      if (isNaN(idx)) {
+        // capstone tab has no numeric data-tab on some packs — derive by position
+        idx = Array.prototype.indexOf.call(document.querySelectorAll('.module-tab'), tab);
+      }
+      if (idx >= CFG.freeModules && !tab.querySelector('.pp-lock-pill')) {
+        var pill = document.createElement('span');
+        pill.className = 'pp-lock-pill';
+        pill.innerHTML = LOCK_SVG + 'Premium';
+        tab.appendChild(pill);
+      }
+    });
+  }
+
+  // ── The paywall modal ────────────────────────────────────────────────
+  function buildModal() {
+    var redirect = encodeURIComponent(location.pathname);
+    var backdrop = document.createElement('div');
+    backdrop.className = 'pp-gate-backdrop';
+    backdrop.innerHTML =
+      '<div class="pp-gate-modal" role="dialog" aria-modal="true" aria-label="Unlock this Practice Pack">' +
+        '<button class="pp-gate-close" aria-label="Close">&times;</button>' +
+        '<div class="pp-gate-head">' +
+          '<span class="pp-gate-badge">' + LOCK_SVG + 'Free preview complete</span>' +
+          '<h3>Keep going — finish the pack</h3>' +
+          '<p>You\'ve worked through the first ' + CFG.freeModules + ' modules. The remaining modules and your auto-built <strong>' + esc(CFG.artefact) + '</strong> are part of ImpactMojo Premium.</p>' +
+        '</div>' +
+        '<div class="pp-gate-body">' +
+          '<a class="pp-offer primary" href="/premium.html#detail-practitioner">' +
+            '<div class="pp-offer-row"><span class="pp-offer-name">All 18 Practice Packs</span><span class="pp-offer-price">' + esc(CFG.tierPrice) + '</span></div>' +
+            '<p class="pp-offer-desc">Practitioner membership — every pack, plus Research Question Builder Pro, ToC Workbench Pro &amp; certificates.</p>' +
+          '</a>' +
+          '<a class="pp-offer" href="/premium.html?pack=' + encodeURIComponent(CFG.slug) + '#payment">' +
+            '<div class="pp-offer-row"><span class="pp-offer-name">Just this pack</span><span class="pp-offer-price">' + esc(CFG.price) + '</span></div>' +
+            '<p class="pp-offer-desc">One-time access to <strong>' + esc(CFG.title) + '</strong> — all modules and the capstone builder.</p>' +
+          '</a>' +
+          '<a class="pp-offer" href="/contact.html?topic=PracticePackReview&pack=' + encodeURIComponent(CFG.slug) + '">' +
+            '<div class="pp-offer-row"><span class="pp-offer-name">Add a 1:1 expert review</span><span class="pp-offer-price">' + esc(CFG.review) + '</span></div>' +
+            '<p class="pp-offer-desc">Optional — we review your finished ' + esc(CFG.artefact) + ' and send written feedback.</p>' +
+          '</a>' +
+        '</div>' +
+        '<div class="pp-gate-foot"><a href="/login.html?redirect=' + redirect + '">Already a member? Log in &rarr;</a></div>' +
+      '</div>';
+    document.body.appendChild(backdrop);
+
+    function close() { backdrop.classList.remove('open'); document.body.style.overflow = ''; }
+    backdrop.querySelector('.pp-gate-close').addEventListener('click', close);
+    backdrop.addEventListener('click', function (e) { if (e.target === backdrop) close(); });
+    document.addEventListener('keydown', function (e) { if (e.key === 'Escape') close(); });
+    return backdrop;
+  }
+
+  function esc(str) {
+    return String(str).replace(/[&<>"]/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c];
+    });
+  }
+
+  var modalEl = null;
+  function showPaywall() {
+    if (!modalEl) modalEl = buildModal();
+    modalEl.classList.add('open');
+    document.body.style.overflow = 'hidden';
+    try {
+      if (typeof window.gtag === 'function') {
+        window.gtag('event', 'practice_pack_paywall', { pack: CFG.slug });
+      }
+    } catch (e) { /* ignore */ }
+  }
+
+  // ── Wrap goTab so every entry point (tabs + nav buttons) is gated ────
+  function installGate() {
+    var orig = window.goTab;
+    if (typeof orig !== 'function') {
+      // Fallback: capture-phase interception on tab clicks.
+      document.addEventListener('click', function (e) {
+        var tab = e.target.closest('.module-tab');
+        if (!tab) return;
+        var idx = parseInt(tab.getAttribute('data-tab'), 10);
+        if (!isNaN(idx) && idx >= CFG.freeModules) {
+          e.preventDefault(); e.stopImmediatePropagation(); showPaywall();
+        }
+      }, true);
+      return;
+    }
+    window.goTab = function (idx) {
+      if (typeof idx === 'number' && idx >= CFG.freeModules) { showPaywall(); return; }
+      return orig.apply(this, arguments);
+    };
+  }
+
+  function init() {
+    if (hasAccess()) return; // full pack, nothing to do
+    injectStyles();
+    lockTabs();
+    installGate();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/js/state-manager.js
+++ b/js/state-manager.js
@@ -351,6 +351,7 @@
           avatar_url: profile.avatar_url || null,
           subscription_tier: profile.subscription_tier || 'explorer',
           subscription_status: profile.subscription_status || null,
+          resource_grants: profile.resource_grants || null,
           organization: profile.organization || null,
           role: profile.role || null,
           cachedAt: new Date().toISOString()

--- a/practice-packs/climate-evaluation/index.html
+++ b/practice-packs/climate-evaluation/index.html
@@ -258,5 +258,7 @@ function copyCapstone(){const text=document.getElementById('capstoneOutput').inn
 document.querySelectorAll('.theme-btn').forEach(b=>b.addEventListener('click',()=>{const t=b.dataset.themeSet;document.documentElement.setAttribute('data-theme',t);try{localStorage.setItem('impactmojo-theme',t);}catch(e){}}));
 attachSaveHandlers();loadAll();
 </script>
+<script>window.IM_PACK={slug:'climate-evaluation',title:'Climate Adaptation Evaluation',artefact:'adaptation evaluation design',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
+<script src="/js/practice-pack-gate.js"></script>
 </body>
 </html>

--- a/practice-packs/critiquing-evidence/index.html
+++ b/practice-packs/critiquing-evidence/index.html
@@ -279,5 +279,7 @@ function copyCapstone(){const t=document.getElementById('capstoneOutput').innerT
 document.querySelectorAll('.theme-btn').forEach(b=>b.addEventListener('click',()=>{document.documentElement.setAttribute('data-theme',b.dataset.themeSet);try{localStorage.setItem('impactmojo-theme',b.dataset.themeSet);}catch(e){}}));
 attachSaveHandlers();loadAll();
 </script>
+<script>window.IM_PACK={slug:'critiquing-evidence',title:'Reading & Critiquing an Evidence Paper',artefact:'1-page critique',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
+<script src="/js/practice-pack-gate.js"></script>
 </body>
 </html>

--- a/practice-packs/donor-reporting/index.html
+++ b/practice-packs/donor-reporting/index.html
@@ -283,5 +283,7 @@ function copyCapstone(){const t=document.getElementById('capstoneOutput').innerT
 document.querySelectorAll('.theme-btn').forEach(b=>b.addEventListener('click',()=>{document.documentElement.setAttribute('data-theme',b.dataset.themeSet);try{localStorage.setItem('impactmojo-theme',b.dataset.themeSet);}catch(e){}}));
 attachSaveHandlers();loadAll();
 </script>
+<script>window.IM_PACK={slug:'donor-reporting',title:'Donor Reporting That Funders Read',artefact:'report skeleton',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
+<script src="/js/practice-pack-gate.js"></script>
 </body>
 </html>

--- a/practice-packs/education-evaluation/index.html
+++ b/practice-packs/education-evaluation/index.html
@@ -476,5 +476,7 @@ function copyCapstone(){const text=document.getElementById('capstoneOutput').inn
 document.querySelectorAll('.theme-btn').forEach(b=>b.addEventListener('click',()=>{const t=b.dataset.themeSet;document.documentElement.setAttribute('data-theme',t);try{localStorage.setItem('impactmojo-theme',t);}catch(e){}}));
 attachSaveHandlers();loadAll();
 </script>
+<script>window.IM_PACK={slug:'education-evaluation',title:'Education Programme Evaluation',artefact:'education evaluation design',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
+<script src="/js/practice-pack-gate.js"></script>
 </body>
 </html>

--- a/practice-packs/focus-group-discussion/index.html
+++ b/practice-packs/focus-group-discussion/index.html
@@ -280,5 +280,7 @@ function copyCapstone(){const t=document.getElementById('capstoneOutput').innerT
 document.querySelectorAll('.theme-btn').forEach(b=>b.addEventListener('click',()=>{document.documentElement.setAttribute('data-theme',b.dataset.themeSet);try{localStorage.setItem('impactmojo-theme',b.dataset.themeSet);}catch(e){}}));
 attachSaveHandlers();loadAll();
 </script>
+<script>window.IM_PACK={slug:'focus-group-discussion',title:'Running a Real Focus Group Discussion',artefact:'FGD facilitator\'s guide',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
+<script src="/js/practice-pack-gate.js"></script>
 </body>
 </html>

--- a/practice-packs/gender-impact/index.html
+++ b/practice-packs/gender-impact/index.html
@@ -684,5 +684,7 @@ function copyCapstone(){const text=document.getElementById('capstoneOutput').inn
 document.querySelectorAll('.theme-btn').forEach(b=>b.addEventListener('click',()=>{const t=b.dataset.themeSet;document.documentElement.setAttribute('data-theme',t);try{localStorage.setItem('impactmojo-theme',t);}catch(e){}}));
 attachSaveHandlers();loadAll();
 </script>
+<script>window.IM_PACK={slug:'gender-impact',title:'Gender Impact Assessment Design',artefact:'GIA design',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
+<script src="/js/practice-pack-gate.js"></script>
 </body>
 </html>

--- a/practice-packs/governance-evaluation/index.html
+++ b/practice-packs/governance-evaluation/index.html
@@ -143,5 +143,7 @@ function copyCapstone(){const text=document.getElementById('capstoneOutput').inn
 document.querySelectorAll('.theme-btn').forEach(b=>b.addEventListener('click',()=>{const t=b.dataset.themeSet;document.documentElement.setAttribute('data-theme',t);try{localStorage.setItem('impactmojo-theme',t);}catch(e){}}));
 attachSaveHandlers();loadAll();
 </script>
+<script>window.IM_PACK={slug:'governance-evaluation',title:'Governance Reform Evaluation',artefact:'governance evaluation design',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
+<script src="/js/practice-pack-gate.js"></script>
 </body>
 </html>

--- a/practice-packs/health-evaluation/index.html
+++ b/practice-packs/health-evaluation/index.html
@@ -310,5 +310,7 @@ function copyCapstone(){const text=document.getElementById('capstoneOutput').inn
 document.querySelectorAll('.theme-btn').forEach(b=>b.addEventListener('click',()=>{const t=b.dataset.themeSet;document.documentElement.setAttribute('data-theme',t);try{localStorage.setItem('impactmojo-theme',t);}catch(e){}}));
 attachSaveHandlers();loadAll();
 </script>
+<script>window.IM_PACK={slug:'health-evaluation',title:'Health Intervention Evaluation',artefact:'health evaluation design',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
+<script src="/js/practice-pack-gate.js"></script>
 </body>
 </html>

--- a/practice-packs/index.html
+++ b/practice-packs/index.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
 <meta name="theme-color" content="#0F172A">
 <title>Practice Packs — Interactive Job-to-be-Done Sprints | ImpactMojo</title>
-<meta name="description" content="ImpactMojo Practice Packs — short, interactive 3-hour sprints that take you from a job-to-be-done to a finished artefact. Two tracks: Subject Packs (per-domain evaluation design) and Method Packs (cross-cutting toolkit skills). Free.">
+<meta name="description" content="ImpactMojo Practice Packs — short, interactive 3-hour sprints that take you from a job-to-be-done to a finished artefact. Two tracks: Subject Packs (per-domain evaluation design) and Method Packs (cross-cutting toolkit skills). First 2 modules free; full pack with Premium (₹399/mo) or ₹299 per pack.">
 <meta name="keywords" content="practice packs, mini courses, MEL, SEL evaluation, livelihoods, ToR, logframe, India, interactive, ImpactMojo">
 <link rel="canonical" href="https://www.impactmojo.in/practice-packs/">
 <meta property="og:title" content="Practice Packs — Interactive Sprints | ImpactMojo">
@@ -155,6 +155,7 @@ body{padding-top:60px}
     <span class="hero-eyebrow">New · Interactive Practice Packs</span>
     <h1>Job-to-be-Done Sprints</h1>
     <p class="hero-tagline">Short, focused, <strong>interactive</strong> practice sets for development practitioners. 4 modules. ~3 hours. One concrete deliverable. Lab-like in-browser tools — your inputs auto-save, the capstone builds itself as you go.</p>
+    <p class="hero-tagline" style="font-size:.95rem;margin-top:-.5rem"><strong>First 2 modules of every pack are free.</strong> Unlock the rest — modules 3-4 plus the capstone builder — with <a href="/premium.html#detail-practitioner">Premium (₹399/mo, all packs)</a> or buy a single pack for ₹299.</p>
   </section>
 
   <div class="format-card">
@@ -331,7 +332,7 @@ body{padding-top:60px}
       <li><strong>Subject Packs</strong> — per-domain. The first instinct most clients have is "we need a livelihoods evaluation" or "an SEL evaluation," not "a survey instrument." Subject packs meet that instinct.</li>
       <li><strong>Method Packs</strong> — cross-cutting. Once you've done two or three Subject Packs, you'll want to deepen specific skills. Method packs go deep on one skill.</li>
       <li><strong>Lab-like interactivity</strong> — every pack is now a working tool, not just reading material. Inputs auto-save, capstone builds itself, export when done.</li>
-      <li><strong>Free, no login required</strong> — like everything on ImpactMojo. Your inputs stay in your browser; nothing transmitted.</li>
+      <li><strong>Free preview, no login</strong> — the first two modules of every pack are open to all. Your inputs stay in your browser; nothing transmitted. Unlock the full pack with Premium or a one-time ₹299 purchase.</li>
       <li><strong>Living documents</strong> — updated as practice evolves and reader feedback arrives.</li>
     </ul>
     <p style="margin-top:1rem;font-size:.92rem;color:var(--text-muted)"><em>Suggest a Practice Pack topic, or volunteer to co-author one, at <a href="/contact.html?topic=PracticePacks">/contact</a>.</em></p>

--- a/practice-packs/livelihoods-evaluation/index.html
+++ b/practice-packs/livelihoods-evaluation/index.html
@@ -919,5 +919,7 @@ attachSaveHandlers();
 loadAll();
 </script>
 
+<script>window.IM_PACK={slug:'livelihoods-evaluation',title:'Livelihoods Evaluation: Design & Instruments',artefact:'evaluation design',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
+<script src="/js/practice-pack-gate.js"></script>
 </body>
 </html>

--- a/practice-packs/logframe-building/index.html
+++ b/practice-packs/logframe-building/index.html
@@ -309,5 +309,7 @@ function copyCapstone(){const t=document.getElementById('capstoneOutput').innerT
 document.querySelectorAll('.theme-btn').forEach(b=>b.addEventListener('click',()=>{document.documentElement.setAttribute('data-theme',b.dataset.themeSet);try{localStorage.setItem('impactmojo-theme',b.dataset.themeSet);}catch(e){}}));
 attachSaveHandlers();loadAll();
 </script>
+<script>window.IM_PACK={slug:'logframe-building',title:'Building a Logframe That Actually Tracks',artefact:'DAC-compatible logframe',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
+<script src="/js/practice-pack-gate.js"></script>
 </body>
 </html>

--- a/practice-packs/media-evaluation/index.html
+++ b/practice-packs/media-evaluation/index.html
@@ -141,5 +141,7 @@ function copyCapstone(){const text=document.getElementById('capstoneOutput').inn
 document.querySelectorAll('.theme-btn').forEach(b=>b.addEventListener('click',()=>{const t=b.dataset.themeSet;document.documentElement.setAttribute('data-theme',t);try{localStorage.setItem('impactmojo-theme',t);}catch(e){}}));
 attachSaveHandlers();loadAll();
 </script>
+<script>window.IM_PACK={slug:'media-evaluation',title:'Media Campaign Evaluation',artefact:'media evaluation design',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
+<script src="/js/practice-pack-gate.js"></script>
 </body>
 </html>

--- a/practice-packs/mel-from-scratch/index.html
+++ b/practice-packs/mel-from-scratch/index.html
@@ -836,5 +836,7 @@ attachSaveHandlers();
 loadAll();
 </script>
 
+<script>window.IM_PACK={slug:'mel-from-scratch',title:'Building an MEL System from Scratch',artefact:'90-day MEL setup plan',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
+<script src="/js/practice-pack-gate.js"></script>
 </body>
 </html>

--- a/practice-packs/policy-evaluation/index.html
+++ b/practice-packs/policy-evaluation/index.html
@@ -143,5 +143,7 @@ function copyCapstone(){const text=document.getElementById('capstoneOutput').inn
 document.querySelectorAll('.theme-btn').forEach(b=>b.addEventListener('click',()=>{const t=b.dataset.themeSet;document.documentElement.setAttribute('data-theme',t);try{localStorage.setItem('impactmojo-theme',t);}catch(e){}}));
 attachSaveHandlers();loadAll();
 </script>
+<script>window.IM_PACK={slug:'policy-evaluation',title:'Public Policy Evaluation',artefact:'policy evaluation design',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
+<script src="/js/practice-pack-gate.js"></script>
 </body>
 </html>

--- a/practice-packs/programme-costing/index.html
+++ b/practice-packs/programme-costing/index.html
@@ -306,5 +306,7 @@ function copyCapstone(){const t=document.getElementById('capstoneOutput').innerT
 document.querySelectorAll('.theme-btn').forEach(b=>b.addEventListener('click',()=>{document.documentElement.setAttribute('data-theme',b.dataset.themeSet);try{localStorage.setItem('impactmojo-theme',b.dataset.themeSet);}catch(e){}}));
 attachSaveHandlers();loadAll();
 </script>
+<script>window.IM_PACK={slug:'programme-costing',title:'Costing a Programme from Activities Up',artefact:'activity-based budget',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
+<script src="/js/practice-pack-gate.js"></script>
 </body>
 </html>

--- a/practice-packs/sel-evaluation/index.html
+++ b/practice-packs/sel-evaluation/index.html
@@ -931,5 +931,7 @@ attachSaveHandlers();
 loadAll();
 </script>
 
+<script>window.IM_PACK={slug:'sel-evaluation',title:'SEL Evaluation: Design & Instruments',artefact:'evaluation design',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
+<script src="/js/practice-pack-gate.js"></script>
 </body>
 </html>

--- a/practice-packs/stakeholder-mapping/index.html
+++ b/practice-packs/stakeholder-mapping/index.html
@@ -267,5 +267,7 @@ function copyCapstone(){const t=document.getElementById('capstoneOutput').innerT
 document.querySelectorAll('.theme-btn').forEach(b=>b.addEventListener('click',()=>{document.documentElement.setAttribute('data-theme',b.dataset.themeSet);try{localStorage.setItem('impactmojo-theme',b.dataset.themeSet);}catch(e){}}));
 attachSaveHandlers();loadAll();
 </script>
+<script>window.IM_PACK={slug:'stakeholder-mapping',title:'Stakeholder Mapping for Influence',artefact:'power-interest-alignment map',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
+<script src="/js/practice-pack-gate.js"></script>
 </body>
 </html>

--- a/practice-packs/survey-instrument/index.html
+++ b/practice-packs/survey-instrument/index.html
@@ -320,5 +320,7 @@ function copyCapstone(){const text=document.getElementById('capstoneOutput').inn
 document.querySelectorAll('.theme-btn').forEach(b=>b.addEventListener('click',()=>{const t=b.dataset.themeSet;document.documentElement.setAttribute('data-theme',t);try{localStorage.setItem('impactmojo-theme',t);}catch(e){}}));
 attachSaveHandlers();loadAll();
 </script>
+<script>window.IM_PACK={slug:'survey-instrument',title:'Designing a Survey Instrument',artefact:'survey instrument',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
+<script src="/js/practice-pack-gate.js"></script>
 </body>
 </html>

--- a/practice-packs/tor-writing/index.html
+++ b/practice-packs/tor-writing/index.html
@@ -694,5 +694,7 @@ function copyCapstone(){const text=document.getElementById('capstoneOutput').inn
 document.querySelectorAll('.theme-btn').forEach(b=>b.addEventListener('click',()=>{const t=b.dataset.themeSet;document.documentElement.setAttribute('data-theme',t);try{localStorage.setItem('impactmojo-theme',t);}catch(e){}}));
 attachSaveHandlers();loadAll();
 </script>
+<script>window.IM_PACK={slug:'tor-writing',title:'Writing a ToR That Gets You Useful Research',artefact:'ToR + costing sheet',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
+<script src="/js/practice-pack-gate.js"></script>
 </body>
 </html>

--- a/premium.html
+++ b/premium.html
@@ -1605,6 +1605,7 @@ body.dark-mode .badge-free, body.dark-mode .badge-status-live, body.dark-mode .s
             <ul class="tier-features">
                 <li><svg class="check" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg>Everything in Explorer</li>
                 <li><svg class="check" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg>Research Question Builder Pro & Theory of Change Workbench Pro</li>
+                <li><svg class="check" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg>All 18 Practice Packs (interactive job-to-be-done sprints)</li>
                 <li><svg class="check" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg>Completion certificates (LinkedIn)</li>
                 <li class="highlight"><svg class="check" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg>WhatsApp PLC, Discord & Telegram</li>
             </ul>
@@ -1737,6 +1738,10 @@ body.dark-mode .badge-free, body.dark-mode .badge-status-live, body.dark-mode .s
             <div class="detail-item">
                 <h4>Theory of Change Workbench Pro</h4>
                 <p>Build, iterate, and export publication-ready theories of change. Includes assumption mapping, evidence linkage for each causal pathway, and export to PDF/PNG for donor reports and proposals. Goes well beyond the free TOC lab with version history and collaborative features.</p>
+            </div>
+            <div class="detail-item">
+                <h4>All 18 Practice Packs</h4>
+                <p>Short, interactive job-to-be-done sprints — 4 modules, ~3 hours, one finished artefact. Two tracks: Subject Packs (per-domain evaluation design — SEL, livelihoods, gender, education, health, climate, policy, media, governance) and Method Packs (ToR writing, survey design, logframes, costing, focus groups, evidence critique, stakeholder mapping, donor reporting, MEL from scratch). The first two modules of every pack are free to preview; Practitioner unlocks all modules and the auto-built capstone across every pack. <a href="/practice-packs/">Browse Practice Packs &rarr;</a> Single packs are also available standalone for ₹299, with an optional ₹999 expert review of your finished artefact.</p>
             </div>
             <div class="detail-item">
                 <h4>Completion Certificates</h4>
@@ -1919,7 +1924,16 @@ body.dark-mode .badge-free, body.dark-mode .badge-status-live, body.dark-mode .s
                         <option value="Professional - ₹999/month">Professional - ₹999/month</option>
                         <option value="Professional - ₹9,990/year (2 months free)">Professional - ₹9,990/year (Annual)</option>
                         <option value="Team Plan - Custom">Team Plan - Custom Quote</option>
+                        <option value="Practice Pack (single) - ₹299">Practice Pack (single) - ₹299</option>
+                        <option value="Practice Pack + Expert Review - ₹1,298">Practice Pack + Expert Review - ₹1,298</option>
+                        <option value="Practice Pack Expert Review - ₹999">Practice Pack Expert Review (₹999)</option>
                     </select>
+                </div>
+
+                <div class="form-group" id="packField" style="display:none">
+                    <label for="practice_pack">Which Practice Pack?</label>
+                    <input type="text" id="practice_pack" name="practice_pack" placeholder="e.g. Writing a ToR That Gets You Useful Research">
+                    <p class="form-hint">Required for single-pack purchases and reviews — name (or paste the link of) the pack you bought.</p>
                 </div>
                 
                 <div class="form-group">
@@ -2069,6 +2083,18 @@ body.dark-mode .badge-free, body.dark-mode .badge-status-live, body.dark-mode .s
             Yes! Annual plans get 2 months free (pay for 10, get 12). You can select annual billing in the registration form. Annual amounts: Practitioner ₹3,990/year, Professional ₹9,990/year.
         </div>
     </div>
+
+    <div class="faq-item">
+        <button class="faq-question" aria-expanded="false" onclick="toggleFAQ(this)">
+            Can I buy a single Practice Pack without subscribing?
+            <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+                <polyline points="6 9 12 15 18 9"/>
+            </svg>
+        </button>
+        <div class="faq-answer">
+            Yes. The first two modules of every <a href="/practice-packs/">Practice Pack</a> are free to preview. To unlock the rest of one specific pack — all modules plus the auto-built capstone — pay ₹299 via UPI and submit the registration form with "Practice Pack (single)" and the pack name. We'll grant access within 24 hours. If you want several packs, a Practitioner subscription (₹399/month) unlocks all 18 and works out cheaper after two packs. You can also add a ₹999 expert review of your finished artefact.
+        </div>
+    </div>
 </section>
 
 <!-- Footer -->
@@ -2205,6 +2231,49 @@ document.addEventListener('DOMContentLoaded', function() {
     const dateInput = document.getElementById('payment_date');
     if (dateInput) {
         dateInput.valueAsDate = new Date();
+    }
+
+    // ── Practice Pack standalone purchase wiring ───────────────────────
+    const planSel = document.getElementById('plan');
+    const packField = document.getElementById('packField');
+    const packInput = document.getElementById('practice_pack');
+    function syncPackField() {
+        if (!planSel || !packField) return;
+        const isPack = /Practice Pack/.test(planSel.value);
+        packField.style.display = isPack ? '' : 'none';
+        if (packInput) packInput.required = isPack;
+    }
+    if (planSel) { planSel.addEventListener('change', syncPackField); syncPackField(); }
+
+    // Deep link: /premium.html?pack=<slug> (from a pack paywall) preselects
+    // the standalone option, prefills the pack name, and jumps to payment.
+    const packSlug = urlParams.get('pack');
+    if (packSlug && planSel) {
+        const PACK_TITLES = {
+            'sel-evaluation':'SEL Evaluation: Design & Instruments',
+            'livelihoods-evaluation':'Livelihoods Evaluation: Design & Instruments',
+            'gender-impact':'Gender Impact Assessment Design',
+            'education-evaluation':'Education Programme Evaluation',
+            'health-evaluation':'Health Intervention Evaluation',
+            'climate-evaluation':'Climate Adaptation Evaluation',
+            'policy-evaluation':'Public Policy Evaluation',
+            'media-evaluation':'Media Campaign Evaluation',
+            'governance-evaluation':'Governance Reform Evaluation',
+            'tor-writing':'Writing a ToR That Gets You Useful Research',
+            'survey-instrument':'Designing a Survey Instrument',
+            'logframe-building':'Building a Logframe That Actually Tracks',
+            'programme-costing':'Costing a Programme from Activities Up',
+            'focus-group-discussion':'Running a Real Focus Group Discussion',
+            'critiquing-evidence':'Reading & Critiquing an Evidence Paper',
+            'stakeholder-mapping':'Stakeholder Mapping for Influence',
+            'donor-reporting':'Donor Reporting That Funders Read',
+            'mel-from-scratch':'Building an MEL System from Scratch'
+        };
+        planSel.value = 'Practice Pack (single) - ₹299';
+        syncPackField();
+        if (packInput) packInput.value = PACK_TITLES[packSlug] || packSlug;
+        const upi = document.getElementById('payment');
+        if (upi && urlParams.get('success') !== 'true') upi.scrollIntoView({ behavior: 'smooth' });
     }
 });
 

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS public.profiles (
     subscription_status TEXT DEFAULT 'active', -- active, cancelled, expired, trial
     subscription_start DATE,
     subscription_end DATE,
+    resource_grants TEXT[], -- standalone one-time purchases (e.g. Practice Pack slugs) granted outside a subscription tier
     upi_vpa TEXT,  -- user's UPI VPA for payment tracking
     phone TEXT,
     country TEXT DEFAULT 'India',

--- a/supabase/migrations/20260602_add_resource_grants.sql
+++ b/supabase/migrations/20260602_add_resource_grants.sql
@@ -1,0 +1,30 @@
+-- ============================================================
+-- Add resource_grants to profiles
+-- Date: 2026-06-02
+--
+-- Enables standalone, one-time purchases that grant access to a single
+-- premium resource OUTSIDE the subscription-tier ladder — the first use
+-- case being Practice Packs sold individually for ₹299.
+--
+-- resource_grants holds an array of resource slugs (e.g. the Practice Pack
+-- directory name: 'tor-writing', 'logframe-building', ...). The client gate
+-- (js/practice-pack-gate.js + ImpactMojoAuth.hasResourceAccess) unlocks a
+-- resource if the user's tier qualifies OR the slug is present here.
+--
+-- Granting flow (matches the existing manual-UPI model): after a buyer pays
+-- via UPI and submits the premium registration form with their pack, an admin
+-- appends the slug:
+--   UPDATE public.profiles
+--   SET resource_grants = array_append(coalesce(resource_grants, '{}'), 'tor-writing')
+--   WHERE email = 'buyer@example.com';
+-- ============================================================
+
+ALTER TABLE public.profiles
+    ADD COLUMN IF NOT EXISTS resource_grants TEXT[];
+
+COMMENT ON COLUMN public.profiles.resource_grants IS
+    'Standalone one-time purchases (e.g. individually-bought Practice Pack slugs) granted outside the subscription tier ladder.';
+
+-- GIN index so "does this user own slug X" stays fast as grants grow.
+CREATE INDEX IF NOT EXISTS idx_profiles_resource_grants
+    ON public.profiles USING GIN (resource_grants);

--- a/upgrade.html
+++ b/upgrade.html
@@ -584,6 +584,7 @@ body { padding-top: 56px; }
     <ul class="offer-features">
         <li>Research Question Builder Pro — PICO/SPIDER framing with method suggestions and worked examples</li>
         <li>Theory of Change Workbench Pro — assumption mapping, evidence linkage, PDF/PNG export</li>
+        <li>All 18 Practice Packs — interactive sprints (ToR, logframes, survey design, evaluation design and more); finish a real artefact in an afternoon</li>
         <li>Downloadable PDF certificates for every course you complete</li>
         <li>LinkedIn-shareable credentials for your professional portfolio</li>
         <li>Discord and Telegram community with peer support and expert access</li>


### PR DESCRIPTION
## What this does

Moves Practice Packs from fully free to a **freemium model**: the first **2 modules** of every pack are a free preview; Module 3, Module 4, and the auto-built capstone are gated.

Unlock paths:
- **Practitioner ₹399/mo** — all 18 packs (existing subscription tier)
- **₹299 standalone** — a single pack
- **₹999 optional expert review** of the finished artefact

## How it works

- **`js/practice-pack-gate.js`** (new) — one reusable gate dropped into all 18 packs. Wraps the shared `goTab()` function so every tab + nav button is covered by a single hook. Locked modules trigger a themed paywall modal; gated tabs get a "🔒 Premium" pill. Config per pack via `window.IM_PACK`.
- **Auto-unlocks** for Practitioner-tier+ (reads the cached Supabase profile — packs stay lightweight, no full auth stack needed) **or** for standalone buyers via the new `resource_grants` check.
- **Supabase:** new `profiles.resource_grants TEXT[]` column (GIN-indexed). Migration `20260602_add_resource_grants.sql` — **already applied to the live DB** (additive/idempotent), because `auth.js` now selects the column. `auth.js` exposes `hasResourceAccess(slug)`; `state-manager.js` caches it. Grant flow matches the existing manual-UPI process: `array_append(resource_grants, '<slug>')` after payment.
- **`premium.html` / `upgrade.html`:** Practice Packs added to the Practitioner tier; registration form gains single-pack / +review / review options, a conditional pack-name field, a `?pack=<slug>` deep link, and a new FAQ.
- **Housekeeping:** search-index reframed; both changelogs updated (v10.34.0).

## Notes for review

- This is a **client-side freemium teaser**, consistent with the platform's existing tier gating — not a hard server-enforced paywall. The protected value is the personalised capstone built from the user's own inputs.
- Nothing changes for live users until merge → Netlify auto-deploy. The DB column is already live (safe, additive).
- **To verify:** open `/practice-packs/tor-writing/` logged out → Modules 1–2 work, Module 3 triggers the paywall. As Practitioner+, it stays fully open.

https://claude.ai/code/session_01ShatjbJZ9GzS7AVpaYjbZP

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShatjbJZ9GzS7AVpaYjbZP)_