### PR TITLE
Modernise (1/N): CI action bumps + index updates.html

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -29,17 +29,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6  # Updated from v3 to v4
+        uses: actions/checkout@v6
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5  # Updated from v3 to v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5  # This is correct - it's the pages-specific action
+        uses: actions/upload-pages-artifact@v5
         with:
           # Upload entire repository (since your index.html is in the root)
           path: '.'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5  # Updated from v2 to v4
+        uses: actions/deploy-pages@v5

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -5839,6 +5839,22 @@
     ]
   },
   {
+    "id": "updates",
+    "title": "Updates & Roadmap",
+    "description": "What's new on ImpactMojo and what's coming next — recent releases, new courses, games, labs, and the public product roadmap.",
+    "type": "page",
+    "category": "About",
+    "url": "/updates.html",
+    "tags": [
+      "updates",
+      "roadmap",
+      "changelog",
+      "whats new",
+      "releases",
+      "announcements"
+    ]
+  },
+  {
     "id": "catalog",
     "title": "Full Catalog",
     "description": "Browse the complete catalog of courses, labs, games, tools, and resources available on ImpactMojo.",


### PR DESCRIPTION
First, low-risk slice of the modernisation programme (quick wins + CI).

## Changes
- **`mobile.yml`**: `actions/setup-python@v5` → **`@v6`**. v5 runs on Node 20, which GitHub deprecates ~July 2026 (the source of the `Node.js 20 actions are deprecated` warning in CI logs).
- **`static.yml`**: `actions/configure-pages@v5` → **`@v6`** (supersedes Dependabot **#343**); removed stale `# Updated from vN to vM` comments.
- **`search-index.json`**: added the **Updates & Roadmap** page (`/updates.html`) — it's linked in the nav but was missing from site search.

## Dependabot reconciliation
- **#344** (checkout v4→v6) is **obsolete** — every workflow already uses `actions/checkout@v6`. Will close it.
- **#343** (configure-pages v5→v6) is **done here**. Will close it on merge.

## Not done (false positives from the audit, verified)
- **jQuery removal** — 0 non-backup references exist; nothing to remove.
- **Viewport meta on email/seed files** — all 56 are HTML *fragments* (no `<head>`) injected into an app/email shell, so a `<meta viewport>` doesn't apply.
- **Emoji→SVG** (21 in 7 files) — needs bespoke per-use icon mapping; deferred to its own focused pass, not a "quick win".

## Validation
`python3 -m json.tool data/search-index.json` OK (635 entries); both workflows parse as valid YAML.

Part of the modernisation effort agreed with the maintainer; subsequent PRs will cover the cookie/corner-zones consolidation, theme-switcher cleanup, and the `imx-main.css` `!important` refactor.

https://claude.ai/code/session_01PnKhcZz7iJc6GEpoxwDmVg

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnKhcZz7iJc6GEpoxwDmVg)_