### PR TITLE
Fix mobile deck sliver for real: stop .slide-viewport flex-shrinking (verified)

### DIFF
--- a/101-courses/SRHR-basics.html
+++ b/101-courses/SRHR-basics.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/advocacy-basics.html
+++ b/101-courses/advocacy-basics.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/bcc-comms.html
+++ b/101-courses/bcc-comms.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/bi-analysis.html
+++ b/101-courses/bi-analysis.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/care-economy-101.html
+++ b/101-courses/care-economy-101.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/child-development.html
+++ b/101-courses/child-development.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/climate-essentials.html
+++ b/101-courses/climate-essentials.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#e8e2da;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/community-dev.html
+++ b/101-courses/community-dev.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/cost-effectiveness.html
+++ b/101-courses/cost-effectiveness.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/data-feminism.html
+++ b/101-courses/data-feminism.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/data-lit.html
+++ b/101-courses/data-lit.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/decolonize-dev.html
+++ b/101-courses/decolonize-dev.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/dev-architecture.html
+++ b/101-courses/dev-architecture.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/dev-economics.html
+++ b/101-courses/dev-economics.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/digital-ethics.html
+++ b/101-courses/digital-ethics.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/econometrics-101.html
+++ b/101-courses/econometrics-101.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/eda-hhs.html
+++ b/101-courses/eda-hhs.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/edu-pedagogy.html
+++ b/101-courses/edu-pedagogy.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/eng-dev.html
+++ b/101-courses/eng-dev.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/env-justice.html
+++ b/101-courses/env-justice.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/feminist-research.html
+++ b/101-courses/feminist-research.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/fundraising-basics.html
+++ b/101-courses/fundraising-basics.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/gender-mainstreaming.html
+++ b/101-courses/gender-mainstreaming.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/impact-eval.html
+++ b/101-courses/impact-eval.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/ind-constitution.html
+++ b/101-courses/ind-constitution.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/inequality-basics.html
+++ b/101-courses/inequality-basics.html
@@ -19,7 +19,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#e8e2da;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/irt-basics.html
+++ b/101-courses/irt-basics.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/maternal-health.html
+++ b/101-courses/maternal-health.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/mel-basics.html
+++ b/101-courses/mel-basics.html
@@ -19,7 +19,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#e8e2da;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/mixed-methods.html
+++ b/101-courses/mixed-methods.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/multivariate-basics.html
+++ b/101-courses/multivariate-basics.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/obs2insight.html
+++ b/101-courses/obs2insight.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/pol-economy.html
+++ b/101-courses/pol-economy.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/post-truth-101.html
+++ b/101-courses/post-truth-101.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/pub-health-basics.html
+++ b/101-courses/pub-health-basics.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/public-finance-budgeting.html
+++ b/101-courses/public-finance-budgeting.html
@@ -35,7 +35,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/qual-methods.html
+++ b/101-courses/qual-methods.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/research-ethics.html
+++ b/101-courses/research-ethics.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/sel-basics.html
+++ b/101-courses/sel-basics.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/social-margins.html
+++ b/101-courses/social-margins.html
@@ -35,7 +35,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/survey-design.html
+++ b/101-courses/survey-design.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/toc-workbench.html
+++ b/101-courses/toc-workbench.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/visual-eth.html
+++ b/101-courses/visual-eth.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/wee-studies.html
+++ b/101-courses/wee-studies.html
@@ -18,7 +18,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 

--- a/101-courses/work-labour-livelihoods.html
+++ b/101-courses/work-labour-livelihoods.html
@@ -35,7 +35,7 @@
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
 #deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
-.slide-viewport{position:relative;width:1280px;height:720px;transform-origin:center center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
 .slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
 .slide.active{display:flex}
 


### PR DESCRIPTION
## The real fix for the mobile deck sliver

Verified in a headless browser at a 412px phone viewport:

| | `.slide-viewport` width | slide aspect | result |
|---|---|---|---|
| **Before** | **412px** (shrunk from 1280) | 0.57 (portrait) | tiny unreadable sliver |
| **After** | **1280px** | 1.78 (16:9) | full phone width, readable |

### Root cause
`#deck` is `display:flex` and `.slide-viewport` had no `flex-shrink` override → it defaulted to `flex-shrink:1`. On any container narrower than 1280px (every phone, and narrow desktop windows) the flex item **shrank its width toward the container** while `height:720px` stayed fixed, collapsing the 16:9 stage into a cramped **portrait** box that `transform:scale()` then shrank to a sliver. A uniformly-scaled stage can't be portrait — that was the tell.

### Fix
`.slide-viewport{flex-shrink:0}` on all **45 native decks** + the `build.py` donor, so the stage stays 1280×720 and `transform:scale()` fits it to width. (This supersedes the earlier timing patch, which addressed the wrong cause.)

Remaining top/bottom letterbox is inherent to a 16:9 stage on a tall portrait phone; the broken sliver is gone.

https://claude.ai/code/session_01PnKhcZz7iJc6GEpoxwDmVg

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnKhcZz7iJc6GEpoxwDmVg)_