### PR TITLE
Fix two mobile bottom-corner UI bugs: cookie ellipse + blocking language bar

### DIFF
--- a/css/imx-main.css
+++ b/css/imx-main.css
@@ -743,21 +743,15 @@
         }
 
         .cookie-icon-btn svg {
-            width: 28px;
-            height: 28px;
-            fill: var(--warning-color);
+            width: 26px;
+            height: 26px;
+            fill: #c0853f; /* warm cookie tan — self-consistent on any background */
         }
 
-        /* Bite mark effect */
-        .cookie-icon-btn::after {
-            content: '';
-            position: absolute;
-            top: -2px;
-            right: -2px;
-            width: 16px;
-            height: 16px;
-            background: var(--primary-bg);
-            border-radius: 50%;
+        /* Chocolate chips: fixed cocoa brown, NOT the page background (which
+           rendered as mismatched blobs when the button floated over content). */
+        .cookie-icon-btn svg circle[fill] {
+            fill: #5a3a1e !important;
         }
 
         .cookie-expanded {
@@ -792,7 +786,10 @@
         .cookie-expanded-header svg {
             width: 20px;
             height: 20px;
-            fill: var(--warning-color);
+            fill: #c0853f;
+        }
+        .cookie-expanded-header svg circle[fill] {
+            fill: #5a3a1e !important;
         }
 
         .cookie-expanded-header span {
@@ -854,8 +851,8 @@
         /* Mobile adjustment */
         @media (max-width: 480px) {
             .cookie-consent {
-                left: 10px;
-                bottom: 1.5rem;
+                left: 1rem;
+                bottom: 5.5rem; /* clear the bottom-left tools speed-dial */
             }
             .cookie-expanded {
                 width: calc(100vw - 40px);
@@ -6669,18 +6666,19 @@ footer::before {
         height: 44px !important;
     }
     
-    /* === COOKIE CONSENT - SIMPLE === */
+    /* === COOKIE CONSENT — minimal icon, bottom-left ===
+       The container must HUG its 48px round toggle (no full-width banner / no
+       padding), otherwise the icon is pushed inward and the round button gets
+       stretched into an ellipse. The expanded panel sizes itself separately. */
     .cookie-consent,
     #cookieConsent {
         left: 1rem !important;
-        right: 1rem !important;
-        bottom: 1rem !important;
+        right: auto !important;
+        bottom: 5.5rem !important; /* stack ABOVE the bottom-left tools speed-dial */
         width: auto !important;
         max-width: none !important;
-        padding: 1rem !important;
-        border-radius: 12px !important;
-        flex-direction: column !important;
-        gap: 0.75rem !important;
+        padding: 0 !important;
+        border-radius: 0 !important;
     }
     
     .cookie-consent p,
@@ -6690,8 +6688,11 @@ footer::before {
         margin: 0 !important;
     }
     
-    .cookie-consent button,
-    #cookieConsent button {
+    /* Stretch only the action buttons in the expanded panel — NOT the round
+       .cookie-icon-btn toggle (which must stay a 48px circle, not a full-width
+       ellipse). */
+    .cookie-expanded-buttons button,
+    #cookieConsent .cookie-expanded-buttons button {
         width: 100% !important;
         padding: 0.75rem !important;
         font-size: 0.9rem !important;

--- a/js/translate-sarvam.js
+++ b/js/translate-sarvam.js
@@ -137,44 +137,95 @@
 
   function save(lang) { try { localStorage.setItem(KEY_LS, lang); } catch (e) {} }
 
-  // ---- UI ----
-  var bar;
+  // ---- UI: compact collapsible globe (stacks ABOVE the cookie, bottom-left) ----
+  // A single 44px round button; tapping it opens a small upward popover with the
+  // five languages, then collapses. Replaces the old wide pill that overlapped
+  // the cookie / accessibility widgets on mobile.
+  var fab, menu, isOpen = false;
+
   function markActive(lang) {
-    if (!bar) return;
-    [].forEach.call(bar.querySelectorAll("button"), function (b) {
-      b.style.background = b.dataset.l === lang ? "rgba(29,78,216,0.9)" : "transparent";
-      b.style.color = b.dataset.l === lang ? "#fff" : "#475569";
-    });
+    if (menu) {
+      [].forEach.call(menu.querySelectorAll("button"), function (b) {
+        var on = b.dataset.l === lang;
+        b.style.background = on ? "rgba(29,78,216,0.95)" : "transparent";
+        b.style.color = on ? "#fff" : "#1e293b";
+        b.style.fontWeight = on ? "700" : "600";
+      });
+    }
+    if (fab) {
+      var lbl = fab.querySelector(".im-fab-lbl");
+      if (lbl) {
+        if (lang === "en") { lbl.style.display = "none"; lbl.textContent = ""; }
+        else { lbl.textContent = LANGS[lang].label; lbl.style.display = "block"; }
+      }
+    }
   }
   function markBusy(on) {
-    if (!bar) return;
-    bar.style.opacity = on ? "0.85" : "1";
-    var s = document.getElementById("im-xlate-status");
-    if (s) { s.style.display = on ? "inline-block" : "none"; }
+    if (!fab) return;
+    var sp = fab.querySelector(".im-fab-spin");
+    if (sp) sp.style.display = on ? "block" : "none";
+  }
+  function toggleMenu(force) {
+    isOpen = (typeof force === "boolean") ? force : !isOpen;
+    if (menu) {
+      menu.style.opacity = isOpen ? "1" : "0";
+      menu.style.visibility = isOpen ? "visible" : "hidden";
+      menu.style.transform = isOpen ? "translateY(0)" : "translateY(8px)";
+    }
+    if (fab) fab.setAttribute("aria-expanded", isOpen ? "true" : "false");
   }
   function buildUI() {
-    bar = document.createElement("div");
-    bar.id = "im-lang-switch"; bar.setAttribute("data-no-translate", "");
-    bar.setAttribute("aria-label", "Language");
-    bar.style.cssText = "position:fixed;bottom:14px;left:14px;z-index:99998;display:flex;gap:2px;" +
-      "background:#ffffff;backdrop-filter:blur(8px);border:1px solid rgba(0,0,0,0.1);" +
-      "border-radius:999px;padding:3px;box-shadow:0 4px 14px rgba(0,0,0,0.15);font-family:system-ui,sans-serif";
+    var wrap = document.createElement("div");
+    wrap.id = "im-lang-switch"; wrap.setAttribute("data-no-translate", "");
+    // Bottom-RIGHT corner: the bottom-left is owned by the learning-tools
+    // speed-dial + cookie, so we keep clear of them entirely.
+    wrap.style.cssText = "position:fixed;right:16px;bottom:24px;z-index:9990;font-family:system-ui,-apple-system,sans-serif";
+
+    // upward popover menu, anchored to the right edge
+    menu = document.createElement("div");
+    menu.setAttribute("role", "menu"); menu.setAttribute("aria-label", "Choose language");
+    menu.style.cssText = "position:absolute;bottom:54px;right:0;left:auto;display:flex;flex-direction:column;gap:3px;" +
+      "background:#fff;border:1px solid rgba(0,0,0,0.12);border-radius:14px;padding:5px;" +
+      "box-shadow:0 8px 28px rgba(0,0,0,0.18);min-width:130px;" +
+      "opacity:0;visibility:hidden;transform:translateY(8px);transition:opacity .18s ease,transform .18s ease,visibility .18s";
     Object.keys(LANGS).forEach(function (code) {
       var b = document.createElement("button");
-      b.textContent = LANGS[code].label; b.dataset.l = code;
-      b.title = LANGS[code].native;
-      b.style.cssText = "border:none;cursor:pointer;font-size:12px;font-weight:600;padding:5px 9px;border-radius:999px;background:transparent;color:#475569";
-      b.addEventListener("click", function () { translateTo(code); });
-      bar.appendChild(b);
+      b.dataset.l = code; b.type = "button"; b.setAttribute("role", "menuitem");
+      b.textContent = LANGS[code].native; b.title = LANGS[code].native;
+      b.style.cssText = "border:none;cursor:pointer;font-size:14px;font-weight:600;text-align:left;" +
+        "padding:9px 12px;border-radius:10px;background:transparent;color:#1e293b;white-space:nowrap";
+      b.addEventListener("click", function () { translateTo(code); toggleMenu(false); });
+      menu.appendChild(b);
     });
-    var status = document.createElement("span");
-    status.id = "im-xlate-status"; status.textContent = "translating…";
-    status.style.cssText = "display:none;align-self:center;font-size:11px;font-weight:600;color:#1D4ED8;padding:0 8px 0 4px;animation:imXlatePulse 1s ease-in-out infinite";
-    bar.appendChild(status);
+    wrap.appendChild(menu);
+
+    // round globe button
+    fab = document.createElement("button");
+    fab.type = "button"; fab.className = "im-fab";
+    fab.setAttribute("aria-label", "Choose language");
+    fab.setAttribute("aria-haspopup", "true"); fab.setAttribute("aria-expanded", "false");
+    fab.style.cssText = "width:44px;height:44px;border-radius:50%;background:#fff;padding:0;" +
+      "border:2px solid rgba(0,0,0,0.12);box-shadow:0 4px 15px rgba(0,0,0,0.2);cursor:pointer;" +
+      "display:flex;align-items:center;justify-content:center;position:relative;transition:transform .2s ease";
+    fab.innerHTML =
+      '<svg width="23" height="23" viewBox="0 0 24 24" fill="none" stroke="#1D4ED8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><path d="M3 12h18"></path><path d="M12 3a14 14 0 0 1 0 18 14 14 0 0 1 0-18z"></path></svg>' +
+      '<span class="im-fab-lbl" style="display:none;position:absolute;bottom:-4px;right:-4px;background:#1D4ED8;color:#fff;font-size:9px;font-weight:700;line-height:1;padding:2px 4px;border-radius:8px;min-width:8px;text-align:center;box-shadow:0 1px 3px rgba(0,0,0,.3)"></span>' +
+      '<span class="im-fab-spin" style="display:none;position:absolute;inset:-3px;border-radius:50%;border:2px solid transparent;border-top-color:#1D4ED8;animation:imXlateSpin .8s linear infinite"></span>';
+    fab.addEventListener("click", function (e) { e.stopPropagation(); toggleMenu(); });
+    wrap.appendChild(fab);
+
     var kf = document.createElement("style");
-    kf.textContent = "@keyframes imXlatePulse{0%,100%{opacity:.45}50%{opacity:1}}";
+    kf.textContent = "@keyframes imXlateSpin{to{transform:rotate(360deg)}}" +
+      "#im-lang-switch .im-fab:active{transform:scale(.93)}" +
+      "#im-lang-switch [role=menuitem]:hover{background:rgba(0,0,0,0.05)!important}" +
+      "@media(max-width:480px){#im-lang-switch{right:14px!important;bottom:20px!important}}";
     document.head.appendChild(kf);
-    document.body.appendChild(bar);
+
+    // collapse on outside tap / Escape
+    document.addEventListener("click", function () { if (isOpen) toggleMenu(false); });
+    document.addEventListener("keydown", function (e) { if (e.key === "Escape" && isOpen) toggleMenu(false); });
+
+    document.body.appendChild(wrap);
   }
 
   // Translate content injected later (flagship Supabase module bodies, auth bar,


### PR DESCRIPTION
## Two mobile UI problems (reported with screenshots)

### 1. "Horrible cookie 🍪" — rendered as a full-width white ellipse
Two compounding CSS bugs on mobile:
- A broad `.cookie-consent button { width:100% !important }` rule (intended for the expanded panel's *Accept / Learn More* buttons) was also hitting the round 48px `.cookie-icon-btn` toggle, stretching it.
- A "SIMPLE" mobile rule forced the consent container into a full-width banner (`left:1rem; right:1rem; padding:1rem; flex-direction:column`).

**Fix:** scope the width rule to `.cookie-expanded-buttons` only; make the container hug its 48px icon; recolour to a clean tan cookie with cocoa-brown chips (dropping the page-background-dependent bite-mark / chip blobs that looked broken when floating over content); and stack the cookie **above** the bottom-left learning-tools speed-dial so it no longer covers it.

### 2. "Language bar is blocking"
The site-wide language switcher was a wide pill pinned bottom-left that overlapped the cookie and the speed-dial. Replaced it with a **compact 44px collapsible globe in the free bottom-right corner**: tapping opens a small upward popover of the five languages and collapses on selection / outside tap. Colours are WCAG AA-safe (slate-900 on white, white on `#1D4ED8`), so it won't re-trip the axe-core gate.

## Verification
At 390px in headless Chromium:
- No overlap between globe, cookie and speed-dial (collapsed or with menus open).
- Both menus open fully on-screen.
- Mobile overflow audit: no horizontal overflow.

## Files
- `css/imx-main.css` — cookie restyle, scoped width rule, raised position
- `js/translate-sarvam.js` — compact collapsible globe (bottom-right)

https://claude.ai/code/session_01PnKhcZz7iJc6GEpoxwDmVg

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnKhcZz7iJc6GEpoxwDmVg)_