### PR TITLE
Marginalia: rewrite intro for clarity

### DIFF
--- a/specials/marginalia/index.html
+++ b/specials/marginalia/index.html
@@ -254,8 +254,8 @@ body {
 <main class="cfi-wrap" id="main-content">
   <div class="cfi-eyebrow">An ImpactMojo Special</div>
   <h1 class="cfi-title">Margi<em>nalia</em></h1>
-  <p class="cfi-lede">Cartoon essays on development work — drawn in the margin, footnoted in earnest.</p>
-  <p class="cfi-note">Every panel runs the same device: someone in a lanyard says the thing the sector says, and someone who does the actual work — a field officer, an ASHA, a farmer, a beneficiary — says the thing the sector tends not to write down. The reply is the note scribbled in the margin of the script, and the margin is where those voices usually get filed. The jokes are drawn; every footnote is real. <a href="/podcast.html" style="color:var(--cfi-ink);">A companion in spirit to the <em>Between the Logframes</em> podcast.</a></p>
+  <p class="cfi-lede">Cartoon essays on development work — the sector’s claim, the field’s reply, and a footnote to back it up.</p>
+  <p class="cfi-note">Every cartoon runs the same setup: someone official says the polished thing the development sector likes to say, and someone who does the real work — a field officer, an ASHA, a farmer, a beneficiary — says what usually goes unsaid. The jokes are drawn; every footnote is real. <a href="/podcast.html" style="color:var(--cfi-ink);">A companion in spirit to the <em>Between the Logframes</em> podcast.</a></p>
   <hr class="cfi-divider">
 
   <div class="mg-grid">


### PR DESCRIPTION
## What
Readers reported the Marginalia intro was hard to understand. It leaned on metaphors that needed decoding — "someone in a lanyard," "the thing the sector tends not to write down," and a doubled margin image ("the note scribbled in the margin of the script, and the margin is where those voices usually get filed").

Rewrites the visible lede + body (`specials/marginalia/index.html`) to state plainly what each cartoon does, while keeping the wit and rhythm. The already-clear social/meta descriptions are unchanged and now match the on-page copy.

**Before**
> Cartoon essays on development work — drawn in the margin, footnoted in earnest.
> Every panel runs the same device: someone in a lanyard says the thing the sector says… The reply is the note scribbled in the margin of the script, and the margin is where those voices usually get filed.

**After**
> Cartoon essays on development work — the sector's claim, the field's reply, and a footnote to back it up.
> Every cartoon runs the same setup: someone official says the polished thing the development sector likes to say, and someone who does the real work — a field officer, an ASHA, a farmer, a beneficiary — says what usually goes unsaid. The jokes are drawn; every footnote is real.

https://claude.ai/code/session_01PnKhcZz7iJc6GEpoxwDmVg

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnKhcZz7iJc6GEpoxwDmVg)_