### PR TITLE
The Long View: plainer copy, drop hardcoded chart count

### DIFF
--- a/index.html
+++ b/index.html
@@ -980,11 +980,11 @@ window.addEventListener('authStateChanged', function(e) {
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none"><use href="#si_Bar_chart"/></svg>
         </div>
         <h3 class="imx-resource-title">The Long View</h3>
-        <p class="imx-resource-desc">Our own data-visualization studio and a gallery of the greats — original charts built from cited evidence, the frameworks we teach drawn from scratch, the timeless classics rebuilt, and the modern masterworks worth studying.</p>
+        <p class="imx-resource-desc">Charts we built from public data on the things we teach, plus diagrams of the ideas behind them, a few famous old charts rebuilt in code, and a shelf of modern work by others.</p>
         <div class="imx-resource-stats">
-            <span><strong>6</strong> Original charts</span>
-            <span><strong>5</strong> Frameworks</span>
-            <span><strong>4</strong> Classics rebuilt</span>
+            <span><strong>Original</strong> charts</span>
+            <span><strong>Frameworks</strong></span>
+            <span><strong>The</strong> greats</span>
         </div>
         <span class="imx-resource-cta">Open The Long View <svg width="14" height="14" viewBox="0 0 24 24" fill="none"><use href="#si_Arrow_right"/></svg></span>
     </a>

--- a/the-long-view.html
+++ b/the-long-view.html
@@ -248,8 +248,8 @@ a { color: var(--color-primary); }
   <div class="hero-inner">
     <span class="eyebrow">An ImpactMojo Original</span>
     <h1>The <span class="accent">Long View</span></h1>
-    <p class="lede">Development, seen clearly — one honest chart at a time.</p>
-    <p class="sub">Our own data-visualization studio — and a gallery of the greats. We build original charts by hand from real, cited evidence on the questions we teach, draw the frameworks behind the numbers, rebuild the timeless classics in code, and point you to the modern masterworks worth studying. The whole craft, in one room.</p>
+    <p class="lede">Charts about the things we teach, built from public data.</p>
+    <p class="sub">Some we made ourselves from named datasets. Some are diagrams of the ideas we use at work. A few are famous old charts we rebuilt in code to see how they were made, and there's a shelf of newer work by other people worth your time.</p>
     <div class="hero-cta">
       <a href="#data" class="btn btn-primary">Our data</a>
       <a href="#frameworks" class="btn btn-ghost">Frameworks</a>
@@ -266,8 +266,8 @@ a { color: var(--color-primary); }
   <div class="wrap">
     <div class="section-head">
       <span class="kicker">The Data Wing</span>
-      <h2>Twelve charts, built from real evidence</h2>
-      <p>Each is drawn from scratch in your browser from a named, public dataset. Hover a source line to see exactly where every number came from — because a chart you can't trace is just decoration.</p>
+      <h2>Built from public data</h2>
+      <p>Each chart is drawn in your browser from a named dataset, with the source printed underneath so you can check it.</p>
     </div>
 
     <div class="grid">
@@ -276,7 +276,7 @@ a { color: var(--color-primary); }
         <span class="tag">Poverty</span>
         <h3>The great escape</h3>
         <div class="chart-holder"><svg id="c-poverty" role="img" aria-label="Line chart: the share of the world living in extreme poverty fell from 37.9% in 1990 to 8.4% in 2019."></svg></div>
-        <p class="insight">In a single generation, the share of humanity in extreme poverty fell from nearly <strong>4 in 10</strong> to fewer than <strong>1 in 10</strong> — the steepest decline in deprivation in recorded history.</p>
+        <p class="insight">Over one generation, the share of people living in extreme poverty fell from about <strong>38%</strong> to under <strong>9%</strong> — roughly 1.9 billion people down to 660 million.</p>
         <p class="source">Source: World Bank Poverty &amp; Inequality Platform, via Our World in Data. Poverty line $2.15/day (2017 PPP).</p>
       </article>
 
@@ -284,7 +284,7 @@ a { color: var(--color-primary); }
         <span class="tag">Child Survival</span>
         <h3>India's children, 1990–2022</h3>
         <div class="chart-holder"><svg id="c-u5mr" role="img" aria-label="Line chart: India's under-five mortality rate fell from 127 per 1,000 live births in 1990 to 29.5 in 2022."></svg></div>
-        <p class="insight">A child born in India today is more than <strong>four times as likely</strong> to reach their fifth birthday as one born in 1990 — under-five deaths fell from 127 to 30 per 1,000.</p>
+        <p class="insight">Under-five deaths in India fell from 127 to about 30 per 1,000 live births. A child today is roughly <strong>four times</strong> more likely to reach age five than one born in 1990.</p>
         <p class="source">Source: UN Inter-agency Group for Child Mortality Estimation / World Bank Open Data (SH.DYN.MORT), 2024.</p>
       </article>
 
@@ -292,7 +292,7 @@ a { color: var(--color-primary); }
         <span class="tag">Caste &amp; Equity</span>
         <h3>Poverty is not caste-blind</h3>
         <div class="chart-holder"><svg id="c-caste" role="img" aria-label="Bar chart: multidimensional poverty headcount in India by social group — Scheduled Tribes 44.4%, Scheduled Castes 29.2%, OBC 24.5%, Others 14.9%."></svg></div>
-        <p class="insight">A Scheduled Tribe household is about <strong>three times</strong> as likely to be multidimensionally poor as an "Other" household. Nationally, poverty has since fallen — from <strong>24.8% to 15.0%</strong> by NFHS-5 — but the gap between groups persists.</p>
+        <p class="insight">A Scheduled Tribe household is about <strong>three times</strong> as likely to be poor as an "Other" household. National poverty has fallen since (24.8% to 15.0% by NFHS-5), but the gap between groups holds.</p>
         <p class="source">Source: NITI Aayog National MPI. By social group: NFHS-4 (2015–16). National headcount fell from 24.85% to 14.96% by NFHS-5 (2019–21).</p>
       </article>
 
@@ -300,7 +300,7 @@ a { color: var(--color-primary); }
         <span class="tag">Climate Justice</span>
         <h3>Whose carbon?</h3>
         <div class="chart-holder"><svg id="c-co2" role="img" aria-label="A beeswarm of CO2 emissions per capita by country in 2023: most countries cluster at low values with India near the bottom, while Qatar, the Gulf states and the US sit far to the right."></svg></div>
-        <p class="insight">Every dot is a country. Most of humanity emits very little — India sits near the bottom of the pack — while a single <strong>Qatari</strong> emits over <strong>20×</strong> as much CO₂ as the average Indian.</p>
+        <p class="insight">Each dot is a country. Most emit little, and India sits near the bottom. The average person in <strong>Qatar</strong> emits more than <strong>20 times</strong> what the average Indian does.</p>
         <p class="source">Source: EDGAR (European Commission / JRC) — territorial CO₂ emissions per capita, 2023.</p>
       </article>
 
@@ -308,7 +308,7 @@ a { color: var(--color-primary); }
         <span class="tag">Climate</span>
         <h3>India is heating up</h3>
         <div class="chart-holder"><svg id="c-climate" role="img" aria-label="India's 2024 annual mean temperature was +0.65°C above the 1991–2020 average — the warmest year since 1901 — shown over a blue-to-red warming gradient."></svg></div>
-        <p class="insight">2024 was India's <strong>warmest year since 1901</strong>, and ten of the fifteen warmest years on record have all arrived since 2010. How large the number looks depends on the baseline you measure from.</p>
+        <p class="insight">2024 was India's <strong>warmest year since 1901</strong>. Ten of the fifteen warmest years have come since 2010. How big the number looks depends on the baseline you pick.</p>
         <p class="source">Source: India Meteorological Department high-resolution gridded data (1901–2024), via Data for India. The warming band is schematic of the documented trend, not per-year values.</p>
       </article>
 
@@ -316,7 +316,7 @@ a { color: var(--color-primary); }
         <span class="tag">Gender &amp; Work</span>
         <h3>Women re-enter the workforce</h3>
         <div class="chart-holder"><svg id="c-flfp" role="img" aria-label="Slope chart: India's female labour force participation rate rose from 23.3% in 2017-18 to 37.0% in 2022-23."></svg></div>
-        <p class="insight">After decades of decline, women's recorded participation in India's workforce has turned <strong>sharply upward</strong> — though much of the rise is unpaid family and self-employment, not salaried jobs.</p>
+        <p class="insight">After years of decline, women's recorded workforce participation has <strong>risen sharply</strong>. Much of the rise is unpaid family work and self-employment, not salaried jobs.</p>
         <p class="source">Source: Periodic Labour Force Survey (PLFS), MoSPI. Female LFPR, usual status, age 15+.</p>
       </article>
 
@@ -324,7 +324,7 @@ a { color: var(--color-primary); }
         <span class="tag">Education</span>
         <h3>The leaky pipeline</h3>
         <div class="chart-holder"><svg id="c-pipeline" role="img" aria-label="A funnel of female gross enrolment in India narrowing from 104.8% in primary school to 28.5% in higher education."></svg></div>
-        <p class="insight">India has all but closed the gender gap in school — girls' enrolment even tops 100% in primary. But the pipeline leaks at every stage: barely <strong>1 in 4</strong> young women reaches higher education.</p>
+        <p class="insight">The gender gap in school enrolment is mostly closed; girls' primary enrolment even tops 100%. But enrolment drops at every stage, and only about <strong>1 in 4</strong> young women reaches higher education.</p>
         <p class="source">Source: UDISE+ 2021–22 (school) and AISHE 2021–22 (higher education). Female gross enrolment ratio (GER) by level.</p>
       </article>
 
@@ -332,7 +332,7 @@ a { color: var(--color-primary); }
         <span class="tag">Energy</span>
         <h3>How India keeps the lights on</h3>
         <div class="chart-holder"><svg id="c-energy" role="img" aria-label="A donut chart of India's 2024 electricity generation mix: coal 73%, hydro 8%, solar 7%, wind 5%, nuclear 3%, gas 2%, bioenergy 2%."></svg></div>
-        <p class="insight">Nearly <strong>three-quarters</strong> of India's electricity still comes from coal. Solar and wind are climbing fast — now a combined 12% — but the transition is only beginning.</p>
+        <p class="insight">About <strong>three-quarters</strong> of India's electricity still comes from coal. Solar and wind are growing — together about 12% — but the shift is early.</p>
         <p class="source">Source: Ember / Central Electricity Authority — share of electricity generation, 2024. Figures rounded.</p>
       </article>
 
@@ -340,23 +340,23 @@ a { color: var(--color-primary); }
         <span class="tag">Gender</span>
         <h3>The same gap, four ways</h3>
         <div class="chart-holder"><svg id="c-gender" role="img" aria-label="A dumbbell chart of India gender gaps: women now slightly lead men in college enrolment, are close in literacy, but trail far behind in labour-force participation and seats in the Lok Sabha."></svg></div>
-        <p class="insight">Indian women have <strong>caught up — even pulled ahead — in college</strong>, and the literacy gap is closing. Yet they remain far behind where power and pay are decided: paid work and Parliament.</p>
+        <p class="insight">Women have caught up with men in college enrolment, and slightly passed them; the literacy gap is narrowing. In <strong>paid work and in Parliament</strong>, they are still far behind.</p>
         <p class="source">Sources: NFHS-5 (literacy), AISHE 2021–22 (college GER), PLFS 2023–24 (labour force), Lok Sabha 2024 (seats).</p>
       </article>
 
       <article class="card" data-card>
         <span class="tag">Health &amp; Nutrition</span>
-        <h3>Two decades of progress — and one stubborn row</h3>
+        <h3>Two decades of progress, and one row that won't move</h3>
         <div class="chart-holder"><svg id="c-nfhs" role="img" aria-label="A heatmap of India's progress across three NFHS rounds on five indicators: institutional births, immunisation, women's bank accounts, child not stunted, and women not anaemic. Most improve and turn green over time, but the anaemia row stays pale and even worsens."></svg></div>
-        <p class="insight">Across three national surveys, India's services raced ahead — institutional births, immunisation and women's bank accounts all turned deep green. But the bottom row barely moves: <strong>anaemia among women has actually worsened</strong>.</p>
+        <p class="insight">Across three national surveys, services improved a lot: institutional births, immunisation and women's bank accounts all rose. The bottom row barely moves — by NFHS-5, <strong>anaemia among women is slightly worse</strong>.</p>
         <p class="source">Source: National Family Health Survey rounds 3 (2005–06), 4 (2015–16) and 5 (2019–21). Each cell is the share with the positive outcome.</p>
       </article>
 
       <article class="card" data-card>
         <span class="tag">Climate · Evidence</span>
-        <h3>How hot, by 2100? It's a choice</h3>
+        <h3>How hot, by 2100?</h3>
         <div class="chart-holder"><svg id="c-forest" role="img" aria-label="A forest plot of projected global warming by 2100 under five emissions scenarios: net zero ~2050 gives 1.4°C (very likely 1.0–1.8), rising to 4.4°C (3.3–5.7) under very high emissions; only the lowest scenarios stay near the 1.5°C and 2°C Paris limits."></svg></div>
-        <p class="insight">Each bar is a possible future: the dot is the best estimate, the whisker the IPCC's "very likely" range. Even deep, immediate cuts only just hold the line near <strong>1.5°C</strong> — and a high-emissions path blows past every Paris guardrail.</p>
+        <p class="insight">The dot is the IPCC's best estimate; the bar is its "very likely" range. Only the lowest-emission paths stay near the <strong>1.5°C and 2°C</strong> limits; the higher ones pass them comfortably.</p>
         <p class="source">Source: IPCC Sixth Assessment Report (AR6, WG1, 2021) — projected global surface warming by 2081–2100 vs 1850–1900, best estimate and very likely range, by scenario.</p>
       </article>
 
@@ -364,7 +364,7 @@ a { color: var(--color-primary); }
         <span class="tag">Read the method</span>
         <h3>How to read a chart honestly</h3>
         <div class="chart-holder"><svg id="c-ethic" role="img" aria-label="A small diagram contrasting a truncated y-axis that exaggerates a trend with a zero-baseline axis that shows it honestly."></svg></div>
-        <p class="insight">The same data, two axes. Start a bar chart's axis anywhere but <strong>zero</strong> and you can manufacture a crisis — or hide one. Every chart here starts at zero, on purpose.</p>
+        <p class="insight">Same numbers, two y-axes. Start a bar chart anywhere but <strong>zero</strong> and you can invent a trend or hide one. Every chart here starts at zero.</p>
         <p class="source">Principle: Tufte's "lie factor". A graphic should not say more, or less, than the data.</p>
       </article>
 
@@ -378,7 +378,7 @@ a { color: var(--color-primary); }
     <div class="section-head">
       <span class="kicker">The Frameworks Wing</span>
       <h2>The ideas behind the numbers</h2>
-      <p>Data tells you <em>what</em>. Frameworks tell you <em>why</em>, and <em>so what</em>. Here are five of the mental models we teach, drawn from scratch — the scaffolding every good evaluator carries in their head.</p>
+      <p>Numbers tell you what happened. These are some of the models we use to ask why, and what to do next.</p>
     </div>
 
     <div class="grid">
@@ -416,7 +416,7 @@ a { color: var(--color-primary); }
       <article class="card" data-card>
         <h3>Build your own</h3>
         <div class="frame-canvas"><svg id="f-make" role="img" aria-label="A friendly prompt encouraging the reader to make their own visualization, with simple chart icons."></svg></div>
-        <p class="caption">These were all made with nothing but a browser and honest data. The same tools are waiting for you — pull a dataset, pick a frame, and tell the truth with it.</p>
+        <p class="caption">Every chart here was made with a browser and a public dataset. Pick a dataset, pick a frame, and try it yourself.</p>
       </article>
 
     </div>
@@ -429,7 +429,7 @@ a { color: var(--color-primary); }
     <div class="section-head">
       <span class="kicker">The Masters' Wing</span>
       <h2>The greats, rebuilt by hand</h2>
-      <p>Four visualizations that changed how the world sees — each in the public domain, and each rebuilt from scratch in your browser, in code, so you can study the craft up close.</p>
+      <p>Famous old charts, all out of copyright, rebuilt here in code so you can see how they were put together.</p>
     </div>
     <div class="masters">
 
@@ -440,7 +440,7 @@ a { color: var(--color-primary); }
           <h3>The Rose of Mortality</h3>
           <div class="meta">Florence Nightingale · 1858</div>
           <p>Her polar-area "coxcomb" showed that the great blue wedges — soldiers killed by <em>preventable</em> disease in the Crimean War — dwarfed the red of battle wounds. Area, not radius, carries the count.</p>
-          <p class="why">Why it matters: the original act of data activism — a chart built to move a government. Sanitation reform followed.</p>
+          <p class="why">One of the first charts made to change policy. Sanitation reforms followed.</p>
           <a class="source" href="https://en.wikipedia.org/wiki/Florence_Nightingale#Statistics_and_sanitary_reform" target="_blank" rel="noopener">About the original →</a>
         </div>
       </article>
@@ -452,7 +452,7 @@ a { color: var(--color-primary); }
           <h3>Napoleon's March</h3>
           <div class="meta">Charles Joseph Minard · 1869</div>
           <p>The width of the band is the size of the army; tan advancing on Moscow, black in retreat, with the freezing temperature traced below. 422,000 marched out. 10,000 came home.</p>
-          <p class="why">Why it matters: Edward Tufte called it possibly the best statistical graphic ever drawn — six variables on one flat page.</p>
+          <p class="why">Tufte called it perhaps the best statistical graphic ever drawn: six variables on one flat page.</p>
           <a class="source" href="https://en.wikipedia.org/wiki/Charles_Joseph_Minard#The_map_of_Napoleon's_Russian_campaign" target="_blank" rel="noopener">About the original →</a>
         </div>
       </article>
@@ -464,7 +464,7 @@ a { color: var(--color-primary); }
           <h3>The Broad Street Pump</h3>
           <div class="meta">Dr. John Snow · 1854</div>
           <p>Each mark is a cholera death. Plotted on a street map of Soho, they swarm around a single water pump — the evidence that cholera travelled through water, not "bad air".</p>
-          <p class="why">Why it matters: the founding map of modern epidemiology. A picture located a cause and saved a neighbourhood.</p>
+          <p class="why">An early landmark in epidemiology: the map pointed to the source, and the pump was shut off.</p>
           <a class="source" href="https://en.wikipedia.org/wiki/1854_Broad_Street_cholera_outbreak" target="_blank" rel="noopener">About the original →</a>
         </div>
       </article>
@@ -476,7 +476,7 @@ a { color: var(--color-primary); }
           <h3>A Du Bois Data Portrait</h3>
           <div class="meta">W. E. B. Du Bois &amp; team · 1900</div>
           <p>For the 1900 Paris Exposition, Du Bois hand-drew dozens of radical, modernist charts of Black American life. This spiral — rising property values against the odds — is rebuilt in his palette.</p>
-          <p class="why">Why it matters: data visualization as a fight for dignity, decades ahead of its design time. The template for every justice dashboard since.</p>
+          <p class="why">Charts made as an argument for dignity, decades ahead of their design time.</p>
           <a class="source" href="https://www.loc.gov/pictures/collection/anedub/" target="_blank" rel="noopener">See the originals (Library of Congress) →</a>
         </div>
       </article>
@@ -491,7 +491,7 @@ a { color: var(--color-primary); }
     <div class="section-head">
       <span class="kicker">The Greats</span>
       <h2>Masterworks worth studying</h2>
-      <p>Living, breathing visualizations on the themes we teach. We can't reprint them here — so each card sends you to the original, where it belongs. Filter by the question it asks.</p>
+      <p>Modern work on the same themes, by other people. We can't reprint it, so each card links to the original. Filter by topic.</p>
     </div>
 
     <div class="filters" id="filters" role="group" aria-label="Filter visualizations by theme">
@@ -515,8 +515,8 @@ a { color: var(--color-primary); }
 <section class="methods">
   <div class="wrap">
     <span class="section-head" style="display:block;text-align:left;margin:0;max-width:none;"><span class="kicker" style="color:#f093fb;">Made in the open</span></span>
-    <h2>Every number, traceable</h2>
-    <p class="intro">We hold ourselves to the standard we teach: a visualization is only as trustworthy as its source. Here is exactly where each chart's data comes from. Check our work.</p>
+    <h2>Where the numbers come from</h2>
+    <p class="intro">A chart is only as good as its source. Here is the dataset behind each one.</p>
 
     <ul class="source-list">
       <li><b>The great escape</b>World Bank Poverty &amp; Inequality Platform (PIP), via Our World in Data — extreme poverty at $2.15/day (2017 PPP), 1990–2019.</li>
@@ -533,13 +533,13 @@ a { color: var(--color-primary); }
     </ul>
 
     <div class="tools-grid">
-      <a class="tool-link" href="/dataverse.html"><h4>Dataverse →</h4><span>Curated, citable datasets on development, gender and the economy.</span></a>
+      <a class="tool-link" href="/dataverse.html"><h4>Dataverse →</h4><span>The datasets and tools we drew on, in one place.</span></a>
       <a class="tool-link" href="/Labs/"><h4>Interactive Labs →</h4><span>Browser tools to explore and chart data without code.</span></a>
-      <a class="tool-link" href="/catalog.html"><h4>Data Visualization course →</h4><span>Learn to build charts that are honest, clear and your own.</span></a>
-      <a class="tool-link" href="/blog.html"><h4>Learning Loops →</h4><span>Essays on measurement and telling the truth with numbers.</span></a>
+      <a class="tool-link" href="/catalog.html"><h4>Data Visualization course →</h4><span>How to build charts that are clear and honest.</span></a>
+      <a class="tool-link" href="/blog.html"><h4>Learning Loops →</h4><span>Notes on measurement and working with numbers.</span></a>
     </div>
 
-    <p class="credit-note">Begun in the spirit of <a href="https://vizchitra.com/" target="_blank" rel="noopener">VizChitra</a>, India's data-visualization community — but made entirely our own.</p>
+    <p class="credit-note">Inspired by <a href="https://vizchitra.com/" target="_blank" rel="noopener">VizChitra</a>, India's data-visualization community.</p>
   </div>
 </section>
 
@@ -1107,7 +1107,7 @@ a { color: var(--color-primary); }
       var rect = mk('rect', { x: b[0], y: cy + 30 - b[1], width: 26, height: b[1], rx: 4, fill: b[2], opacity: 0.9 });
       svg.appendChild(rect); fadeIn(rect, 0.6 + i*0.1);
     });
-    svg.appendChild(mk('text', { x: W/2, y: H - 20, 'text-anchor': 'middle', 'font-size': 14, 'font-weight': 800, fill: ink(), 'font-family': 'Inter, sans-serif' }, 'your data + your frame + the truth' ));
+    svg.appendChild(mk('text', { x: W/2, y: H - 20, 'text-anchor': 'middle', 'font-size': 14, 'font-weight': 800, fill: ink(), 'font-family': 'Inter, sans-serif' }, 'your data, your frame, your turn' ));
   }
 
   /* ---------- Render everything ---------- */


### PR DESCRIPTION
Two pieces of feedback on The Long View's copy:

1. **Hardcoded count in the headline** ("Twelve charts…") — brittle, since we'll keep adding. Removed it: the Data Wing header is now "Built from public data", and the homepage card's stats are count-free too.
2. **"Very AI" writing** — rewrote the prose across the page to sound plainer and more human:
   - fewer dramatic em-dashes
   - dropped the superlatives ("the steepest decline in deprivation in recorded history", "raced ahead", "blows past every Paris guardrail")
   - dropped the self-congratulation ("Check our work", "the whole craft, in one room", "made entirely our own")
   - shorter, plainer sentences in the hero, section headers, all chart insights, the masters' captions, and the closing.

No data or chart code changed — copy only (`the-long-view.html` + the homepage card in `index.html`). mojibake PASS, JS valid.

https://claude.ai/code/session_01Xpta1BU7c52vLx8u7BEaDj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xpta1BU7c52vLx8u7BEaDj)_