### PR TITLE
Fix about.html: unterminated string literal that broke its entire inline script

### DIFF
--- a/about.html
+++ b/about.html
@@ -2542,8 +2542,7 @@ function selectOption(option) {
     
     const userMsg = document.createElement('div');
     userMsg.className = 'message';
-    userMsg.innerHTML = '<div class="bot-bubble" style="margin-left: auto; background: var(--gradient-primary);
- background-color: #0369A1; /* WCAG AA fallback for pa11y — override gradient-reset */ color: white; border-radius: 12px; border-top-right-radius: 4px;">' + option.charAt(0).toUpperCase() + option.slice(1) + '</div>';
+    userMsg.innerHTML = '<div class="bot-bubble" style="margin-left: auto; background: var(--gradient-primary); background-color: #0369A1; /* WCAG AA fallback for pa11y — override gradient-reset */ color: white; border-radius: 12px; border-top-right-radius: 4px;">' + option.charAt(0).toUpperCase() + option.slice(1) + '</div>';
     messages.appendChild(userMsg);
     
     setTimeout(function() {
@@ -2571,8 +2570,7 @@ function sendChatMessage() {
     
     const userMsg = document.createElement('div');
     userMsg.className = 'message';
-    userMsg.innerHTML = '<div class="bot-bubble" style="margin-left: auto; background: var(--gradient-primary);
- background-color: #0369A1; /* WCAG AA fallback for pa11y — override gradient-reset */ color: white; border-radius: 12px; border-top-right-radius: 4px;">' + message + '</div>';
+    userMsg.innerHTML = '<div class="bot-bubble" style="margin-left: auto; background: var(--gradient-primary); background-color: #0369A1; /* WCAG AA fallback for pa11y — override gradient-reset */ color: white; border-radius: 12px; border-top-right-radius: 4px;">' + message + '</div>';
     messages.appendChild(userMsg);
     
     input.value = '';


### PR DESCRIPTION
Fixes a pre-existing bug discovered while consolidating the cookie CSS (#557).

## The bug
A pa11y WCAG-fallback pass injected a `background-color` override **with a literal newline** into two single-quoted JS strings in about.html's Mojini chatbot code:

```js
userMsg.innerHTML = '<div class="bot-bubble" style="… background: var(--gradient-primary);
 background-color: #0369A1; /* WCAG AA fallback … */ …">' + … ;
```

A single-quoted JS string can't span a newline, so the entire `<script>` block threw `SyntaxError: Invalid or unexpected token`. That killed **all** of about.html's main inline script — theme toggle, mobile menu, chatbot, and the cookie-expand were all dead on production.

## Fix
Joined each broken string back onto one line (2 occurrences). No behaviour change beyond restoring the script.

## Verified
- All inline `<script>` blocks now pass `node --check`.
- `typeof toggleCookieExpand === 'function'` (was `undefined`).
- Cookie button expands on click.

https://claude.ai/code/session_01PnKhcZz7iJc6GEpoxwDmVg

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnKhcZz7iJc6GEpoxwDmVg)_