### PR TITLE
The Long View redesign (stage 1): fix overlaps, light-mode masters, reorder

### DIFF
--- a/the-long-view.html
+++ b/the-long-view.html
@@ -173,19 +173,24 @@ a { color: var(--color-primary); }
 /* ---------- Masters' wing (recreated classics) ---------- */
 .masters { display: grid; grid-template-columns: 1fr; gap: 1.8rem; }
 @media (min-width: 860px) { .masters { grid-template-columns: 1fr 1fr; } }
-.plate { background: linear-gradient(160deg, #131a2e, #1a2238); border: 1px solid rgba(255,255,255,0.08); border-radius: 18px; overflow: hidden; box-shadow: 0 16px 40px rgba(8,12,30,0.3); display: flex; flex-direction: column; opacity: 0; transform: translateY(22px); }
+.plate { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: 18px; overflow: hidden; box-shadow: 0 10px 30px rgba(15,23,42,0.06); display: flex; flex-direction: column; opacity: 0; transform: translateY(22px); }
+[data-theme="dark"] .plate { background: linear-gradient(160deg, #131a2e, #1a2238); border-color: rgba(255,255,255,0.08); box-shadow: 0 16px 40px rgba(8,12,30,0.3); }
 .plate.in { opacity: 1; transform: none; transition: opacity 0.7s ease, transform 0.7s ease; }
-.plate-canvas { position: relative; aspect-ratio: 4 / 3; padding: 1.1rem; display: flex; align-items: center; justify-content: center; background: radial-gradient(560px 280px at 50% 0%, rgba(118,75,162,0.18), transparent 70%); }
+.plate-canvas { position: relative; aspect-ratio: 4 / 3; padding: 1.1rem; display: flex; align-items: center; justify-content: center; background: #f4f1ea; }
+[data-theme="dark"] .plate-canvas { background: radial-gradient(560px 280px at 50% 0%, rgba(118,75,162,0.18), transparent 70%); }
 .plate-canvas svg { width: 100%; height: 100%; display: block; }
-.plate-caption { padding: 1.3rem 1.5rem 1.6rem; border-top: 1px solid rgba(255,255,255,0.08); }
-.plate-caption .tag { display: inline-block; font-family: var(--font-mono); font-size: 0.66rem; letter-spacing: 1.4px; text-transform: uppercase; color: #c9b8ff; background: rgba(118,75,162,0.25); padding: 0.22rem 0.6rem; border-radius: 6px; margin-bottom: 0.6rem; }
-.plate-caption h3 { color: #e8ecf8; font-size: 1.25rem; margin: 0 0 0.15rem; }
-.plate-caption .meta { font-family: var(--font-mono); font-size: 0.78rem; color: #9aa6c8; margin-bottom: 0.7rem; }
-.plate-caption p { color: #c4cce6; font-size: 0.93rem; margin: 0 0 0.8rem; }
-.plate-caption .why { color: #9aa6c8; font-size: 0.88rem; border-left: 2px solid var(--color-accent-blue); padding-left: 0.8rem; }
-.plate-caption a.source { display: inline-flex; align-items: center; gap: 0.3rem; margin-top: 0.9rem; font-family: var(--font-heading); font-weight: 700; font-size: 0.84rem; color: #8fb4ff; text-decoration: none; }
+.plate-caption { padding: 1.3rem 1.5rem 1.6rem; border-top: 1px solid var(--color-border); }
+[data-theme="dark"] .plate-caption { border-top-color: rgba(255,255,255,0.08); }
+.plate-caption .tag { display: inline-block; font-family: var(--font-mono); font-size: 0.66rem; letter-spacing: 1.4px; text-transform: uppercase; color: #6b4ea0; background: rgba(118,75,162,0.12); padding: 0.22rem 0.6rem; border-radius: 6px; margin-bottom: 0.6rem; }
+[data-theme="dark"] .plate-caption .tag { color: #c9b8ff; background: rgba(118,75,162,0.25); }
+.plate-caption h3 { color: var(--color-text); font-size: 1.25rem; margin: 0 0 0.15rem; }
+.plate-caption .meta { font-family: var(--font-mono); font-size: 0.78rem; color: var(--color-text-muted); margin-bottom: 0.7rem; }
+.plate-caption p { color: var(--color-text); font-size: 0.93rem; margin: 0 0 0.8rem; }
+.plate-caption .why { color: var(--color-text-muted); font-size: 0.88rem; border-left: 2px solid var(--color-accent-blue); padding-left: 0.8rem; }
+.plate-caption a.source { display: inline-flex; align-items: center; gap: 0.3rem; margin-top: 0.9rem; font-family: var(--font-heading); font-weight: 700; font-size: 0.84rem; color: var(--color-primary); text-decoration: none; }
 .plate-caption a.source:hover { text-decoration: underline; }
-.plate--dubois .plate-canvas { background: #e8d9b8; }
+.plate-canvas { background: #f4f1ea; }
+.plate--dubois .plate-canvas { background: #e8d9b8 !important; }
 
 /* ---------- Greats gallery (curated, links out) ---------- */
 .filters { display: flex; flex-wrap: wrap; gap: 0.5rem; justify-content: center; margin-bottom: 2.4rem; }
@@ -273,19 +278,11 @@ a { color: var(--color-primary); }
     <div class="grid">
 
       <article class="card" data-card>
-        <span class="tag">Poverty</span>
-        <h3>The great escape</h3>
-        <div class="chart-holder"><svg id="c-poverty" role="img" aria-label="Line chart: the share of the world living in extreme poverty fell from 37.9% in 1990 to 8.4% in 2019."></svg></div>
-        <p class="insight">Over one generation, the share of people living in extreme poverty fell from about <strong>38%</strong> to under <strong>9%</strong> — roughly 1.9 billion people down to 660 million.</p>
-        <p class="source">Source: World Bank Poverty &amp; Inequality Platform, via Our World in Data. Poverty line $2.15/day (2017 PPP).</p>
-      </article>
-
-      <article class="card" data-card>
-        <span class="tag">Child Survival</span>
-        <h3>India's children, 1990–2022</h3>
-        <div class="chart-holder"><svg id="c-u5mr" role="img" aria-label="Line chart: India's under-five mortality rate fell from 127 per 1,000 live births in 1990 to 29.5 in 2022."></svg></div>
-        <p class="insight">Under-five deaths in India fell from 127 to about 30 per 1,000 live births. A child today is roughly <strong>four times</strong> more likely to reach age five than one born in 1990.</p>
-        <p class="source">Source: UN Inter-agency Group for Child Mortality Estimation / World Bank Open Data (SH.DYN.MORT), 2024.</p>
+        <span class="tag">Gender</span>
+        <h3>The same gap, four ways</h3>
+        <div class="chart-holder"><svg id="c-gender" role="img" aria-label="A dumbbell chart of India gender gaps: women now slightly lead men in college enrolment, are close in literacy, but trail far behind in labour-force participation and seats in the Lok Sabha."></svg></div>
+        <p class="insight">Women have caught up with men in college enrolment, and slightly passed them; the literacy gap is narrowing. In <strong>paid work and in Parliament</strong>, they are still far behind.</p>
+        <p class="source">Sources: NFHS-5 (literacy), AISHE 2021–22 (college GER), PLFS 2023–24 (labour force), Lok Sabha 2024 (seats).</p>
       </article>
 
       <article class="card" data-card>
@@ -305,43 +302,11 @@ a { color: var(--color-primary); }
       </article>
 
       <article class="card" data-card>
-        <span class="tag">Climate</span>
-        <h3>India is heating up</h3>
-        <div class="chart-holder"><svg id="c-climate" role="img" aria-label="India's 2024 annual mean temperature was +0.65°C above the 1991–2020 average — the warmest year since 1901 — shown over a blue-to-red warming gradient."></svg></div>
-        <p class="insight">2024 was India's <strong>warmest year since 1901</strong>. Ten of the fifteen warmest years have come since 2010. How big the number looks depends on the baseline you pick.</p>
-        <p class="source">Source: India Meteorological Department high-resolution gridded data (1901–2024), via Data for India. The warming band is schematic of the documented trend, not per-year values.</p>
-      </article>
-
-      <article class="card" data-card>
-        <span class="tag">Gender &amp; Work</span>
-        <h3>Women re-enter the workforce</h3>
-        <div class="chart-holder"><svg id="c-flfp" role="img" aria-label="Slope chart: India's female labour force participation rate rose from 23.3% in 2017-18 to 37.0% in 2022-23."></svg></div>
-        <p class="insight">After years of decline, women's recorded workforce participation has <strong>risen sharply</strong>. Much of the rise is unpaid family work and self-employment, not salaried jobs.</p>
-        <p class="source">Source: Periodic Labour Force Survey (PLFS), MoSPI. Female LFPR, usual status, age 15+.</p>
-      </article>
-
-      <article class="card" data-card>
-        <span class="tag">Education</span>
-        <h3>The leaky pipeline</h3>
-        <div class="chart-holder"><svg id="c-pipeline" role="img" aria-label="A funnel of female gross enrolment in India narrowing from 104.8% in primary school to 28.5% in higher education."></svg></div>
-        <p class="insight">The gender gap in school enrolment is mostly closed; girls' primary enrolment even tops 100%. But enrolment drops at every stage, and only about <strong>1 in 4</strong> young women reaches higher education.</p>
-        <p class="source">Source: UDISE+ 2021–22 (school) and AISHE 2021–22 (higher education). Female gross enrolment ratio (GER) by level.</p>
-      </article>
-
-      <article class="card" data-card>
         <span class="tag">Energy</span>
         <h3>How India keeps the lights on</h3>
         <div class="chart-holder"><svg id="c-energy" role="img" aria-label="A donut chart of India's 2024 electricity generation mix: coal 73%, hydro 8%, solar 7%, wind 5%, nuclear 3%, gas 2%, bioenergy 2%."></svg></div>
         <p class="insight">About <strong>three-quarters</strong> of India's electricity still comes from coal. Solar and wind are growing — together about 12% — but the shift is early.</p>
         <p class="source">Source: Ember / Central Electricity Authority — share of electricity generation, 2024. Figures rounded.</p>
-      </article>
-
-      <article class="card" data-card>
-        <span class="tag">Gender</span>
-        <h3>The same gap, four ways</h3>
-        <div class="chart-holder"><svg id="c-gender" role="img" aria-label="A dumbbell chart of India gender gaps: women now slightly lead men in college enrolment, are close in literacy, but trail far behind in labour-force participation and seats in the Lok Sabha."></svg></div>
-        <p class="insight">Women have caught up with men in college enrolment, and slightly passed them; the literacy gap is narrowing. In <strong>paid work and in Parliament</strong>, they are still far behind.</p>
-        <p class="source">Sources: NFHS-5 (literacy), AISHE 2021–22 (college GER), PLFS 2023–24 (labour force), Lok Sabha 2024 (seats).</p>
       </article>
 
       <article class="card" data-card>
@@ -361,13 +326,52 @@ a { color: var(--color-primary); }
       </article>
 
       <article class="card" data-card>
+        <span class="tag">Poverty</span>
+        <h3>The great escape</h3>
+        <div class="chart-holder"><svg id="c-poverty" role="img" aria-label="Line chart: the share of the world living in extreme poverty fell from 37.9% in 1990 to 8.4% in 2019."></svg></div>
+        <p class="insight">Over one generation, the share of people living in extreme poverty fell from about <strong>38%</strong> to under <strong>9%</strong> — roughly 1.9 billion people down to 660 million.</p>
+        <p class="source">Source: World Bank Poverty &amp; Inequality Platform, via Our World in Data. Poverty line $2.15/day (2017 PPP).</p>
+      </article>
+
+      <article class="card" data-card>
+        <span class="tag">Child Survival</span>
+        <h3>India's children, 1990–2022</h3>
+        <div class="chart-holder"><svg id="c-u5mr" role="img" aria-label="Line chart: India's under-five mortality rate fell from 127 per 1,000 live births in 1990 to 29.5 in 2022."></svg></div>
+        <p class="insight">Under-five deaths in India fell from 127 to about 30 per 1,000 live births. A child today is roughly <strong>four times</strong> more likely to reach age five than one born in 1990.</p>
+        <p class="source">Source: UN Inter-agency Group for Child Mortality Estimation / World Bank Open Data (SH.DYN.MORT), 2024.</p>
+      </article>
+
+      <article class="card" data-card>
+        <span class="tag">Gender &amp; Work</span>
+        <h3>Women re-enter the workforce</h3>
+        <div class="chart-holder"><svg id="c-flfp" role="img" aria-label="Slope chart: India's female labour force participation rate rose from 23.3% in 2017-18 to 37.0% in 2022-23."></svg></div>
+        <p class="insight">After years of decline, women's recorded workforce participation has <strong>risen sharply</strong>. Much of the rise is unpaid family work and self-employment, not salaried jobs.</p>
+        <p class="source">Source: Periodic Labour Force Survey (PLFS), MoSPI. Female LFPR, usual status, age 15+.</p>
+      </article>
+
+      <article class="card" data-card>
+        <span class="tag">Education</span>
+        <h3>The leaky pipeline</h3>
+        <div class="chart-holder"><svg id="c-pipeline" role="img" aria-label="A funnel of female gross enrolment in India narrowing from 104.8% in primary school to 28.5% in higher education."></svg></div>
+        <p class="insight">The gender gap in school enrolment is mostly closed; girls' primary enrolment even tops 100%. But enrolment drops at every stage, and only about <strong>1 in 4</strong> young women reaches higher education.</p>
+        <p class="source">Source: UDISE+ 2021–22 (school) and AISHE 2021–22 (higher education). Female gross enrolment ratio (GER) by level.</p>
+      </article>
+
+      <article class="card" data-card>
+        <span class="tag">Climate</span>
+        <h3>India is heating up</h3>
+        <div class="chart-holder"><svg id="c-climate" role="img" aria-label="India's 2024 annual mean temperature was +0.65°C above the 1991–2020 average — the warmest year since 1901 — shown over a blue-to-red warming gradient."></svg></div>
+        <p class="insight">2024 was India's <strong>warmest year since 1901</strong>. Ten of the fifteen warmest years have come since 2010. How big the number looks depends on the baseline you pick.</p>
+        <p class="source">Source: India Meteorological Department high-resolution gridded data (1901–2024), via Data for India. The warming band is schematic of the documented trend, not per-year values.</p>
+      </article>
+
+      <article class="card" data-card>
         <span class="tag">Read the method</span>
         <h3>How to read a chart honestly</h3>
         <div class="chart-holder"><svg id="c-ethic" role="img" aria-label="A small diagram contrasting a truncated y-axis that exaggerates a trend with a zero-baseline axis that shows it honestly."></svg></div>
         <p class="insight">Same numbers, two y-axes. Start a bar chart anywhere but <strong>zero</strong> and you can invent a trend or hide one. Every chart here starts at zero.</p>
         <p class="source">Principle: Tufte's "lie factor". A graphic should not say more, or less, than the data.</p>
       </article>
-
     </div>
   </div>
 </section>
@@ -1114,19 +1118,11 @@ a { color: var(--color-primary); }
   function renderAll() {
     lineChart('c-poverty',
       [{x:1990,y:37.9},{x:2000,y:29.7},{x:2010,y:16.7},{x:2015,y:10.4},{x:2019,y:8.4}],
-      { yMax: 44, color: '#0d9488', area: true, valfmt: function(v){return v+'%';}, xfmt: function(x){return "'"+String(x).slice(2);},
-        callout: { x: W-54, y: 56, anchor: 'end', lines: [
-          { t: '−30 points', s: 22, w: 800, c: '#0d9488' },
-          { t: 'in a single generation', s: 11, c: ink(), gap: 18 },
-          { t: '≈1.9bn → 660m people', s: 10.5, w: 700, c: ink(), f: 'JetBrains Mono, monospace' } ] } });
+      { yMax: 44, color: '#0d9488', area: true, valfmt: function(v){return v+'%';}, xfmt: function(x){return "'"+String(x).slice(2);} });
 
     lineChart('c-u5mr',
       [{x:1990,y:127},{x:1995,y:109.7},{x:2000,y:91.8},{x:2005,y:74.3},{x:2010,y:58.1},{x:2015,y:43.7},{x:2020,y:33},{x:2022,y:29.5}],
-      { yMax: 138, color: '#4f46e5', area: true, valfmt: function(v){return Math.round(v);}, labelEvery: 2, xfmt: function(x){return "'"+String(x).slice(2);},
-        callout: { x: W-54, y: 56, anchor: 'end', lines: [
-          { t: '−77%', s: 24, w: 800, c: '#4f46e5' },
-          { t: 'under-5 deaths, 1990–2022', s: 11, c: ink(), gap: 18 },
-          { t: '4× more likely to survive', s: 10.5, w: 700, c: ink(), f: 'JetBrains Mono, monospace' } ] } });
+      { yMax: 138, color: '#4f46e5', area: true, valfmt: function(v){return Math.round(v);}, labelEvery: 2, xfmt: function(x){return "'"+String(x).slice(2);} });
 
     hbarChart('c-caste',
       [{label:'Sched. Tribes',y:44.4,color:'#7d0d23'},{label:'Sched. Castes',y:29.2,color:'#b81d36'},{label:'OBC',y:24.5,color:'#e0566a'},{label:'Others',y:14.9,color:'#f3a6b0'}],
@@ -1140,10 +1136,7 @@ a { color: var(--color-primary); }
        {n:'Indonesia',v:2.41},{n:'Brazil',v:2.20},{n:'India',v:2.07,hl:true,label:'India'},
        {n:'Pakistan',v:0.91},{n:'Bangladesh',v:0.71},{n:'Nigeria',v:0.58},{n:'Ethiopia',v:0.14},{n:'DR Congo',v:0.04}],
       { vMax: 46, ticks: [0,10,20,30,40], dotColor: '#94a3b8', hlColor: '#0d9488',
-        ref: { v: 4.7, label: 'world avg' }, axisLabel: 'tonnes CO₂ per person, per year (2023)',
-        callout: { x: W-18, y: 50, anchor: 'end', lines: [
-          { t: '20×', s: 24, w: 800, c: '#e11d48' },
-          { t: 'a Qatari vs an Indian', s: 11, c: ink(), gap: 18 } ] } });
+        ref: { v: 4.7, label: 'world avg' }, axisLabel: 'tonnes CO₂ per person, per year (2023)' });
 
     funnel('c-pipeline',
       [{label:'Primary (1–5)',v:104.8},{label:'Upper primary',v:94.9},{label:'Secondary',v:79.4},{label:'Higher secondary',v:57.6},{label:'Higher education',v:28.5}],
@@ -1176,11 +1169,7 @@ a { color: var(--color-primary); }
     lineChart('c-flfp',
       [{x:2017.5,y:23.3},{x:2021.5,y:32.8},{x:2022.5,y:37.0},{x:2023.5,y:41.7}],
       { yMax: 50, color: '#7c3aed', area: true, valfmt: function(v){return v.toFixed(1)+'%';},
-        xfmt: function(x){var a=Math.floor(x); return "'"+String(a).slice(2)+"–"+String(a+1).slice(2);},
-        callout: { x: 34, y: 52, anchor: 'start', lines: [
-          { t: '+18 points', s: 22, w: 800, c: '#7c3aed' },
-          { t: 'women 15+, since 2017–18', s: 11, c: ink(), gap: 18 },
-          { t: 'much of it unpaid / self-employed', s: 10, w: 700, c: ink(), f: 'JetBrains Mono, monospace' } ] } });
+        xfmt: function(x){var a=Math.floor(x); return "'"+String(a).slice(2)+"–"+String(a+1).slice(2);} });
 
     climateChart('c-climate');
     ethicChart('c-ethic');
@@ -1205,8 +1194,13 @@ a { color: var(--color-primary); }
            " A" + r + "," + r + " 0 " + large + " 1 " + p1[0].toFixed(1) + "," + p1[1].toFixed(1) + " Z";
   }
 
+  function plateTokens() {
+    var dk = document.documentElement.getAttribute('data-theme') === 'dark';
+    return { dk: dk, ink: dk ? '#e8ecf8' : '#1a2236', mut: dk ? '#9aa6c8' : '#5b6678', grid: dk ? 'rgba(255,255,255,0.07)' : 'rgba(20,30,60,0.08)', sep: dk ? '#0e1326' : '#cdbfa3' };
+  }
   function drawRose() {
     var svg = document.getElementById('viz-rose'); if (!svg) return;
+    clear(svg); var T = plateTokens();
     var cx = 200, cy = 165, n = 12, step = 360 / n;
     var disease = [22, 38, 95, 130, 175, 240, 205, 168, 110, 60, 34, 26];
     var wounds  = [3, 5, 8, 12, 16, 22, 18, 14, 10, 7, 5, 4];
@@ -1216,70 +1210,77 @@ a { color: var(--color-primary); }
     function ring(values, fill, op) {
       for (var i = 0; i < n; i++) {
         var r = Math.sqrt(values[i]) * scale;
-        var path = el('path', { d: wedgePath(cx, cy, r, i*step, (i+1)*step), fill: fill, 'fill-opacity': op, stroke: '#0e1326', 'stroke-width': 0.6 });
+        var path = el('path', { d: wedgePath(cx, cy, r, i*step, (i+1)*step), fill: fill, 'fill-opacity': op, stroke: T.sep, 'stroke-width': 0.6 });
         if (!reduced()) { path.style.opacity = 0; path.style.transition = 'opacity 0.5s ease ' + (i*0.04) + 's'; }
         svg.appendChild(path);
         if (!reduced()) requestAnimationFrame(function(p){ return function(){ p.style.opacity = 1; }; }(path));
       }
     }
     ring(disease.map(function(d,i){return d+wounds[i]+other[i];}), '#3b6fb0', 0.95);
-    ring(wounds.map(function(w,i){return w+other[i];}), '#b33', 0.95);
-    ring(other, '#1a1f33', 0.95);
-    svg.appendChild(el('circle', { cx: cx, cy: cy, r: 2, fill: '#e8ecf8' }));
-    var leg = [['#3b6fb0','Preventable disease'], ['#b33','Wounds in battle'], ['#1a1f33','Other causes']];
+    ring(wounds.map(function(w,i){return w+other[i];}), '#c0392b', 0.95);
+    ring(other, T.dk ? '#cbd3e6' : '#2b3450', 0.95);
+    svg.appendChild(el('circle', { cx: cx, cy: cy, r: 2, fill: T.ink }));
+    var leg = [['#3b6fb0','Preventable disease'], ['#c0392b','Wounds in battle'], [T.dk ? '#cbd3e6' : '#2b3450','Other causes']];
     leg.forEach(function(item, i) {
       svg.appendChild(el('rect', { x: 16, y: 270 + i*15, width: 11, height: 11, rx: 2, fill: item[0] }));
-      var t = el('text', { x: 32, y: 279 + i*15, fill: '#9aa6c8', 'font-size': 10, 'font-family': 'JetBrains Mono, monospace' }); t.textContent = item[1]; svg.appendChild(t);
+      var t = el('text', { x: 32, y: 279 + i*15, fill: T.mut, 'font-size': 10, 'font-family': 'JetBrains Mono, monospace' }); t.textContent = item[1]; svg.appendChild(t);
     });
   }
 
   function drawMinard() {
     var svg = document.getElementById('viz-minard'); if (!svg) return;
+    clear(svg); var T = plateTokens();
     var advance = [[40,422],[105,400],[165,233],[225,175],[300,127]];
     var retreat = [[300,100],[235,50],[170,28],[110,20],[55,12],[28,4]];
-    var midY = 120, k = 0.13;
+    var midY = 118, k = 0.12;
     function band(pts, fill) {
       var top = "M", bot = "";
       pts.forEach(function(p, i) { var t = Math.max(2, p[1]*k); top += (i?" L":"") + p[0] + "," + (midY - t/2).toFixed(1); });
       for (var i = pts.length - 1; i >= 0; i--) { var t = Math.max(2, pts[i][1]*k); bot += " L" + pts[i][0] + "," + (midY + t/2).toFixed(1); }
-      var path = el('path', { d: top + bot + " Z", fill: fill, stroke: '#0e1326', 'stroke-width': 0.5 });
+      var path = el('path', { d: top + bot + " Z", fill: fill, stroke: T.sep, 'stroke-width': 0.5 });
       if (!reduced()) { path.style.opacity = 0; path.style.transition = 'opacity 0.9s ease'; }
       svg.appendChild(path);
       if (!reduced()) requestAnimationFrame(function(){ path.style.opacity = 1; });
     }
-    band(advance, '#d9b38c'); band(retreat, '#2a2f45');
-    svg.appendChild(el('circle', { cx: 300, cy: midY, r: 3.5, fill: '#b33' }));
-    var mt = el('text', { x: 300, y: midY - 18, fill: '#e8ecf8', 'font-size': 11, 'font-family': 'JetBrains Mono, monospace', 'text-anchor': 'middle' }); mt.textContent = 'Moscow'; svg.appendChild(mt);
-    var st = el('text', { x: 40, y: midY - 16, fill: '#e8ecf8', 'font-size': 11, 'font-family': 'JetBrains Mono, monospace' }); st.textContent = '422,000'; svg.appendChild(st);
-    var et = el('text', { x: 28, y: midY + 26, fill: '#9aa6c8', 'font-size': 11, 'font-family': 'JetBrains Mono, monospace' }); et.textContent = '10,000'; svg.appendChild(et);
-    var temps = [[300,200],[235,212],[170,232],[110,250],[55,262],[28,270]];
+    band(advance, T.dk ? '#d9b38c' : '#b07a30'); band(retreat, T.dk ? '#566' : '#2b3450');
+    svg.appendChild(el('circle', { cx: 300, cy: midY, r: 3.5, fill: '#c0392b' }));
+    var mono = 'JetBrains Mono, monospace';
+    var mt = el('text', { x: 300, y: 84, fill: T.ink, 'font-size': 11, 'font-family': mono, 'text-anchor': 'middle' }); mt.textContent = 'Moscow'; svg.appendChild(mt);
+    var st = el('text', { x: 36, y: 72, fill: T.ink, 'font-size': 11, 'font-family': mono }); st.textContent = '422,000 set out'; svg.appendChild(st);
+    var et = el('text', { x: 24, y: 170, fill: T.mut, 'font-size': 11, 'font-family': mono }); et.textContent = '≈10,000 returned'; svg.appendChild(et);
+    var temps = [[300,206],[235,218],[170,238],[110,256],[55,268],[28,276]];
     var d = "M"; temps.forEach(function(p,i){ d += (i?" L":"") + p[0] + "," + p[1]; });
-    svg.appendChild(el('path', { d: d, fill: 'none', stroke: '#8fb4ff', 'stroke-width': 1.6, 'stroke-dasharray': '3,3' }));
-    var tlab = el('text', { x: 28, y: 288, fill: '#8fb4ff', 'font-size': 9.5, 'font-family': 'JetBrains Mono, monospace' }); tlab.textContent = '−30°  the cold of the retreat'; svg.appendChild(tlab);
+    var tcol = T.dk ? '#8fb4ff' : '#3b6fb0';
+    svg.appendChild(el('path', { d: d, fill: 'none', stroke: tcol, 'stroke-width': 1.6, 'stroke-dasharray': '3,3' }));
+    var tlab = el('text', { x: 24, y: 298, fill: tcol, 'font-size': 9.5, 'font-family': mono }); tlab.textContent = 'temperature on the retreat, to −30°'; svg.appendChild(tlab);
   }
 
   function drawSnow() {
     var svg = document.getElementById('viz-snow'); if (!svg) return;
-    for (var gx = 40; gx <= 360; gx += 40) svg.appendChild(el('line', { x1: gx, y1: 30, x2: gx, y2: 290, stroke: 'rgba(255,255,255,0.06)', 'stroke-width': 1 }));
-    for (var gy = 40; gy <= 280; gy += 40) svg.appendChild(el('line', { x1: 30, y1: gy, x2: 370, y2: gy, stroke: 'rgba(255,255,255,0.06)', 'stroke-width': 1 }));
-    var pump = [200, 150], seed = 7;
+    clear(svg); var T = plateTokens();
+    for (var gx = 40; gx <= 360; gx += 40) svg.appendChild(el('line', { x1: gx, y1: 46, x2: gx, y2: 290, stroke: T.grid, 'stroke-width': 1 }));
+    for (var gy = 60; gy <= 280; gy += 40) svg.appendChild(el('line', { x1: 30, y1: gy, x2: 370, y2: gy, stroke: T.grid, 'stroke-width': 1 }));
+    var pump = [200, 158], seed = 7;
     function rnd() { seed = (seed * 9301 + 49297) % 233280; return seed / 233280; }
     function gauss() { return (rnd() + rnd() + rnd() + rnd() - 2) / 2; }
     for (var i = 0; i < 90; i++) {
-      var x = Math.max(34, Math.min(366, pump[0] + gauss() * 70)), y = Math.max(34, Math.min(286, pump[1] + gauss() * 55));
-      var dot = el('rect', { x: x.toFixed(1), y: y.toFixed(1), width: 3.4, height: 3.4, fill: '#1a1f33', stroke: '#e8ecf8', 'stroke-width': 0.5 });
+      var x = Math.max(34, Math.min(366, pump[0] + gauss() * 70)), y = Math.max(50, Math.min(286, pump[1] + gauss() * 52));
+      var dot = el('rect', { x: x.toFixed(1), y: y.toFixed(1), width: 3.6, height: 3.6, fill: T.dk ? '#dfe5f2' : '#1a1f33', stroke: 'none' });
       if (!reduced()) { dot.style.opacity = 0; dot.style.transition = 'opacity 0.4s ease ' + (i*0.012) + 's'; }
       svg.appendChild(dot);
       if (!reduced()) requestAnimationFrame(function(d){ return function(){ d.style.opacity = 1; }; }(dot));
     }
-    [[80,70],[330,90],[300,250],[90,240]].forEach(function(p) { svg.appendChild(el('circle', { cx: p[0], cy: p[1], r: 5, fill: 'none', stroke: '#9aa6c8', 'stroke-width': 1.5 })); });
-    svg.appendChild(el('circle', { cx: pump[0], cy: pump[1], r: 9, fill: 'none', stroke: '#f093fb', 'stroke-width': 2 }));
-    svg.appendChild(el('circle', { cx: pump[0], cy: pump[1], r: 4, fill: '#f093fb' }));
-    var lab = el('text', { x: pump[0] + 14, y: pump[1] - 8, fill: '#f5c6ff', 'font-size': 11, 'font-family': 'JetBrains Mono, monospace' }); lab.textContent = 'Broad St. pump'; svg.appendChild(lab);
+    [[80,84],[330,100],[300,252],[92,246]].forEach(function(p) { svg.appendChild(el('circle', { cx: p[0], cy: p[1], r: 5, fill: 'none', stroke: T.mut, 'stroke-width': 1.5 })); });
+    svg.appendChild(el('circle', { cx: pump[0], cy: pump[1], r: 9, fill: 'none', stroke: '#d6336c', 'stroke-width': 2 }));
+    svg.appendChild(el('circle', { cx: pump[0], cy: pump[1], r: 4, fill: '#d6336c' }));
+    // legend (kept clear of the cluster)
+    svg.appendChild(el('circle', { cx: 24, cy: 26, r: 4, fill: '#d6336c' }));
+    var lab = el('text', { x: 34, y: 30, fill: T.mut, 'font-size': 10.5, 'font-family': 'JetBrains Mono, monospace' }); lab.textContent = 'the Broad Street pump · each mark is a death'; svg.appendChild(lab);
   }
 
   function drawDuBois() {
     var svg = document.getElementById('viz-dubois'); if (!svg) return;
+    clear(svg);
     var cx = 200, cy = 160, palette = ['#c1272d', '#e8b22a', '#21563f', '#1b1b3a', '#d98e2b', '#7a5230'], segs = 30, base = 6, turns = 3.4, prev = null;
     for (var i = 0; i < segs; i++) {
       var ang = (i / segs) * turns * 360, rad = base + i * 4.6, p = polar(cx, cy, rad, ang);
@@ -1374,12 +1375,12 @@ a { color: var(--color-primary); }
 
   document.addEventListener('DOMContentLoaded', function() {
     heroDots(); reveal(); renderAll();
-    // the recreations + curated cards are drawn once (they don't depend on theme)
-    drawRose(); drawMinard(); drawSnow(); drawDuBois();
+    function drawMasters(){ drawRose(); drawMinard(); drawSnow(); drawDuBois(); }
+    drawMasters();
     buildCards(); wireFilters();
-    // re-render charts when the theme changes so ink/grid stay legible
+    // re-render charts and recreations when the theme changes so ink/grid stay legible
     var obs = new MutationObserver(function(muts){
-      muts.forEach(function(m){ if (m.attributeName === 'data-theme') renderAll(); });
+      muts.forEach(function(m){ if (m.attributeName === 'data-theme') { renderAll(); drawMasters(); } });
     });
     obs.observe(document.documentElement, { attributes: true });
   });


### PR DESCRIPTION
Stage 1 of the redesign you signed off on (focused cleanup; Stage 2 — split masters/greats to their own page + clickable per-chart explainer pages — follows).

Addresses the concrete problems you flagged:

- **Overlapping text → removed, not nudged.** The big callout blocks that sat *on top of* the line and beeswarm charts are gone (Tufte: the takeaway belongs in the caption, not over the data). That's the real fix for the collisions.
- **Light mode is genuinely light now.** The Masters' recreations are theme-aware: light "paper" plates in light mode — which is how the Nightingale / Minard / Snow originals actually looked — and dark in dark mode. They re-render when you switch themes.
- **Fixed the Napoleon/Minard label collisions** (repositioned "Moscow", "422,000 set out", "10,000 returned", the temperature note) and moved Snow's pump label out of the death cluster into a legend.
- **No longer opens on line charts** — the data wing now leads with the gender dumbbell, the caste bars, and the carbon beeswarm.

Verified every affected chart in **light and dark** with the real Inter/Amaranth/JetBrains fonts. Only `the-long-view.html` changed; mojibake PASS, JS valid.

Still to come in Stage 2: this page becomes purely our originals, the recreated masters + curated greats move to their own gallery page, and each original becomes a clickable tile opening its own explainer (data source, what it shows, why that chart type, how it's built, the takeaway).

https://claude.ai/code/session_01Xpta1BU7c52vLx8u7BEaDj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xpta1BU7c52vLx8u7BEaDj)_