### PR TITLE
Modernise (3a/N): extract canonical theme controller to js/theme.js (67 pages)

### DIFF
--- a/404.html
+++ b/404.html
@@ -1963,47 +1963,7 @@ document.addEventListener('click', function(e) {
 <script defer src="js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 
 <!-- Supabase Auth -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>

--- a/ImpactMojo_PressKit.html
+++ b/ImpactMojo_PressKit.html
@@ -986,47 +986,7 @@ function cp(btn){
 }
 </script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/about.html
+++ b/about.html
@@ -2619,47 +2619,7 @@ document.addEventListener('click', function(e) {
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 
 <!-- Supabase Auth -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>

--- a/account.html
+++ b/account.html
@@ -2973,47 +2973,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
 </body>
 </html>

--- a/ai-policy.html
+++ b/ai-policy.html
@@ -1297,47 +1297,7 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', fun
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/bct-repository.html
+++ b/bct-repository.html
@@ -2555,47 +2555,7 @@ window.addEventListener('hashchange', handleHash);
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog.html
+++ b/blog.html
@@ -2990,47 +2990,7 @@ document.addEventListener('click', function(e) {
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 
 <!-- Supabase Auth -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>

--- a/blog/adaptive-management-toc.html
+++ b/blog/adaptive-management-toc.html
@@ -435,47 +435,7 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/assumption-testing.html
+++ b/blog/assumption-testing.html
@@ -441,47 +441,7 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/building-mel-culture.html
+++ b/blog/building-mel-culture.html
@@ -405,47 +405,7 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/community-feedback-loops.html
+++ b/blog/community-feedback-loops.html
@@ -405,47 +405,7 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/data-driven-decisions.html
+++ b/blog/data-driven-decisions.html
@@ -413,47 +413,7 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/data-quality-field.html
+++ b/blog/data-quality-field.html
@@ -442,47 +442,7 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/ethical-research-south-asia.html
+++ b/blog/ethical-research-south-asia.html
@@ -409,47 +409,7 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/from-learner-to-leader.html
+++ b/blog/from-learner-to-leader.html
@@ -803,47 +803,7 @@ function updateThemeIcons() {
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/github-open-dev-ecosystem.html
+++ b/blog/github-open-dev-ecosystem.html
@@ -544,47 +544,7 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/history-of-mel.html
+++ b/blog/history-of-mel.html
@@ -447,47 +447,7 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/impactmojo-mcp-server.html
+++ b/blog/impactmojo-mcp-server.html
@@ -498,47 +498,7 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/indicators-that-matter.html
+++ b/blog/indicators-that-matter.html
@@ -414,47 +414,7 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/learning-by-doing.html
+++ b/blog/learning-by-doing.html
@@ -712,47 +712,7 @@ function updateThemeIcons() {
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/making-accessible-websites.html
+++ b/blog/making-accessible-websites.html
@@ -592,47 +592,7 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/meal-demystified.html
+++ b/blog/meal-demystified.html
@@ -1117,47 +1117,7 @@ function updateThemeIcons() {
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/mixed-methods-evaluation.html
+++ b/blog/mixed-methods-evaluation.html
@@ -408,47 +408,7 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/multilingual-learning.html
+++ b/blog/multilingual-learning.html
@@ -407,47 +407,7 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/open-education-matters.html
+++ b/blog/open-education-matters.html
@@ -403,47 +403,7 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/participatory-mel.html
+++ b/blog/participatory-mel.html
@@ -440,47 +440,7 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/quasi-experimental-designs.html
+++ b/blog/quasi-experimental-designs.html
@@ -409,47 +409,7 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/sample-size-matters.html
+++ b/blog/sample-size-matters.html
@@ -758,47 +758,7 @@ function updateThemeIcons() {
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/south-asia-development-landscape.html
+++ b/blog/south-asia-development-landscape.html
@@ -407,47 +407,7 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/theory-of-change-pitfalls.html
+++ b/blog/theory-of-change-pitfalls.html
@@ -1019,47 +1019,7 @@ function updateThemeIcons() {
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/toc-for-complex-programmes.html
+++ b/blog/toc-for-complex-programmes.html
@@ -430,47 +430,7 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/toc-vs-logframe.html
+++ b/blog/toc-vs-logframe.html
@@ -437,47 +437,7 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/tools-we-use.html
+++ b/blog/tools-we-use.html
@@ -406,47 +406,7 @@ function updateThemeIcons() { const isLight = document.body.classList.contains('
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/what-the-evidence-says-about-cash-transfers.html
+++ b/blog/what-the-evidence-says-about-cash-transfers.html
@@ -582,47 +582,7 @@ function updateThemeIcons() {
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/whats-coming-in-2026.html
+++ b/blog/whats-coming-in-2026.html
@@ -914,47 +914,7 @@ function updateThemeIcons() {
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/blog/why-impactmojo-exists.html
+++ b/blog/why-impactmojo-exists.html
@@ -1013,47 +1013,7 @@ function updateThemeIcons() {
 <script defer src="../js/translate.js"></script>
 <script src="/js/search.js" defer></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/catalog.html
+++ b/catalog.html
@@ -2782,47 +2782,7 @@ document.addEventListener('click', function(e) {
 })();
 </script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 
 <!-- Supabase Auth -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>

--- a/challenges.html
+++ b/challenges.html
@@ -954,47 +954,7 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', fun
 </script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 
 <!-- Supabase Auth -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>

--- a/climate-trace-india.html
+++ b/climate-trace-india.html
@@ -1196,47 +1196,7 @@ document.querySelectorAll('.tab-btn').forEach(btn => {
 });
 </script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/coaching.html
+++ b/coaching.html
@@ -1753,47 +1753,7 @@ document.addEventListener('DOMContentLoaded', function() {
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -1726,47 +1726,7 @@ document.addEventListener('DOMContentLoaded', function() {
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/content-marketing-kit.html
+++ b/content-marketing-kit.html
@@ -1694,47 +1694,7 @@ function nxt(id){const s=gcs(id);s.cur=(s.cur+1)%s.tot;upd(id);}
 function gt(id,i){gcs(id).cur=i;upd(id);}
 </script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/data-protection.html
+++ b/data-protection.html
@@ -1986,47 +1986,7 @@ function addBotMessage(text) {
 <script defer src="js/translate.js"></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 
 <!-- Supabase Auth -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>

--- a/dataverse.html
+++ b/dataverse.html
@@ -2281,47 +2281,7 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', fun
 })();
 </script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -1442,47 +1442,7 @@ function addBotMessage(text) {
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 
 <!-- Supabase Auth -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>

--- a/faq.html
+++ b/faq.html
@@ -2185,47 +2185,7 @@ function searchFAQ() {
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 
 <!-- Supabase Auth -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>

--- a/forgot-password.html
+++ b/forgot-password.html
@@ -2293,47 +2293,7 @@ document.addEventListener('click', function(e) {
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
 </body>
 </html>

--- a/grievance.html
+++ b/grievance.html
@@ -1868,47 +1868,7 @@ function addBotMessage(text) {
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 
 <!-- Supabase Auth -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>

--- a/handouts.html
+++ b/handouts.html
@@ -1949,47 +1949,7 @@ loadHandouts();
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 
 <!-- Supabase Auth -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,0 +1,51 @@
+/* ImpactMojo — canonical theme controller (shared).
+   Single source of truth for the System/Light/Dark selector. Replaces the
+   per-page inline copy that was duplicated across hundreds of pages.
+
+   Markup contract (unchanged):
+     <div class="im-theme-selector">
+       <button class="im-theme-btn" data-imtheme="system">…</button>
+       <button class="im-theme-btn" data-imtheme="light">…</button>
+       <button class="im-theme-btn" data-imtheme="dark">…</button>
+     </div>
+   Canonical localStorage key: 'im-theme' (values: system | light | dark).
+   Applies <html data-theme="light|dark"> + body.light-mode / body.dark-mode. */
+(function () {
+    function getSystemTheme() {
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+    function applyTheme(theme) {
+        var resolved = theme === 'system' ? getSystemTheme() : theme;
+        document.documentElement.setAttribute('data-theme', resolved);
+        // Also handle legacy body classes
+        document.body.classList.remove('dark-mode', 'light-mode');
+        if (resolved === 'light') document.body.classList.add('light-mode');
+        else document.body.classList.add('dark-mode');
+    }
+    function updateButtons(pref) {
+        document.querySelectorAll('.im-theme-btn').forEach(function (btn) {
+            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
+        });
+    }
+    var saved = localStorage.getItem('im-theme') || 'system';
+    // Apply immediately before render
+    applyTheme(saved);
+    document.addEventListener('DOMContentLoaded', function () {
+        applyTheme(saved);
+        updateButtons(saved);
+        document.querySelectorAll('.im-theme-btn').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                var t = this.getAttribute('data-imtheme');
+                localStorage.setItem('im-theme', t);
+                applyTheme(t);
+                updateButtons(t);
+            });
+        });
+    });
+    // Listen for system theme changes
+    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function () {
+        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
+            applyTheme('system');
+        }
+    });
+})();

--- a/live-projects.html
+++ b/live-projects.html
@@ -1271,47 +1271,7 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', fun
 </script>
 
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/login.html
+++ b/login.html
@@ -1988,47 +1988,7 @@ document.addEventListener('click', function(e) {
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
 </body>
 </html>

--- a/offline.html
+++ b/offline.html
@@ -517,47 +517,7 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', fun
 });
 </script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 
 <!-- Supabase Auth -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>

--- a/org-dashboard.html
+++ b/org-dashboard.html
@@ -3179,47 +3179,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 
         printHtml += '<div class="footer">Generated from ImpactMojo Organization Dashboard &middot; impactmojo.in &middot; ' + new Date().toLocaleDateString('en-IN', { day: 'numeric', month: 'long', year: 'numeric' }) + '</div>';
         printHtml += '<!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 </body></html>';
 
         var blob = new Blob([printHtml], { type: 'text/html;charset=utf-8' });

--- a/podcast.html
+++ b/podcast.html
@@ -2042,47 +2042,7 @@ function addBotMessage(text) {
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 
 <!-- Supabase Auth -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>

--- a/portfolio.html
+++ b/portfolio.html
@@ -1377,47 +1377,7 @@ document.getElementById('headlineInput').addEventListener('input', function() {
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
 </body>
 </html>

--- a/premium.html
+++ b/premium.html
@@ -2365,47 +2365,7 @@ function toggleTierDetail(id) {
 })();
 </script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
 </body>
 </html>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1378,47 +1378,7 @@ function addBotMessage(text) {
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 
 <!-- Supabase Auth -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>

--- a/refund-policy.html
+++ b/refund-policy.html
@@ -1529,47 +1529,7 @@ function addBotMessage(text) {
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 
 <!-- Supabase Auth -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>

--- a/signup.html
+++ b/signup.html
@@ -2405,47 +2405,7 @@ document.addEventListener('DOMContentLoaded', function() {
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
 </body>
 </html>

--- a/sitemap.html
+++ b/sitemap.html
@@ -1320,47 +1320,7 @@ body { padding-top: 56px; }
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -1478,47 +1478,7 @@ function addBotMessage(text) {
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 
 <!-- Supabase Auth -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>

--- a/testimonials.html
+++ b/testimonials.html
@@ -975,47 +975,7 @@ function filterLang(lang) {
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 
 <!-- Supabase Auth -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>

--- a/toc-builder.html
+++ b/toc-builder.html
@@ -1286,47 +1286,7 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change',func
 </script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Footer -->
 <footer class="im-footer" role="contentinfo">
 <div class="im-footer-content">

--- a/toc-workbench.html
+++ b/toc-workbench.html
@@ -1365,47 +1365,7 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change',func
 </script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/transparency.html
+++ b/transparency.html
@@ -1437,47 +1437,7 @@ window.addEventListener('resize', function() {
 })();
 </script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/verify-certificate.html
+++ b/verify-certificate.html
@@ -1055,47 +1055,7 @@ document.addEventListener('DOMContentLoaded', function() {
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->
 <svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>

--- a/workshops.html
+++ b/workshops.html
@@ -1819,47 +1819,7 @@ function addBotMessage(text) {
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
 <!-- ImpactMojo Theme Toggle JS -->
-<script>
-(function() {
-    function getSystemTheme() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-        var resolved = theme === 'system' ? getSystemTheme() : theme;
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Also handle legacy body classes
-        document.body.classList.remove('dark-mode', 'light-mode');
-        if (resolved === 'light') document.body.classList.add('light-mode');
-        else document.body.classList.add('dark-mode');
-    }
-    function updateButtons(pref) {
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.classList.toggle('active', btn.getAttribute('data-imtheme') === pref);
-        });
-    }
-    var saved = localStorage.getItem('im-theme') || 'system';
-    // Apply immediately before render
-    applyTheme(saved);
-    document.addEventListener('DOMContentLoaded', function() {
-        applyTheme(saved);
-        updateButtons(saved);
-        document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var t = this.getAttribute('data-imtheme');
-                localStorage.setItem('im-theme', t);
-                applyTheme(t);
-                updateButtons(t);
-            });
-        });
-    });
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function() {
-        if ((localStorage.getItem('im-theme') || 'system') === 'system') {
-            applyTheme('system');
-        }
-    });
-})();
-</script>
+<script src="/js/theme.js"></script>
 
 <!-- Supabase Auth -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>


### PR DESCRIPTION
First installment of the Phase 3 theme-switcher consolidation (full-sweep, done safely in verified clusters).

## What
- New **`js/theme.js`** — canonical System/Light/Dark controller (verbatim of the dominant inline variant): `im-theme` key, `.im-theme-btn[data-imtheme]` contract, `data-theme` + `body.dark-mode/light-mode`, FOUC apply + system-change listener.
- Replaced the **exact** inline block with `<script src="/js/theme.js"></script>` on the **67 pages** that carried it byte-for-byte (38 top-level + 29 blog).

**−2,629 lines** of duplicated inline JS.

## Why it's safe
- **Exact-string match only** — no regex applied to live JS. A page was touched only if it contained the block character-for-character.
- **Behaviour-identical** — same code, same DOM position (non-`defer`, runs in the same order), same key/markup contract.
- Verified in headless Chromium: `content-marketing-kit.html` toggles correctly (dark/light → `data-theme` + body class + persists to `im-theme`); `js/theme.js` passes `node --check`; every touched file loads it exactly once with no leftover inline copy.

## Scope note
This is installment **3a**. The remaining ~200 pages use micro-variant blocks and a **second** button-wiring convention (`.theme-btn` + `onclick` globals like `setTheme/toggleTheme`). Those need their own exact-match variants + a behavioural superset in `theme.js`, handled in follow-up installments so each stays small and reviewable.

https://claude.ai/code/session_01PnKhcZz7iJc6GEpoxwDmVg

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnKhcZz7iJc6GEpoxwDmVg)_