### PR TITLE
SEO: Course JSON-LD + remove 1-hour meta-refresh (all flagships)

### DIFF
--- a/courses/dataviz/index.html
+++ b/courses/dataviz/index.html
@@ -3115,6 +3115,23 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 [data-theme="light"] .hero-badge { color: #0369A1 !important; }
 [data-theme="light"] .hero-tagline { color: #4338CA !important; }
 </style>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Course",
+      "name": "Seeing Data: Visualization for Impact",
+      "description": "Master data visualization for development impact. 12 modules covering theory, design, and practice.",
+      "url": "https://www.impactmojo.in/courses/dataviz/",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "provider": {
+        "@type": "Organization",
+        "name": "ImpactMojo",
+        "url": "https://www.impactmojo.in"
+      },
+      "image": "https://www.impactmojo.in/assets/images/data-viz-og.jpg"
+    }
+    </script>
 </head>
 <body>
 <!-- ImpactMojo Top Bar -->

--- a/courses/devai/index.html
+++ b/courses/devai/index.html
@@ -732,6 +732,23 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <meta name="robots" content="index, follow">
 <link rel="icon" type="image/png" href="/assets/images/favicon.png">
 <link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Course",
+      "name": "AI for Impact: Data Monitoring & Evaluation in Development",
+      "description": "When should you use AI in development M&E? A rigorous course covering computer vision, NLP, algorithmic targeting, and ethical frameworks.",
+      "url": "https://www.impactmojo.in/courses/devai/",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "provider": {
+        "@type": "Organization",
+        "name": "ImpactMojo",
+        "url": "https://www.impactmojo.in"
+      },
+      "image": "https://www.impactmojo.in/assets/images/ai-mne-og.png"
+    }
+    </script>
 </head>
 <body>
 <!-- ImpactMojo Top Bar -->

--- a/courses/devecon/index.html
+++ b/courses/devecon/index.html
@@ -27,7 +27,6 @@
     })();
     </script>
 
-    <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -3091,6 +3090,23 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <meta name="robots" content="index, follow">
 <link rel="icon" type="image/png" href="/assets/images/favicon.png">
 <link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Course",
+      "name": "Understanding Development: An Economics Perspective",
+      "description": "A comprehensive, free course exploring poverty, growth, and economic transformation in developing nations. Deep focus on South Asia with rigorous academic foundations.",
+      "url": "https://www.impactmojo.in/courses/devecon/",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "provider": {
+        "@type": "Organization",
+        "name": "ImpactMojo",
+        "url": "https://www.impactmojo.in"
+      },
+      "image": "https://www.impactmojo.in/assets/images/dev-econ-og.jpg"
+    }
+    </script>
 </head>
 <body>
 <!-- ImpactMojo Top Bar -->

--- a/courses/gandhi/index.html
+++ b/courses/gandhi/index.html
@@ -2210,6 +2210,23 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <meta name="robots" content="index, follow">
 <link rel="icon" type="image/png" href="/assets/images/favicon.png">
 <link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Course",
+      "name": "Gandhi's Political Thought: Philosophy for Praxis",
+      "description": "A comprehensive journey through Gandhi's political thought—from Swaraj and Satyagraha to Gram Swaraj and Trusteeship. Includes an interactive lexicon with 55+ annotated terms.",
+      "url": "https://www.impactmojo.in/courses/gandhi/",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "provider": {
+        "@type": "Organization",
+        "name": "ImpactMojo",
+        "url": "https://www.impactmojo.in"
+      },
+      "image": "https://www.impactmojo.in/assets/images/gandhi-og.jpg"
+    }
+    </script>
 </head>
 <body>
 <!-- ImpactMojo Top Bar -->

--- a/courses/gender/index.html
+++ b/courses/gender/index.html
@@ -1601,6 +1601,23 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
 <meta name="twitter:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
 <link rel="icon" type="image/png" href="/assets/images/favicon.png">
 <link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Course",
+      "name": "Gender Studies: Feminisms, Power & Social Change",
+      "description": "Gender Studies: Feminisms, Power & Social Change — free development education from ImpactMojo. Browse courses, games, labs, and resources for practitioners",
+      "url": "https://www.impactmojo.in/courses/gender/index.html",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "provider": {
+        "@type": "Organization",
+        "name": "ImpactMojo",
+        "url": "https://www.impactmojo.in"
+      },
+      "image": "https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png"
+    }
+    </script>
 </head>
 <body>
 

--- a/courses/law/index.html
+++ b/courses/law/index.html
@@ -27,7 +27,6 @@
     })();
     </script>
 
-    <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -3059,6 +3058,23 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <meta name="robots" content="index, follow">
 <link rel="icon" type="image/png" href="/assets/images/favicon.png">
 <link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Course",
+      "name": "Constitution & Law for Development Practice",
+      "description": "A practitioner's guide to constitutional law and rights-based frameworks across South Asia. From basic structure doctrine to PIL, Article 21, digital rights and climate justice.",
+      "url": "https://www.impactmojo.in/courses/law/",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "provider": {
+        "@type": "Organization",
+        "name": "ImpactMojo",
+        "url": "https://www.impactmojo.in"
+      },
+      "image": "https://www.impactmojo.in/assets/images/dev-econ-og.jpg"
+    }
+    </script>
 </head>
 <body>
 <!-- ImpactMojo Top Bar -->

--- a/courses/livelihoods/index.html
+++ b/courses/livelihoods/index.html
@@ -27,7 +27,6 @@
     })();
     </script>
 
-    <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -3152,6 +3151,23 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 .related-card-desc{font-size:.82rem;color:var(--text-muted);line-height:1.55}
 
 </style>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Course",
+      "name": "Livelihoods in India: Rural, Urban, and Skills",
+      "description": "Comprehensive flagship on Indian livelihoods — rural (NRLM, SHGs, agriculture), urban (informal work, gig economy, vendors), and skills (Skill India, FLFPR). Evidence-driven, India-centred, practitioner-oriented.",
+      "url": "https://www.impactmojo.in/courses/livelihoods/",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "provider": {
+        "@type": "Organization",
+        "name": "ImpactMojo",
+        "url": "https://www.impactmojo.in"
+      },
+      "image": "https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png"
+    }
+    </script>
 </head>
 <body>
 <div class="im-topbar" id="imTopbar" role="navigation" aria-label="Site navigation">

--- a/courses/media/index.html
+++ b/courses/media/index.html
@@ -27,7 +27,6 @@
     })();
     </script>
 
-    <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -3105,6 +3104,23 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 [data-theme="light"] .hero-badge { color: #0369A1 !important; }
 [data-theme="light"] .hero-tagline { color: #4338CA !important; }
 </style>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Course",
+      "name": "Media for Development: Communicating Impact",
+      "description": "A rigorous, free course on development communication, ethical storytelling, and media impact.",
+      "url": "https://www.impactmojo.in/courses/media/",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "provider": {
+        "@type": "Organization",
+        "name": "ImpactMojo",
+        "url": "https://www.impactmojo.in"
+      },
+      "image": "https://www.impactmojo.in/assets/images/media-og.jpg"
+    }
+    </script>
 </head>
 <body>
 <!-- ImpactMojo Top Bar -->

--- a/courses/mel/index.html
+++ b/courses/mel/index.html
@@ -3104,6 +3104,23 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 [data-theme="light"] .hero-badge { color: #0369A1 !important; }
 [data-theme="light"] .hero-tagline { color: #4338CA !important; }
 </style>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Course",
+      "name": "The Evidence Question: Monitoring, Evaluation & Learning for Practice",
+      "description": "A comprehensive, free course on MEL systems for development professionals. From theory of change to adaptive management.",
+      "url": "https://www.impactmojo.in/courses/mel/",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "provider": {
+        "@type": "Organization",
+        "name": "ImpactMojo",
+        "url": "https://www.impactmojo.in"
+      },
+      "image": "https://www.impactmojo.in/assets/images/mel-og.jpg"
+    }
+    </script>
 </head>
 <body>
 <!-- ImpactMojo Top Bar -->

--- a/courses/poa/index.html
+++ b/courses/poa/index.html
@@ -27,7 +27,6 @@
     })();
     </script>
 
-    <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -3165,6 +3164,23 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <meta name="robots" content="index, follow">
 <link rel="icon" type="image/png" href="/assets/images/favicon.png">
 <link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Course",
+      "name": "Politics of Aspiration: Rights, Insurance & Social Mobility",
+      "description": "How India's rights-based architecture creates enabling conditions for poor households to imagine and pursue better futures. A comprehensive course bridging development economics, political economy, and grassroots practice.",
+      "url": "https://www.impactmojo.in/courses/poa/",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "provider": {
+        "@type": "Organization",
+        "name": "ImpactMojo",
+        "url": "https://www.impactmojo.in"
+      },
+      "image": "https://www.impactmojo.in/assets/images/politics-aspiration-og.jpg"
+    }
+    </script>
 </head>
 <body>
 <!-- ImpactMojo Top Bar -->

--- a/courses/powerBI/powerbi.html
+++ b/courses/powerBI/powerbi.html
@@ -27,7 +27,6 @@
     })();
     </script>
 
-    <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -3320,6 +3319,23 @@ html[data-theme="dark"]{--s-card:#0F172A;--s-soft:#1E293B;--s-ink:#E2E8F0;--s-fa
 .serif-q{font-family:var(--serif);font-style:italic;font-size:18px;color:var(--ink2);border-left:3px solid var(--indigo);padding:4px 0 4px 16px;margin:16px 0}
 </style>
 
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Course",
+      "name": "Power BI for Practitioners: A Free Hands-On Course",
+      "description": "A free, hands-on Power BI flagship for South Asian development practitioners. Build honest dashboards from real survey data: Power Query, star schemas, DAX, visualisation ethics, and the free-tier and privacy realities.",
+      "url": "https://www.impactmojo.in/courses/powerbi/",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "provider": {
+        "@type": "Organization",
+        "name": "ImpactMojo",
+        "url": "https://www.impactmojo.in"
+      },
+      "image": "https://www.impactmojo.in/assets/images/powerbi-og.jpg"
+    }
+    </script>
 </head>
 <body>
 <!-- ImpactMojo Top Bar -->

--- a/courses/pubchoice/index.html
+++ b/courses/pubchoice/index.html
@@ -27,7 +27,6 @@
     })();
     </script>
 
-    <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -3321,6 +3320,23 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <meta name="robots" content="index, follow">
 <link rel="icon" type="image/png" href="/assets/images/favicon.png">
 <link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Course",
+      "name": "Public Choice: Decisions, Incentives & Institutions",
+      "description": "A flagship course on the mechanics of collective decision-making: voting rules, rent-seeking, bureaucracy, commons governance, and institutional design. Synthesises Virginia, Bloomington, and New Institutional traditions with deep South Asian case material.",
+      "url": "https://www.impactmojo.in/courses/pubchoice/",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "provider": {
+        "@type": "Organization",
+        "name": "ImpactMojo",
+        "url": "https://www.impactmojo.in"
+      },
+      "image": "https://www.impactmojo.in/assets/images/pubchoice-og.jpg"
+    }
+    </script>
 </head>
 <body>
 <!-- ImpactMojo Top Bar -->

--- a/courses/pubpol/index.html
+++ b/courses/pubpol/index.html
@@ -27,7 +27,6 @@
     })();
     </script>
 
-    <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -752,6 +751,23 @@ body.dark-mode, [data-theme="dark"] {
 <meta name="robots" content="index, follow">
 <link rel="icon" type="image/png" href="/assets/images/favicon.png">
 <link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Course",
+      "name": "Public Policy: Process, Design & Governance in India",
+      "description": "How policy gets made, implemented, and why it often doesn't work.",
+      "url": "https://www.impactmojo.in/courses/pubpol/",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "provider": {
+        "@type": "Organization",
+        "name": "ImpactMojo",
+        "url": "https://www.impactmojo.in"
+      },
+      "image": "https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png"
+    }
+    </script>
 </head>
 <body>
 

--- a/courses/sel/index.html
+++ b/courses/sel/index.html
@@ -27,7 +27,6 @@
     })();
     </script>
 
-    <meta http-equiv="refresh" content="3600">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
     <meta name="theme-color" content="#0F172A">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -3028,7 +3027,24 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 </style>
 
 
-    <body>
+        <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Course",
+      "name": "Social-Emotional Learning for Development Practice",
+      "description": "How social-emotional competencies shape effective development practice. Draws on multiple SEL frameworks (CASEL, SEE Learning, WHO Life Skills, Delhi Happiness Curriculum + EMC, Indian indigenous traditions, NEP 2020 teacher-side provisions) connected with daily practitioner realities across South Asia.",
+      "url": "https://www.impactmojo.in/courses/sel/",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "provider": {
+        "@type": "Organization",
+        "name": "ImpactMojo",
+        "url": "https://www.impactmojo.in"
+      },
+      "image": "https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png"
+    }
+    </script>
+<body>
 <!-- ImpactMojo Top Bar -->
 <div class="im-topbar" id="imTopbar" role="navigation" aria-label="Site navigation">
     <div class="im-topbar-left">


### PR DESCRIPTION
The third of the three follow-ups (#1 mobile "Contents" + #2 coach photos shipped in #525).

## SEO + a11y polish across all 14 flagship courses
- **Removed the 1-hour `<meta http-equiv="refresh" content="3600">`** from every course. A timed auto-reload interrupts long-form reading and is a WCAG 2.2.1 violation (and was the lone axe "critical" flag on media). Caching is handled by Netlify headers, not meta-refresh.
- **Added schema.org `Course` JSON-LD** to all 14 courses — none had structured data before. Each block is sourced from the page's existing og/canonical meta (name, description, url, image) + `provider: ImpactMojo`, `isAccessibleForFree: true`, `inLanguage: en`. All 14 validated as parseable JSON.

Verified: 0 meta-refresh remaining, 14/14 JSON-LD present and valid, pages render clean (incl. sel, which omits `</head>` — handled by inserting before `<body>`).

https://claude.ai/code/session_01ShatjbJZ9GzS7AVpaYjbZP

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShatjbJZ9GzS7AVpaYjbZP)_