### PR TITLE
chore: gitignore Backups/supabase/ (protected content snapshots)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,7 @@ scripts/course-content-seed.json
 scripts/seed-course-content.sql
 gender-course-papers.zip
 gender-course-papers.zip
+
+# Supabase content snapshots — protected course_content (kept local, never committed:
+# course HTML lives in Supabase by design so forks cannot redistribute it)
+Backups/supabase/


### PR DESCRIPTION
Small follow-up to the coach-callout work. While converting gender's coach callouts I saved Supabase `course_content` snapshots to `Backups/supabase/` as a safety net. Those JSON files contain the full course `content_html`, which lives in Supabase **by design** so forks can't redistribute course material — so they must never be committed.

This adds `Backups/supabase/` to `.gitignore` so those local snapshots stay local. No content or behavior change.

https://claude.ai/code/session_01ShatjbJZ9GzS7AVpaYjbZP

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShatjbJZ9GzS7AVpaYjbZP)_