### PR TITLE
The Long View: add radial, dumbbell, and heatmap charts from Dataverse sources

### DIFF
--- a/the-long-view.html
+++ b/the-long-view.html
@@ -266,7 +266,7 @@ a { color: var(--color-primary); }
   <div class="wrap">
     <div class="section-head">
       <span class="kicker">The Data Wing</span>
-      <h2>Eight charts, built from real evidence</h2>
+      <h2>Eleven charts, built from real evidence</h2>
       <p>Each is drawn from scratch in your browser from a named, public dataset. Hover a source line to see exactly where every number came from — because a chart you can't trace is just decoration.</p>
     </div>
 
@@ -326,6 +326,30 @@ a { color: var(--color-primary); }
         <div class="chart-holder"><svg id="c-pipeline" role="img" aria-label="A funnel of female gross enrolment in India narrowing from 104.8% in primary school to 28.5% in higher education."></svg></div>
         <p class="insight">India has all but closed the gender gap in school — girls' enrolment even tops 100% in primary. But the pipeline leaks at every stage: barely <strong>1 in 4</strong> young women reaches higher education.</p>
         <p class="source">Source: UDISE+ 2021–22 (school) and AISHE 2021–22 (higher education). Female gross enrolment ratio (GER) by level.</p>
+      </article>
+
+      <article class="card" data-card>
+        <span class="tag">Energy</span>
+        <h3>How India keeps the lights on</h3>
+        <div class="chart-holder"><svg id="c-energy" role="img" aria-label="A donut chart of India's 2024 electricity generation mix: coal 73%, hydro 8%, solar 7%, wind 5%, nuclear 3%, gas 2%, bioenergy 2%."></svg></div>
+        <p class="insight">Nearly <strong>three-quarters</strong> of India's electricity still comes from coal. Solar and wind are climbing fast — now a combined 12% — but the transition is only beginning.</p>
+        <p class="source">Source: Ember / Central Electricity Authority — share of electricity generation, 2024. Figures rounded.</p>
+      </article>
+
+      <article class="card" data-card>
+        <span class="tag">Gender</span>
+        <h3>The same gap, four ways</h3>
+        <div class="chart-holder"><svg id="c-gender" role="img" aria-label="A dumbbell chart of India gender gaps: women now slightly lead men in college enrolment, are close in literacy, but trail far behind in labour-force participation and seats in the Lok Sabha."></svg></div>
+        <p class="insight">Indian women have <strong>caught up — even pulled ahead — in college</strong>, and the literacy gap is closing. Yet they remain far behind where power and pay are decided: paid work and Parliament.</p>
+        <p class="source">Sources: NFHS-5 (literacy), AISHE 2021–22 (college GER), PLFS 2023–24 (labour force), Lok Sabha 2024 (seats).</p>
+      </article>
+
+      <article class="card" data-card>
+        <span class="tag">Health &amp; Nutrition</span>
+        <h3>Two decades of progress — and one stubborn row</h3>
+        <div class="chart-holder"><svg id="c-nfhs" role="img" aria-label="A heatmap of India's progress across three NFHS rounds on five indicators: institutional births, immunisation, women's bank accounts, child not stunted, and women not anaemic. Most improve and turn green over time, but the anaemia row stays pale and even worsens."></svg></div>
+        <p class="insight">Across three national surveys, India's services raced ahead — institutional births, immunisation and women's bank accounts all turned deep green. But the bottom row barely moves: <strong>anaemia among women has actually worsened</strong>.</p>
+        <p class="source">Source: National Family Health Survey rounds 3 (2005–06), 4 (2015–16) and 5 (2019–21). Each cell is the share with the positive outcome.</p>
       </article>
 
       <article class="card" data-card>
@@ -492,6 +516,9 @@ a { color: var(--color-primary); }
       <li><b>Poverty is not caste-blind</b>NFHS-4 (2015–16) multidimensional poverty headcount by social group; national MPI ≈ 24.8%.</li>
       <li><b>Whose carbon?</b>EDGAR (European Commission / JRC) — territorial CO₂ emissions per capita by country, 2023.</li>
       <li><b>The leaky pipeline</b>UDISE+ 2021–22 (school) and AISHE 2021–22 (higher education) — female gross enrolment ratio by level.</li>
+      <li><b>How India keeps the lights on</b>Ember / Central Electricity Authority — share of electricity generation, 2024.</li>
+      <li><b>The same gap, four ways</b>NFHS-5, AISHE 2021–22, PLFS 2023–24, and Lok Sabha 2024 — by sex.</li>
+      <li><b>Two decades of progress</b>National Family Health Survey rounds 3, 4 and 5 — national indicators.</li>
       <li><b>India is heating up</b>India Meteorological Department high-resolution gridded data (1901–2024), via Data for India — annual mean temperature anomaly.</li>
       <li><b>Women re-enter the workforce</b>Periodic Labour Force Survey (PLFS), MoSPI — female LFPR, usual status, age 15+, 2017-18 and 2022-23.</li>
     </ul>
@@ -819,6 +846,87 @@ a { color: var(--color-primary); }
     });
   }
 
+  /* ---------- Radial donut (parts of a whole) ---------- */
+  function donut(id, data, o) {
+    var svg = frame(id); if (!svg) return;
+    var cx = 138, cy = 150, rO = 92, rI = 54, total = data.reduce(function(s, d){ return s + d.v; }, 0);
+    function arc(a0, a1) {
+      var p0o = polar(cx, cy, rO, a0), p1o = polar(cx, cy, rO, a1), p1i = polar(cx, cy, rI, a1), p0i = polar(cx, cy, rI, a0);
+      var lg = (a1 - a0) > 180 ? 1 : 0;
+      return 'M' + p0o[0].toFixed(1) + ',' + p0o[1].toFixed(1) + ' A' + rO + ',' + rO + ' 0 ' + lg + ' 1 ' + p1o[0].toFixed(1) + ',' + p1o[1].toFixed(1) +
+             ' L' + p1i[0].toFixed(1) + ',' + p1i[1].toFixed(1) + ' A' + rI + ',' + rI + ' 0 ' + lg + ' 0 ' + p0i[0].toFixed(1) + ',' + p0i[1].toFixed(1) + ' Z';
+    }
+    var ang = 0;
+    data.forEach(function(d, i){
+      var a1 = ang + d.v / total * 360;
+      var p = mk('path', { d: arc(ang, a1), fill: d.color });
+      svg.appendChild(p); fadeIn(p, i * 0.08);
+      ang = a1;
+    });
+    // centre stat
+    svg.appendChild(mk('text', { x: cx, y: cy - 4, 'text-anchor': 'middle', 'font-size': 28, 'font-weight': 800, fill: ink(), 'font-family': 'Inter, sans-serif' }, o.centerBig));
+    svg.appendChild(mk('text', { x: cx, y: cy + 14, 'text-anchor': 'middle', 'font-size': 11, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, o.centerSub));
+    // legend
+    var lx = 268, ly = 44, lh = (H - 70) / data.length;
+    data.forEach(function(d, i){
+      var y = ly + i * lh;
+      svg.appendChild(mk('rect', { x: lx, y: y - 9, width: 12, height: 12, rx: 3, fill: d.color }));
+      svg.appendChild(mk('text', { x: lx + 19, y: y + 1, 'font-size': 11.5, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, d.label));
+      svg.appendChild(mk('text', { x: W - 16, y: y + 1, 'text-anchor': 'end', 'font-size': 12, 'font-weight': 800, fill: d.color, 'font-family': 'Inter, sans-serif' }, d.v + '%'));
+    });
+  }
+
+  /* ---------- Dumbbell (gap between two values) ---------- */
+  function dumbbell(id, data, o) {
+    var svg = frame(id); if (!svg) return;
+    var mL = 134, mR = 26, mT = 44, mB = 30;
+    var n = data.length, rowH = (H - mT - mB) / n;
+    function X(v){ return mL + (v / 100) * (W - mL - mR); }
+    [0, 25, 50, 75, 100].forEach(function(t){
+      svg.appendChild(mk('line', { x1: X(t), y1: mT - 6, x2: X(t), y2: H - mB, stroke: gridc(), 'stroke-width': 1 }));
+      tick(svg, X(t), H - mB + 15, t + '%');
+    });
+    // legend
+    svg.appendChild(mk('circle', { cx: mL + 2, cy: 22, r: 5, fill: o.fColor }));
+    svg.appendChild(mk('text', { x: mL + 12, y: 26, 'font-size': 11, 'font-weight': 700, fill: o.fColor, 'font-family': 'Inter, sans-serif' }, 'Women'));
+    svg.appendChild(mk('circle', { cx: mL + 78, cy: 22, r: 5, fill: o.mColor }));
+    svg.appendChild(mk('text', { x: mL + 88, y: 26, 'font-size': 11, 'font-weight': 700, fill: o.mColor, 'font-family': 'Inter, sans-serif' }, 'Men'));
+    data.forEach(function(d, i){
+      var y = mT + i * rowH + rowH / 2;
+      svg.appendChild(mk('text', { x: mL - 12, y: y + 4, 'text-anchor': 'end', 'font-size': 11.5, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, d.label));
+      var xf = X(d.f), xm = X(d.m), lo = Math.min(xf, xm), hi = Math.max(xf, xm);
+      var line = mk('line', { x1: lo, y1: y, x2: hi, y2: y, stroke: ink(), 'stroke-width': 2.4, 'stroke-linecap': 'round', opacity: 0.45 });
+      svg.appendChild(line); fadeIn(line, i * 0.08);
+      svg.appendChild(mk('circle', { cx: xm, cy: y, r: 5.5, fill: o.mColor }));
+      svg.appendChild(mk('circle', { cx: xf, cy: y, r: 5.5, fill: o.fColor }));
+      // value labels: put each just outside its dot
+      svg.appendChild(mk('text', { x: xf + (xf <= xm ? -9 : 9), y: y + 4, 'text-anchor': xf <= xm ? 'end' : 'start', 'font-size': 11, 'font-weight': 800, fill: o.fColor, 'font-family': 'Inter, sans-serif' }, d.f));
+      svg.appendChild(mk('text', { x: xm + (xm < xf ? -9 : 9), y: y + 4, 'text-anchor': xm < xf ? 'end' : 'start', 'font-size': 11, 'font-weight': 800, fill: o.mColor, 'font-family': 'Inter, sans-serif' }, d.m));
+    });
+  }
+
+  /* ---------- Heatmap (matrix) ---------- */
+  function heatmap(id, m, o) {
+    var svg = frame(id); if (!svg) return;
+    var mL = 150, mT = 40, mR = 16, mB = 16, nc = m.cols.length, nr = m.rows.length;
+    var cw = (W - mL - mR) / nc, ch = (H - mT - mB) / nr, gap = 3;
+    function shade(v){ if (v == null) return gridc(); var t = Math.max(0, Math.min(1, (v - o.min) / (o.max - o.min)));
+      // light -> deep green
+      var r = Math.round(237 + (22 - 237) * t), g = Math.round(247 + (138 - 247) * t), b = Math.round(233 + (90 - 233) * t);
+      return 'rgb(' + r + ',' + g + ',' + b + ')'; }
+    m.cols.forEach(function(c, j){ svg.appendChild(mk('text', { x: mL + j * cw + cw / 2, y: mT - 12, 'text-anchor': 'middle', 'font-size': 10.5, 'font-weight': 700, fill: ink(), 'font-family': 'Inter, sans-serif' }, c)); });
+    m.rows.forEach(function(rw, i){
+      svg.appendChild(mk('text', { x: mL - 10, y: mT + i * ch + ch / 2 + 4, 'text-anchor': 'end', 'font-size': 11, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, rw));
+      m.cols.forEach(function(c, j){
+        var v = m.values[i][j], x = mL + j * cw + gap / 2, y = mT + i * ch + gap / 2;
+        var cell = mk('rect', { x: x, y: y, width: cw - gap, height: ch - gap, rx: 5, fill: shade(v) });
+        svg.appendChild(cell); fadeIn(cell, (i + j) * 0.05);
+        var t = v == null ? 0 : Math.max(0, Math.min(1, (v - o.min) / (o.max - o.min)));
+        svg.appendChild(mk('text', { x: x + (cw - gap) / 2, y: y + (ch - gap) / 2 + 4, 'text-anchor': 'middle', 'font-size': 12, 'font-weight': 800, fill: v == null ? ink() : (t > 0.55 ? '#fff' : '#14532d'), 'font-family': 'Inter, sans-serif' }, v == null ? '–' : v + '%'));
+      });
+    });
+  }
+
   /* ---------- Framework: Arnstein's ladder ---------- */
   function ladder(id) {
     var svg = frame(id); if (!svg) return;
@@ -1007,6 +1115,22 @@ a { color: var(--color-primary); }
     funnel('c-pipeline',
       [{label:'Primary (1–5)',v:104.8},{label:'Upper primary',v:94.9},{label:'Secondary',v:79.4},{label:'Higher secondary',v:57.6},{label:'Higher education',v:28.5}],
       { vMax: 104.8, colors: ['#0d9488','#22a06b','#eab308','#f97316','#e11d48'] });
+
+    donut('c-energy',
+      [{label:'Coal',v:73,color:'#475569'},{label:'Hydro',v:8,color:'#2563eb'},{label:'Solar',v:7,color:'#f59e0b'},
+       {label:'Wind',v:5,color:'#0ea5a4'},{label:'Nuclear',v:3,color:'#7c3aed'},{label:'Gas',v:2,color:'#94a3b8'},{label:'Bioenergy',v:2,color:'#16a34a'}],
+      { centerBig: '73%', centerSub: 'still fossil' });
+
+    dumbbell('c-gender',
+      [{label:'Adult literacy',m:84.7,f:70.3},{label:'College enrolment',m:28.3,f:28.5},
+       {label:'In the labour force',m:78.8,f:41.7},{label:'Seats in the Lok Sabha',m:86.6,f:13.4}],
+      { mColor: '#1971c2', fColor: '#d6336c' });
+
+    heatmap('c-nfhs',
+      { cols: ['NFHS-3 ’05', 'NFHS-4 ’15', 'NFHS-5 ’21'],
+        rows: ['Institutional births', 'Full immunisation', 'Woman uses a bank a/c', 'Child not stunted', 'Woman not anaemic'],
+        values: [[39,79,89],[44,62,76],[null,53,79],[52,62,64],[45,47,43]] },
+      { min: 38, max: 90 });
 
     lineChart('c-flfp',
       [{x:2017.5,y:23.3},{x:2021.5,y:32.8},{x:2022.5,y:37.0},{x:2023.5,y:41.7}],


### PR DESCRIPTION
Adds three more fancy chart types to The Long View, each grounded in a public dataset catalogued in ImpactMojo's **Dataverse**, and each verified by rendering with the real fonts in **both light and dark**.

- **Radial donut — "How India keeps the lights on"** — the electricity generation mix: coal 73%, hydro 8%, solar 7%, wind 5%, nuclear 3%, gas 2%, bioenergy 2%. Source: Ember / CEA, 2024.
- **Dumbbell — "The same gap, four ways"** — gender gaps where the story flips: women now **lead** men in college enrolment (28.5 vs 28.3) and have nearly closed the literacy gap, yet trail badly in the labour force (41.7 vs 78.8) and the Lok Sabha (13.4 vs 86.6). Sources: NFHS-5, AISHE 2021-22, PLFS 2023-24, Lok Sabha 2024.
- **Heatmap — "Two decades of progress, and one stubborn row"** — five indicators across NFHS-3/4/5, all framed in the positive direction so a single green scale is honest. Services green up dramatically (institutional births, immunisation, women's bank accounts) while the bottom row — women not anaemic — stays pale and even worsens.

Data Wing is now **eleven charts**. Only `the-long-view.html` changed; mojibake PASS, JS valid, no duplicate IDs.

**Forest plot deferred:** I tried (microcredit + graduation RCTs) but couldn't reliably source the published confidence intervals — the paper PDF wouldn't extract and summaries don't list them. Rather than fabricate uncertainty bars I left it out; happy to add a real one if you point me at a study/table with CIs.

https://claude.ai/code/session_01Xpta1BU7c52vLx8u7BEaDj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xpta1BU7c52vLx8u7BEaDj)_