### PR TITLE
The Long View redesign (stage 2): clickable per-chart explainer pages + split gallery

### DIFF
--- a/css/longview.css
+++ b/css/longview.css
@@ -1,0 +1,180 @@
+:root {
+  --font-body: 'Amaranth', Arial, sans-serif;
+  --font-heading: 'Inter', Helvetica, sans-serif;
+  --font-mono: 'JetBrains Mono', monospace;
+
+  --color-primary: #667eea;
+  --color-primary-2: #764ba2;
+  --color-accent-pink: #f093fb;
+  --color-accent-blue: #4facfe;
+
+  --color-text: #2d3748;
+  --color-text-muted: #718096;
+  --color-bg: #f7fafc;
+  --color-bg-card: #ffffff;
+  --color-border: #e2e8f0;
+
+  /* chart ink adapts to theme so original charts stay legible in both modes */
+  --chart-ink: #475569;
+  --chart-grid: #e8edf4;
+}
+[data-theme="dark"] {
+  --color-text: #e2e8f0;
+  --color-text-muted: #a0aec0;
+  --color-bg: #141a26;
+  --color-bg-card: #1f2735;
+  --color-border: #33415a;
+  --chart-ink: #aab6cc;
+  --chart-grid: #2c374a;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0; font-family: var(--font-body); color: var(--color-text);
+  background: var(--color-bg); line-height: 1.6; padding-top: 44px; -webkit-font-smoothing: antialiased;
+}
+@media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } * { animation-duration: 0.001ms !important; transition-duration: 0.001ms !important; } }
+
+h1, h2, h3, h4 { font-family: var(--font-heading); font-weight: 800; line-height: 1.2; }
+a { color: var(--color-primary); }
+
+.skip-link { position: absolute; left: -999px; top: 0; z-index: 10000; background: var(--color-primary); color: #fff; padding: 10px 16px; border-radius: 0 0 8px 0; }
+.skip-link:focus { left: 0; }
+
+/* ---------- Top bar ---------- */
+.im-topbar { position: fixed; top: 0; left: 0; right: 0; z-index: 9999; background: rgba(16, 21, 34, 0.95); backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px); border-bottom: 1px solid rgba(255,255,255,0.08); padding: 0.5rem 1rem; display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; }
+.im-topbar-home { display: flex; align-items: center; gap: 0.5rem; color: #fff; text-decoration: none; font-family: var(--font-heading); font-weight: 700; }
+.im-topbar-right { display: flex; align-items: center; gap: 0.6rem; }
+.im-premium-btn { display: inline-flex; align-items: center; gap: 0.35rem; background: linear-gradient(135deg, #667eea, #764ba2); color: #ffffff; -webkit-text-fill-color: #ffffff; text-decoration: none; font-weight: 700; font-size: 0.85rem; padding: 0.4rem 0.8rem; border-radius: 8px; font-family: var(--font-heading); }
+.im-premium-btn svg { width: 15px; height: 15px; }
+.im-theme-selector { display: flex; gap: 2px; background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; padding: 2px; }
+.im-theme-btn { background: transparent; border: none; color: #9aa6c8; padding: 6px; border-radius: 5px; cursor: pointer; transition: all 0.2s; display: flex; align-items: center; justify-content: center; width: 30px; height: 30px; }
+.im-theme-btn:hover { background: rgba(255,255,255,0.1); color: #fff; }
+.im-theme-btn.active { background: var(--color-primary); color: #fff; }
+.im-theme-btn svg { width: 16px; height: 16px; }
+
+/* ---------- Hero ---------- */
+.hero { position: relative; overflow: hidden; background: radial-gradient(1100px 540px at 78% -10%, rgba(118,75,162,0.5), transparent 60%), radial-gradient(820px 480px at 8% 115%, rgba(79,172,254,0.38), transparent 55%), linear-gradient(135deg, #101522 0%, #1a1838 55%, #241a44 100%); color: #fff; padding: 6rem 1.5rem 5rem; text-align: center; }
+.hero-inner { max-width: 880px; margin: 0 auto; position: relative; z-index: 2; }
+.hero .eyebrow { display: inline-block; font-family: var(--font-mono); font-size: 0.78rem; letter-spacing: 3px; text-transform: uppercase; color: #c9b8ff; border: 1px solid rgba(255,255,255,0.2); padding: 0.35rem 0.9rem; border-radius: 999px; margin-bottom: 1.5rem; }
+.hero h1 { font-size: clamp(2.6rem, 7vw, 4.6rem); margin: 0; letter-spacing: -1.5px; }
+.hero h1 .accent { background: linear-gradient(90deg, #f093fb, #4facfe); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }
+.hero .lede { font-size: 1.25rem; color: #eef1ff; font-weight: 700; font-family: var(--font-heading); margin: 1rem auto 0; max-width: 660px; }
+.hero .sub { font-size: 1.02rem; color: #cdd5f2; max-width: 640px; margin: 1.1rem auto 0; }
+.hero-cta { margin-top: 2.2rem; display: flex; gap: 0.8rem; justify-content: center; flex-wrap: wrap; }
+.btn { display: inline-flex; align-items: center; gap: 0.4rem; font-family: var(--font-heading); font-weight: 700; text-decoration: none; padding: 0.75rem 1.4rem; border-radius: 10px; font-size: 0.95rem; cursor: pointer; border: none; }
+.btn-primary { background: linear-gradient(135deg, #667eea, #764ba2); color: #fff; -webkit-text-fill-color: #fff; }
+.btn-ghost { background: rgba(255,255,255,0.08); color: #fff; border: 1px solid rgba(255,255,255,0.22); }
+.btn:hover { transform: translateY(-2px); transition: transform 0.2s; }
+.hero-dots { position: absolute; inset: 0; z-index: 1; opacity: 0.5; }
+.hero-dots span { position: absolute; border-radius: 50%; background: rgba(255,255,255,0.5); animation: drift 9s ease-in-out infinite; }
+
+/* ---------- Layout ---------- */
+.wrap { max-width: 1200px; margin: 0 auto; padding: 0 1.5rem; }
+.section { padding: 4.5rem 0; }
+.section-head { max-width: 760px; margin: 0 auto 3rem; text-align: center; }
+.section-head .kicker { font-family: var(--font-mono); font-size: 0.76rem; letter-spacing: 2.5px; text-transform: uppercase; color: var(--color-primary); }
+.section-head h2 { font-size: clamp(1.9rem, 4vw, 2.7rem); margin: 0.6rem 0 0.8rem; color: var(--color-text); }
+.section-head p { color: var(--color-text-muted); font-size: 1.05rem; margin: 0; }
+
+/* ---------- Cards grid ---------- */
+.grid { display: grid; grid-template-columns: 1fr; gap: 1.8rem; }
+@media (min-width: 860px) { .grid { grid-template-columns: 1fr 1fr; } }
+
+.card { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: 18px; padding: 1.6rem 1.7rem 1.5rem; box-shadow: 0 10px 30px rgba(15,23,42,0.06); display: flex; flex-direction: column; opacity: 0; transform: translateY(22px); }
+.card.in { opacity: 1; transform: none; transition: opacity 0.7s ease, transform 0.7s ease; }
+.card .tag { align-self: flex-start; font-family: var(--font-mono); font-size: 0.66rem; letter-spacing: 1.4px; text-transform: uppercase; color: var(--color-primary); background: rgba(102,126,234,0.12); padding: 0.22rem 0.6rem; border-radius: 6px; margin-bottom: 0.7rem; }
+.card h3 { font-size: 1.3rem; margin: 0 0 0.5rem; color: var(--color-text); }
+.chart-holder { width: 100%; margin: 0.4rem 0 0.9rem; }
+.chart-holder svg { width: 100%; height: auto; display: block; }
+.card .insight { color: var(--color-text); font-size: 0.98rem; margin: 0.2rem 0 0.9rem; }
+.card .insight strong { color: var(--color-primary); }
+.card .source { font-family: var(--font-mono); font-size: 0.72rem; color: var(--color-text-muted); border-top: 1px solid var(--color-border); padding-top: 0.8rem; margin-top: auto; }
+
+/* Frameworks have a taller, simpler canvas */
+.frame-canvas { width: 100%; margin: 0.4rem 0 0.9rem; }
+.frame-canvas svg { width: 100%; height: auto; display: block; }
+.card .caption { color: var(--color-text-muted); font-size: 0.92rem; margin: 0.2rem 0 0; }
+
+.frameworks-bg { background: var(--color-bg-card); border-top: 1px solid var(--color-border); border-bottom: 1px solid var(--color-border); }
+.frameworks-bg .card { background: var(--color-bg); }
+
+/* ---------- Methods / closing ---------- */
+.methods { background: linear-gradient(135deg, #101522, #251447); color: #fff; }
+.methods .wrap { padding-top: 4.5rem; padding-bottom: 4.5rem; }
+.methods h2 { color: #fff; font-size: clamp(1.7rem, 4vw, 2.3rem); }
+.methods p.intro { color: #cdd5f2; max-width: 700px; font-size: 1.03rem; }
+.source-list { list-style: none; padding: 0; margin: 1.8rem 0 0; display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 0.7rem; }
+.source-list li { background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1); border-radius: 10px; padding: 0.8rem 1rem; font-size: 0.85rem; color: #c4cce6; }
+.source-list li b { color: #fff; font-family: var(--font-heading); display: block; font-size: 0.82rem; margin-bottom: 0.15rem; }
+.tools-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1.1rem; margin-top: 2.5rem; }
+.tool-link { background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.12); border-radius: 14px; padding: 1.3rem; text-decoration: none; color: #fff; transition: background 0.2s, transform 0.2s; }
+.tool-link:hover { background: rgba(255,255,255,0.1); transform: translateY(-3px); }
+.tool-link h4 { margin: 0 0 0.3rem; font-size: 1.02rem; color: #fff; }
+.tool-link span { color: #aeb8df; font-size: 0.86rem; }
+.credit-note { margin-top: 2.4rem; font-size: 0.9rem; color: #aeb8df; }
+.credit-note a { color: #fff; font-weight: 700; }
+
+/* ---------- Footer ---------- */
+.site-footer { background: #101522; color: #cdd5f2; padding: 3.5rem 1.5rem 1.5rem; }
+.footer-grid { max-width: 1200px; margin: 0 auto; display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 2rem; }
+.footer-col h4 { color: #fff; font-size: 1rem; margin: 0 0 1rem; }
+.footer-col a { display: block; color: #9aa6c8; text-decoration: none; font-size: 0.9rem; padding: 0.25rem 0; }
+.footer-col a:hover { color: #fff; }
+.footer-bottom { max-width: 1200px; margin: 2.5rem auto 0; padding-top: 1.5rem; border-top: 1px solid rgba(255,255,255,0.1); text-align: center; color: #7c87aa; font-size: 0.85rem; }
+
+/* ---------- Masters' wing (recreated classics) ---------- */
+.masters { display: grid; grid-template-columns: 1fr; gap: 1.8rem; }
+@media (min-width: 860px) { .masters { grid-template-columns: 1fr 1fr; } }
+.plate { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: 18px; overflow: hidden; box-shadow: 0 10px 30px rgba(15,23,42,0.06); display: flex; flex-direction: column; opacity: 0; transform: translateY(22px); }
+[data-theme="dark"] .plate { background: linear-gradient(160deg, #131a2e, #1a2238); border-color: rgba(255,255,255,0.08); box-shadow: 0 16px 40px rgba(8,12,30,0.3); }
+.plate.in { opacity: 1; transform: none; transition: opacity 0.7s ease, transform 0.7s ease; }
+.plate-canvas { position: relative; aspect-ratio: 4 / 3; padding: 1.1rem; display: flex; align-items: center; justify-content: center; background: #f4f1ea; }
+[data-theme="dark"] .plate-canvas { background: radial-gradient(560px 280px at 50% 0%, rgba(118,75,162,0.18), transparent 70%); }
+.plate-canvas svg { width: 100%; height: 100%; display: block; }
+.plate-caption { padding: 1.3rem 1.5rem 1.6rem; border-top: 1px solid var(--color-border); }
+[data-theme="dark"] .plate-caption { border-top-color: rgba(255,255,255,0.08); }
+.plate-caption .tag { display: inline-block; font-family: var(--font-mono); font-size: 0.66rem; letter-spacing: 1.4px; text-transform: uppercase; color: #6b4ea0; background: rgba(118,75,162,0.12); padding: 0.22rem 0.6rem; border-radius: 6px; margin-bottom: 0.6rem; }
+[data-theme="dark"] .plate-caption .tag { color: #c9b8ff; background: rgba(118,75,162,0.25); }
+.plate-caption h3 { color: var(--color-text); font-size: 1.25rem; margin: 0 0 0.15rem; }
+.plate-caption .meta { font-family: var(--font-mono); font-size: 0.78rem; color: var(--color-text-muted); margin-bottom: 0.7rem; }
+.plate-caption p { color: var(--color-text); font-size: 0.93rem; margin: 0 0 0.8rem; }
+.plate-caption .why { color: var(--color-text-muted); font-size: 0.88rem; border-left: 2px solid var(--color-accent-blue); padding-left: 0.8rem; }
+.plate-caption a.source { display: inline-flex; align-items: center; gap: 0.3rem; margin-top: 0.9rem; font-family: var(--font-heading); font-weight: 700; font-size: 0.84rem; color: var(--color-primary); text-decoration: none; }
+.plate-caption a.source:hover { text-decoration: underline; }
+.plate-canvas { background: #f4f1ea; }
+.plate--dubois .plate-canvas { background: #e8d9b8 !important; }
+
+/* ---------- Greats gallery (curated, links out) ---------- */
+.filters { display: flex; flex-wrap: wrap; gap: 0.5rem; justify-content: center; margin-bottom: 2.4rem; }
+.filter-chip { font-family: var(--font-heading); font-weight: 600; font-size: 0.82rem; background: var(--color-bg); color: var(--color-text-muted); border: 1px solid var(--color-border); padding: 0.45rem 0.95rem; border-radius: 999px; cursor: pointer; transition: all 0.18s; }
+.filter-chip:hover { color: var(--color-text); border-color: var(--color-primary); }
+.filter-chip.active { background: linear-gradient(135deg, #667eea, #764ba2); color: #fff; border-color: transparent; }
+.cards-gallery { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.6rem; }
+.viz-card { display: flex; flex-direction: column; background: var(--color-bg); border: 1px solid var(--color-border); border-radius: 16px; overflow: hidden; text-decoration: none; color: inherit; transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s; }
+.viz-card:hover { transform: translateY(-5px); box-shadow: 0 16px 36px rgba(0,0,0,0.13); border-color: var(--color-primary); }
+.viz-card .swatch { height: 96px; position: relative; }
+.viz-card .swatch::after { content: ""; position: absolute; inset: 0; background: linear-gradient(180deg, transparent 45%, rgba(0,0,0,0.18)); }
+.viz-card .vbody { padding: 1.2rem 1.3rem 1.4rem; display: flex; flex-direction: column; flex: 1; }
+.viz-card .theme-tag { align-self: flex-start; font-family: var(--font-mono); font-size: 0.64rem; letter-spacing: 1px; text-transform: uppercase; color: var(--color-primary); background: rgba(102,126,234,0.12); padding: 0.2rem 0.55rem; border-radius: 5px; margin-bottom: 0.7rem; }
+.viz-card h3 { font-size: 1.08rem; margin: 0 0 0.25rem; color: var(--color-text); }
+.viz-card .meta { font-family: var(--font-mono); font-size: 0.74rem; color: var(--color-text-muted); margin-bottom: 0.7rem; }
+.viz-card p { font-size: 0.88rem; color: var(--color-text-muted); margin: 0 0 1rem; flex: 1; }
+.viz-card .view { font-family: var(--font-heading); font-weight: 700; font-size: 0.82rem; color: var(--color-primary); display: inline-flex; align-items: center; gap: 0.3rem; }
+.viz-card.hidden { display: none; }
+
+/* ---------- Paper plane ---------- */
+.paper-plane { position: fixed; bottom: 2rem; right: 2rem; opacity: 0.1; pointer-events: none; z-index: 0; animation: float 6s ease-in-out infinite; }
+@keyframes float { 0%, 100% { transform: translateY(0) rotate(0deg); } 50% { transform: translateY(-15px) rotate(3deg); } }
+@keyframes drift { 0%,100% { transform: translateY(0); } 50% { transform: translateY(-18px); } }
+@media (prefers-reduced-motion: reduce) { .paper-plane, .hero-dots span { animation: none; } }
+
+/* ---------- clickable tiles + gallery link (Stage 2) ---------- */
+.card-link { display: block; text-decoration: none; color: inherit; }
+.card-link .card.tile { cursor: pointer; height: 100%; transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s; }
+.card-link:hover .card.tile { transform: translateY(-4px); box-shadow: 0 16px 36px rgba(0,0,0,0.12); border-color: var(--color-primary); }
+.card .explore { padding-top: 0.7rem; font-family: var(--font-heading); font-weight: 700; font-size: 0.82rem; color: var(--color-primary); display: inline-flex; align-items: center; gap: 0.3rem; }
+.gallery-cta { display: flex; align-items: center; justify-content: space-between; gap: 1.5rem; background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: 18px; padding: 1.6rem 1.8rem; text-decoration: none; box-shadow: 0 10px 30px rgba(15,23,42,0.06); transition: transform 0.2s, border-color 0.2s; }
+.gallery-cta:hover { transform: translateY(-3px); border-color: var(--color-primary); }
+.gallery-arrow { font-size: 1.8rem; color: var(--color-primary); font-weight: 800; }

--- a/js/longview-charts.js
+++ b/js/longview-charts.js
@@ -1,0 +1,824 @@
+/* The Long View — shared chart engine. window.LV = { renderAll, drawMasters, buildCards, wireFilters, heroDots, reveal, VIZ } */
+window.LV = (function() {
+  var NS = "http://www.w3.org/2000/svg";
+  function mk(tag, attrs, text) {
+    var e = document.createElementNS(NS, tag);
+    for (var k in attrs) e.setAttribute(k, attrs[k]);
+    if (text != null) e.textContent = text;
+    return e;
+  }
+  function clear(el) { while (el && el.firstChild) el.removeChild(el.firstChild); }
+  function ink() { return (getComputedStyle(document.documentElement).getPropertyValue('--chart-ink') || '#475569').trim(); }
+  function gridc() { return (getComputedStyle(document.documentElement).getPropertyValue('--chart-grid') || '#e8edf4').trim(); }
+  function reduced() { return window.matchMedia('(prefers-reduced-motion: reduce)').matches; }
+
+  var W = 460, H = 290;
+  var COL = { blue: '#4361ee', teal: '#0d9488', amber: '#f59e0b', red: '#e11d48', purple: '#7c3aed', green: '#16a34a', slate: '#64748b' };
+
+  function frame(id) {
+    var svg = document.getElementById(id); if (!svg) return null;
+    clear(svg); svg.setAttribute('viewBox', '0 0 ' + W + ' ' + H); return svg;
+  }
+  function animPath(path) {
+    if (reduced() || !path.getTotalLength) return;
+    var len = path.getTotalLength(); if (!len) return;
+    path.style.strokeDasharray = len; path.style.strokeDashoffset = len;
+    path.style.transition = 'stroke-dashoffset 1.3s ease';
+    requestAnimationFrame(function(){ path.style.strokeDashoffset = 0; });
+  }
+  function fadeIn(node, delay) {
+    if (reduced()) return;
+    node.style.opacity = 0; node.style.transition = 'opacity 0.6s ease ' + (delay || 0) + 's';
+    requestAnimationFrame(function(){ node.style.opacity = 1; });
+  }
+
+  /* ---------- Generic line chart ---------- */
+  /* ===== shared design helpers ===== */
+  function ensureDefs(svg) { var d = svg.querySelector('defs'); if (!d) { d = mk('defs', {}); svg.insertBefore(d, svg.firstChild); } return d; }
+  function vGrad(svg, gid, color, topOp, botOp) {
+    var g = mk('linearGradient', { id: gid, x1: '0', y1: '0', x2: '0', y2: '1' });
+    g.appendChild(mk('stop', { offset: '0', 'stop-color': color, 'stop-opacity': topOp }));
+    g.appendChild(mk('stop', { offset: '1', 'stop-color': color, 'stop-opacity': botOp }));
+    ensureDefs(svg).appendChild(g); return 'url(#' + gid + ')';
+  }
+  function smooth(pts) {
+    if (pts.length < 3) return 'M' + pts.map(function(p){ return p[0].toFixed(1) + ',' + p[1].toFixed(1); }).join(' L');
+    var d = 'M' + pts[0][0].toFixed(1) + ',' + pts[0][1].toFixed(1);
+    for (var i = 0; i < pts.length - 1; i++) {
+      var p0 = pts[i-1] || pts[i], p1 = pts[i], p2 = pts[i+1], p3 = pts[i+2] || p2;
+      var c1x = p1[0] + (p2[0]-p0[0])/6, c1y = p1[1] + (p2[1]-p0[1])/6;
+      var c2x = p2[0] - (p3[0]-p1[0])/6, c2y = p2[1] - (p3[1]-p1[1])/6;
+      d += ' C' + c1x.toFixed(1) + ',' + c1y.toFixed(1) + ' ' + c2x.toFixed(1) + ',' + c2y.toFixed(1) + ' ' + p2[0].toFixed(1) + ',' + p2[1].toFixed(1);
+    }
+    return d;
+  }
+  function callout(svg, x, y, anchor, lines) {
+    var yy = y;
+    lines.forEach(function(ln) {
+      svg.appendChild(mk('text', { x: x, y: yy, 'text-anchor': anchor, 'font-size': ln.s || 11, 'font-weight': ln.w || 400, fill: ln.c || ink(), 'font-family': ln.f || 'Inter, sans-serif' }, ln.t));
+      yy += ln.gap || ((ln.s || 11) + 4);
+    });
+  }
+  function tick(svg, x, y, txt, anchor) {
+    svg.appendChild(mk('text', { x: x, y: y, 'text-anchor': anchor || 'middle', 'font-size': 9.5, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, txt));
+  }
+
+  /* ---------- Line / area chart with annotation callout ---------- */
+  function lineChart(id, data, o) {
+    var svg = frame(id); if (!svg) return;
+    var mL = 30, mR = 54, mT = 30, mB = 36;
+    var xs = data.map(function(d){ return d.x; });
+    var xmin = Math.min.apply(null, xs), xmax = Math.max.apply(null, xs), yMax = o.yMax;
+    function X(x){ return mL + (x - xmin) / (xmax - xmin) * (W - mL - mR); }
+    function Y(y){ return H - mB - (y / yMax) * (H - mT - mB); }
+    var pts = data.map(function(p){ return [X(p.x), Y(p.y)]; });
+    svg.appendChild(mk('line', { x1: mL, y1: Y(0), x2: W - mR, y2: Y(0), stroke: gridc(), 'stroke-width': 1 }));
+    var lineD = smooth(pts);
+    if (o.area) {
+      var fill = vGrad(svg, id + '-area', o.color, 0.32, 0.015);
+      svg.appendChild(mk('path', { d: lineD + ' L' + X(xmax).toFixed(1) + ',' + Y(0).toFixed(1) + ' L' + X(xmin).toFixed(1) + ',' + Y(0).toFixed(1) + ' Z', fill: fill }));
+    }
+    var path = mk('path', { d: lineD, fill: 'none', stroke: o.color, 'stroke-width': 3, 'stroke-linejoin': 'round', 'stroke-linecap': 'round' });
+    svg.appendChild(path); animPath(path);
+    data.forEach(function(p, i){
+      var isEnd = (i === 0 || i === data.length - 1);
+      if (isEnd || (o.labelEvery && i % o.labelEvery === 0)) tick(svg, X(p.x), H - mB + 16, o.xfmt ? o.xfmt(p.x) : p.x);
+      svg.appendChild(mk('circle', { cx: X(p.x), cy: Y(p.y), r: isEnd ? 5 : 3, fill: o.color, stroke: '#fff', 'stroke-width': isEnd ? 1.6 : 0 }));
+    });
+    var f = data[0], l = data[data.length - 1];
+    svg.appendChild(mk('text', { x: X(f.x) + 8, y: Y(f.y) - 11, 'text-anchor': 'start', 'font-size': 15, 'font-weight': 800, fill: o.color, 'font-family': 'Inter, sans-serif' }, o.valfmt(f.y)));
+    svg.appendChild(mk('text', { x: X(l.x) - 6, y: Y(l.y) - 11, 'text-anchor': 'end', 'font-size': 15, 'font-weight': 800, fill: o.color, 'font-family': 'Inter, sans-serif' }, o.valfmt(l.y)));
+    if (o.callout) callout(svg, o.callout.x, o.callout.y, o.callout.anchor, o.callout.lines);
+  }
+
+  /* ---------- Vertical bar chart with reference line ---------- */
+  function barChart(id, data, o) {
+    var svg = frame(id); if (!svg) return;
+    var mL = 18, mR = 66, mT = 30, mB = 42;
+    var yMax = o.yMax, n = data.length, gap = 30;
+    var bw = (W - mL - mR - gap * (n - 1)) / n;
+    function Y(y){ return H - mB - (y / yMax) * (H - mT - mB); }
+    svg.appendChild(mk('line', { x1: mL, y1: Y(0), x2: W - mR, y2: Y(0), stroke: ink(), 'stroke-width': 1.4 }));
+    data.forEach(function(dd, i){
+      var x = mL + i * (bw + gap);
+      var fill = vGrad(svg, id + '-b' + i, dd.color, dd.highlight ? 1 : 0.78, dd.highlight ? 0.72 : 0.5);
+      var rect = mk('rect', { x: x, y: Y(dd.y), width: bw, height: Y(0) - Y(dd.y), rx: 7, fill: fill });
+      svg.appendChild(rect); fadeIn(rect, i * 0.1);
+      svg.appendChild(mk('text', { x: x + bw/2, y: Y(dd.y) - 9, 'text-anchor': 'middle', 'font-size': 15, 'font-weight': 800, fill: dd.color, 'font-family': 'Inter, sans-serif' }, o.valfmt(dd.y)));
+      svg.appendChild(mk('text', { x: x + bw/2, y: H - mB + 18, 'text-anchor': 'middle', 'font-size': 12, 'font-weight': dd.highlight ? 700 : 400, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, dd.label));
+    });
+    if (o.refLine) {
+      var ry = Y(o.refLine.value);
+      svg.appendChild(mk('line', { x1: mL, y1: ry, x2: W - mR + 6, y2: ry, stroke: ink(), 'stroke-width': 1, 'stroke-dasharray': '5,4', opacity: 0.7 }));
+      svg.appendChild(mk('text', { x: W - mR + 10, y: ry - 4, 'font-size': 9.5, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, o.refLine.label));
+    }
+    if (o.callout) callout(svg, o.callout.x, o.callout.y, o.callout.anchor, o.callout.lines);
+  }
+
+  /* ---------- Horizontal bar chart with reference line ---------- */
+  function hbarChart(id, data, o) {
+    var svg = frame(id); if (!svg) return;
+    var mL = 108, mR = 50, mT = 24, mB = 28;
+    var xMax = o.xMax, n = data.length, gap = 18;
+    var bh = (H - mT - mB - gap * (n - 1)) / n;
+    function Xv(v){ return mL + (v / xMax) * (W - mL - mR); }
+    data.forEach(function(dd, i){
+      var y = mT + i * (bh + gap);
+      svg.appendChild(mk('text', { x: mL - 12, y: y + bh/2 + 4, 'text-anchor': 'end', 'font-size': 12, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, dd.label));
+      svg.appendChild(mk('rect', { x: mL, y: y, width: W - mL - mR, height: bh, rx: 7, fill: gridc(), opacity: 0.5 }));
+      var bar = mk('rect', { x: mL, y: y, width: Xv(dd.y) - mL, height: bh, rx: 7, fill: dd.color });
+      svg.appendChild(bar); fadeIn(bar, i * 0.1);
+      svg.appendChild(mk('text', { x: Xv(dd.y) + 8, y: y + bh/2 + 4.5, 'font-size': 14, 'font-weight': 800, fill: dd.vcolor || ink(), 'font-family': 'Inter, sans-serif' }, o.valfmt(dd.y)));
+    });
+    if (o.refLine) {
+      var rx = Xv(o.refLine.value);
+      svg.appendChild(mk('line', { x1: rx, y1: mT - 13, x2: rx, y2: H - mB + 3, stroke: ink(), 'stroke-width': 1, 'stroke-dasharray': '5,4', opacity: 0.8 }));
+      svg.appendChild(mk('text', { x: rx, y: mT - 17, 'text-anchor': 'middle', 'font-size': 9.5, 'font-weight': 700, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, o.refLine.label));
+    }
+  }
+
+  /* ---------- The "honest axis" method panel ---------- */
+  function ethicChart(id) {
+    var svg = frame(id); if (!svg) return;
+    var vals = [52, 55, 58];
+    svg.appendChild(mk('text', { x: W/2, y: 20, 'text-anchor': 'middle', 'font-size': 12, 'font-weight': 700, fill: ink(), 'font-family': 'Inter, sans-serif' }, 'Same three numbers — 52, 55, 58'));
+    function panel(ox, pw, yScaleMin, title, color) {
+      var top = 44, base = H - 40, n = vals.length, gap = 18, bw = (pw - gap * (n - 1)) / n, range = 60 - yScaleMin;
+      function Y(v){ return top + (60 - v) / range * (base - top); }
+      svg.appendChild(mk('line', { x1: ox - 6, y1: base, x2: ox + pw + 4, y2: base, stroke: ink(), 'stroke-width': 1.3 }));
+      vals.forEach(function(v, i){
+        var x = ox + i * (bw + gap);
+        var fill = vGrad(svg, id + '-' + ox + '-' + i, color, 0.95, 0.6);
+        var r = mk('rect', { x: x, y: Y(v), width: bw, height: base - Y(v), rx: 4, fill: fill });
+        svg.appendChild(r); fadeIn(r, i * 0.08);
+      });
+      svg.appendChild(mk('text', { x: ox - 9, y: base + 3, 'text-anchor': 'end', 'font-size': 9, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, yScaleMin));
+      svg.appendChild(mk('text', { x: ox + pw/2, y: H - 12, 'text-anchor': 'middle', 'font-size': 11, 'font-weight': 700, fill: color, 'font-family': 'Inter, sans-serif' }, title));
+    }
+    panel(58, 150, 50, 'axis cut at 50 → "a surge!"', COL.red);
+    panel(268, 150, 0, 'axis at 0 → the truth', COL.teal);
+  }
+
+  /* ---------- India warming (verified IMD anomalies + schematic stripe) ---------- */
+  function climateChart(id) {
+    var svg = frame(id); if (!svg) return;
+    var defs = mk('defs', {});
+    var lg = mk('linearGradient', { id: 'warmgrad', x1: '0', y1: '0', x2: '1', y2: '0' });
+    [['0','#08306b'],['0.45','#f2f2f2'],['0.7','#fdae61'],['1','#a50026']].forEach(function(s){ lg.appendChild(mk('stop', { offset: s[0], 'stop-color': s[1] })); });
+    defs.appendChild(lg); svg.appendChild(defs);
+    var bandY = 26, bandH = 44;
+    svg.appendChild(mk('rect', { x: 20, y: bandY, width: W - 40, height: bandH, rx: 6, fill: 'url(#warmgrad)' }));
+    svg.appendChild(mk('text', { x: 22, y: bandY - 7, 'font-size': 10, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, '1901'));
+    svg.appendChild(mk('text', { x: W - 22, y: bandY - 7, 'text-anchor': 'end', 'font-size': 10, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, '2024'));
+    svg.appendChild(mk('text', { x: W/2, y: bandY + bandH + 15, 'text-anchor': 'middle', 'font-size': 9.5, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, 'warming trend — schematic (cool → hot)'));
+    svg.appendChild(mk('text', { x: W/2, y: 150, 'text-anchor': 'middle', 'font-size': 44, 'font-weight': 800, fill: COL.red, 'font-family': 'Inter, sans-serif' }, '+0.65°C'));
+    svg.appendChild(mk('text', { x: W/2, y: 171, 'text-anchor': 'middle', 'font-size': 12, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, '2024 vs 1991–2020 — warmest year since 1901'));
+    var items = [['vs 1981–2010', '+0.78°C'], ['vs 1951–80', '+0.98°C']], cw = (W - 40) / 2;
+    items.forEach(function(it, i){
+      var cx = 20 + cw * i + cw / 2;
+      svg.appendChild(mk('text', { x: cx, y: 212, 'text-anchor': 'middle', 'font-size': 19, 'font-weight': 800, fill: COL.amber, 'font-family': 'Inter, sans-serif' }, it[1]));
+      svg.appendChild(mk('text', { x: cx, y: 230, 'text-anchor': 'middle', 'font-size': 10, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, it[0]));
+    });
+    svg.appendChild(mk('text', { x: W/2, y: 266, 'text-anchor': 'middle', 'font-size': 11, 'font-weight': 700, fill: ink(), 'font-family': 'Inter, sans-serif' }, '10 of the 15 warmest years have come since 2010'));
+  }
+
+  /* ---------- Beeswarm (distribution, one dot per item) ---------- */
+  function beeswarm(id, data, o) {
+    var svg = frame(id); if (!svg) return;
+    var mL = 26, mR = 22, mB = 46, baseY = H - mB, vMax = o.vMax, r = 3.6, step = r * 2.15;
+    function X(v){ return mL + (v / vMax) * (W - mL - mR); }
+    svg.appendChild(mk('line', { x1: mL, y1: baseY, x2: W - mR, y2: baseY, stroke: ink(), 'stroke-width': 1.2 }));
+    (o.ticks || []).forEach(function(t){ if (X(t) <= W - mR) { svg.appendChild(mk('line', { x1: X(t), y1: baseY, x2: X(t), y2: baseY + 5, stroke: ink(), 'stroke-width': 1 })); tick(svg, X(t), baseY + 17, t); } });
+    if (o.ref) {
+      svg.appendChild(mk('line', { x1: X(o.ref.v), y1: baseY, x2: X(o.ref.v), y2: 66, stroke: ink(), 'stroke-width': 1, 'stroke-dasharray': '5,4', opacity: 0.6 }));
+      svg.appendChild(mk('text', { x: X(o.ref.v) + 4, y: 62, 'font-size': 9.5, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, o.ref.label));
+    }
+    var placed = [];
+    data.slice().sort(function(a, b){ return a.v - b.v; }).forEach(function(d){
+      var cx = X(d.v), cy = baseY - r - 1, k = 0;
+      while (placed.some(function(p){ return Math.abs(p.x - cx) < step && Math.abs(p.y - cy) < step; })) { k++; cy = baseY - r - 1 - k * step; }
+      placed.push({ x: cx, y: cy, d: d });
+    });
+    placed.forEach(function(p){ var d = p.d; svg.appendChild(mk('circle', { cx: p.x, cy: p.y, r: d.hl ? 6.5 : r, fill: d.hl ? o.hlColor : o.dotColor, 'fill-opacity': d.hl ? 1 : 0.8, stroke: d.hl ? '#fff' : 'none', 'stroke-width': d.hl ? 1.6 : 0 })); });
+    placed.forEach(function(p){
+      if (!p.d.label) return;
+      var ly = p.y - (p.d.hl ? 17 : 14);
+      svg.appendChild(mk('line', { x1: p.x, y1: p.y - (p.d.hl ? 9 : 6), x2: p.x, y2: ly + 3, stroke: p.d.hl ? o.hlColor : ink(), 'stroke-width': 1, opacity: 0.55 }));
+      svg.appendChild(mk('text', { x: p.x, y: ly, 'text-anchor': 'middle', 'font-size': p.d.hl ? 12 : 10, 'font-weight': p.d.hl ? 800 : 700, fill: p.d.hl ? o.hlColor : ink(), 'font-family': 'Inter, sans-serif' }, p.d.hl ? (p.d.label + ' ' + p.d.v + 't') : p.d.label));
+    });
+    svg.appendChild(mk('text', { x: (mL + W - mR) / 2, y: H - 6, 'text-anchor': 'middle', 'font-size': 9.5, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, o.axisLabel));
+    if (o.callout) callout(svg, o.callout.x, o.callout.y, o.callout.anchor, o.callout.lines);
+  }
+
+  /* ---------- Funnel (a narrowing pipeline) ---------- */
+  function funnel(id, data, o) {
+    var svg = frame(id); if (!svg) return;
+    var mT = 22, mB = 18, cx = W / 2 + 18, n = data.length, gap = 9, maxW = W - 200;
+    var bh = (H - mT - mB - gap * (n - 1)) / n;
+    function bw(v){ return (v / o.vMax) * maxW; }
+    data.forEach(function(d, i){
+      var y = mT + i * (bh + gap), w = bw(d.v);
+      if (i < n - 1) {
+        var w2 = bw(data[i+1].v), y2 = y + bh + gap;
+        svg.appendChild(mk('path', { d: 'M' + (cx - w/2) + ',' + (y + bh) + ' L' + (cx + w/2) + ',' + (y + bh) + ' L' + (cx + w2/2) + ',' + y2 + ' L' + (cx - w2/2) + ',' + y2 + ' Z', fill: o.colors[i], opacity: 0.13 }));
+      }
+      var fill = vGrad(svg, id + '-f' + i, o.colors[i], 0.95, 0.68);
+      var rect = mk('rect', { x: cx - w/2, y: y, width: w, height: bh, rx: 5, fill: fill });
+      svg.appendChild(rect); fadeIn(rect, i * 0.1);
+      svg.appendChild(mk('text', { x: 16, y: y + bh/2 + 4, 'font-size': 11, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, d.label));
+      svg.appendChild(mk('text', { x: cx + w/2 - 9, y: y + bh/2 + 4.5, 'text-anchor': 'end', 'font-size': 13, 'font-weight': 800, fill: '#fff', 'font-family': 'Inter, sans-serif' }, d.v + '%'));
+    });
+  }
+
+  /* ---------- Radial donut (parts of a whole) ---------- */
+  function donut(id, data, o) {
+    var svg = frame(id); if (!svg) return;
+    var cx = 138, cy = 150, rO = 92, rI = 54, total = data.reduce(function(s, d){ return s + d.v; }, 0);
+    function arc(a0, a1) {
+      var p0o = polar(cx, cy, rO, a0), p1o = polar(cx, cy, rO, a1), p1i = polar(cx, cy, rI, a1), p0i = polar(cx, cy, rI, a0);
+      var lg = (a1 - a0) > 180 ? 1 : 0;
+      return 'M' + p0o[0].toFixed(1) + ',' + p0o[1].toFixed(1) + ' A' + rO + ',' + rO + ' 0 ' + lg + ' 1 ' + p1o[0].toFixed(1) + ',' + p1o[1].toFixed(1) +
+             ' L' + p1i[0].toFixed(1) + ',' + p1i[1].toFixed(1) + ' A' + rI + ',' + rI + ' 0 ' + lg + ' 0 ' + p0i[0].toFixed(1) + ',' + p0i[1].toFixed(1) + ' Z';
+    }
+    var ang = 0;
+    data.forEach(function(d, i){
+      var a1 = ang + d.v / total * 360;
+      var p = mk('path', { d: arc(ang, a1), fill: d.color });
+      svg.appendChild(p); fadeIn(p, i * 0.08);
+      ang = a1;
+    });
+    // centre stat
+    svg.appendChild(mk('text', { x: cx, y: cy - 4, 'text-anchor': 'middle', 'font-size': 28, 'font-weight': 800, fill: ink(), 'font-family': 'Inter, sans-serif' }, o.centerBig));
+    svg.appendChild(mk('text', { x: cx, y: cy + 14, 'text-anchor': 'middle', 'font-size': 11, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, o.centerSub));
+    // legend
+    var lx = 268, ly = 44, lh = (H - 70) / data.length;
+    data.forEach(function(d, i){
+      var y = ly + i * lh;
+      svg.appendChild(mk('rect', { x: lx, y: y - 9, width: 12, height: 12, rx: 3, fill: d.color }));
+      svg.appendChild(mk('text', { x: lx + 19, y: y + 1, 'font-size': 11.5, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, d.label));
+      svg.appendChild(mk('text', { x: W - 16, y: y + 1, 'text-anchor': 'end', 'font-size': 12, 'font-weight': 800, fill: d.color, 'font-family': 'Inter, sans-serif' }, d.v + '%'));
+    });
+  }
+
+  /* ---------- Dumbbell (gap between two values) ---------- */
+  function dumbbell(id, data, o) {
+    var svg = frame(id); if (!svg) return;
+    var mL = 134, mR = 26, mT = 44, mB = 30;
+    var n = data.length, rowH = (H - mT - mB) / n;
+    function X(v){ return mL + (v / 100) * (W - mL - mR); }
+    [0, 25, 50, 75, 100].forEach(function(t){
+      svg.appendChild(mk('line', { x1: X(t), y1: mT - 6, x2: X(t), y2: H - mB, stroke: gridc(), 'stroke-width': 1 }));
+      tick(svg, X(t), H - mB + 15, t + '%');
+    });
+    // legend
+    svg.appendChild(mk('circle', { cx: mL + 2, cy: 22, r: 5, fill: o.fColor }));
+    svg.appendChild(mk('text', { x: mL + 12, y: 26, 'font-size': 11, 'font-weight': 700, fill: o.fColor, 'font-family': 'Inter, sans-serif' }, 'Women'));
+    svg.appendChild(mk('circle', { cx: mL + 78, cy: 22, r: 5, fill: o.mColor }));
+    svg.appendChild(mk('text', { x: mL + 88, y: 26, 'font-size': 11, 'font-weight': 700, fill: o.mColor, 'font-family': 'Inter, sans-serif' }, 'Men'));
+    data.forEach(function(d, i){
+      var y = mT + i * rowH + rowH / 2;
+      svg.appendChild(mk('text', { x: mL - 12, y: y + 4, 'text-anchor': 'end', 'font-size': 11.5, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, d.label));
+      var xf = X(d.f), xm = X(d.m), lo = Math.min(xf, xm), hi = Math.max(xf, xm);
+      var line = mk('line', { x1: lo, y1: y, x2: hi, y2: y, stroke: ink(), 'stroke-width': 2.4, 'stroke-linecap': 'round', opacity: 0.45 });
+      svg.appendChild(line); fadeIn(line, i * 0.08);
+      svg.appendChild(mk('circle', { cx: xm, cy: y, r: 5.5, fill: o.mColor }));
+      svg.appendChild(mk('circle', { cx: xf, cy: y, r: 5.5, fill: o.fColor }));
+      // value labels: put each just outside its dot
+      svg.appendChild(mk('text', { x: xf + (xf <= xm ? -9 : 9), y: y + 4, 'text-anchor': xf <= xm ? 'end' : 'start', 'font-size': 11, 'font-weight': 800, fill: o.fColor, 'font-family': 'Inter, sans-serif' }, d.f));
+      svg.appendChild(mk('text', { x: xm + (xm < xf ? -9 : 9), y: y + 4, 'text-anchor': xm < xf ? 'end' : 'start', 'font-size': 11, 'font-weight': 800, fill: o.mColor, 'font-family': 'Inter, sans-serif' }, d.m));
+    });
+  }
+
+  /* ---------- Heatmap (matrix) ---------- */
+  function heatmap(id, m, o) {
+    var svg = frame(id); if (!svg) return;
+    var mL = 150, mT = 40, mR = 16, mB = 16, nc = m.cols.length, nr = m.rows.length;
+    var cw = (W - mL - mR) / nc, ch = (H - mT - mB) / nr, gap = 3;
+    function shade(v){ if (v == null) return gridc(); var t = Math.max(0, Math.min(1, (v - o.min) / (o.max - o.min)));
+      // light -> deep green
+      var r = Math.round(237 + (22 - 237) * t), g = Math.round(247 + (138 - 247) * t), b = Math.round(233 + (90 - 233) * t);
+      return 'rgb(' + r + ',' + g + ',' + b + ')'; }
+    m.cols.forEach(function(c, j){ svg.appendChild(mk('text', { x: mL + j * cw + cw / 2, y: mT - 12, 'text-anchor': 'middle', 'font-size': 10.5, 'font-weight': 700, fill: ink(), 'font-family': 'Inter, sans-serif' }, c)); });
+    m.rows.forEach(function(rw, i){
+      svg.appendChild(mk('text', { x: mL - 10, y: mT + i * ch + ch / 2 + 4, 'text-anchor': 'end', 'font-size': 11, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, rw));
+      m.cols.forEach(function(c, j){
+        var v = m.values[i][j], x = mL + j * cw + gap / 2, y = mT + i * ch + gap / 2;
+        var cell = mk('rect', { x: x, y: y, width: cw - gap, height: ch - gap, rx: 5, fill: shade(v) });
+        svg.appendChild(cell); fadeIn(cell, (i + j) * 0.05);
+        var t = v == null ? 0 : Math.max(0, Math.min(1, (v - o.min) / (o.max - o.min)));
+        svg.appendChild(mk('text', { x: x + (cw - gap) / 2, y: y + (ch - gap) / 2 + 4, 'text-anchor': 'middle', 'font-size': 12, 'font-weight': 800, fill: v == null ? ink() : (t > 0.55 ? '#fff' : '#14532d'), 'font-family': 'Inter, sans-serif' }, v == null ? '–' : v + '%'));
+      });
+    });
+  }
+
+  /* ---------- Forest plot (estimate + uncertainty range) ---------- */
+  function forest(id, data, o) {
+    var svg = frame(id); if (!svg) return;
+    var mL = 128, mR = 40, mT = 32, mB = 34, n = data.length, rowH = (H - mT - mB) / n;
+    function X(v){ return mL + (v / o.vMax) * (W - mL - mR); }
+    (o.ticks || []).forEach(function(t){
+      svg.appendChild(mk('line', { x1: X(t), y1: mT - 6, x2: X(t), y2: H - mB, stroke: gridc(), 'stroke-width': 1 }));
+      tick(svg, X(t), H - mB + 15, t + '°');
+    });
+    (o.refs || []).forEach(function(rf){
+      svg.appendChild(mk('line', { x1: X(rf.v), y1: mT - 7, x2: X(rf.v), y2: H - mB + 2, stroke: rf.color, 'stroke-width': 1.2, 'stroke-dasharray': '4,3' }));
+      svg.appendChild(mk('text', { x: X(rf.v) + (rf.side === 'end' ? -3 : 3), y: mT - 10, 'text-anchor': rf.side || 'middle', 'font-size': 9.5, 'font-weight': 700, fill: rf.color, 'font-family': 'JetBrains Mono, monospace' }, rf.label));
+    });
+    data.forEach(function(d, i){
+      var y = mT + i * rowH + rowH / 2;
+      svg.appendChild(mk('text', { x: mL - 12, y: y + 4, 'text-anchor': 'end', 'font-size': 11, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, d.label));
+      var wk = mk('line', { x1: X(d.lo), y1: y, x2: X(d.hi), y2: y, stroke: d.color, 'stroke-width': 2.4, 'stroke-linecap': 'round' });
+      svg.appendChild(wk); fadeIn(wk, i * 0.08);
+      [d.lo, d.hi].forEach(function(v){ svg.appendChild(mk('line', { x1: X(v), y1: y - 4, x2: X(v), y2: y + 4, stroke: d.color, 'stroke-width': 2 })); });
+      svg.appendChild(mk('circle', { cx: X(d.est), cy: y, r: 5, fill: d.color, stroke: '#fff', 'stroke-width': 1.4 }));
+      svg.appendChild(mk('text', { x: X(d.hi) + 8, y: y + 4, 'font-size': 11.5, 'font-weight': 800, fill: d.color, 'font-family': 'Inter, sans-serif' }, d.est + '°'));
+    });
+  }
+
+  /* ---------- Framework: Arnstein's ladder ---------- */
+  function ladder(id) {
+    var svg = frame(id); if (!svg) return;
+    var rungs = [
+      ['Manipulation', COL.red], ['Therapy', COL.red],
+      ['Informing', COL.amber], ['Consultation', COL.amber], ['Placation', COL.amber],
+      ['Partnership', COL.green], ['Delegated power', COL.green], ['Citizen control', COL.green]
+    ];
+    var bands = [['Nonparticipation', COL.red, 0, 2], ['Tokenism', COL.amber, 2, 5], ['Citizen power', COL.green, 5, 8]];
+    var mT = 16, mB = 14, x = 150, rw = 250, n = rungs.length;
+    var rh = (H - mT - mB - (n - 1) * 6) / n;
+    rungs.forEach(function(r, i){
+      var idx = n - 1 - i; // draw top rung first
+      var y = mT + i * (rh + 6);
+      var rect = mk('rect', { x: x, y: y, width: rw, height: rh, rx: 5, fill: rungs[idx][1], opacity: 0.9 });
+      svg.appendChild(rect); fadeIn(rect, i * 0.06);
+      svg.appendChild(mk('text', { x: x + 12, y: y + rh/2 + 4, 'font-size': 12, 'font-weight': 700, fill: '#fff', 'font-family': 'Inter, sans-serif' }, (idx + 1) + '. ' + rungs[idx][0]));
+    });
+    bands.forEach(function(b){
+      var yTop = mT + (n - 1 - (b[3] - 1)) * (rh + 6);
+      var yBot = mT + (n - 1 - b[2]) * (rh + 6) + rh;
+      svg.appendChild(mk('line', { x1: x - 10, y1: yTop + 2, x2: x - 10, y2: yBot - 2, stroke: b[1], 'stroke-width': 3 }));
+      svg.appendChild(mk('text', { x: x - 18, y: (yTop + yBot)/2 + 4, 'text-anchor': 'end', 'font-size': 11, 'font-weight': 700, fill: b[1], 'font-family': 'Inter, sans-serif' }, b[0]));
+    });
+    // upward arrow
+    svg.appendChild(mk('path', { d: 'M' + (x + rw + 18) + ',' + (H - mB) + ' L' + (x + rw + 18) + ',' + (mT + 10), stroke: ink(), 'stroke-width': 1.5, 'marker-end': 'url(#arrUp)' }));
+    var defs = mk('defs', {});
+    var marker = mk('marker', { id: 'arrUp', markerWidth: 8, markerHeight: 8, refX: 4, refY: 6, orient: 'auto' });
+    marker.appendChild(mk('path', { d: 'M0,6 L4,0 L8,6', fill: 'none', stroke: ink(), 'stroke-width': 1.5 }));
+    defs.appendChild(marker); svg.appendChild(defs);
+    svg.appendChild(mk('text', { x: x + rw + 30, y: H/2, 'text-anchor': 'middle', 'font-size': 10, fill: ink(), 'font-family': 'JetBrains Mono, monospace', transform: 'rotate(-90 ' + (x + rw + 30) + ' ' + (H/2) + ')' }, 'more power'));
+  }
+
+  /* ---------- Framework: results chain ---------- */
+  function resultsChain(id) {
+    var svg = frame(id); if (!svg) return;
+    var steps = [['Inputs', COL.slate], ['Activities', COL.slate], ['Outputs', COL.blue], ['Outcomes', COL.teal], ['Impact', COL.purple]];
+    var n = steps.length, bw = 70, by = H/2 - 22, bh = 44, gap = (W - 24 - n * bw) / (n - 1);
+    steps.forEach(function(s, i){
+      var x = 12 + i * (bw + gap);
+      var rect = mk('rect', { x: x, y: by, width: bw, height: bh, rx: 8, fill: s[1], opacity: 0.92 });
+      svg.appendChild(rect); fadeIn(rect, i * 0.1);
+      svg.appendChild(mk('text', { x: x + bw/2, y: by + bh/2 + 4, 'text-anchor': 'middle', 'font-size': 11.5, 'font-weight': 700, fill: '#fff', 'font-family': 'Inter, sans-serif' }, s[1]===COL.slate? s[0] : s[0]));
+      if (i < n - 1) {
+        var ax = x + bw, ax2 = x + bw + gap;
+        svg.appendChild(mk('path', { d: 'M' + (ax + 3) + ',' + (by + bh/2) + ' L' + (ax2 - 3) + ',' + (by + bh/2), stroke: ink(), 'stroke-width': 1.6, 'marker-end': 'url(#arrR)' }));
+      }
+    });
+    var defs = mk('defs', {});
+    var marker = mk('marker', { id: 'arrR', markerWidth: 8, markerHeight: 8, refX: 6, refY: 4, orient: 'auto' });
+    marker.appendChild(mk('path', { d: 'M0,0 L8,4 L0,8', fill: ink() }));
+    defs.appendChild(marker); svg.appendChild(defs);
+    // attribution gap between Outputs (i=2) and Outcomes (i=3)
+    var gx = 12 + 2 * (bw + gap) + bw + gap/2;
+    svg.appendChild(mk('line', { x1: gx, y1: by - 22, x2: gx, y2: by + bh + 22, stroke: COL.red, 'stroke-width': 1.5, 'stroke-dasharray': '4,4' }));
+    svg.appendChild(mk('text', { x: gx, y: by - 28, 'text-anchor': 'middle', 'font-size': 10.5, 'font-weight': 700, fill: COL.red, 'font-family': 'Inter, sans-serif' }, 'the attribution gap'));
+    svg.appendChild(mk('text', { x: W/2, y: H - 14, 'text-anchor': 'middle', 'font-size': 10, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, 'what we control  →  what we hope to cause'));
+  }
+
+  /* ---------- Framework: poverty trap loop ---------- */
+  function trapLoop(id) {
+    var svg = frame(id); if (!svg) return;
+    var cx = W/2, cy = H/2 + 2, r = 86, nr = 33;
+    var nodes = [['Low', 'income', COL.red], ['Low', 'savings', COL.amber], ['Low', 'investment', COL.purple], ['Low', 'productivity', COL.blue]];
+    var pts = nodes.map(function(_, i){ var a = (i / nodes.length) * 2 * Math.PI - Math.PI/2; return [cx + r * Math.cos(a), cy + r * Math.sin(a)]; });
+    var defs = mk('defs', {});
+    var marker = mk('marker', { id: id + '-arr', markerWidth: 10, markerHeight: 10, refX: 7, refY: 5, orient: 'auto' });
+    marker.appendChild(mk('path', { d: 'M0,0 L10,5 L0,10 Z', fill: '#e11d48' }));
+    defs.appendChild(marker); svg.appendChild(defs);
+    for (var i = 0; i < pts.length; i++) {
+      var p = pts[i], q = pts[(i+1) % pts.length];
+      var a0 = Math.atan2(p[1]-cy, p[0]-cx), a1 = Math.atan2(q[1]-cy, q[0]-cx);
+      // start/end on the node rims, arc bowed outward
+      var sx = p[0] + Math.cos(a0 + 0.7) * 0, sy = p[1];
+      var s = [cx + (r) * Math.cos(a0 + 0.42), cy + (r) * Math.sin(a0 + 0.42)];
+      var e = [cx + (r) * Math.cos(a1 - 0.42), cy + (r) * Math.sin(a1 - 0.42)];
+      var mcx = (s[0]+e[0])/2, mcy = (s[1]+e[1])/2, ol = Math.hypot(mcx-cx, mcy-cy);
+      var ctrl = [mcx + (mcx-cx)/ol * 26, mcy + (mcy-cy)/ol * 26];
+      var path = mk('path', { d: 'M' + s[0].toFixed(1) + ',' + s[1].toFixed(1) + ' Q' + ctrl[0].toFixed(1) + ',' + ctrl[1].toFixed(1) + ' ' + e[0].toFixed(1) + ',' + e[1].toFixed(1), fill: 'none', stroke: '#e11d48', 'stroke-width': 2.6, 'stroke-linecap': 'round', 'marker-end': 'url(#' + id + '-arr)' });
+      svg.appendChild(path); animPath(path);
+    }
+    pts.forEach(function(p, i){
+      var g = mk('g', {}); fadeIn(g, i * 0.12);
+      g.appendChild(mk('circle', { cx: p[0], cy: p[1], r: nr, fill: nodes[i][2] }));
+      g.appendChild(mk('text', { x: p[0], y: p[1] - 2, 'text-anchor': 'middle', 'font-size': 10.5, 'font-weight': 600, fill: '#fff', 'font-family': 'Inter, sans-serif' }, nodes[i][0]));
+      g.appendChild(mk('text', { x: p[0], y: p[1] + 11, 'text-anchor': 'middle', 'font-size': 10.5, 'font-weight': 800, fill: '#fff', 'font-family': 'Inter, sans-serif' }, nodes[i][1]));
+      svg.appendChild(g);
+    });
+    svg.appendChild(mk('text', { x: cx, y: cy - 2, 'text-anchor': 'middle', 'font-size': 11, 'font-weight': 700, fill: '#e11d48', 'font-family': 'Inter, sans-serif' }, 'self-' ));
+    svg.appendChild(mk('text', { x: cx, y: cy + 11, 'text-anchor': 'middle', 'font-size': 11, 'font-weight': 700, fill: '#e11d48', 'font-family': 'Inter, sans-serif' }, 'reinforcing'));
+  }
+
+  /* ---------- Framework: intersectionality venn ---------- */
+  function venn(id) {
+    var svg = frame(id); if (!svg) return;
+    var r = 62;
+    var circles = [['Gender', COL.red, 230, 106], ['Caste', '#2563eb', 192, 168], ['Class', COL.amber, 268, 168]];
+    circles.forEach(function(c, i){
+      var circ = mk('circle', { cx: c[2], cy: c[3], r: r, fill: c[1], 'fill-opacity': 0.18, stroke: c[1], 'stroke-width': 2.5 });
+      svg.appendChild(circ); fadeIn(circ, i * 0.12);
+    });
+    svg.appendChild(mk('text', { x: 230, y: 36, 'text-anchor': 'middle', 'font-size': 15, 'font-weight': 800, fill: COL.red, 'font-family': 'Inter, sans-serif' }, 'Gender'));
+    svg.appendChild(mk('text', { x: 138, y: 250, 'text-anchor': 'middle', 'font-size': 15, 'font-weight': 800, fill: '#2563eb', 'font-family': 'Inter, sans-serif' }, 'Caste'));
+    svg.appendChild(mk('text', { x: 322, y: 250, 'text-anchor': 'middle', 'font-size': 15, 'font-weight': 800, fill: COL.amber, 'font-family': 'Inter, sans-serif' }, 'Class'));
+    // central intersection — a clear, readable highlight
+    var ccx = 230, ccy = 149;
+    svg.appendChild(mk('rect', { x: ccx - 44, y: ccy - 15, width: 88, height: 31, rx: 9, fill: '#ffffff', stroke: '#1f2937', 'stroke-width': 1.3 }));
+    svg.appendChild(mk('text', { x: ccx, y: ccy - 1, 'text-anchor': 'middle', 'font-size': 10, 'font-weight': 800, fill: '#1f2937', 'font-family': 'Inter, sans-serif' }, 'compounded'));
+    svg.appendChild(mk('text', { x: ccx, y: ccy + 11, 'text-anchor': 'middle', 'font-size': 10, 'font-weight': 800, fill: '#1f2937', 'font-family': 'Inter, sans-serif' }, 'disadvantage'));
+  }
+
+  /* ---------- Framework: systems iceberg ---------- */
+  function iceberg(id) {
+    var svg = frame(id); if (!svg) return;
+    var waterY = 92, cx = 230;
+    // sea tint below the waterline
+    svg.appendChild(mk('rect', { x: 0, y: waterY, width: W, height: H - waterY, fill: '#4361ee', 'fill-opacity': 0.06 }));
+    // iceberg — small tip above water, broad mass below, centred
+    var berg = mk('path', { d: 'M230,30 L266,92 L300,150 L286,205 L250,248 L210,248 L174,205 L160,150 L194,92 Z', fill: '#cfe3f5', stroke: '#7da9d8', 'stroke-width': 1.5 });
+    svg.appendChild(berg); fadeIn(berg, 0);
+    // waterline across the top
+    svg.appendChild(mk('line', { x1: 0, y1: waterY, x2: W, y2: waterY, stroke: '#4361ee', 'stroke-width': 1.4, 'stroke-dasharray': '6,4', opacity: 0.7 }));
+    svg.appendChild(mk('text', { x: W - 8, y: waterY - 6, 'text-anchor': 'end', 'font-size': 9.5, fill: '#4361ee', 'font-family': 'JetBrains Mono, monospace' }, 'waterline' ));
+    // above-water label on the tip
+    svg.appendChild(mk('text', { x: cx, y: 74, 'text-anchor': 'middle', 'font-size': 12, 'font-weight': 800, fill: '#1d4ed8', 'font-family': 'Inter, sans-serif' }, 'EVENTS'));
+    svg.appendChild(mk('text', { x: cx, y: 86, 'text-anchor': 'middle', 'font-size': 9, fill: '#1d4ed8', 'font-family': 'JetBrains Mono, monospace' }, 'what we see'));
+    // below-water layers, navy text on the light berg
+    [['Patterns of behaviour', 126], ['Structures & systems', 168], ['Mental models', 210]].forEach(function(l){
+      svg.appendChild(mk('text', { x: cx, y: l[1], 'text-anchor': 'middle', 'font-size': 12, 'font-weight': 700, fill: '#13335f', 'font-family': 'Inter, sans-serif' }, l[0]));
+    });
+    // contrast note
+    svg.appendChild(mk('text', { x: 12, y: H - 10, 'font-size': 9.5, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, 'below the surface: where lasting change happens' ));
+  }
+
+  /* ---------- Framework: make your own (closing) ---------- */
+  function makeYourOwn(id) {
+    var svg = frame(id); if (!svg) return;
+    var cy = H/2;
+    // tiny line
+    var d = 'M40,' + (cy+30) + ' L90,' + (cy-10) + ' L140,' + (cy+10) + ' L190,' + (cy-40);
+    var p = mk('path', { d: d, fill: 'none', stroke: COL.teal, 'stroke-width': 3, 'stroke-linecap': 'round', 'stroke-linejoin': 'round' });
+    svg.appendChild(p); animPath(p);
+    // tiny bars
+    [[260,40,COL.blue],[300,70,COL.amber],[340,30,COL.purple],[380,60,COL.red]].forEach(function(b, i){
+      var rect = mk('rect', { x: b[0], y: cy + 30 - b[1], width: 26, height: b[1], rx: 4, fill: b[2], opacity: 0.9 });
+      svg.appendChild(rect); fadeIn(rect, 0.6 + i*0.1);
+    });
+    svg.appendChild(mk('text', { x: W/2, y: H - 20, 'text-anchor': 'middle', 'font-size': 14, 'font-weight': 800, fill: ink(), 'font-family': 'Inter, sans-serif' }, 'your data, your frame, your turn' ));
+  }
+
+  /* ---------- Render everything ---------- */
+  function renderAll() {
+    lineChart('c-poverty',
+      [{x:1990,y:37.9},{x:2000,y:29.7},{x:2010,y:16.7},{x:2015,y:10.4},{x:2019,y:8.4}],
+      { yMax: 44, color: '#0d9488', area: true, valfmt: function(v){return v+'%';}, xfmt: function(x){return "'"+String(x).slice(2);} });
+
+    lineChart('c-u5mr',
+      [{x:1990,y:127},{x:1995,y:109.7},{x:2000,y:91.8},{x:2005,y:74.3},{x:2010,y:58.1},{x:2015,y:43.7},{x:2020,y:33},{x:2022,y:29.5}],
+      { yMax: 138, color: '#4f46e5', area: true, valfmt: function(v){return Math.round(v);}, labelEvery: 2, xfmt: function(x){return "'"+String(x).slice(2);} });
+
+    hbarChart('c-caste',
+      [{label:'Sched. Tribes',y:44.4,color:'#7d0d23'},{label:'Sched. Castes',y:29.2,color:'#b81d36'},{label:'OBC',y:24.5,color:'#e0566a'},{label:'Others',y:14.9,color:'#f3a6b0'}],
+      { xMax: 50, valfmt: function(v){return v+'%';}, refLine: { value: 24.85, label: 'national 24.8%' } });
+
+    beeswarm('c-co2',
+      [{n:'Qatar',v:43.55,label:'Qatar'},{n:'Kuwait',v:24.90},{n:'UAE',v:20.22},{n:'Saudi',v:17.15},
+       {n:'Canada',v:14.91},{n:'Russia',v:14.45},{n:'Australia',v:14.21},{n:'USA',v:13.83},
+       {n:'S Korea',v:11.04},{n:'China',v:9.24},{n:'Iran',v:9.10},{n:'Poland',v:7.63},
+       {n:'Japan',v:7.54},{n:'Germany',v:7.06},{n:'S Africa',v:6.56},{n:'UK',v:4.42},{n:'France',v:4.25},
+       {n:'Indonesia',v:2.41},{n:'Brazil',v:2.20},{n:'India',v:2.07,hl:true,label:'India'},
+       {n:'Pakistan',v:0.91},{n:'Bangladesh',v:0.71},{n:'Nigeria',v:0.58},{n:'Ethiopia',v:0.14},{n:'DR Congo',v:0.04}],
+      { vMax: 46, ticks: [0,10,20,30,40], dotColor: '#94a3b8', hlColor: '#0d9488',
+        ref: { v: 4.7, label: 'world avg' }, axisLabel: 'tonnes CO₂ per person, per year (2023)' });
+
+    funnel('c-pipeline',
+      [{label:'Primary (1–5)',v:104.8},{label:'Upper primary',v:94.9},{label:'Secondary',v:79.4},{label:'Higher secondary',v:57.6},{label:'Higher education',v:28.5}],
+      { vMax: 104.8, colors: ['#0d9488','#22a06b','#eab308','#f97316','#e11d48'] });
+
+    donut('c-energy',
+      [{label:'Coal',v:73,color:'#475569'},{label:'Hydro',v:8,color:'#2563eb'},{label:'Solar',v:7,color:'#f59e0b'},
+       {label:'Wind',v:5,color:'#0ea5a4'},{label:'Nuclear',v:3,color:'#7c3aed'},{label:'Gas',v:2,color:'#94a3b8'},{label:'Bioenergy',v:2,color:'#16a34a'}],
+      { centerBig: '73%', centerSub: 'still fossil' });
+
+    dumbbell('c-gender',
+      [{label:'Adult literacy',m:84.7,f:70.3},{label:'College enrolment',m:28.3,f:28.5},
+       {label:'In the labour force',m:78.8,f:41.7},{label:'Seats in the Lok Sabha',m:86.6,f:13.4}],
+      { mColor: '#1971c2', fColor: '#d6336c' });
+
+    heatmap('c-nfhs',
+      { cols: ['NFHS-3 ’05', 'NFHS-4 ’15', 'NFHS-5 ’21'],
+        rows: ['Institutional births', 'Full immunisation', 'Woman uses a bank a/c', 'Child not stunted', 'Woman not anaemic'],
+        values: [[39,79,89],[44,62,76],[null,53,79],[52,62,64],[45,47,43]] },
+      { min: 38, max: 90 });
+
+    forest('c-forest',
+      [{label:'Net zero ~2050', est:1.4, lo:1.0, hi:1.8, color:'#16a34a'},
+       {label:'Strong cuts', est:1.8, lo:1.3, hi:2.4, color:'#0d9488'},
+       {label:'Middle of the road', est:2.7, lo:2.1, hi:3.5, color:'#eab308'},
+       {label:'High emissions', est:3.6, lo:2.8, hi:4.6, color:'#f97316'},
+       {label:'Very high emissions', est:4.4, lo:3.3, hi:5.7, color:'#e11d48'}],
+      { vMax: 6, ticks: [0,2,4,6], refs: [{v:1.5, label:'1.5°', color:'#16a34a', side:'end'}, {v:2.0, label:'2° Paris', color:'#e11d48', side:'start'}] });
+
+    lineChart('c-flfp',
+      [{x:2017.5,y:23.3},{x:2021.5,y:32.8},{x:2022.5,y:37.0},{x:2023.5,y:41.7}],
+      { yMax: 50, color: '#7c3aed', area: true, valfmt: function(v){return v.toFixed(1)+'%';},
+        xfmt: function(x){var a=Math.floor(x); return "'"+String(a).slice(2)+"–"+String(a+1).slice(2);} });
+
+    climateChart('c-climate');
+    ethicChart('c-ethic');
+
+    ladder('f-ladder');
+    resultsChain('f-toc');
+    trapLoop('f-trap');
+    venn('f-venn');
+    iceberg('f-iceberg');
+    makeYourOwn('f-make');
+  }
+
+  /* ============================================================
+     MASTERS' WING — recreated public-domain classics (drawn once)
+     ============================================================ */
+  function el(name, attrs) { var n = document.createElementNS(NS, name); for (var k in attrs) n.setAttribute(k, attrs[k]); return n; }
+  function polar(cx, cy, r, deg) { var a = (deg - 90) * Math.PI / 180; return [cx + r * Math.cos(a), cy + r * Math.sin(a)]; }
+  function wedgePath(cx, cy, r, a0, a1) {
+    var p0 = polar(cx, cy, r, a0), p1 = polar(cx, cy, r, a1);
+    var large = (a1 - a0) > 180 ? 1 : 0;
+    return "M" + cx + "," + cy + " L" + p0[0].toFixed(1) + "," + p0[1].toFixed(1) +
+           " A" + r + "," + r + " 0 " + large + " 1 " + p1[0].toFixed(1) + "," + p1[1].toFixed(1) + " Z";
+  }
+
+  function plateTokens() {
+    var dk = document.documentElement.getAttribute('data-theme') === 'dark';
+    return { dk: dk, ink: dk ? '#e8ecf8' : '#1a2236', mut: dk ? '#9aa6c8' : '#5b6678', grid: dk ? 'rgba(255,255,255,0.07)' : 'rgba(20,30,60,0.08)', sep: dk ? '#0e1326' : '#cdbfa3' };
+  }
+  function drawRose() {
+    var svg = document.getElementById('viz-rose'); if (!svg) return;
+    clear(svg); var T = plateTokens();
+    var cx = 200, cy = 165, n = 12, step = 360 / n;
+    var disease = [22, 38, 95, 130, 175, 240, 205, 168, 110, 60, 34, 26];
+    var wounds  = [3, 5, 8, 12, 16, 22, 18, 14, 10, 7, 5, 4];
+    var other   = [4, 6, 9, 11, 13, 15, 14, 12, 9, 6, 5, 4];
+    var maxR = 130, maxV = Math.max.apply(null, disease.map(function(d,i){return d+wounds[i]+other[i];}));
+    var scale = maxR / Math.sqrt(maxV);
+    function ring(values, fill, op) {
+      for (var i = 0; i < n; i++) {
+        var r = Math.sqrt(values[i]) * scale;
+        var path = el('path', { d: wedgePath(cx, cy, r, i*step, (i+1)*step), fill: fill, 'fill-opacity': op, stroke: T.sep, 'stroke-width': 0.6 });
+        if (!reduced()) { path.style.opacity = 0; path.style.transition = 'opacity 0.5s ease ' + (i*0.04) + 's'; }
+        svg.appendChild(path);
+        if (!reduced()) requestAnimationFrame(function(p){ return function(){ p.style.opacity = 1; }; }(path));
+      }
+    }
+    ring(disease.map(function(d,i){return d+wounds[i]+other[i];}), '#3b6fb0', 0.95);
+    ring(wounds.map(function(w,i){return w+other[i];}), '#c0392b', 0.95);
+    ring(other, T.dk ? '#cbd3e6' : '#2b3450', 0.95);
+    svg.appendChild(el('circle', { cx: cx, cy: cy, r: 2, fill: T.ink }));
+    var leg = [['#3b6fb0','Preventable disease'], ['#c0392b','Wounds in battle'], [T.dk ? '#cbd3e6' : '#2b3450','Other causes']];
+    leg.forEach(function(item, i) {
+      svg.appendChild(el('rect', { x: 16, y: 270 + i*15, width: 11, height: 11, rx: 2, fill: item[0] }));
+      var t = el('text', { x: 32, y: 279 + i*15, fill: T.mut, 'font-size': 10, 'font-family': 'JetBrains Mono, monospace' }); t.textContent = item[1]; svg.appendChild(t);
+    });
+  }
+
+  function drawMinard() {
+    var svg = document.getElementById('viz-minard'); if (!svg) return;
+    clear(svg); var T = plateTokens();
+    var advance = [[40,422],[105,400],[165,233],[225,175],[300,127]];
+    var retreat = [[300,100],[235,50],[170,28],[110,20],[55,12],[28,4]];
+    var midY = 118, k = 0.12;
+    function band(pts, fill) {
+      var top = "M", bot = "";
+      pts.forEach(function(p, i) { var t = Math.max(2, p[1]*k); top += (i?" L":"") + p[0] + "," + (midY - t/2).toFixed(1); });
+      for (var i = pts.length - 1; i >= 0; i--) { var t = Math.max(2, pts[i][1]*k); bot += " L" + pts[i][0] + "," + (midY + t/2).toFixed(1); }
+      var path = el('path', { d: top + bot + " Z", fill: fill, stroke: T.sep, 'stroke-width': 0.5 });
+      if (!reduced()) { path.style.opacity = 0; path.style.transition = 'opacity 0.9s ease'; }
+      svg.appendChild(path);
+      if (!reduced()) requestAnimationFrame(function(){ path.style.opacity = 1; });
+    }
+    band(advance, T.dk ? '#d9b38c' : '#b07a30'); band(retreat, T.dk ? '#566' : '#2b3450');
+    svg.appendChild(el('circle', { cx: 300, cy: midY, r: 3.5, fill: '#c0392b' }));
+    var mono = 'JetBrains Mono, monospace';
+    var mt = el('text', { x: 300, y: 84, fill: T.ink, 'font-size': 11, 'font-family': mono, 'text-anchor': 'middle' }); mt.textContent = 'Moscow'; svg.appendChild(mt);
+    var st = el('text', { x: 36, y: 72, fill: T.ink, 'font-size': 11, 'font-family': mono }); st.textContent = '422,000 set out'; svg.appendChild(st);
+    var et = el('text', { x: 24, y: 170, fill: T.mut, 'font-size': 11, 'font-family': mono }); et.textContent = '≈10,000 returned'; svg.appendChild(et);
+    var temps = [[300,206],[235,218],[170,238],[110,256],[55,268],[28,276]];
+    var d = "M"; temps.forEach(function(p,i){ d += (i?" L":"") + p[0] + "," + p[1]; });
+    var tcol = T.dk ? '#8fb4ff' : '#3b6fb0';
+    svg.appendChild(el('path', { d: d, fill: 'none', stroke: tcol, 'stroke-width': 1.6, 'stroke-dasharray': '3,3' }));
+    var tlab = el('text', { x: 24, y: 298, fill: tcol, 'font-size': 9.5, 'font-family': mono }); tlab.textContent = 'temperature on the retreat, to −30°'; svg.appendChild(tlab);
+  }
+
+  function drawSnow() {
+    var svg = document.getElementById('viz-snow'); if (!svg) return;
+    clear(svg); var T = plateTokens();
+    for (var gx = 40; gx <= 360; gx += 40) svg.appendChild(el('line', { x1: gx, y1: 46, x2: gx, y2: 290, stroke: T.grid, 'stroke-width': 1 }));
+    for (var gy = 60; gy <= 280; gy += 40) svg.appendChild(el('line', { x1: 30, y1: gy, x2: 370, y2: gy, stroke: T.grid, 'stroke-width': 1 }));
+    var pump = [200, 158], seed = 7;
+    function rnd() { seed = (seed * 9301 + 49297) % 233280; return seed / 233280; }
+    function gauss() { return (rnd() + rnd() + rnd() + rnd() - 2) / 2; }
+    for (var i = 0; i < 90; i++) {
+      var x = Math.max(34, Math.min(366, pump[0] + gauss() * 70)), y = Math.max(50, Math.min(286, pump[1] + gauss() * 52));
+      var dot = el('rect', { x: x.toFixed(1), y: y.toFixed(1), width: 3.6, height: 3.6, fill: T.dk ? '#dfe5f2' : '#1a1f33', stroke: 'none' });
+      if (!reduced()) { dot.style.opacity = 0; dot.style.transition = 'opacity 0.4s ease ' + (i*0.012) + 's'; }
+      svg.appendChild(dot);
+      if (!reduced()) requestAnimationFrame(function(d){ return function(){ d.style.opacity = 1; }; }(dot));
+    }
+    [[80,84],[330,100],[300,252],[92,246]].forEach(function(p) { svg.appendChild(el('circle', { cx: p[0], cy: p[1], r: 5, fill: 'none', stroke: T.mut, 'stroke-width': 1.5 })); });
+    svg.appendChild(el('circle', { cx: pump[0], cy: pump[1], r: 9, fill: 'none', stroke: '#d6336c', 'stroke-width': 2 }));
+    svg.appendChild(el('circle', { cx: pump[0], cy: pump[1], r: 4, fill: '#d6336c' }));
+    // legend (kept clear of the cluster)
+    svg.appendChild(el('circle', { cx: 24, cy: 26, r: 4, fill: '#d6336c' }));
+    var lab = el('text', { x: 34, y: 30, fill: T.mut, 'font-size': 10.5, 'font-family': 'JetBrains Mono, monospace' }); lab.textContent = 'the Broad Street pump · each mark is a death'; svg.appendChild(lab);
+  }
+
+  function drawDuBois() {
+    var svg = document.getElementById('viz-dubois'); if (!svg) return;
+    clear(svg);
+    var cx = 200, cy = 160, palette = ['#c1272d', '#e8b22a', '#21563f', '#1b1b3a', '#d98e2b', '#7a5230'], segs = 30, base = 6, turns = 3.4, prev = null;
+    for (var i = 0; i < segs; i++) {
+      var ang = (i / segs) * turns * 360, rad = base + i * 4.6, p = polar(cx, cy, rad, ang);
+      if (prev) {
+        var seg = el('line', { x1: prev[0].toFixed(1), y1: prev[1].toFixed(1), x2: p[0].toFixed(1), y2: p[1].toFixed(1), stroke: palette[i % palette.length], 'stroke-width': 7, 'stroke-linecap': 'round' });
+        if (!reduced()) { seg.style.opacity = 0; seg.style.transition = 'opacity 0.4s ease ' + (i*0.03) + 's'; }
+        svg.appendChild(seg);
+        if (!reduced()) requestAnimationFrame(function(s){ return function(){ s.style.opacity = 1; }; }(seg));
+      }
+      prev = p;
+    }
+    svg.appendChild(el('circle', { cx: cx, cy: cy, r: 5, fill: '#1b1b3a' }));
+    var t1 = el('text', { x: 200, y: 296, fill: '#1b1b3a', 'font-size': 12, 'font-family': 'Inter, sans-serif', 'font-weight': 700, 'text-anchor': 'middle', 'letter-spacing': 2 }); t1.textContent = 'VALUE OF PROPERTY OWNED'; svg.appendChild(t1);
+    var t2 = el('text', { x: 200, y: 312, fill: '#7a5230', 'font-size': 9.5, 'font-family': 'JetBrains Mono, monospace', 'text-anchor': 'middle' }); t2.textContent = 'in the style of W. E. B. Du Bois, 1900'; svg.appendChild(t2);
+  }
+
+  /* ============================================================
+     THE GREATS — curated gallery of modern masterworks (links out)
+     ============================================================ */
+  var VIZ = [
+    { theme:'poverty', tag:'Poverty & Inequality', title:'The Wealth & Health of Nations', who:'Hans Rosling · Gapminder', year:'2006', g:['#48bb78','#4facfe'], desc:'The animated bubble chart that made 200 years of global development legible in four minutes. Income vs. life expectancy, every country, every year.', url:'https://www.gapminder.org/tools/' },
+    { theme:'poverty', tag:'Poverty & Inequality', title:'Dollar Street', who:'Anna Rosling Rönnlund · Gapminder', year:'2016', g:['#ed8936','#f6ad55'], desc:'Homes photographed across the world, sorted by income. It turns an abstract poverty line into toothbrushes, beds and front doors.', url:'https://www.gapminder.org/dollar-street' },
+    { theme:'health', tag:'Public Health', title:'Global Child Mortality', who:'Max Roser · Our World in Data', year:'2013–', g:['#3182ce','#4facfe'], desc:'The single most important — and most hopeful — line in development: the share of children who die before age five, falling across two centuries.', url:'https://ourworldindata.org/child-mortality' },
+    { theme:'race', tag:'Race & Equity', title:'The Data Portraits of Black America', who:'W. E. B. Du Bois', year:'1900', g:['#c1272d','#e8b22a'], desc:'The hand-drawn originals behind our recreation — radical, modernist infographics made to confront the 1900 Paris Exposition with the truth of Black life.', url:'https://www.loc.gov/pictures/collection/anedub/' },
+    { theme:'justice', tag:'Justice & Rights', title:'U.S. Gun Deaths — Stolen Years', who:'Periscopic', year:'2013', g:['#e53e3e','#fc8181'], desc:'Each life arcs across the screen, then is cut short — the grey arc showing the years that person might have lived. Data as elegy.', url:'https://guns.periscopic.com/' },
+    { theme:'migration', tag:'Migration', title:'The Refugee Project', who:'Hyperakt & Ekene Ijeoma', year:'2014', g:['#805ad5','#f093fb'], desc:'Every refugee movement since 1975, mapped and narrated year by year. Migration as a global, historical rhythm rather than a headline.', url:'https://www.therefugeeproject.org/' },
+    { theme:'climate', tag:'Climate', title:'The Carbon Map', who:'Duncan Clark & Robin Houston · Kiln', year:'2013', g:['#38a169','#48bb78'], desc:'The world re-drawn by who emits carbon and who suffers for it — two morphing cartograms that hold the central injustice of climate change in one frame.', url:'https://www.carbonmap.org/' },
+    { theme:'climate', tag:'Climate', title:'Warming Stripes', who:'Ed Hawkins', year:'2018', g:['#3182ce','#e53e3e'], desc:'No axes, no numbers — just a barcode of blue-to-red years. The most-shared climate graphic ever made, because anyone can read it instantly.', url:'https://showyourstripes.info/' },
+    { theme:'health', tag:'Public Health', title:'How the Virus Got Out', who:'The New York Times', year:'2020', g:['#d53f8c','#f093fb'], desc:'A scrollytelling map of the early pandemic — how a local outbreak became a planet-wide event before borders ever closed.', url:'https://www.nytimes.com/interactive/2020/03/22/world/coronavirus-spread.html' },
+    { theme:'gender', tag:'Gender', title:'Women’s Pockets, Quantified', who:'Jan Diehm & Amber Thomas · The Pudding', year:'2018', g:['#d53f8c','#f5a8ff'], desc:'They measured the pockets on 80 pairs of jeans. A small, witty, rigorous proof of a structural gender inequity hiding in plain sight.', url:'https://pudding.cool/2018/08/pockets/' },
+    { theme:'education', tag:'Education', title:'Segregation Now', who:'ProPublica', year:'2014', g:['#d69e2e','#ed8936'], desc:'How American schools quietly re-segregated, told through one town and decades of enrolment data. Investigative journalism as data narrative.', url:'https://projects.propublica.org/segregation-now/' },
+    { theme:'india', tag:'India & South Asia', title:'People’s Archive of Rural India', who:'PARI', year:'2014–', g:['#dd6b20','#f6ad55'], desc:'A living multimedia archive of rural India — maps, faces and livelihoods that national statistics flatten into a single average.', url:'https://ruralindiaonline.org/' },
+    { theme:'india', tag:'India & South Asia', title:'IndiaSpend', who:'IndiaSpend', year:'2011–', g:['#3182ce','#667eea'], desc:'India’s pioneering data-journalism newsroom — health, gender, jobs and budgets charted from the public record, story after story.', url:'https://www.indiaspend.com/' },
+    { theme:'climate', tag:'Climate', title:'2°C: Beyond the Limit', who:'The Washington Post', year:'2019', g:['#e53e3e','#ed8936'], desc:'A Pulitzer-winning series mapping the places already past 2°C of warming. Global abstraction made local and undeniable.', url:'https://www.washingtonpost.com/graphics/2019/national/climate-environment/climate-change-world/' },
+    { theme:'poverty', tag:'Poverty & Inequality', title:'Information is Beautiful', who:'David McCandless', year:'2009–', g:['#667eea','#4facfe'], desc:'The studio that made data visualization mainstream — endlessly studied for how colour, scale and wit turn numbers into something you actually feel.', url:'https://informationisbeautiful.net/' },
+    { theme:'india', tag:'India & South Asia', title:'Reuters Graphics', who:'Reuters', year:'ongoing', g:['#dd6b20','#e53e3e'], desc:'Award-winning visual investigations, often on South Asia — migrant labour, heat, elections. A reference standard for newsroom dataviz craft.', url:'https://www.reuters.com/graphics/' }
+  ];
+
+  function buildCards() {
+    var host = document.getElementById('cards'); if (!host) return;
+    VIZ.forEach(function(v) {
+      var a = document.createElement('a');
+      a.className = 'viz-card'; a.href = v.url; a.target = '_blank'; a.rel = 'noopener'; a.setAttribute('data-theme-cat', v.theme);
+      var sw = document.createElement('div'); sw.className = 'swatch'; sw.style.background = 'linear-gradient(135deg, ' + v.g[0] + ', ' + v.g[1] + ')';
+      var body = document.createElement('div'); body.className = 'vbody';
+      var tag = document.createElement('span'); tag.className = 'theme-tag'; tag.textContent = v.tag;
+      var h = document.createElement('h3'); h.textContent = v.title;
+      var meta = document.createElement('div'); meta.className = 'meta'; meta.textContent = v.who + ' · ' + v.year;
+      var p = document.createElement('p'); p.textContent = v.desc;
+      var view = document.createElement('span'); view.className = 'view'; view.textContent = 'View the original →';
+      body.appendChild(tag); body.appendChild(h); body.appendChild(meta); body.appendChild(p); body.appendChild(view);
+      a.appendChild(sw); a.appendChild(body); host.appendChild(a);
+    });
+  }
+
+  function wireFilters() {
+    var chips = document.querySelectorAll('.filter-chip');
+    chips.forEach(function(chip) {
+      chip.addEventListener('click', function() {
+        chips.forEach(function(c){ c.classList.remove('active'); });
+        chip.classList.add('active');
+        var f = chip.getAttribute('data-filter');
+        document.querySelectorAll('.viz-card').forEach(function(card) {
+          card.classList.toggle('hidden', !(f === 'all' || card.getAttribute('data-theme-cat') === f));
+        });
+      });
+    });
+  }
+
+  /* ---------- reveal cards + hero dots ---------- */
+  function reveal() {
+    var cards = document.querySelectorAll('[data-card], [data-plate]');
+    if (!('IntersectionObserver' in window)) { cards.forEach(function(c){ c.classList.add('in'); }); return; }
+    var io = new IntersectionObserver(function(entries){
+      entries.forEach(function(e){ if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } });
+    }, { threshold: 0.15 });
+    cards.forEach(function(c){ io.observe(c); });
+  }
+  function heroDots() {
+    var host = document.getElementById('heroDots'); if (!host) return;
+    for (var i = 0; i < 24; i++) {
+      var s = document.createElement('span');
+      var size = (Math.random() * 4 + 1.5).toFixed(1);
+      s.style.width = size + 'px'; s.style.height = size + 'px';
+      s.style.left = (Math.random() * 100).toFixed(1) + '%';
+      s.style.top = (Math.random() * 100).toFixed(1) + '%';
+      s.style.animationDelay = (Math.random() * 9).toFixed(1) + 's';
+      s.style.opacity = (Math.random() * 0.6 + 0.2).toFixed(2);
+      host.appendChild(s);
+    }
+  }
+
+  function drawMasters(){ drawRose(); drawMinard(); drawSnow(); drawDuBois(); }
+
+  var ORDER = ['c-gender','c-caste','c-co2','c-energy','c-nfhs','c-forest','c-poverty','c-u5mr','c-flfp','c-pipeline','c-climate'];
+  var DETAILS = {
+    'c-gender': { tag:'Gender', title:'The same gap, four ways',
+      takeaway:"Women have caught up with men in college enrolment, and slightly passed them. In paid work and Parliament, they're still far behind.",
+      source:"NFHS-5 (literacy), AISHE 2021–22 (college GER), PLFS 2023–24 (labour force), Lok Sabha 2024 (seats).",
+      why:"A dumbbell chart puts two values on one line so the gap between them is the first thing you read. Stacking four indicators lets you compare gaps at a glance — and spot the one place the gap reverses.",
+      how:"Drawn in plain SVG: a faint connecting line per row, a dot for each sex, values at the ends. No charting library — just the figures and a little geometry.",
+      look:"The length of each grey line is the gap. Look at college, where the women's dot sits to the right of the men's." },
+    'c-caste': { tag:'Caste & Equity', title:'Poverty is not caste-blind',
+      takeaway:"A Scheduled Tribe household is about three times as likely to be poor as an 'Other' household.",
+      source:"NFHS-4 (2015–16), multidimensional poverty headcount by social group. National headcount has since fallen to about 15% (NFHS-5).",
+      why:"A bar chart is the honest choice for comparing a few categories: length is easy to judge. A single dark-to-light red scale reinforces the ranking without adding a second variable.",
+      how:"Horizontal bars from zero, with a dashed line at the national average so each group reads as above or below it.",
+      look:"How far each bar sits past the dashed national line. The drop from Scheduled Tribes to 'Others' is the point." },
+    'c-co2': { tag:'Climate', title:'Whose carbon?',
+      takeaway:"Most countries emit little, and India sits near the bottom. The average person in Qatar emits more than 20 times an Indian.",
+      source:"EDGAR (European Commission / JRC), per-capita CO₂ emissions, 2023.",
+      why:"A beeswarm shows every country as a dot on one axis, so you see the whole spread — the dense low-emitting cluster and the lonely outliers — instead of a single average.",
+      how:"Each country is placed at its value, then nudged up just enough to avoid overlapping its neighbours. India is highlighted; a dashed line marks the world average.",
+      look:"How crowded the left side is, and how far Qatar sits alone on the right." },
+    'c-energy': { tag:'Energy', title:'How India keeps the lights on',
+      takeaway:"About three-quarters of India's electricity still comes from coal; solar and wind together are about 12%.",
+      source:"Ember / Central Electricity Authority — share of electricity generation, 2024.",
+      why:"For a part-to-whole split, a ring works when one slice dominates and you mainly want the headline share — here, how much is still fossil. The centre carries that number.",
+      how:"Each source is an arc sized to its share, with a legend listing the exact percentages.",
+      look:"The size of the coal slice against everything else." },
+    'c-nfhs': { tag:'Health & Nutrition', title:"Two decades of progress, and one row that won't move",
+      takeaway:"Services improved a lot across three surveys. Women's anaemia did not — and by the latest round it is slightly worse.",
+      source:"National Family Health Survey rounds 3 (2005–06), 4 (2015–16) and 5 (2019–21).",
+      why:"A heatmap is good for a small grid you want to scan in both directions. Every indicator is framed in the positive direction, so one green scale reads honestly: greener is always better.",
+      how:"Each cell is coloured by its value on a single green scale, with the number printed in the cell so colour and figure agree.",
+      look:"Most rows turn greener from left to right. The bottom row doesn't." },
+    'c-forest': { tag:'Climate · Evidence', title:'How hot, by 2100?',
+      takeaway:"Only the lowest-emission paths stay near the 1.5°C and 2°C limits; the higher ones pass them comfortably.",
+      source:"IPCC Sixth Assessment Report (AR6, WG1, 2021): best estimate and 'very likely' range by scenario.",
+      why:"A forest plot shows a point estimate and its uncertainty range on the same row, so you compare both the central number and how sure we are. It's the standard way to show estimates with intervals.",
+      how:"Each scenario is a row: a dot for the best estimate, a whisker for the very likely range, with the Paris 1.5°C and 2°C lines marked.",
+      look:"Where each whisker sits relative to the two dashed Paris lines." },
+    'c-poverty': { tag:'Poverty', title:'The great escape',
+      takeaway:"The share of people in extreme poverty fell from about 38% to under 9% in one generation.",
+      source:"World Bank Poverty & Inequality Platform, via Our World in Data ($2.15/day, 2017 PPP).",
+      why:"A line over time is the clearest way to show a trend. The filled area under it gives the fall some weight without adding any new information.",
+      how:"A smooth line through the data points, endpoints labelled, axis starting at zero so the drop isn't exaggerated.",
+      look:"The steady fall, and the two endpoint numbers." },
+    'c-u5mr': { tag:'Child Survival', title:'India’s children, 1990–2022',
+      takeaway:"Under-five deaths fell from 127 to about 30 per 1,000 — a child today is roughly four times as likely to reach age five.",
+      source:"UN Inter-agency Group for Child Mortality Estimation / World Bank (SH.DYN.MORT).",
+      why:"A line over time, the right tool for one number falling across decades. Eight survey years keep the real shape rather than just joining two ends.",
+      how:"A smooth line with a marker at each survey year and the first and last values labelled.",
+      look:"How steep the early-2000s fall is, and where it flattens." },
+    'c-flfp': { tag:'Gender & Work', title:'Women re-enter the workforce',
+      takeaway:"After years of decline, women's recorded participation has risen sharply — though much of it is unpaid family work.",
+      source:"Periodic Labour Force Survey (PLFS), MoSPI; usual status, women aged 15+.",
+      why:"A short line shows the recent turn upward clearly. We plot the official survey rounds rather than smoothing over the gaps between them.",
+      how:"A line through four PLFS rounds, area filled, endpoints labelled.",
+      look:"The direction — up — and the caveat in the caption about what kind of work it is." },
+    'c-pipeline': { tag:'Education', title:'The leaky pipeline',
+      takeaway:"The gender gap in enrolment is mostly closed, but only about 1 in 4 young women reaches higher education.",
+      source:"UDISE+ 2021–22 (school) and AISHE 2021–22 (higher education); female gross enrolment ratio by level.",
+      why:"A funnel shows a quantity shrinking through stages — enrolment falling from primary to higher education — so the drop-off itself is the picture.",
+      how:"Centred bars, each narrower than the last, sized to the enrolment ratio at that level.",
+      look:"How much narrower each band gets, especially after secondary." },
+    'c-climate': { tag:'Climate', title:'India is heating up',
+      takeaway:"2024 was India's warmest year since 1901. How big the number looks depends on the baseline you pick.",
+      source:"India Meteorological Department gridded data (1901–2024), via Data for India.",
+      why:"This one is closer to a single-number readout than a chart — the point is one figure and how the choice of baseline changes it. The colour band is a schematic of the trend, not per-year data.",
+      how:"A coloured gradient with the headline anomaly, and the same year shown against three different baselines.",
+      look:"How the same warming reads as +0.65, +0.78 or +0.98 depending on the comparison period." }
+  };
+
+  return {
+    renderAll: renderAll, drawMasters: drawMasters, buildCards: buildCards,
+    wireFilters: wireFilters, heroDots: heroDots, reveal: reveal, VIZ: VIZ,
+    ORDER: ORDER, DETAILS: DETAILS
+  };
+})();

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1238,6 +1238,12 @@
         <priority>0.7</priority>
     </url>
     <url>
+        <loc>https://www.impactmojo.in/the-long-view/gallery.html</loc>
+        <lastmod>2026-06-06</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.5</priority>
+    </url>
+    <url>
         <loc>https://www.impactmojo.in/portfolio.html</loc>
         <lastmod>2026-03-21</lastmod>
         <changefreq>monthly</changefreq>

--- a/the-long-view.html
+++ b/the-long-view.html
@@ -43,179 +43,7 @@
 <link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
 <link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&amp;family=Inter:wght@400;500;600;700;800&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
 
-<style>
-:root {
-  --font-body: 'Amaranth', Arial, sans-serif;
-  --font-heading: 'Inter', Helvetica, sans-serif;
-  --font-mono: 'JetBrains Mono', monospace;
-
-  --color-primary: #667eea;
-  --color-primary-2: #764ba2;
-  --color-accent-pink: #f093fb;
-  --color-accent-blue: #4facfe;
-
-  --color-text: #2d3748;
-  --color-text-muted: #718096;
-  --color-bg: #f7fafc;
-  --color-bg-card: #ffffff;
-  --color-border: #e2e8f0;
-
-  /* chart ink adapts to theme so original charts stay legible in both modes */
-  --chart-ink: #475569;
-  --chart-grid: #e8edf4;
-}
-[data-theme="dark"] {
-  --color-text: #e2e8f0;
-  --color-text-muted: #a0aec0;
-  --color-bg: #141a26;
-  --color-bg-card: #1f2735;
-  --color-border: #33415a;
-  --chart-ink: #aab6cc;
-  --chart-grid: #2c374a;
-}
-
-* { box-sizing: border-box; }
-html { scroll-behavior: smooth; }
-body {
-  margin: 0; font-family: var(--font-body); color: var(--color-text);
-  background: var(--color-bg); line-height: 1.6; padding-top: 44px; -webkit-font-smoothing: antialiased;
-}
-@media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } * { animation-duration: 0.001ms !important; transition-duration: 0.001ms !important; } }
-
-h1, h2, h3, h4 { font-family: var(--font-heading); font-weight: 800; line-height: 1.2; }
-a { color: var(--color-primary); }
-
-.skip-link { position: absolute; left: -999px; top: 0; z-index: 10000; background: var(--color-primary); color: #fff; padding: 10px 16px; border-radius: 0 0 8px 0; }
-.skip-link:focus { left: 0; }
-
-/* ---------- Top bar ---------- */
-.im-topbar { position: fixed; top: 0; left: 0; right: 0; z-index: 9999; background: rgba(16, 21, 34, 0.95); backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px); border-bottom: 1px solid rgba(255,255,255,0.08); padding: 0.5rem 1rem; display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; }
-.im-topbar-home { display: flex; align-items: center; gap: 0.5rem; color: #fff; text-decoration: none; font-family: var(--font-heading); font-weight: 700; }
-.im-topbar-right { display: flex; align-items: center; gap: 0.6rem; }
-.im-premium-btn { display: inline-flex; align-items: center; gap: 0.35rem; background: linear-gradient(135deg, #667eea, #764ba2); color: #ffffff; -webkit-text-fill-color: #ffffff; text-decoration: none; font-weight: 700; font-size: 0.85rem; padding: 0.4rem 0.8rem; border-radius: 8px; font-family: var(--font-heading); }
-.im-premium-btn svg { width: 15px; height: 15px; }
-.im-theme-selector { display: flex; gap: 2px; background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; padding: 2px; }
-.im-theme-btn { background: transparent; border: none; color: #9aa6c8; padding: 6px; border-radius: 5px; cursor: pointer; transition: all 0.2s; display: flex; align-items: center; justify-content: center; width: 30px; height: 30px; }
-.im-theme-btn:hover { background: rgba(255,255,255,0.1); color: #fff; }
-.im-theme-btn.active { background: var(--color-primary); color: #fff; }
-.im-theme-btn svg { width: 16px; height: 16px; }
-
-/* ---------- Hero ---------- */
-.hero { position: relative; overflow: hidden; background: radial-gradient(1100px 540px at 78% -10%, rgba(118,75,162,0.5), transparent 60%), radial-gradient(820px 480px at 8% 115%, rgba(79,172,254,0.38), transparent 55%), linear-gradient(135deg, #101522 0%, #1a1838 55%, #241a44 100%); color: #fff; padding: 6rem 1.5rem 5rem; text-align: center; }
-.hero-inner { max-width: 880px; margin: 0 auto; position: relative; z-index: 2; }
-.hero .eyebrow { display: inline-block; font-family: var(--font-mono); font-size: 0.78rem; letter-spacing: 3px; text-transform: uppercase; color: #c9b8ff; border: 1px solid rgba(255,255,255,0.2); padding: 0.35rem 0.9rem; border-radius: 999px; margin-bottom: 1.5rem; }
-.hero h1 { font-size: clamp(2.6rem, 7vw, 4.6rem); margin: 0; letter-spacing: -1.5px; }
-.hero h1 .accent { background: linear-gradient(90deg, #f093fb, #4facfe); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }
-.hero .lede { font-size: 1.25rem; color: #eef1ff; font-weight: 700; font-family: var(--font-heading); margin: 1rem auto 0; max-width: 660px; }
-.hero .sub { font-size: 1.02rem; color: #cdd5f2; max-width: 640px; margin: 1.1rem auto 0; }
-.hero-cta { margin-top: 2.2rem; display: flex; gap: 0.8rem; justify-content: center; flex-wrap: wrap; }
-.btn { display: inline-flex; align-items: center; gap: 0.4rem; font-family: var(--font-heading); font-weight: 700; text-decoration: none; padding: 0.75rem 1.4rem; border-radius: 10px; font-size: 0.95rem; cursor: pointer; border: none; }
-.btn-primary { background: linear-gradient(135deg, #667eea, #764ba2); color: #fff; -webkit-text-fill-color: #fff; }
-.btn-ghost { background: rgba(255,255,255,0.08); color: #fff; border: 1px solid rgba(255,255,255,0.22); }
-.btn:hover { transform: translateY(-2px); transition: transform 0.2s; }
-.hero-dots { position: absolute; inset: 0; z-index: 1; opacity: 0.5; }
-.hero-dots span { position: absolute; border-radius: 50%; background: rgba(255,255,255,0.5); animation: drift 9s ease-in-out infinite; }
-
-/* ---------- Layout ---------- */
-.wrap { max-width: 1200px; margin: 0 auto; padding: 0 1.5rem; }
-.section { padding: 4.5rem 0; }
-.section-head { max-width: 760px; margin: 0 auto 3rem; text-align: center; }
-.section-head .kicker { font-family: var(--font-mono); font-size: 0.76rem; letter-spacing: 2.5px; text-transform: uppercase; color: var(--color-primary); }
-.section-head h2 { font-size: clamp(1.9rem, 4vw, 2.7rem); margin: 0.6rem 0 0.8rem; color: var(--color-text); }
-.section-head p { color: var(--color-text-muted); font-size: 1.05rem; margin: 0; }
-
-/* ---------- Cards grid ---------- */
-.grid { display: grid; grid-template-columns: 1fr; gap: 1.8rem; }
-@media (min-width: 860px) { .grid { grid-template-columns: 1fr 1fr; } }
-
-.card { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: 18px; padding: 1.6rem 1.7rem 1.5rem; box-shadow: 0 10px 30px rgba(15,23,42,0.06); display: flex; flex-direction: column; opacity: 0; transform: translateY(22px); }
-.card.in { opacity: 1; transform: none; transition: opacity 0.7s ease, transform 0.7s ease; }
-.card .tag { align-self: flex-start; font-family: var(--font-mono); font-size: 0.66rem; letter-spacing: 1.4px; text-transform: uppercase; color: var(--color-primary); background: rgba(102,126,234,0.12); padding: 0.22rem 0.6rem; border-radius: 6px; margin-bottom: 0.7rem; }
-.card h3 { font-size: 1.3rem; margin: 0 0 0.5rem; color: var(--color-text); }
-.chart-holder { width: 100%; margin: 0.4rem 0 0.9rem; }
-.chart-holder svg { width: 100%; height: auto; display: block; }
-.card .insight { color: var(--color-text); font-size: 0.98rem; margin: 0.2rem 0 0.9rem; }
-.card .insight strong { color: var(--color-primary); }
-.card .source { font-family: var(--font-mono); font-size: 0.72rem; color: var(--color-text-muted); border-top: 1px solid var(--color-border); padding-top: 0.8rem; margin-top: auto; }
-
-/* Frameworks have a taller, simpler canvas */
-.frame-canvas { width: 100%; margin: 0.4rem 0 0.9rem; }
-.frame-canvas svg { width: 100%; height: auto; display: block; }
-.card .caption { color: var(--color-text-muted); font-size: 0.92rem; margin: 0.2rem 0 0; }
-
-.frameworks-bg { background: var(--color-bg-card); border-top: 1px solid var(--color-border); border-bottom: 1px solid var(--color-border); }
-.frameworks-bg .card { background: var(--color-bg); }
-
-/* ---------- Methods / closing ---------- */
-.methods { background: linear-gradient(135deg, #101522, #251447); color: #fff; }
-.methods .wrap { padding-top: 4.5rem; padding-bottom: 4.5rem; }
-.methods h2 { color: #fff; font-size: clamp(1.7rem, 4vw, 2.3rem); }
-.methods p.intro { color: #cdd5f2; max-width: 700px; font-size: 1.03rem; }
-.source-list { list-style: none; padding: 0; margin: 1.8rem 0 0; display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 0.7rem; }
-.source-list li { background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1); border-radius: 10px; padding: 0.8rem 1rem; font-size: 0.85rem; color: #c4cce6; }
-.source-list li b { color: #fff; font-family: var(--font-heading); display: block; font-size: 0.82rem; margin-bottom: 0.15rem; }
-.tools-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1.1rem; margin-top: 2.5rem; }
-.tool-link { background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.12); border-radius: 14px; padding: 1.3rem; text-decoration: none; color: #fff; transition: background 0.2s, transform 0.2s; }
-.tool-link:hover { background: rgba(255,255,255,0.1); transform: translateY(-3px); }
-.tool-link h4 { margin: 0 0 0.3rem; font-size: 1.02rem; color: #fff; }
-.tool-link span { color: #aeb8df; font-size: 0.86rem; }
-.credit-note { margin-top: 2.4rem; font-size: 0.9rem; color: #aeb8df; }
-.credit-note a { color: #fff; font-weight: 700; }
-
-/* ---------- Footer ---------- */
-.site-footer { background: #101522; color: #cdd5f2; padding: 3.5rem 1.5rem 1.5rem; }
-.footer-grid { max-width: 1200px; margin: 0 auto; display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 2rem; }
-.footer-col h4 { color: #fff; font-size: 1rem; margin: 0 0 1rem; }
-.footer-col a { display: block; color: #9aa6c8; text-decoration: none; font-size: 0.9rem; padding: 0.25rem 0; }
-.footer-col a:hover { color: #fff; }
-.footer-bottom { max-width: 1200px; margin: 2.5rem auto 0; padding-top: 1.5rem; border-top: 1px solid rgba(255,255,255,0.1); text-align: center; color: #7c87aa; font-size: 0.85rem; }
-
-/* ---------- Masters' wing (recreated classics) ---------- */
-.masters { display: grid; grid-template-columns: 1fr; gap: 1.8rem; }
-@media (min-width: 860px) { .masters { grid-template-columns: 1fr 1fr; } }
-.plate { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: 18px; overflow: hidden; box-shadow: 0 10px 30px rgba(15,23,42,0.06); display: flex; flex-direction: column; opacity: 0; transform: translateY(22px); }
-[data-theme="dark"] .plate { background: linear-gradient(160deg, #131a2e, #1a2238); border-color: rgba(255,255,255,0.08); box-shadow: 0 16px 40px rgba(8,12,30,0.3); }
-.plate.in { opacity: 1; transform: none; transition: opacity 0.7s ease, transform 0.7s ease; }
-.plate-canvas { position: relative; aspect-ratio: 4 / 3; padding: 1.1rem; display: flex; align-items: center; justify-content: center; background: #f4f1ea; }
-[data-theme="dark"] .plate-canvas { background: radial-gradient(560px 280px at 50% 0%, rgba(118,75,162,0.18), transparent 70%); }
-.plate-canvas svg { width: 100%; height: 100%; display: block; }
-.plate-caption { padding: 1.3rem 1.5rem 1.6rem; border-top: 1px solid var(--color-border); }
-[data-theme="dark"] .plate-caption { border-top-color: rgba(255,255,255,0.08); }
-.plate-caption .tag { display: inline-block; font-family: var(--font-mono); font-size: 0.66rem; letter-spacing: 1.4px; text-transform: uppercase; color: #6b4ea0; background: rgba(118,75,162,0.12); padding: 0.22rem 0.6rem; border-radius: 6px; margin-bottom: 0.6rem; }
-[data-theme="dark"] .plate-caption .tag { color: #c9b8ff; background: rgba(118,75,162,0.25); }
-.plate-caption h3 { color: var(--color-text); font-size: 1.25rem; margin: 0 0 0.15rem; }
-.plate-caption .meta { font-family: var(--font-mono); font-size: 0.78rem; color: var(--color-text-muted); margin-bottom: 0.7rem; }
-.plate-caption p { color: var(--color-text); font-size: 0.93rem; margin: 0 0 0.8rem; }
-.plate-caption .why { color: var(--color-text-muted); font-size: 0.88rem; border-left: 2px solid var(--color-accent-blue); padding-left: 0.8rem; }
-.plate-caption a.source { display: inline-flex; align-items: center; gap: 0.3rem; margin-top: 0.9rem; font-family: var(--font-heading); font-weight: 700; font-size: 0.84rem; color: var(--color-primary); text-decoration: none; }
-.plate-caption a.source:hover { text-decoration: underline; }
-.plate-canvas { background: #f4f1ea; }
-.plate--dubois .plate-canvas { background: #e8d9b8 !important; }
-
-/* ---------- Greats gallery (curated, links out) ---------- */
-.filters { display: flex; flex-wrap: wrap; gap: 0.5rem; justify-content: center; margin-bottom: 2.4rem; }
-.filter-chip { font-family: var(--font-heading); font-weight: 600; font-size: 0.82rem; background: var(--color-bg); color: var(--color-text-muted); border: 1px solid var(--color-border); padding: 0.45rem 0.95rem; border-radius: 999px; cursor: pointer; transition: all 0.18s; }
-.filter-chip:hover { color: var(--color-text); border-color: var(--color-primary); }
-.filter-chip.active { background: linear-gradient(135deg, #667eea, #764ba2); color: #fff; border-color: transparent; }
-.cards-gallery { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.6rem; }
-.viz-card { display: flex; flex-direction: column; background: var(--color-bg); border: 1px solid var(--color-border); border-radius: 16px; overflow: hidden; text-decoration: none; color: inherit; transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s; }
-.viz-card:hover { transform: translateY(-5px); box-shadow: 0 16px 36px rgba(0,0,0,0.13); border-color: var(--color-primary); }
-.viz-card .swatch { height: 96px; position: relative; }
-.viz-card .swatch::after { content: ""; position: absolute; inset: 0; background: linear-gradient(180deg, transparent 45%, rgba(0,0,0,0.18)); }
-.viz-card .vbody { padding: 1.2rem 1.3rem 1.4rem; display: flex; flex-direction: column; flex: 1; }
-.viz-card .theme-tag { align-self: flex-start; font-family: var(--font-mono); font-size: 0.64rem; letter-spacing: 1px; text-transform: uppercase; color: var(--color-primary); background: rgba(102,126,234,0.12); padding: 0.2rem 0.55rem; border-radius: 5px; margin-bottom: 0.7rem; }
-.viz-card h3 { font-size: 1.08rem; margin: 0 0 0.25rem; color: var(--color-text); }
-.viz-card .meta { font-family: var(--font-mono); font-size: 0.74rem; color: var(--color-text-muted); margin-bottom: 0.7rem; }
-.viz-card p { font-size: 0.88rem; color: var(--color-text-muted); margin: 0 0 1rem; flex: 1; }
-.viz-card .view { font-family: var(--font-heading); font-weight: 700; font-size: 0.82rem; color: var(--color-primary); display: inline-flex; align-items: center; gap: 0.3rem; }
-.viz-card.hidden { display: none; }
-
-/* ---------- Paper plane ---------- */
-.paper-plane { position: fixed; bottom: 2rem; right: 2rem; opacity: 0.1; pointer-events: none; z-index: 0; animation: float 6s ease-in-out infinite; }
-@keyframes float { 0%, 100% { transform: translateY(0) rotate(0deg); } 50% { transform: translateY(-15px) rotate(3deg); } }
-@keyframes drift { 0%,100% { transform: translateY(0); } 50% { transform: translateY(-18px); } }
-@media (prefers-reduced-motion: reduce) { .paper-plane, .hero-dots span { animation: none; } }
-</style>
+<link rel="stylesheet" href="/css/longview.css">
 </head>
 <body>
 <a href="#main-content" class="skip-link">Skip to content</a>
@@ -258,8 +86,7 @@ a { color: var(--color-primary); }
     <div class="hero-cta">
       <a href="#data" class="btn btn-primary">Our data</a>
       <a href="#frameworks" class="btn btn-ghost">Frameworks</a>
-      <a href="#masters" class="btn btn-ghost">The masters</a>
-      <a href="#greats" class="btn btn-ghost">The greats</a>
+      <a href="/the-long-view/gallery.html" class="btn btn-ghost">The classics &amp; the greats</a>
     </div>
   </div>
 </header>
@@ -277,93 +104,93 @@ a { color: var(--color-primary); }
 
     <div class="grid">
 
-      <article class="card" data-card>
+      <a class="card-link" href="/the-long-view/chart.html?c=c-gender"><article class="card tile" data-card>
         <span class="tag">Gender</span>
         <h3>The same gap, four ways</h3>
         <div class="chart-holder"><svg id="c-gender" role="img" aria-label="A dumbbell chart of India gender gaps: women now slightly lead men in college enrolment, are close in literacy, but trail far behind in labour-force participation and seats in the Lok Sabha."></svg></div>
         <p class="insight">Women have caught up with men in college enrolment, and slightly passed them; the literacy gap is narrowing. In <strong>paid work and in Parliament</strong>, they are still far behind.</p>
         <p class="source">Sources: NFHS-5 (literacy), AISHE 2021–22 (college GER), PLFS 2023–24 (labour force), Lok Sabha 2024 (seats).</p>
-      </article>
+      <span class="explore">Explore this chart →</span></article></a>
 
-      <article class="card" data-card>
+      <a class="card-link" href="/the-long-view/chart.html?c=c-caste"><article class="card tile" data-card>
         <span class="tag">Caste &amp; Equity</span>
         <h3>Poverty is not caste-blind</h3>
         <div class="chart-holder"><svg id="c-caste" role="img" aria-label="Bar chart: multidimensional poverty headcount in India by social group — Scheduled Tribes 44.4%, Scheduled Castes 29.2%, OBC 24.5%, Others 14.9%."></svg></div>
         <p class="insight">A Scheduled Tribe household is about <strong>three times</strong> as likely to be poor as an "Other" household. National poverty has fallen since (24.8% to 15.0% by NFHS-5), but the gap between groups holds.</p>
         <p class="source">Source: NITI Aayog National MPI. By social group: NFHS-4 (2015–16). National headcount fell from 24.85% to 14.96% by NFHS-5 (2019–21).</p>
-      </article>
+      <span class="explore">Explore this chart →</span></article></a>
 
-      <article class="card" data-card>
+      <a class="card-link" href="/the-long-view/chart.html?c=c-co2"><article class="card tile" data-card>
         <span class="tag">Climate Justice</span>
         <h3>Whose carbon?</h3>
         <div class="chart-holder"><svg id="c-co2" role="img" aria-label="A beeswarm of CO2 emissions per capita by country in 2023: most countries cluster at low values with India near the bottom, while Qatar, the Gulf states and the US sit far to the right."></svg></div>
         <p class="insight">Each dot is a country. Most emit little, and India sits near the bottom. The average person in <strong>Qatar</strong> emits more than <strong>20 times</strong> what the average Indian does.</p>
         <p class="source">Source: EDGAR (European Commission / JRC) — territorial CO₂ emissions per capita, 2023.</p>
-      </article>
+      <span class="explore">Explore this chart →</span></article></a>
 
-      <article class="card" data-card>
+      <a class="card-link" href="/the-long-view/chart.html?c=c-energy"><article class="card tile" data-card>
         <span class="tag">Energy</span>
         <h3>How India keeps the lights on</h3>
         <div class="chart-holder"><svg id="c-energy" role="img" aria-label="A donut chart of India's 2024 electricity generation mix: coal 73%, hydro 8%, solar 7%, wind 5%, nuclear 3%, gas 2%, bioenergy 2%."></svg></div>
         <p class="insight">About <strong>three-quarters</strong> of India's electricity still comes from coal. Solar and wind are growing — together about 12% — but the shift is early.</p>
         <p class="source">Source: Ember / Central Electricity Authority — share of electricity generation, 2024. Figures rounded.</p>
-      </article>
+      <span class="explore">Explore this chart →</span></article></a>
 
-      <article class="card" data-card>
+      <a class="card-link" href="/the-long-view/chart.html?c=c-nfhs"><article class="card tile" data-card>
         <span class="tag">Health &amp; Nutrition</span>
         <h3>Two decades of progress, and one row that won't move</h3>
         <div class="chart-holder"><svg id="c-nfhs" role="img" aria-label="A heatmap of India's progress across three NFHS rounds on five indicators: institutional births, immunisation, women's bank accounts, child not stunted, and women not anaemic. Most improve and turn green over time, but the anaemia row stays pale and even worsens."></svg></div>
         <p class="insight">Across three national surveys, services improved a lot: institutional births, immunisation and women's bank accounts all rose. The bottom row barely moves — by NFHS-5, <strong>anaemia among women is slightly worse</strong>.</p>
         <p class="source">Source: National Family Health Survey rounds 3 (2005–06), 4 (2015–16) and 5 (2019–21). Each cell is the share with the positive outcome.</p>
-      </article>
+      <span class="explore">Explore this chart →</span></article></a>
 
-      <article class="card" data-card>
+      <a class="card-link" href="/the-long-view/chart.html?c=c-forest"><article class="card tile" data-card>
         <span class="tag">Climate · Evidence</span>
         <h3>How hot, by 2100?</h3>
         <div class="chart-holder"><svg id="c-forest" role="img" aria-label="A forest plot of projected global warming by 2100 under five emissions scenarios: net zero ~2050 gives 1.4°C (very likely 1.0–1.8), rising to 4.4°C (3.3–5.7) under very high emissions; only the lowest scenarios stay near the 1.5°C and 2°C Paris limits."></svg></div>
         <p class="insight">The dot is the IPCC's best estimate; the bar is its "very likely" range. Only the lowest-emission paths stay near the <strong>1.5°C and 2°C</strong> limits; the higher ones pass them comfortably.</p>
         <p class="source">Source: IPCC Sixth Assessment Report (AR6, WG1, 2021) — projected global surface warming by 2081–2100 vs 1850–1900, best estimate and very likely range, by scenario.</p>
-      </article>
+      <span class="explore">Explore this chart →</span></article></a>
 
-      <article class="card" data-card>
+      <a class="card-link" href="/the-long-view/chart.html?c=c-poverty"><article class="card tile" data-card>
         <span class="tag">Poverty</span>
         <h3>The great escape</h3>
         <div class="chart-holder"><svg id="c-poverty" role="img" aria-label="Line chart: the share of the world living in extreme poverty fell from 37.9% in 1990 to 8.4% in 2019."></svg></div>
         <p class="insight">Over one generation, the share of people living in extreme poverty fell from about <strong>38%</strong> to under <strong>9%</strong> — roughly 1.9 billion people down to 660 million.</p>
         <p class="source">Source: World Bank Poverty &amp; Inequality Platform, via Our World in Data. Poverty line $2.15/day (2017 PPP).</p>
-      </article>
+      <span class="explore">Explore this chart →</span></article></a>
 
-      <article class="card" data-card>
+      <a class="card-link" href="/the-long-view/chart.html?c=c-u5mr"><article class="card tile" data-card>
         <span class="tag">Child Survival</span>
         <h3>India's children, 1990–2022</h3>
         <div class="chart-holder"><svg id="c-u5mr" role="img" aria-label="Line chart: India's under-five mortality rate fell from 127 per 1,000 live births in 1990 to 29.5 in 2022."></svg></div>
         <p class="insight">Under-five deaths in India fell from 127 to about 30 per 1,000 live births. A child today is roughly <strong>four times</strong> more likely to reach age five than one born in 1990.</p>
         <p class="source">Source: UN Inter-agency Group for Child Mortality Estimation / World Bank Open Data (SH.DYN.MORT), 2024.</p>
-      </article>
+      <span class="explore">Explore this chart →</span></article></a>
 
-      <article class="card" data-card>
+      <a class="card-link" href="/the-long-view/chart.html?c=c-flfp"><article class="card tile" data-card>
         <span class="tag">Gender &amp; Work</span>
         <h3>Women re-enter the workforce</h3>
         <div class="chart-holder"><svg id="c-flfp" role="img" aria-label="Slope chart: India's female labour force participation rate rose from 23.3% in 2017-18 to 37.0% in 2022-23."></svg></div>
         <p class="insight">After years of decline, women's recorded workforce participation has <strong>risen sharply</strong>. Much of the rise is unpaid family work and self-employment, not salaried jobs.</p>
         <p class="source">Source: Periodic Labour Force Survey (PLFS), MoSPI. Female LFPR, usual status, age 15+.</p>
-      </article>
+      <span class="explore">Explore this chart →</span></article></a>
 
-      <article class="card" data-card>
+      <a class="card-link" href="/the-long-view/chart.html?c=c-pipeline"><article class="card tile" data-card>
         <span class="tag">Education</span>
         <h3>The leaky pipeline</h3>
         <div class="chart-holder"><svg id="c-pipeline" role="img" aria-label="A funnel of female gross enrolment in India narrowing from 104.8% in primary school to 28.5% in higher education."></svg></div>
         <p class="insight">The gender gap in school enrolment is mostly closed; girls' primary enrolment even tops 100%. But enrolment drops at every stage, and only about <strong>1 in 4</strong> young women reaches higher education.</p>
         <p class="source">Source: UDISE+ 2021–22 (school) and AISHE 2021–22 (higher education). Female gross enrolment ratio (GER) by level.</p>
-      </article>
+      <span class="explore">Explore this chart →</span></article></a>
 
-      <article class="card" data-card>
+      <a class="card-link" href="/the-long-view/chart.html?c=c-climate"><article class="card tile" data-card>
         <span class="tag">Climate</span>
         <h3>India is heating up</h3>
         <div class="chart-holder"><svg id="c-climate" role="img" aria-label="India's 2024 annual mean temperature was +0.65°C above the 1991–2020 average — the warmest year since 1901 — shown over a blue-to-red warming gradient."></svg></div>
         <p class="insight">2024 was India's <strong>warmest year since 1901</strong>. Ten of the fifteen warmest years have come since 2010. How big the number looks depends on the baseline you pick.</p>
         <p class="source">Source: India Meteorological Department high-resolution gridded data (1901–2024), via Data for India. The warming band is schematic of the documented trend, not per-year values.</p>
-      </article>
+      <span class="explore">Explore this chart →</span></article></a>
 
       <article class="card" data-card>
         <span class="tag">Read the method</span>
@@ -427,91 +254,21 @@ a { color: var(--color-primary); }
   </div>
 </section>
 
-<!-- ===== MASTERS' WING (recreated classics) ===== -->
-<section class="section" id="masters">
+
+
+
+
+<!-- ===== Gallery link ===== -->
+<section class="section">
   <div class="wrap">
-    <div class="section-head">
-      <span class="kicker">The Masters' Wing</span>
-      <h2>The greats, rebuilt by hand</h2>
-      <p>Famous old charts, all out of copyright, rebuilt here in code so you can see how they were put together.</p>
-    </div>
-    <div class="masters">
-
-      <article class="plate" data-plate>
-        <div class="plate-canvas"><svg id="viz-rose" viewBox="0 0 400 320" role="img" aria-label="A recreation of Florence Nightingale's rose diagram showing that most soldier deaths in the Crimean War came from preventable disease, not wounds."></svg></div>
-        <div class="plate-caption">
-          <span class="tag">Public Health</span>
-          <h3>The Rose of Mortality</h3>
-          <div class="meta">Florence Nightingale · 1858</div>
-          <p>Her polar-area "coxcomb" showed that the great blue wedges — soldiers killed by <em>preventable</em> disease in the Crimean War — dwarfed the red of battle wounds. Area, not radius, carries the count.</p>
-          <p class="why">One of the first charts made to change policy. Sanitation reforms followed.</p>
-          <a class="source" href="https://en.wikipedia.org/wiki/Florence_Nightingale#Statistics_and_sanitary_reform" target="_blank" rel="noopener">About the original →</a>
-        </div>
-      </article>
-
-      <article class="plate" data-plate>
-        <div class="plate-canvas"><svg id="viz-minard" viewBox="0 0 400 320" role="img" aria-label="A recreation of Charles Minard's flow map of Napoleon's 1812 march on Moscow, the thinning band showing an army of 422,000 reduced to 10,000."></svg></div>
-        <div class="plate-caption">
-          <span class="tag">War &amp; Loss</span>
-          <h3>Napoleon's March</h3>
-          <div class="meta">Charles Joseph Minard · 1869</div>
-          <p>The width of the band is the size of the army; tan advancing on Moscow, black in retreat, with the freezing temperature traced below. 422,000 marched out. 10,000 came home.</p>
-          <p class="why">Tufte called it perhaps the best statistical graphic ever drawn: six variables on one flat page.</p>
-          <a class="source" href="https://en.wikipedia.org/wiki/Charles_Joseph_Minard#The_map_of_Napoleon's_Russian_campaign" target="_blank" rel="noopener">About the original →</a>
-        </div>
-      </article>
-
-      <article class="plate" data-plate>
-        <div class="plate-canvas"><svg id="viz-snow" viewBox="0 0 400 320" role="img" aria-label="A recreation of John Snow's 1854 cholera map, with death markers clustered tightly around the Broad Street water pump."></svg></div>
-        <div class="plate-caption">
-          <span class="tag">Public Health</span>
-          <h3>The Broad Street Pump</h3>
-          <div class="meta">Dr. John Snow · 1854</div>
-          <p>Each mark is a cholera death. Plotted on a street map of Soho, they swarm around a single water pump — the evidence that cholera travelled through water, not "bad air".</p>
-          <p class="why">An early landmark in epidemiology: the map pointed to the source, and the pump was shut off.</p>
-          <a class="source" href="https://en.wikipedia.org/wiki/1854_Broad_Street_cholera_outbreak" target="_blank" rel="noopener">About the original →</a>
-        </div>
-      </article>
-
-      <article class="plate plate--dubois" data-plate>
-        <div class="plate-canvas"><svg id="viz-dubois" viewBox="0 0 400 320" role="img" aria-label="A recreation in the style of W. E. B. Du Bois's 1900 data portraits: a spiral of growing bars on a cream ground, charting the rising value of property owned by Black Americans in Georgia."></svg></div>
-        <div class="plate-caption">
-          <span class="tag">Race &amp; Equity</span>
-          <h3>A Du Bois Data Portrait</h3>
-          <div class="meta">W. E. B. Du Bois &amp; team · 1900</div>
-          <p>For the 1900 Paris Exposition, Du Bois hand-drew dozens of radical, modernist charts of Black American life. This spiral — rising property values against the odds — is rebuilt in his palette.</p>
-          <p class="why">Charts made as an argument for dignity, decades ahead of their design time.</p>
-          <a class="source" href="https://www.loc.gov/pictures/collection/anedub/" target="_blank" rel="noopener">See the originals (Library of Congress) →</a>
-        </div>
-      </article>
-
-    </div>
-  </div>
-</section>
-
-<!-- ===== THE GREATS (curated gallery, links out) ===== -->
-<section class="section frameworks-bg" id="greats">
-  <div class="wrap">
-    <div class="section-head">
-      <span class="kicker">The Greats</span>
-      <h2>Masterworks worth studying</h2>
-      <p>Modern work on the same themes, by other people. We can't reprint it, so each card links to the original. Filter by topic.</p>
-    </div>
-
-    <div class="filters" id="filters" role="group" aria-label="Filter visualizations by theme">
-      <button class="filter-chip active" data-filter="all">All</button>
-      <button class="filter-chip" data-filter="poverty">Poverty &amp; Inequality</button>
-      <button class="filter-chip" data-filter="gender">Gender</button>
-      <button class="filter-chip" data-filter="race">Race &amp; Caste</button>
-      <button class="filter-chip" data-filter="health">Public Health</button>
-      <button class="filter-chip" data-filter="climate">Climate</button>
-      <button class="filter-chip" data-filter="migration">Migration</button>
-      <button class="filter-chip" data-filter="education">Education</button>
-      <button class="filter-chip" data-filter="india">India &amp; South Asia</button>
-      <button class="filter-chip" data-filter="justice">Justice &amp; Rights</button>
-    </div>
-
-    <div class="cards-gallery" id="cards"><!-- cards injected by JS --></div>
+    <a class="gallery-cta" href="/the-long-view/gallery.html">
+      <div>
+        <span class="kicker" style="font-family:var(--font-mono);font-size:0.76rem;letter-spacing:2.5px;text-transform:uppercase;color:var(--color-primary);">Also worth your time</span>
+        <h2 style="margin:0.4rem 0 0.3rem;font-size:1.6rem;color:var(--color-text);">The classics, rebuilt &amp; the greats</h2>
+        <p style="margin:0;color:var(--color-text-muted);">Famous old charts rebuilt in code, and a shelf of modern work by other people.</p>
+      </div>
+      <span class="gallery-arrow">→</span>
+    </a>
   </div>
 </section>
 
@@ -627,763 +384,15 @@ a { color: var(--color-primary); }
 </script>
 
 <!-- ===== The Long View: original charts + frameworks ===== -->
+<script src="/js/longview-charts.js"></script>
 <script>
-(function() {
-  var NS = "http://www.w3.org/2000/svg";
-  function mk(tag, attrs, text) {
-    var e = document.createElementNS(NS, tag);
-    for (var k in attrs) e.setAttribute(k, attrs[k]);
-    if (text != null) e.textContent = text;
-    return e;
-  }
-  function clear(el) { while (el && el.firstChild) el.removeChild(el.firstChild); }
-  function ink() { return (getComputedStyle(document.documentElement).getPropertyValue('--chart-ink') || '#475569').trim(); }
-  function gridc() { return (getComputedStyle(document.documentElement).getPropertyValue('--chart-grid') || '#e8edf4').trim(); }
-  function reduced() { return window.matchMedia('(prefers-reduced-motion: reduce)').matches; }
-
-  var W = 460, H = 290;
-  var COL = { blue: '#4361ee', teal: '#0d9488', amber: '#f59e0b', red: '#e11d48', purple: '#7c3aed', green: '#16a34a', slate: '#64748b' };
-
-  function frame(id) {
-    var svg = document.getElementById(id); if (!svg) return null;
-    clear(svg); svg.setAttribute('viewBox', '0 0 ' + W + ' ' + H); return svg;
-  }
-  function animPath(path) {
-    if (reduced() || !path.getTotalLength) return;
-    var len = path.getTotalLength(); if (!len) return;
-    path.style.strokeDasharray = len; path.style.strokeDashoffset = len;
-    path.style.transition = 'stroke-dashoffset 1.3s ease';
-    requestAnimationFrame(function(){ path.style.strokeDashoffset = 0; });
-  }
-  function fadeIn(node, delay) {
-    if (reduced()) return;
-    node.style.opacity = 0; node.style.transition = 'opacity 0.6s ease ' + (delay || 0) + 's';
-    requestAnimationFrame(function(){ node.style.opacity = 1; });
-  }
-
-  /* ---------- Generic line chart ---------- */
-  /* ===== shared design helpers ===== */
-  function ensureDefs(svg) { var d = svg.querySelector('defs'); if (!d) { d = mk('defs', {}); svg.insertBefore(d, svg.firstChild); } return d; }
-  function vGrad(svg, gid, color, topOp, botOp) {
-    var g = mk('linearGradient', { id: gid, x1: '0', y1: '0', x2: '0', y2: '1' });
-    g.appendChild(mk('stop', { offset: '0', 'stop-color': color, 'stop-opacity': topOp }));
-    g.appendChild(mk('stop', { offset: '1', 'stop-color': color, 'stop-opacity': botOp }));
-    ensureDefs(svg).appendChild(g); return 'url(#' + gid + ')';
-  }
-  function smooth(pts) {
-    if (pts.length < 3) return 'M' + pts.map(function(p){ return p[0].toFixed(1) + ',' + p[1].toFixed(1); }).join(' L');
-    var d = 'M' + pts[0][0].toFixed(1) + ',' + pts[0][1].toFixed(1);
-    for (var i = 0; i < pts.length - 1; i++) {
-      var p0 = pts[i-1] || pts[i], p1 = pts[i], p2 = pts[i+1], p3 = pts[i+2] || p2;
-      var c1x = p1[0] + (p2[0]-p0[0])/6, c1y = p1[1] + (p2[1]-p0[1])/6;
-      var c2x = p2[0] - (p3[0]-p1[0])/6, c2y = p2[1] - (p3[1]-p1[1])/6;
-      d += ' C' + c1x.toFixed(1) + ',' + c1y.toFixed(1) + ' ' + c2x.toFixed(1) + ',' + c2y.toFixed(1) + ' ' + p2[0].toFixed(1) + ',' + p2[1].toFixed(1);
-    }
-    return d;
-  }
-  function callout(svg, x, y, anchor, lines) {
-    var yy = y;
-    lines.forEach(function(ln) {
-      svg.appendChild(mk('text', { x: x, y: yy, 'text-anchor': anchor, 'font-size': ln.s || 11, 'font-weight': ln.w || 400, fill: ln.c || ink(), 'font-family': ln.f || 'Inter, sans-serif' }, ln.t));
-      yy += ln.gap || ((ln.s || 11) + 4);
-    });
-  }
-  function tick(svg, x, y, txt, anchor) {
-    svg.appendChild(mk('text', { x: x, y: y, 'text-anchor': anchor || 'middle', 'font-size': 9.5, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, txt));
-  }
-
-  /* ---------- Line / area chart with annotation callout ---------- */
-  function lineChart(id, data, o) {
-    var svg = frame(id); if (!svg) return;
-    var mL = 30, mR = 54, mT = 30, mB = 36;
-    var xs = data.map(function(d){ return d.x; });
-    var xmin = Math.min.apply(null, xs), xmax = Math.max.apply(null, xs), yMax = o.yMax;
-    function X(x){ return mL + (x - xmin) / (xmax - xmin) * (W - mL - mR); }
-    function Y(y){ return H - mB - (y / yMax) * (H - mT - mB); }
-    var pts = data.map(function(p){ return [X(p.x), Y(p.y)]; });
-    svg.appendChild(mk('line', { x1: mL, y1: Y(0), x2: W - mR, y2: Y(0), stroke: gridc(), 'stroke-width': 1 }));
-    var lineD = smooth(pts);
-    if (o.area) {
-      var fill = vGrad(svg, id + '-area', o.color, 0.32, 0.015);
-      svg.appendChild(mk('path', { d: lineD + ' L' + X(xmax).toFixed(1) + ',' + Y(0).toFixed(1) + ' L' + X(xmin).toFixed(1) + ',' + Y(0).toFixed(1) + ' Z', fill: fill }));
-    }
-    var path = mk('path', { d: lineD, fill: 'none', stroke: o.color, 'stroke-width': 3, 'stroke-linejoin': 'round', 'stroke-linecap': 'round' });
-    svg.appendChild(path); animPath(path);
-    data.forEach(function(p, i){
-      var isEnd = (i === 0 || i === data.length - 1);
-      if (isEnd || (o.labelEvery && i % o.labelEvery === 0)) tick(svg, X(p.x), H - mB + 16, o.xfmt ? o.xfmt(p.x) : p.x);
-      svg.appendChild(mk('circle', { cx: X(p.x), cy: Y(p.y), r: isEnd ? 5 : 3, fill: o.color, stroke: '#fff', 'stroke-width': isEnd ? 1.6 : 0 }));
-    });
-    var f = data[0], l = data[data.length - 1];
-    svg.appendChild(mk('text', { x: X(f.x) + 8, y: Y(f.y) - 11, 'text-anchor': 'start', 'font-size': 15, 'font-weight': 800, fill: o.color, 'font-family': 'Inter, sans-serif' }, o.valfmt(f.y)));
-    svg.appendChild(mk('text', { x: X(l.x) - 6, y: Y(l.y) - 11, 'text-anchor': 'end', 'font-size': 15, 'font-weight': 800, fill: o.color, 'font-family': 'Inter, sans-serif' }, o.valfmt(l.y)));
-    if (o.callout) callout(svg, o.callout.x, o.callout.y, o.callout.anchor, o.callout.lines);
-  }
-
-  /* ---------- Vertical bar chart with reference line ---------- */
-  function barChart(id, data, o) {
-    var svg = frame(id); if (!svg) return;
-    var mL = 18, mR = 66, mT = 30, mB = 42;
-    var yMax = o.yMax, n = data.length, gap = 30;
-    var bw = (W - mL - mR - gap * (n - 1)) / n;
-    function Y(y){ return H - mB - (y / yMax) * (H - mT - mB); }
-    svg.appendChild(mk('line', { x1: mL, y1: Y(0), x2: W - mR, y2: Y(0), stroke: ink(), 'stroke-width': 1.4 }));
-    data.forEach(function(dd, i){
-      var x = mL + i * (bw + gap);
-      var fill = vGrad(svg, id + '-b' + i, dd.color, dd.highlight ? 1 : 0.78, dd.highlight ? 0.72 : 0.5);
-      var rect = mk('rect', { x: x, y: Y(dd.y), width: bw, height: Y(0) - Y(dd.y), rx: 7, fill: fill });
-      svg.appendChild(rect); fadeIn(rect, i * 0.1);
-      svg.appendChild(mk('text', { x: x + bw/2, y: Y(dd.y) - 9, 'text-anchor': 'middle', 'font-size': 15, 'font-weight': 800, fill: dd.color, 'font-family': 'Inter, sans-serif' }, o.valfmt(dd.y)));
-      svg.appendChild(mk('text', { x: x + bw/2, y: H - mB + 18, 'text-anchor': 'middle', 'font-size': 12, 'font-weight': dd.highlight ? 700 : 400, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, dd.label));
-    });
-    if (o.refLine) {
-      var ry = Y(o.refLine.value);
-      svg.appendChild(mk('line', { x1: mL, y1: ry, x2: W - mR + 6, y2: ry, stroke: ink(), 'stroke-width': 1, 'stroke-dasharray': '5,4', opacity: 0.7 }));
-      svg.appendChild(mk('text', { x: W - mR + 10, y: ry - 4, 'font-size': 9.5, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, o.refLine.label));
-    }
-    if (o.callout) callout(svg, o.callout.x, o.callout.y, o.callout.anchor, o.callout.lines);
-  }
-
-  /* ---------- Horizontal bar chart with reference line ---------- */
-  function hbarChart(id, data, o) {
-    var svg = frame(id); if (!svg) return;
-    var mL = 108, mR = 50, mT = 24, mB = 28;
-    var xMax = o.xMax, n = data.length, gap = 18;
-    var bh = (H - mT - mB - gap * (n - 1)) / n;
-    function Xv(v){ return mL + (v / xMax) * (W - mL - mR); }
-    data.forEach(function(dd, i){
-      var y = mT + i * (bh + gap);
-      svg.appendChild(mk('text', { x: mL - 12, y: y + bh/2 + 4, 'text-anchor': 'end', 'font-size': 12, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, dd.label));
-      svg.appendChild(mk('rect', { x: mL, y: y, width: W - mL - mR, height: bh, rx: 7, fill: gridc(), opacity: 0.5 }));
-      var bar = mk('rect', { x: mL, y: y, width: Xv(dd.y) - mL, height: bh, rx: 7, fill: dd.color });
-      svg.appendChild(bar); fadeIn(bar, i * 0.1);
-      svg.appendChild(mk('text', { x: Xv(dd.y) + 8, y: y + bh/2 + 4.5, 'font-size': 14, 'font-weight': 800, fill: dd.vcolor || ink(), 'font-family': 'Inter, sans-serif' }, o.valfmt(dd.y)));
-    });
-    if (o.refLine) {
-      var rx = Xv(o.refLine.value);
-      svg.appendChild(mk('line', { x1: rx, y1: mT - 13, x2: rx, y2: H - mB + 3, stroke: ink(), 'stroke-width': 1, 'stroke-dasharray': '5,4', opacity: 0.8 }));
-      svg.appendChild(mk('text', { x: rx, y: mT - 17, 'text-anchor': 'middle', 'font-size': 9.5, 'font-weight': 700, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, o.refLine.label));
-    }
-  }
-
-  /* ---------- The "honest axis" method panel ---------- */
-  function ethicChart(id) {
-    var svg = frame(id); if (!svg) return;
-    var vals = [52, 55, 58];
-    svg.appendChild(mk('text', { x: W/2, y: 20, 'text-anchor': 'middle', 'font-size': 12, 'font-weight': 700, fill: ink(), 'font-family': 'Inter, sans-serif' }, 'Same three numbers — 52, 55, 58'));
-    function panel(ox, pw, yScaleMin, title, color) {
-      var top = 44, base = H - 40, n = vals.length, gap = 18, bw = (pw - gap * (n - 1)) / n, range = 60 - yScaleMin;
-      function Y(v){ return top + (60 - v) / range * (base - top); }
-      svg.appendChild(mk('line', { x1: ox - 6, y1: base, x2: ox + pw + 4, y2: base, stroke: ink(), 'stroke-width': 1.3 }));
-      vals.forEach(function(v, i){
-        var x = ox + i * (bw + gap);
-        var fill = vGrad(svg, id + '-' + ox + '-' + i, color, 0.95, 0.6);
-        var r = mk('rect', { x: x, y: Y(v), width: bw, height: base - Y(v), rx: 4, fill: fill });
-        svg.appendChild(r); fadeIn(r, i * 0.08);
-      });
-      svg.appendChild(mk('text', { x: ox - 9, y: base + 3, 'text-anchor': 'end', 'font-size': 9, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, yScaleMin));
-      svg.appendChild(mk('text', { x: ox + pw/2, y: H - 12, 'text-anchor': 'middle', 'font-size': 11, 'font-weight': 700, fill: color, 'font-family': 'Inter, sans-serif' }, title));
-    }
-    panel(58, 150, 50, 'axis cut at 50 → "a surge!"', COL.red);
-    panel(268, 150, 0, 'axis at 0 → the truth', COL.teal);
-  }
-
-  /* ---------- India warming (verified IMD anomalies + schematic stripe) ---------- */
-  function climateChart(id) {
-    var svg = frame(id); if (!svg) return;
-    var defs = mk('defs', {});
-    var lg = mk('linearGradient', { id: 'warmgrad', x1: '0', y1: '0', x2: '1', y2: '0' });
-    [['0','#08306b'],['0.45','#f2f2f2'],['0.7','#fdae61'],['1','#a50026']].forEach(function(s){ lg.appendChild(mk('stop', { offset: s[0], 'stop-color': s[1] })); });
-    defs.appendChild(lg); svg.appendChild(defs);
-    var bandY = 26, bandH = 44;
-    svg.appendChild(mk('rect', { x: 20, y: bandY, width: W - 40, height: bandH, rx: 6, fill: 'url(#warmgrad)' }));
-    svg.appendChild(mk('text', { x: 22, y: bandY - 7, 'font-size': 10, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, '1901'));
-    svg.appendChild(mk('text', { x: W - 22, y: bandY - 7, 'text-anchor': 'end', 'font-size': 10, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, '2024'));
-    svg.appendChild(mk('text', { x: W/2, y: bandY + bandH + 15, 'text-anchor': 'middle', 'font-size': 9.5, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, 'warming trend — schematic (cool → hot)'));
-    svg.appendChild(mk('text', { x: W/2, y: 150, 'text-anchor': 'middle', 'font-size': 44, 'font-weight': 800, fill: COL.red, 'font-family': 'Inter, sans-serif' }, '+0.65°C'));
-    svg.appendChild(mk('text', { x: W/2, y: 171, 'text-anchor': 'middle', 'font-size': 12, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, '2024 vs 1991–2020 — warmest year since 1901'));
-    var items = [['vs 1981–2010', '+0.78°C'], ['vs 1951–80', '+0.98°C']], cw = (W - 40) / 2;
-    items.forEach(function(it, i){
-      var cx = 20 + cw * i + cw / 2;
-      svg.appendChild(mk('text', { x: cx, y: 212, 'text-anchor': 'middle', 'font-size': 19, 'font-weight': 800, fill: COL.amber, 'font-family': 'Inter, sans-serif' }, it[1]));
-      svg.appendChild(mk('text', { x: cx, y: 230, 'text-anchor': 'middle', 'font-size': 10, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, it[0]));
-    });
-    svg.appendChild(mk('text', { x: W/2, y: 266, 'text-anchor': 'middle', 'font-size': 11, 'font-weight': 700, fill: ink(), 'font-family': 'Inter, sans-serif' }, '10 of the 15 warmest years have come since 2010'));
-  }
-
-  /* ---------- Beeswarm (distribution, one dot per item) ---------- */
-  function beeswarm(id, data, o) {
-    var svg = frame(id); if (!svg) return;
-    var mL = 26, mR = 22, mB = 46, baseY = H - mB, vMax = o.vMax, r = 3.6, step = r * 2.15;
-    function X(v){ return mL + (v / vMax) * (W - mL - mR); }
-    svg.appendChild(mk('line', { x1: mL, y1: baseY, x2: W - mR, y2: baseY, stroke: ink(), 'stroke-width': 1.2 }));
-    (o.ticks || []).forEach(function(t){ if (X(t) <= W - mR) { svg.appendChild(mk('line', { x1: X(t), y1: baseY, x2: X(t), y2: baseY + 5, stroke: ink(), 'stroke-width': 1 })); tick(svg, X(t), baseY + 17, t); } });
-    if (o.ref) {
-      svg.appendChild(mk('line', { x1: X(o.ref.v), y1: baseY, x2: X(o.ref.v), y2: 66, stroke: ink(), 'stroke-width': 1, 'stroke-dasharray': '5,4', opacity: 0.6 }));
-      svg.appendChild(mk('text', { x: X(o.ref.v) + 4, y: 62, 'font-size': 9.5, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, o.ref.label));
-    }
-    var placed = [];
-    data.slice().sort(function(a, b){ return a.v - b.v; }).forEach(function(d){
-      var cx = X(d.v), cy = baseY - r - 1, k = 0;
-      while (placed.some(function(p){ return Math.abs(p.x - cx) < step && Math.abs(p.y - cy) < step; })) { k++; cy = baseY - r - 1 - k * step; }
-      placed.push({ x: cx, y: cy, d: d });
-    });
-    placed.forEach(function(p){ var d = p.d; svg.appendChild(mk('circle', { cx: p.x, cy: p.y, r: d.hl ? 6.5 : r, fill: d.hl ? o.hlColor : o.dotColor, 'fill-opacity': d.hl ? 1 : 0.8, stroke: d.hl ? '#fff' : 'none', 'stroke-width': d.hl ? 1.6 : 0 })); });
-    placed.forEach(function(p){
-      if (!p.d.label) return;
-      var ly = p.y - (p.d.hl ? 17 : 14);
-      svg.appendChild(mk('line', { x1: p.x, y1: p.y - (p.d.hl ? 9 : 6), x2: p.x, y2: ly + 3, stroke: p.d.hl ? o.hlColor : ink(), 'stroke-width': 1, opacity: 0.55 }));
-      svg.appendChild(mk('text', { x: p.x, y: ly, 'text-anchor': 'middle', 'font-size': p.d.hl ? 12 : 10, 'font-weight': p.d.hl ? 800 : 700, fill: p.d.hl ? o.hlColor : ink(), 'font-family': 'Inter, sans-serif' }, p.d.hl ? (p.d.label + ' ' + p.d.v + 't') : p.d.label));
-    });
-    svg.appendChild(mk('text', { x: (mL + W - mR) / 2, y: H - 6, 'text-anchor': 'middle', 'font-size': 9.5, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, o.axisLabel));
-    if (o.callout) callout(svg, o.callout.x, o.callout.y, o.callout.anchor, o.callout.lines);
-  }
-
-  /* ---------- Funnel (a narrowing pipeline) ---------- */
-  function funnel(id, data, o) {
-    var svg = frame(id); if (!svg) return;
-    var mT = 22, mB = 18, cx = W / 2 + 18, n = data.length, gap = 9, maxW = W - 200;
-    var bh = (H - mT - mB - gap * (n - 1)) / n;
-    function bw(v){ return (v / o.vMax) * maxW; }
-    data.forEach(function(d, i){
-      var y = mT + i * (bh + gap), w = bw(d.v);
-      if (i < n - 1) {
-        var w2 = bw(data[i+1].v), y2 = y + bh + gap;
-        svg.appendChild(mk('path', { d: 'M' + (cx - w/2) + ',' + (y + bh) + ' L' + (cx + w/2) + ',' + (y + bh) + ' L' + (cx + w2/2) + ',' + y2 + ' L' + (cx - w2/2) + ',' + y2 + ' Z', fill: o.colors[i], opacity: 0.13 }));
-      }
-      var fill = vGrad(svg, id + '-f' + i, o.colors[i], 0.95, 0.68);
-      var rect = mk('rect', { x: cx - w/2, y: y, width: w, height: bh, rx: 5, fill: fill });
-      svg.appendChild(rect); fadeIn(rect, i * 0.1);
-      svg.appendChild(mk('text', { x: 16, y: y + bh/2 + 4, 'font-size': 11, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, d.label));
-      svg.appendChild(mk('text', { x: cx + w/2 - 9, y: y + bh/2 + 4.5, 'text-anchor': 'end', 'font-size': 13, 'font-weight': 800, fill: '#fff', 'font-family': 'Inter, sans-serif' }, d.v + '%'));
-    });
-  }
-
-  /* ---------- Radial donut (parts of a whole) ---------- */
-  function donut(id, data, o) {
-    var svg = frame(id); if (!svg) return;
-    var cx = 138, cy = 150, rO = 92, rI = 54, total = data.reduce(function(s, d){ return s + d.v; }, 0);
-    function arc(a0, a1) {
-      var p0o = polar(cx, cy, rO, a0), p1o = polar(cx, cy, rO, a1), p1i = polar(cx, cy, rI, a1), p0i = polar(cx, cy, rI, a0);
-      var lg = (a1 - a0) > 180 ? 1 : 0;
-      return 'M' + p0o[0].toFixed(1) + ',' + p0o[1].toFixed(1) + ' A' + rO + ',' + rO + ' 0 ' + lg + ' 1 ' + p1o[0].toFixed(1) + ',' + p1o[1].toFixed(1) +
-             ' L' + p1i[0].toFixed(1) + ',' + p1i[1].toFixed(1) + ' A' + rI + ',' + rI + ' 0 ' + lg + ' 0 ' + p0i[0].toFixed(1) + ',' + p0i[1].toFixed(1) + ' Z';
-    }
-    var ang = 0;
-    data.forEach(function(d, i){
-      var a1 = ang + d.v / total * 360;
-      var p = mk('path', { d: arc(ang, a1), fill: d.color });
-      svg.appendChild(p); fadeIn(p, i * 0.08);
-      ang = a1;
-    });
-    // centre stat
-    svg.appendChild(mk('text', { x: cx, y: cy - 4, 'text-anchor': 'middle', 'font-size': 28, 'font-weight': 800, fill: ink(), 'font-family': 'Inter, sans-serif' }, o.centerBig));
-    svg.appendChild(mk('text', { x: cx, y: cy + 14, 'text-anchor': 'middle', 'font-size': 11, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, o.centerSub));
-    // legend
-    var lx = 268, ly = 44, lh = (H - 70) / data.length;
-    data.forEach(function(d, i){
-      var y = ly + i * lh;
-      svg.appendChild(mk('rect', { x: lx, y: y - 9, width: 12, height: 12, rx: 3, fill: d.color }));
-      svg.appendChild(mk('text', { x: lx + 19, y: y + 1, 'font-size': 11.5, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, d.label));
-      svg.appendChild(mk('text', { x: W - 16, y: y + 1, 'text-anchor': 'end', 'font-size': 12, 'font-weight': 800, fill: d.color, 'font-family': 'Inter, sans-serif' }, d.v + '%'));
-    });
-  }
-
-  /* ---------- Dumbbell (gap between two values) ---------- */
-  function dumbbell(id, data, o) {
-    var svg = frame(id); if (!svg) return;
-    var mL = 134, mR = 26, mT = 44, mB = 30;
-    var n = data.length, rowH = (H - mT - mB) / n;
-    function X(v){ return mL + (v / 100) * (W - mL - mR); }
-    [0, 25, 50, 75, 100].forEach(function(t){
-      svg.appendChild(mk('line', { x1: X(t), y1: mT - 6, x2: X(t), y2: H - mB, stroke: gridc(), 'stroke-width': 1 }));
-      tick(svg, X(t), H - mB + 15, t + '%');
-    });
-    // legend
-    svg.appendChild(mk('circle', { cx: mL + 2, cy: 22, r: 5, fill: o.fColor }));
-    svg.appendChild(mk('text', { x: mL + 12, y: 26, 'font-size': 11, 'font-weight': 700, fill: o.fColor, 'font-family': 'Inter, sans-serif' }, 'Women'));
-    svg.appendChild(mk('circle', { cx: mL + 78, cy: 22, r: 5, fill: o.mColor }));
-    svg.appendChild(mk('text', { x: mL + 88, y: 26, 'font-size': 11, 'font-weight': 700, fill: o.mColor, 'font-family': 'Inter, sans-serif' }, 'Men'));
-    data.forEach(function(d, i){
-      var y = mT + i * rowH + rowH / 2;
-      svg.appendChild(mk('text', { x: mL - 12, y: y + 4, 'text-anchor': 'end', 'font-size': 11.5, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, d.label));
-      var xf = X(d.f), xm = X(d.m), lo = Math.min(xf, xm), hi = Math.max(xf, xm);
-      var line = mk('line', { x1: lo, y1: y, x2: hi, y2: y, stroke: ink(), 'stroke-width': 2.4, 'stroke-linecap': 'round', opacity: 0.45 });
-      svg.appendChild(line); fadeIn(line, i * 0.08);
-      svg.appendChild(mk('circle', { cx: xm, cy: y, r: 5.5, fill: o.mColor }));
-      svg.appendChild(mk('circle', { cx: xf, cy: y, r: 5.5, fill: o.fColor }));
-      // value labels: put each just outside its dot
-      svg.appendChild(mk('text', { x: xf + (xf <= xm ? -9 : 9), y: y + 4, 'text-anchor': xf <= xm ? 'end' : 'start', 'font-size': 11, 'font-weight': 800, fill: o.fColor, 'font-family': 'Inter, sans-serif' }, d.f));
-      svg.appendChild(mk('text', { x: xm + (xm < xf ? -9 : 9), y: y + 4, 'text-anchor': xm < xf ? 'end' : 'start', 'font-size': 11, 'font-weight': 800, fill: o.mColor, 'font-family': 'Inter, sans-serif' }, d.m));
-    });
-  }
-
-  /* ---------- Heatmap (matrix) ---------- */
-  function heatmap(id, m, o) {
-    var svg = frame(id); if (!svg) return;
-    var mL = 150, mT = 40, mR = 16, mB = 16, nc = m.cols.length, nr = m.rows.length;
-    var cw = (W - mL - mR) / nc, ch = (H - mT - mB) / nr, gap = 3;
-    function shade(v){ if (v == null) return gridc(); var t = Math.max(0, Math.min(1, (v - o.min) / (o.max - o.min)));
-      // light -> deep green
-      var r = Math.round(237 + (22 - 237) * t), g = Math.round(247 + (138 - 247) * t), b = Math.round(233 + (90 - 233) * t);
-      return 'rgb(' + r + ',' + g + ',' + b + ')'; }
-    m.cols.forEach(function(c, j){ svg.appendChild(mk('text', { x: mL + j * cw + cw / 2, y: mT - 12, 'text-anchor': 'middle', 'font-size': 10.5, 'font-weight': 700, fill: ink(), 'font-family': 'Inter, sans-serif' }, c)); });
-    m.rows.forEach(function(rw, i){
-      svg.appendChild(mk('text', { x: mL - 10, y: mT + i * ch + ch / 2 + 4, 'text-anchor': 'end', 'font-size': 11, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, rw));
-      m.cols.forEach(function(c, j){
-        var v = m.values[i][j], x = mL + j * cw + gap / 2, y = mT + i * ch + gap / 2;
-        var cell = mk('rect', { x: x, y: y, width: cw - gap, height: ch - gap, rx: 5, fill: shade(v) });
-        svg.appendChild(cell); fadeIn(cell, (i + j) * 0.05);
-        var t = v == null ? 0 : Math.max(0, Math.min(1, (v - o.min) / (o.max - o.min)));
-        svg.appendChild(mk('text', { x: x + (cw - gap) / 2, y: y + (ch - gap) / 2 + 4, 'text-anchor': 'middle', 'font-size': 12, 'font-weight': 800, fill: v == null ? ink() : (t > 0.55 ? '#fff' : '#14532d'), 'font-family': 'Inter, sans-serif' }, v == null ? '–' : v + '%'));
-      });
-    });
-  }
-
-  /* ---------- Forest plot (estimate + uncertainty range) ---------- */
-  function forest(id, data, o) {
-    var svg = frame(id); if (!svg) return;
-    var mL = 128, mR = 40, mT = 32, mB = 34, n = data.length, rowH = (H - mT - mB) / n;
-    function X(v){ return mL + (v / o.vMax) * (W - mL - mR); }
-    (o.ticks || []).forEach(function(t){
-      svg.appendChild(mk('line', { x1: X(t), y1: mT - 6, x2: X(t), y2: H - mB, stroke: gridc(), 'stroke-width': 1 }));
-      tick(svg, X(t), H - mB + 15, t + '°');
-    });
-    (o.refs || []).forEach(function(rf){
-      svg.appendChild(mk('line', { x1: X(rf.v), y1: mT - 7, x2: X(rf.v), y2: H - mB + 2, stroke: rf.color, 'stroke-width': 1.2, 'stroke-dasharray': '4,3' }));
-      svg.appendChild(mk('text', { x: X(rf.v) + (rf.side === 'end' ? -3 : 3), y: mT - 10, 'text-anchor': rf.side || 'middle', 'font-size': 9.5, 'font-weight': 700, fill: rf.color, 'font-family': 'JetBrains Mono, monospace' }, rf.label));
-    });
-    data.forEach(function(d, i){
-      var y = mT + i * rowH + rowH / 2;
-      svg.appendChild(mk('text', { x: mL - 12, y: y + 4, 'text-anchor': 'end', 'font-size': 11, fill: ink(), 'font-family': 'Amaranth, sans-serif' }, d.label));
-      var wk = mk('line', { x1: X(d.lo), y1: y, x2: X(d.hi), y2: y, stroke: d.color, 'stroke-width': 2.4, 'stroke-linecap': 'round' });
-      svg.appendChild(wk); fadeIn(wk, i * 0.08);
-      [d.lo, d.hi].forEach(function(v){ svg.appendChild(mk('line', { x1: X(v), y1: y - 4, x2: X(v), y2: y + 4, stroke: d.color, 'stroke-width': 2 })); });
-      svg.appendChild(mk('circle', { cx: X(d.est), cy: y, r: 5, fill: d.color, stroke: '#fff', 'stroke-width': 1.4 }));
-      svg.appendChild(mk('text', { x: X(d.hi) + 8, y: y + 4, 'font-size': 11.5, 'font-weight': 800, fill: d.color, 'font-family': 'Inter, sans-serif' }, d.est + '°'));
-    });
-  }
-
-  /* ---------- Framework: Arnstein's ladder ---------- */
-  function ladder(id) {
-    var svg = frame(id); if (!svg) return;
-    var rungs = [
-      ['Manipulation', COL.red], ['Therapy', COL.red],
-      ['Informing', COL.amber], ['Consultation', COL.amber], ['Placation', COL.amber],
-      ['Partnership', COL.green], ['Delegated power', COL.green], ['Citizen control', COL.green]
-    ];
-    var bands = [['Nonparticipation', COL.red, 0, 2], ['Tokenism', COL.amber, 2, 5], ['Citizen power', COL.green, 5, 8]];
-    var mT = 16, mB = 14, x = 150, rw = 250, n = rungs.length;
-    var rh = (H - mT - mB - (n - 1) * 6) / n;
-    rungs.forEach(function(r, i){
-      var idx = n - 1 - i; // draw top rung first
-      var y = mT + i * (rh + 6);
-      var rect = mk('rect', { x: x, y: y, width: rw, height: rh, rx: 5, fill: rungs[idx][1], opacity: 0.9 });
-      svg.appendChild(rect); fadeIn(rect, i * 0.06);
-      svg.appendChild(mk('text', { x: x + 12, y: y + rh/2 + 4, 'font-size': 12, 'font-weight': 700, fill: '#fff', 'font-family': 'Inter, sans-serif' }, (idx + 1) + '. ' + rungs[idx][0]));
-    });
-    bands.forEach(function(b){
-      var yTop = mT + (n - 1 - (b[3] - 1)) * (rh + 6);
-      var yBot = mT + (n - 1 - b[2]) * (rh + 6) + rh;
-      svg.appendChild(mk('line', { x1: x - 10, y1: yTop + 2, x2: x - 10, y2: yBot - 2, stroke: b[1], 'stroke-width': 3 }));
-      svg.appendChild(mk('text', { x: x - 18, y: (yTop + yBot)/2 + 4, 'text-anchor': 'end', 'font-size': 11, 'font-weight': 700, fill: b[1], 'font-family': 'Inter, sans-serif' }, b[0]));
-    });
-    // upward arrow
-    svg.appendChild(mk('path', { d: 'M' + (x + rw + 18) + ',' + (H - mB) + ' L' + (x + rw + 18) + ',' + (mT + 10), stroke: ink(), 'stroke-width': 1.5, 'marker-end': 'url(#arrUp)' }));
-    var defs = mk('defs', {});
-    var marker = mk('marker', { id: 'arrUp', markerWidth: 8, markerHeight: 8, refX: 4, refY: 6, orient: 'auto' });
-    marker.appendChild(mk('path', { d: 'M0,6 L4,0 L8,6', fill: 'none', stroke: ink(), 'stroke-width': 1.5 }));
-    defs.appendChild(marker); svg.appendChild(defs);
-    svg.appendChild(mk('text', { x: x + rw + 30, y: H/2, 'text-anchor': 'middle', 'font-size': 10, fill: ink(), 'font-family': 'JetBrains Mono, monospace', transform: 'rotate(-90 ' + (x + rw + 30) + ' ' + (H/2) + ')' }, 'more power'));
-  }
-
-  /* ---------- Framework: results chain ---------- */
-  function resultsChain(id) {
-    var svg = frame(id); if (!svg) return;
-    var steps = [['Inputs', COL.slate], ['Activities', COL.slate], ['Outputs', COL.blue], ['Outcomes', COL.teal], ['Impact', COL.purple]];
-    var n = steps.length, bw = 70, by = H/2 - 22, bh = 44, gap = (W - 24 - n * bw) / (n - 1);
-    steps.forEach(function(s, i){
-      var x = 12 + i * (bw + gap);
-      var rect = mk('rect', { x: x, y: by, width: bw, height: bh, rx: 8, fill: s[1], opacity: 0.92 });
-      svg.appendChild(rect); fadeIn(rect, i * 0.1);
-      svg.appendChild(mk('text', { x: x + bw/2, y: by + bh/2 + 4, 'text-anchor': 'middle', 'font-size': 11.5, 'font-weight': 700, fill: '#fff', 'font-family': 'Inter, sans-serif' }, s[1]===COL.slate? s[0] : s[0]));
-      if (i < n - 1) {
-        var ax = x + bw, ax2 = x + bw + gap;
-        svg.appendChild(mk('path', { d: 'M' + (ax + 3) + ',' + (by + bh/2) + ' L' + (ax2 - 3) + ',' + (by + bh/2), stroke: ink(), 'stroke-width': 1.6, 'marker-end': 'url(#arrR)' }));
-      }
-    });
-    var defs = mk('defs', {});
-    var marker = mk('marker', { id: 'arrR', markerWidth: 8, markerHeight: 8, refX: 6, refY: 4, orient: 'auto' });
-    marker.appendChild(mk('path', { d: 'M0,0 L8,4 L0,8', fill: ink() }));
-    defs.appendChild(marker); svg.appendChild(defs);
-    // attribution gap between Outputs (i=2) and Outcomes (i=3)
-    var gx = 12 + 2 * (bw + gap) + bw + gap/2;
-    svg.appendChild(mk('line', { x1: gx, y1: by - 22, x2: gx, y2: by + bh + 22, stroke: COL.red, 'stroke-width': 1.5, 'stroke-dasharray': '4,4' }));
-    svg.appendChild(mk('text', { x: gx, y: by - 28, 'text-anchor': 'middle', 'font-size': 10.5, 'font-weight': 700, fill: COL.red, 'font-family': 'Inter, sans-serif' }, 'the attribution gap'));
-    svg.appendChild(mk('text', { x: W/2, y: H - 14, 'text-anchor': 'middle', 'font-size': 10, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, 'what we control  →  what we hope to cause'));
-  }
-
-  /* ---------- Framework: poverty trap loop ---------- */
-  function trapLoop(id) {
-    var svg = frame(id); if (!svg) return;
-    var cx = W/2, cy = H/2 + 2, r = 86, nr = 33;
-    var nodes = [['Low', 'income', COL.red], ['Low', 'savings', COL.amber], ['Low', 'investment', COL.purple], ['Low', 'productivity', COL.blue]];
-    var pts = nodes.map(function(_, i){ var a = (i / nodes.length) * 2 * Math.PI - Math.PI/2; return [cx + r * Math.cos(a), cy + r * Math.sin(a)]; });
-    var defs = mk('defs', {});
-    var marker = mk('marker', { id: id + '-arr', markerWidth: 10, markerHeight: 10, refX: 7, refY: 5, orient: 'auto' });
-    marker.appendChild(mk('path', { d: 'M0,0 L10,5 L0,10 Z', fill: '#e11d48' }));
-    defs.appendChild(marker); svg.appendChild(defs);
-    for (var i = 0; i < pts.length; i++) {
-      var p = pts[i], q = pts[(i+1) % pts.length];
-      var a0 = Math.atan2(p[1]-cy, p[0]-cx), a1 = Math.atan2(q[1]-cy, q[0]-cx);
-      // start/end on the node rims, arc bowed outward
-      var sx = p[0] + Math.cos(a0 + 0.7) * 0, sy = p[1];
-      var s = [cx + (r) * Math.cos(a0 + 0.42), cy + (r) * Math.sin(a0 + 0.42)];
-      var e = [cx + (r) * Math.cos(a1 - 0.42), cy + (r) * Math.sin(a1 - 0.42)];
-      var mcx = (s[0]+e[0])/2, mcy = (s[1]+e[1])/2, ol = Math.hypot(mcx-cx, mcy-cy);
-      var ctrl = [mcx + (mcx-cx)/ol * 26, mcy + (mcy-cy)/ol * 26];
-      var path = mk('path', { d: 'M' + s[0].toFixed(1) + ',' + s[1].toFixed(1) + ' Q' + ctrl[0].toFixed(1) + ',' + ctrl[1].toFixed(1) + ' ' + e[0].toFixed(1) + ',' + e[1].toFixed(1), fill: 'none', stroke: '#e11d48', 'stroke-width': 2.6, 'stroke-linecap': 'round', 'marker-end': 'url(#' + id + '-arr)' });
-      svg.appendChild(path); animPath(path);
-    }
-    pts.forEach(function(p, i){
-      var g = mk('g', {}); fadeIn(g, i * 0.12);
-      g.appendChild(mk('circle', { cx: p[0], cy: p[1], r: nr, fill: nodes[i][2] }));
-      g.appendChild(mk('text', { x: p[0], y: p[1] - 2, 'text-anchor': 'middle', 'font-size': 10.5, 'font-weight': 600, fill: '#fff', 'font-family': 'Inter, sans-serif' }, nodes[i][0]));
-      g.appendChild(mk('text', { x: p[0], y: p[1] + 11, 'text-anchor': 'middle', 'font-size': 10.5, 'font-weight': 800, fill: '#fff', 'font-family': 'Inter, sans-serif' }, nodes[i][1]));
-      svg.appendChild(g);
-    });
-    svg.appendChild(mk('text', { x: cx, y: cy - 2, 'text-anchor': 'middle', 'font-size': 11, 'font-weight': 700, fill: '#e11d48', 'font-family': 'Inter, sans-serif' }, 'self-' ));
-    svg.appendChild(mk('text', { x: cx, y: cy + 11, 'text-anchor': 'middle', 'font-size': 11, 'font-weight': 700, fill: '#e11d48', 'font-family': 'Inter, sans-serif' }, 'reinforcing'));
-  }
-
-  /* ---------- Framework: intersectionality venn ---------- */
-  function venn(id) {
-    var svg = frame(id); if (!svg) return;
-    var r = 62;
-    var circles = [['Gender', COL.red, 230, 106], ['Caste', '#2563eb', 192, 168], ['Class', COL.amber, 268, 168]];
-    circles.forEach(function(c, i){
-      var circ = mk('circle', { cx: c[2], cy: c[3], r: r, fill: c[1], 'fill-opacity': 0.18, stroke: c[1], 'stroke-width': 2.5 });
-      svg.appendChild(circ); fadeIn(circ, i * 0.12);
-    });
-    svg.appendChild(mk('text', { x: 230, y: 36, 'text-anchor': 'middle', 'font-size': 15, 'font-weight': 800, fill: COL.red, 'font-family': 'Inter, sans-serif' }, 'Gender'));
-    svg.appendChild(mk('text', { x: 138, y: 250, 'text-anchor': 'middle', 'font-size': 15, 'font-weight': 800, fill: '#2563eb', 'font-family': 'Inter, sans-serif' }, 'Caste'));
-    svg.appendChild(mk('text', { x: 322, y: 250, 'text-anchor': 'middle', 'font-size': 15, 'font-weight': 800, fill: COL.amber, 'font-family': 'Inter, sans-serif' }, 'Class'));
-    // central intersection — a clear, readable highlight
-    var ccx = 230, ccy = 149;
-    svg.appendChild(mk('rect', { x: ccx - 44, y: ccy - 15, width: 88, height: 31, rx: 9, fill: '#ffffff', stroke: '#1f2937', 'stroke-width': 1.3 }));
-    svg.appendChild(mk('text', { x: ccx, y: ccy - 1, 'text-anchor': 'middle', 'font-size': 10, 'font-weight': 800, fill: '#1f2937', 'font-family': 'Inter, sans-serif' }, 'compounded'));
-    svg.appendChild(mk('text', { x: ccx, y: ccy + 11, 'text-anchor': 'middle', 'font-size': 10, 'font-weight': 800, fill: '#1f2937', 'font-family': 'Inter, sans-serif' }, 'disadvantage'));
-  }
-
-  /* ---------- Framework: systems iceberg ---------- */
-  function iceberg(id) {
-    var svg = frame(id); if (!svg) return;
-    var waterY = 92, cx = 230;
-    // sea tint below the waterline
-    svg.appendChild(mk('rect', { x: 0, y: waterY, width: W, height: H - waterY, fill: '#4361ee', 'fill-opacity': 0.06 }));
-    // iceberg — small tip above water, broad mass below, centred
-    var berg = mk('path', { d: 'M230,30 L266,92 L300,150 L286,205 L250,248 L210,248 L174,205 L160,150 L194,92 Z', fill: '#cfe3f5', stroke: '#7da9d8', 'stroke-width': 1.5 });
-    svg.appendChild(berg); fadeIn(berg, 0);
-    // waterline across the top
-    svg.appendChild(mk('line', { x1: 0, y1: waterY, x2: W, y2: waterY, stroke: '#4361ee', 'stroke-width': 1.4, 'stroke-dasharray': '6,4', opacity: 0.7 }));
-    svg.appendChild(mk('text', { x: W - 8, y: waterY - 6, 'text-anchor': 'end', 'font-size': 9.5, fill: '#4361ee', 'font-family': 'JetBrains Mono, monospace' }, 'waterline' ));
-    // above-water label on the tip
-    svg.appendChild(mk('text', { x: cx, y: 74, 'text-anchor': 'middle', 'font-size': 12, 'font-weight': 800, fill: '#1d4ed8', 'font-family': 'Inter, sans-serif' }, 'EVENTS'));
-    svg.appendChild(mk('text', { x: cx, y: 86, 'text-anchor': 'middle', 'font-size': 9, fill: '#1d4ed8', 'font-family': 'JetBrains Mono, monospace' }, 'what we see'));
-    // below-water layers, navy text on the light berg
-    [['Patterns of behaviour', 126], ['Structures & systems', 168], ['Mental models', 210]].forEach(function(l){
-      svg.appendChild(mk('text', { x: cx, y: l[1], 'text-anchor': 'middle', 'font-size': 12, 'font-weight': 700, fill: '#13335f', 'font-family': 'Inter, sans-serif' }, l[0]));
-    });
-    // contrast note
-    svg.appendChild(mk('text', { x: 12, y: H - 10, 'font-size': 9.5, fill: ink(), 'font-family': 'JetBrains Mono, monospace' }, 'below the surface: where lasting change happens' ));
-  }
-
-  /* ---------- Framework: make your own (closing) ---------- */
-  function makeYourOwn(id) {
-    var svg = frame(id); if (!svg) return;
-    var cy = H/2;
-    // tiny line
-    var d = 'M40,' + (cy+30) + ' L90,' + (cy-10) + ' L140,' + (cy+10) + ' L190,' + (cy-40);
-    var p = mk('path', { d: d, fill: 'none', stroke: COL.teal, 'stroke-width': 3, 'stroke-linecap': 'round', 'stroke-linejoin': 'round' });
-    svg.appendChild(p); animPath(p);
-    // tiny bars
-    [[260,40,COL.blue],[300,70,COL.amber],[340,30,COL.purple],[380,60,COL.red]].forEach(function(b, i){
-      var rect = mk('rect', { x: b[0], y: cy + 30 - b[1], width: 26, height: b[1], rx: 4, fill: b[2], opacity: 0.9 });
-      svg.appendChild(rect); fadeIn(rect, 0.6 + i*0.1);
-    });
-    svg.appendChild(mk('text', { x: W/2, y: H - 20, 'text-anchor': 'middle', 'font-size': 14, 'font-weight': 800, fill: ink(), 'font-family': 'Inter, sans-serif' }, 'your data, your frame, your turn' ));
-  }
-
-  /* ---------- Render everything ---------- */
-  function renderAll() {
-    lineChart('c-poverty',
-      [{x:1990,y:37.9},{x:2000,y:29.7},{x:2010,y:16.7},{x:2015,y:10.4},{x:2019,y:8.4}],
-      { yMax: 44, color: '#0d9488', area: true, valfmt: function(v){return v+'%';}, xfmt: function(x){return "'"+String(x).slice(2);} });
-
-    lineChart('c-u5mr',
-      [{x:1990,y:127},{x:1995,y:109.7},{x:2000,y:91.8},{x:2005,y:74.3},{x:2010,y:58.1},{x:2015,y:43.7},{x:2020,y:33},{x:2022,y:29.5}],
-      { yMax: 138, color: '#4f46e5', area: true, valfmt: function(v){return Math.round(v);}, labelEvery: 2, xfmt: function(x){return "'"+String(x).slice(2);} });
-
-    hbarChart('c-caste',
-      [{label:'Sched. Tribes',y:44.4,color:'#7d0d23'},{label:'Sched. Castes',y:29.2,color:'#b81d36'},{label:'OBC',y:24.5,color:'#e0566a'},{label:'Others',y:14.9,color:'#f3a6b0'}],
-      { xMax: 50, valfmt: function(v){return v+'%';}, refLine: { value: 24.85, label: 'national 24.8%' } });
-
-    beeswarm('c-co2',
-      [{n:'Qatar',v:43.55,label:'Qatar'},{n:'Kuwait',v:24.90},{n:'UAE',v:20.22},{n:'Saudi',v:17.15},
-       {n:'Canada',v:14.91},{n:'Russia',v:14.45},{n:'Australia',v:14.21},{n:'USA',v:13.83},
-       {n:'S Korea',v:11.04},{n:'China',v:9.24},{n:'Iran',v:9.10},{n:'Poland',v:7.63},
-       {n:'Japan',v:7.54},{n:'Germany',v:7.06},{n:'S Africa',v:6.56},{n:'UK',v:4.42},{n:'France',v:4.25},
-       {n:'Indonesia',v:2.41},{n:'Brazil',v:2.20},{n:'India',v:2.07,hl:true,label:'India'},
-       {n:'Pakistan',v:0.91},{n:'Bangladesh',v:0.71},{n:'Nigeria',v:0.58},{n:'Ethiopia',v:0.14},{n:'DR Congo',v:0.04}],
-      { vMax: 46, ticks: [0,10,20,30,40], dotColor: '#94a3b8', hlColor: '#0d9488',
-        ref: { v: 4.7, label: 'world avg' }, axisLabel: 'tonnes CO₂ per person, per year (2023)' });
-
-    funnel('c-pipeline',
-      [{label:'Primary (1–5)',v:104.8},{label:'Upper primary',v:94.9},{label:'Secondary',v:79.4},{label:'Higher secondary',v:57.6},{label:'Higher education',v:28.5}],
-      { vMax: 104.8, colors: ['#0d9488','#22a06b','#eab308','#f97316','#e11d48'] });
-
-    donut('c-energy',
-      [{label:'Coal',v:73,color:'#475569'},{label:'Hydro',v:8,color:'#2563eb'},{label:'Solar',v:7,color:'#f59e0b'},
-       {label:'Wind',v:5,color:'#0ea5a4'},{label:'Nuclear',v:3,color:'#7c3aed'},{label:'Gas',v:2,color:'#94a3b8'},{label:'Bioenergy',v:2,color:'#16a34a'}],
-      { centerBig: '73%', centerSub: 'still fossil' });
-
-    dumbbell('c-gender',
-      [{label:'Adult literacy',m:84.7,f:70.3},{label:'College enrolment',m:28.3,f:28.5},
-       {label:'In the labour force',m:78.8,f:41.7},{label:'Seats in the Lok Sabha',m:86.6,f:13.4}],
-      { mColor: '#1971c2', fColor: '#d6336c' });
-
-    heatmap('c-nfhs',
-      { cols: ['NFHS-3 ’05', 'NFHS-4 ’15', 'NFHS-5 ’21'],
-        rows: ['Institutional births', 'Full immunisation', 'Woman uses a bank a/c', 'Child not stunted', 'Woman not anaemic'],
-        values: [[39,79,89],[44,62,76],[null,53,79],[52,62,64],[45,47,43]] },
-      { min: 38, max: 90 });
-
-    forest('c-forest',
-      [{label:'Net zero ~2050', est:1.4, lo:1.0, hi:1.8, color:'#16a34a'},
-       {label:'Strong cuts', est:1.8, lo:1.3, hi:2.4, color:'#0d9488'},
-       {label:'Middle of the road', est:2.7, lo:2.1, hi:3.5, color:'#eab308'},
-       {label:'High emissions', est:3.6, lo:2.8, hi:4.6, color:'#f97316'},
-       {label:'Very high emissions', est:4.4, lo:3.3, hi:5.7, color:'#e11d48'}],
-      { vMax: 6, ticks: [0,2,4,6], refs: [{v:1.5, label:'1.5°', color:'#16a34a', side:'end'}, {v:2.0, label:'2° Paris', color:'#e11d48', side:'start'}] });
-
-    lineChart('c-flfp',
-      [{x:2017.5,y:23.3},{x:2021.5,y:32.8},{x:2022.5,y:37.0},{x:2023.5,y:41.7}],
-      { yMax: 50, color: '#7c3aed', area: true, valfmt: function(v){return v.toFixed(1)+'%';},
-        xfmt: function(x){var a=Math.floor(x); return "'"+String(a).slice(2)+"–"+String(a+1).slice(2);} });
-
-    climateChart('c-climate');
-    ethicChart('c-ethic');
-
-    ladder('f-ladder');
-    resultsChain('f-toc');
-    trapLoop('f-trap');
-    venn('f-venn');
-    iceberg('f-iceberg');
-    makeYourOwn('f-make');
-  }
-
-  /* ============================================================
-     MASTERS' WING — recreated public-domain classics (drawn once)
-     ============================================================ */
-  function el(name, attrs) { var n = document.createElementNS(NS, name); for (var k in attrs) n.setAttribute(k, attrs[k]); return n; }
-  function polar(cx, cy, r, deg) { var a = (deg - 90) * Math.PI / 180; return [cx + r * Math.cos(a), cy + r * Math.sin(a)]; }
-  function wedgePath(cx, cy, r, a0, a1) {
-    var p0 = polar(cx, cy, r, a0), p1 = polar(cx, cy, r, a1);
-    var large = (a1 - a0) > 180 ? 1 : 0;
-    return "M" + cx + "," + cy + " L" + p0[0].toFixed(1) + "," + p0[1].toFixed(1) +
-           " A" + r + "," + r + " 0 " + large + " 1 " + p1[0].toFixed(1) + "," + p1[1].toFixed(1) + " Z";
-  }
-
-  function plateTokens() {
-    var dk = document.documentElement.getAttribute('data-theme') === 'dark';
-    return { dk: dk, ink: dk ? '#e8ecf8' : '#1a2236', mut: dk ? '#9aa6c8' : '#5b6678', grid: dk ? 'rgba(255,255,255,0.07)' : 'rgba(20,30,60,0.08)', sep: dk ? '#0e1326' : '#cdbfa3' };
-  }
-  function drawRose() {
-    var svg = document.getElementById('viz-rose'); if (!svg) return;
-    clear(svg); var T = plateTokens();
-    var cx = 200, cy = 165, n = 12, step = 360 / n;
-    var disease = [22, 38, 95, 130, 175, 240, 205, 168, 110, 60, 34, 26];
-    var wounds  = [3, 5, 8, 12, 16, 22, 18, 14, 10, 7, 5, 4];
-    var other   = [4, 6, 9, 11, 13, 15, 14, 12, 9, 6, 5, 4];
-    var maxR = 130, maxV = Math.max.apply(null, disease.map(function(d,i){return d+wounds[i]+other[i];}));
-    var scale = maxR / Math.sqrt(maxV);
-    function ring(values, fill, op) {
-      for (var i = 0; i < n; i++) {
-        var r = Math.sqrt(values[i]) * scale;
-        var path = el('path', { d: wedgePath(cx, cy, r, i*step, (i+1)*step), fill: fill, 'fill-opacity': op, stroke: T.sep, 'stroke-width': 0.6 });
-        if (!reduced()) { path.style.opacity = 0; path.style.transition = 'opacity 0.5s ease ' + (i*0.04) + 's'; }
-        svg.appendChild(path);
-        if (!reduced()) requestAnimationFrame(function(p){ return function(){ p.style.opacity = 1; }; }(path));
-      }
-    }
-    ring(disease.map(function(d,i){return d+wounds[i]+other[i];}), '#3b6fb0', 0.95);
-    ring(wounds.map(function(w,i){return w+other[i];}), '#c0392b', 0.95);
-    ring(other, T.dk ? '#cbd3e6' : '#2b3450', 0.95);
-    svg.appendChild(el('circle', { cx: cx, cy: cy, r: 2, fill: T.ink }));
-    var leg = [['#3b6fb0','Preventable disease'], ['#c0392b','Wounds in battle'], [T.dk ? '#cbd3e6' : '#2b3450','Other causes']];
-    leg.forEach(function(item, i) {
-      svg.appendChild(el('rect', { x: 16, y: 270 + i*15, width: 11, height: 11, rx: 2, fill: item[0] }));
-      var t = el('text', { x: 32, y: 279 + i*15, fill: T.mut, 'font-size': 10, 'font-family': 'JetBrains Mono, monospace' }); t.textContent = item[1]; svg.appendChild(t);
-    });
-  }
-
-  function drawMinard() {
-    var svg = document.getElementById('viz-minard'); if (!svg) return;
-    clear(svg); var T = plateTokens();
-    var advance = [[40,422],[105,400],[165,233],[225,175],[300,127]];
-    var retreat = [[300,100],[235,50],[170,28],[110,20],[55,12],[28,4]];
-    var midY = 118, k = 0.12;
-    function band(pts, fill) {
-      var top = "M", bot = "";
-      pts.forEach(function(p, i) { var t = Math.max(2, p[1]*k); top += (i?" L":"") + p[0] + "," + (midY - t/2).toFixed(1); });
-      for (var i = pts.length - 1; i >= 0; i--) { var t = Math.max(2, pts[i][1]*k); bot += " L" + pts[i][0] + "," + (midY + t/2).toFixed(1); }
-      var path = el('path', { d: top + bot + " Z", fill: fill, stroke: T.sep, 'stroke-width': 0.5 });
-      if (!reduced()) { path.style.opacity = 0; path.style.transition = 'opacity 0.9s ease'; }
-      svg.appendChild(path);
-      if (!reduced()) requestAnimationFrame(function(){ path.style.opacity = 1; });
-    }
-    band(advance, T.dk ? '#d9b38c' : '#b07a30'); band(retreat, T.dk ? '#566' : '#2b3450');
-    svg.appendChild(el('circle', { cx: 300, cy: midY, r: 3.5, fill: '#c0392b' }));
-    var mono = 'JetBrains Mono, monospace';
-    var mt = el('text', { x: 300, y: 84, fill: T.ink, 'font-size': 11, 'font-family': mono, 'text-anchor': 'middle' }); mt.textContent = 'Moscow'; svg.appendChild(mt);
-    var st = el('text', { x: 36, y: 72, fill: T.ink, 'font-size': 11, 'font-family': mono }); st.textContent = '422,000 set out'; svg.appendChild(st);
-    var et = el('text', { x: 24, y: 170, fill: T.mut, 'font-size': 11, 'font-family': mono }); et.textContent = '≈10,000 returned'; svg.appendChild(et);
-    var temps = [[300,206],[235,218],[170,238],[110,256],[55,268],[28,276]];
-    var d = "M"; temps.forEach(function(p,i){ d += (i?" L":"") + p[0] + "," + p[1]; });
-    var tcol = T.dk ? '#8fb4ff' : '#3b6fb0';
-    svg.appendChild(el('path', { d: d, fill: 'none', stroke: tcol, 'stroke-width': 1.6, 'stroke-dasharray': '3,3' }));
-    var tlab = el('text', { x: 24, y: 298, fill: tcol, 'font-size': 9.5, 'font-family': mono }); tlab.textContent = 'temperature on the retreat, to −30°'; svg.appendChild(tlab);
-  }
-
-  function drawSnow() {
-    var svg = document.getElementById('viz-snow'); if (!svg) return;
-    clear(svg); var T = plateTokens();
-    for (var gx = 40; gx <= 360; gx += 40) svg.appendChild(el('line', { x1: gx, y1: 46, x2: gx, y2: 290, stroke: T.grid, 'stroke-width': 1 }));
-    for (var gy = 60; gy <= 280; gy += 40) svg.appendChild(el('line', { x1: 30, y1: gy, x2: 370, y2: gy, stroke: T.grid, 'stroke-width': 1 }));
-    var pump = [200, 158], seed = 7;
-    function rnd() { seed = (seed * 9301 + 49297) % 233280; return seed / 233280; }
-    function gauss() { return (rnd() + rnd() + rnd() + rnd() - 2) / 2; }
-    for (var i = 0; i < 90; i++) {
-      var x = Math.max(34, Math.min(366, pump[0] + gauss() * 70)), y = Math.max(50, Math.min(286, pump[1] + gauss() * 52));
-      var dot = el('rect', { x: x.toFixed(1), y: y.toFixed(1), width: 3.6, height: 3.6, fill: T.dk ? '#dfe5f2' : '#1a1f33', stroke: 'none' });
-      if (!reduced()) { dot.style.opacity = 0; dot.style.transition = 'opacity 0.4s ease ' + (i*0.012) + 's'; }
-      svg.appendChild(dot);
-      if (!reduced()) requestAnimationFrame(function(d){ return function(){ d.style.opacity = 1; }; }(dot));
-    }
-    [[80,84],[330,100],[300,252],[92,246]].forEach(function(p) { svg.appendChild(el('circle', { cx: p[0], cy: p[1], r: 5, fill: 'none', stroke: T.mut, 'stroke-width': 1.5 })); });
-    svg.appendChild(el('circle', { cx: pump[0], cy: pump[1], r: 9, fill: 'none', stroke: '#d6336c', 'stroke-width': 2 }));
-    svg.appendChild(el('circle', { cx: pump[0], cy: pump[1], r: 4, fill: '#d6336c' }));
-    // legend (kept clear of the cluster)
-    svg.appendChild(el('circle', { cx: 24, cy: 26, r: 4, fill: '#d6336c' }));
-    var lab = el('text', { x: 34, y: 30, fill: T.mut, 'font-size': 10.5, 'font-family': 'JetBrains Mono, monospace' }); lab.textContent = 'the Broad Street pump · each mark is a death'; svg.appendChild(lab);
-  }
-
-  function drawDuBois() {
-    var svg = document.getElementById('viz-dubois'); if (!svg) return;
-    clear(svg);
-    var cx = 200, cy = 160, palette = ['#c1272d', '#e8b22a', '#21563f', '#1b1b3a', '#d98e2b', '#7a5230'], segs = 30, base = 6, turns = 3.4, prev = null;
-    for (var i = 0; i < segs; i++) {
-      var ang = (i / segs) * turns * 360, rad = base + i * 4.6, p = polar(cx, cy, rad, ang);
-      if (prev) {
-        var seg = el('line', { x1: prev[0].toFixed(1), y1: prev[1].toFixed(1), x2: p[0].toFixed(1), y2: p[1].toFixed(1), stroke: palette[i % palette.length], 'stroke-width': 7, 'stroke-linecap': 'round' });
-        if (!reduced()) { seg.style.opacity = 0; seg.style.transition = 'opacity 0.4s ease ' + (i*0.03) + 's'; }
-        svg.appendChild(seg);
-        if (!reduced()) requestAnimationFrame(function(s){ return function(){ s.style.opacity = 1; }; }(seg));
-      }
-      prev = p;
-    }
-    svg.appendChild(el('circle', { cx: cx, cy: cy, r: 5, fill: '#1b1b3a' }));
-    var t1 = el('text', { x: 200, y: 296, fill: '#1b1b3a', 'font-size': 12, 'font-family': 'Inter, sans-serif', 'font-weight': 700, 'text-anchor': 'middle', 'letter-spacing': 2 }); t1.textContent = 'VALUE OF PROPERTY OWNED'; svg.appendChild(t1);
-    var t2 = el('text', { x: 200, y: 312, fill: '#7a5230', 'font-size': 9.5, 'font-family': 'JetBrains Mono, monospace', 'text-anchor': 'middle' }); t2.textContent = 'in the style of W. E. B. Du Bois, 1900'; svg.appendChild(t2);
-  }
-
-  /* ============================================================
-     THE GREATS — curated gallery of modern masterworks (links out)
-     ============================================================ */
-  var VIZ = [
-    { theme:'poverty', tag:'Poverty & Inequality', title:'The Wealth & Health of Nations', who:'Hans Rosling · Gapminder', year:'2006', g:['#48bb78','#4facfe'], desc:'The animated bubble chart that made 200 years of global development legible in four minutes. Income vs. life expectancy, every country, every year.', url:'https://www.gapminder.org/tools/' },
-    { theme:'poverty', tag:'Poverty & Inequality', title:'Dollar Street', who:'Anna Rosling Rönnlund · Gapminder', year:'2016', g:['#ed8936','#f6ad55'], desc:'Homes photographed across the world, sorted by income. It turns an abstract poverty line into toothbrushes, beds and front doors.', url:'https://www.gapminder.org/dollar-street' },
-    { theme:'health', tag:'Public Health', title:'Global Child Mortality', who:'Max Roser · Our World in Data', year:'2013–', g:['#3182ce','#4facfe'], desc:'The single most important — and most hopeful — line in development: the share of children who die before age five, falling across two centuries.', url:'https://ourworldindata.org/child-mortality' },
-    { theme:'race', tag:'Race & Equity', title:'The Data Portraits of Black America', who:'W. E. B. Du Bois', year:'1900', g:['#c1272d','#e8b22a'], desc:'The hand-drawn originals behind our recreation — radical, modernist infographics made to confront the 1900 Paris Exposition with the truth of Black life.', url:'https://www.loc.gov/pictures/collection/anedub/' },
-    { theme:'justice', tag:'Justice & Rights', title:'U.S. Gun Deaths — Stolen Years', who:'Periscopic', year:'2013', g:['#e53e3e','#fc8181'], desc:'Each life arcs across the screen, then is cut short — the grey arc showing the years that person might have lived. Data as elegy.', url:'https://guns.periscopic.com/' },
-    { theme:'migration', tag:'Migration', title:'The Refugee Project', who:'Hyperakt & Ekene Ijeoma', year:'2014', g:['#805ad5','#f093fb'], desc:'Every refugee movement since 1975, mapped and narrated year by year. Migration as a global, historical rhythm rather than a headline.', url:'https://www.therefugeeproject.org/' },
-    { theme:'climate', tag:'Climate', title:'The Carbon Map', who:'Duncan Clark & Robin Houston · Kiln', year:'2013', g:['#38a169','#48bb78'], desc:'The world re-drawn by who emits carbon and who suffers for it — two morphing cartograms that hold the central injustice of climate change in one frame.', url:'https://www.carbonmap.org/' },
-    { theme:'climate', tag:'Climate', title:'Warming Stripes', who:'Ed Hawkins', year:'2018', g:['#3182ce','#e53e3e'], desc:'No axes, no numbers — just a barcode of blue-to-red years. The most-shared climate graphic ever made, because anyone can read it instantly.', url:'https://showyourstripes.info/' },
-    { theme:'health', tag:'Public Health', title:'How the Virus Got Out', who:'The New York Times', year:'2020', g:['#d53f8c','#f093fb'], desc:'A scrollytelling map of the early pandemic — how a local outbreak became a planet-wide event before borders ever closed.', url:'https://www.nytimes.com/interactive/2020/03/22/world/coronavirus-spread.html' },
-    { theme:'gender', tag:'Gender', title:'Women’s Pockets, Quantified', who:'Jan Diehm & Amber Thomas · The Pudding', year:'2018', g:['#d53f8c','#f5a8ff'], desc:'They measured the pockets on 80 pairs of jeans. A small, witty, rigorous proof of a structural gender inequity hiding in plain sight.', url:'https://pudding.cool/2018/08/pockets/' },
-    { theme:'education', tag:'Education', title:'Segregation Now', who:'ProPublica', year:'2014', g:['#d69e2e','#ed8936'], desc:'How American schools quietly re-segregated, told through one town and decades of enrolment data. Investigative journalism as data narrative.', url:'https://projects.propublica.org/segregation-now/' },
-    { theme:'india', tag:'India & South Asia', title:'People’s Archive of Rural India', who:'PARI', year:'2014–', g:['#dd6b20','#f6ad55'], desc:'A living multimedia archive of rural India — maps, faces and livelihoods that national statistics flatten into a single average.', url:'https://ruralindiaonline.org/' },
-    { theme:'india', tag:'India & South Asia', title:'IndiaSpend', who:'IndiaSpend', year:'2011–', g:['#3182ce','#667eea'], desc:'India’s pioneering data-journalism newsroom — health, gender, jobs and budgets charted from the public record, story after story.', url:'https://www.indiaspend.com/' },
-    { theme:'climate', tag:'Climate', title:'2°C: Beyond the Limit', who:'The Washington Post', year:'2019', g:['#e53e3e','#ed8936'], desc:'A Pulitzer-winning series mapping the places already past 2°C of warming. Global abstraction made local and undeniable.', url:'https://www.washingtonpost.com/graphics/2019/national/climate-environment/climate-change-world/' },
-    { theme:'poverty', tag:'Poverty & Inequality', title:'Information is Beautiful', who:'David McCandless', year:'2009–', g:['#667eea','#4facfe'], desc:'The studio that made data visualization mainstream — endlessly studied for how colour, scale and wit turn numbers into something you actually feel.', url:'https://informationisbeautiful.net/' },
-    { theme:'india', tag:'India & South Asia', title:'Reuters Graphics', who:'Reuters', year:'ongoing', g:['#dd6b20','#e53e3e'], desc:'Award-winning visual investigations, often on South Asia — migrant labour, heat, elections. A reference standard for newsroom dataviz craft.', url:'https://www.reuters.com/graphics/' }
-  ];
-
-  function buildCards() {
-    var host = document.getElementById('cards'); if (!host) return;
-    VIZ.forEach(function(v) {
-      var a = document.createElement('a');
-      a.className = 'viz-card'; a.href = v.url; a.target = '_blank'; a.rel = 'noopener'; a.setAttribute('data-theme-cat', v.theme);
-      var sw = document.createElement('div'); sw.className = 'swatch'; sw.style.background = 'linear-gradient(135deg, ' + v.g[0] + ', ' + v.g[1] + ')';
-      var body = document.createElement('div'); body.className = 'vbody';
-      var tag = document.createElement('span'); tag.className = 'theme-tag'; tag.textContent = v.tag;
-      var h = document.createElement('h3'); h.textContent = v.title;
-      var meta = document.createElement('div'); meta.className = 'meta'; meta.textContent = v.who + ' · ' + v.year;
-      var p = document.createElement('p'); p.textContent = v.desc;
-      var view = document.createElement('span'); view.className = 'view'; view.textContent = 'View the original →';
-      body.appendChild(tag); body.appendChild(h); body.appendChild(meta); body.appendChild(p); body.appendChild(view);
-      a.appendChild(sw); a.appendChild(body); host.appendChild(a);
-    });
-  }
-
-  function wireFilters() {
-    var chips = document.querySelectorAll('.filter-chip');
-    chips.forEach(function(chip) {
-      chip.addEventListener('click', function() {
-        chips.forEach(function(c){ c.classList.remove('active'); });
-        chip.classList.add('active');
-        var f = chip.getAttribute('data-filter');
-        document.querySelectorAll('.viz-card').forEach(function(card) {
-          card.classList.toggle('hidden', !(f === 'all' || card.getAttribute('data-theme-cat') === f));
-        });
-      });
-    });
-  }
-
-  /* ---------- reveal cards + hero dots ---------- */
-  function reveal() {
-    var cards = document.querySelectorAll('[data-card], [data-plate]');
-    if (!('IntersectionObserver' in window)) { cards.forEach(function(c){ c.classList.add('in'); }); return; }
-    var io = new IntersectionObserver(function(entries){
-      entries.forEach(function(e){ if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } });
-    }, { threshold: 0.15 });
-    cards.forEach(function(c){ io.observe(c); });
-  }
-  function heroDots() {
-    var host = document.getElementById('heroDots'); if (!host) return;
-    for (var i = 0; i < 24; i++) {
-      var s = document.createElement('span');
-      var size = (Math.random() * 4 + 1.5).toFixed(1);
-      s.style.width = size + 'px'; s.style.height = size + 'px';
-      s.style.left = (Math.random() * 100).toFixed(1) + '%';
-      s.style.top = (Math.random() * 100).toFixed(1) + '%';
-      s.style.animationDelay = (Math.random() * 9).toFixed(1) + 's';
-      s.style.opacity = (Math.random() * 0.6 + 0.2).toFixed(2);
-      host.appendChild(s);
-    }
-  }
-
-  document.addEventListener('DOMContentLoaded', function() {
-    heroDots(); reveal(); renderAll();
-    function drawMasters(){ drawRose(); drawMinard(); drawSnow(); drawDuBois(); }
-    drawMasters();
-    buildCards(); wireFilters();
-    // re-render charts and recreations when the theme changes so ink/grid stay legible
-    var obs = new MutationObserver(function(muts){
-      muts.forEach(function(m){ if (m.attributeName === 'data-theme') { renderAll(); drawMasters(); } });
-    });
+(function(){
+  function init(){
+    LV.heroDots(); LV.reveal(); LV.renderAll(); LV.drawMasters(); LV.buildCards(); LV.wireFilters();
+    var obs = new MutationObserver(function(ms){ ms.forEach(function(m){ if (m.attributeName === 'data-theme') { LV.renderAll(); LV.drawMasters(); } }); });
     obs.observe(document.documentElement, { attributes: true });
-  });
+  }
+  if (document.readyState !== 'loading') init(); else document.addEventListener('DOMContentLoaded', init);
 })();
 </script>
 

--- a/the-long-view/chart.html
+++ b/the-long-view/chart.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-JRCMEB9TBW');</script>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="An ImpactMojo original chart, explained: the data and source, why this chart type, how it's built, and what to look for.">
+<title>Chart — The Long View | ImpactMojo</title>
+<link href="/assets/images/favicon.png" rel="icon" type="image/png">
+<meta name="theme-color" content="#667eea">
+<link href="https://fonts.googleapis.com" rel="preconnect">
+<link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&amp;family=Inter:wght@400;500;600;700;800&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
+<style>
+:root{--font-body:'Amaranth',Arial,sans-serif;--font-heading:'Inter',Helvetica,sans-serif;--font-mono:'JetBrains Mono',monospace;--color-primary:#667eea;--color-text:#2d3748;--color-text-muted:#718096;--color-bg:#f7fafc;--color-bg-card:#fff;--color-border:#e2e8f0;--chart-ink:#475569;--chart-grid:#e8edf4;}
+[data-theme="dark"]{--color-text:#e2e8f0;--color-text-muted:#a0aec0;--color-bg:#141a26;--color-bg-card:#1f2735;--color-border:#33415a;--chart-ink:#aab6cc;--chart-grid:#2c374a;}
+*{box-sizing:border-box;}
+body{margin:0;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg);line-height:1.65;padding-top:44px;-webkit-font-smoothing:antialiased;}
+@media (prefers-reduced-motion:reduce){*{animation-duration:.001ms!important;transition-duration:.001ms!important;}}
+h1,h2,h3{font-family:var(--font-heading);font-weight:800;line-height:1.2;}
+a{color:var(--color-primary);}
+.skip-link{position:absolute;left:-999px;top:0;z-index:10000;background:var(--color-primary);color:#fff;padding:10px 16px;border-radius:0 0 8px 0;}
+.skip-link:focus{left:0;}
+.im-topbar{position:fixed;top:0;left:0;right:0;z-index:9999;background:rgba(16,21,34,.95);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);border-bottom:1px solid rgba(255,255,255,.08);padding:.5rem 1rem;display:flex;align-items:center;justify-content:space-between;gap:.75rem;}
+.im-topbar-home{display:flex;align-items:center;gap:.5rem;color:#fff;text-decoration:none;font-family:var(--font-heading);font-weight:700;}
+.im-theme-selector{display:flex;gap:2px;background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.08);border-radius:8px;padding:2px;}
+.im-theme-btn{background:transparent;border:none;color:#9aa6c8;padding:6px;border-radius:5px;cursor:pointer;transition:all .2s;display:flex;align-items:center;justify-content:center;width:30px;height:30px;}
+.im-theme-btn:hover{background:rgba(255,255,255,.1);color:#fff;}
+.im-theme-btn.active{background:var(--color-primary);color:#fff;}
+.im-theme-btn svg{width:16px;height:16px;}
+.wrap{max-width:840px;margin:0 auto;padding:2rem 1.5rem 3rem;}
+.crumb{font-family:var(--font-mono);font-size:.8rem;color:var(--color-text-muted);text-decoration:none;}
+.crumb:hover{color:var(--color-primary);}
+.tag{display:inline-block;font-family:var(--font-mono);font-size:.7rem;letter-spacing:1.4px;text-transform:uppercase;color:var(--color-primary);background:rgba(102,126,234,.12);padding:.25rem .6rem;border-radius:6px;margin:1.4rem 0 .6rem;}
+h1{font-size:clamp(1.8rem,4vw,2.6rem);margin:0 0 .6rem;}
+.takeaway{font-size:1.2rem;color:var(--color-text);font-family:var(--font-heading);font-weight:600;margin:0 0 1.6rem;}
+.chart-stage{background:var(--color-bg-card);border:1px solid var(--color-border);border-radius:18px;padding:1.6rem;box-shadow:0 10px 30px rgba(15,23,42,.06);}
+.chart-stage svg{width:100%;height:auto;display:block;}
+.detail-grid{display:grid;grid-template-columns:1fr;gap:1.4rem;margin-top:2rem;}
+@media(min-width:640px){.detail-grid{grid-template-columns:1fr 1fr;}}
+.block{background:var(--color-bg-card);border:1px solid var(--color-border);border-radius:14px;padding:1.2rem 1.3rem;}
+.block h3{font-size:.78rem;font-family:var(--font-mono);letter-spacing:1.5px;text-transform:uppercase;color:var(--color-text-muted);margin:0 0 .5rem;}
+.block p{margin:0;font-size:.97rem;color:var(--color-text);}
+.block.source{grid-column:1/-1;}
+.block.source p{font-family:var(--font-mono);font-size:.86rem;color:var(--color-text-muted);}
+.pager{display:flex;justify-content:space-between;gap:1rem;margin-top:2.4rem;border-top:1px solid var(--color-border);padding-top:1.4rem;}
+.pager a{text-decoration:none;color:var(--color-text);max-width:46%;}
+.pager a span{display:block;font-family:var(--font-mono);font-size:.72rem;color:var(--color-text-muted);}
+.pager a strong{font-family:var(--font-heading);font-weight:700;font-size:.95rem;color:var(--color-primary);}
+.pager a.next{text-align:right;}
+.site-footer{background:#101522;color:#9aa6c8;text-align:center;padding:2rem 1.5rem;font-size:.85rem;}
+.site-footer a{color:#cdd5f2;}
+</style>
+</head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div class="im-topbar">
+  <a href="/index.html" class="im-topbar-home"><img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="28" height="28" style="border-radius:6px;"><span>ImpactMojo</span></a>
+  <div class="im-theme-selector" aria-label="Theme selection">
+    <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="Use system theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
+    <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Use light theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg></button>
+    <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Use dark theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+  </div>
+</div>
+
+<main id="main" class="wrap">
+  <a href="/the-long-view.html" class="crumb">← The Long View</a>
+  <span class="tag" id="d-tag">Chart</span>
+  <h1 id="d-title">Loading…</h1>
+  <p class="takeaway" id="d-takeaway"></p>
+  <div class="chart-stage"><div id="chart-holder"></div></div>
+  <div class="detail-grid">
+    <div class="block"><h3>Why this chart</h3><p id="d-why"></p></div>
+    <div class="block"><h3>How it's built</h3><p id="d-how"></p></div>
+    <div class="block"><h3>What to look for</h3><p id="d-look"></p></div>
+    <div class="block source"><h3>The data</h3><p id="d-source"></p></div>
+  </div>
+  <nav class="pager">
+    <a class="prev" id="d-prev" href="#"><span>Previous</span><strong></strong></a>
+    <a class="next" id="d-next" href="#"><span>Next</span><strong></strong></a>
+  </nav>
+</main>
+
+<footer class="site-footer"><p>© 2026 ImpactMojo · <a href="/the-long-view.html">Back to The Long View</a> · <a href="/index.html">Home</a></p></footer>
+
+<script>
+(function(){
+  function getSys(){return window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark';}
+  function apply(t){var r=t==='system'?getSys():t;document.documentElement.setAttribute('data-theme',r);}
+  function upd(p){document.querySelectorAll('.im-theme-btn').forEach(function(b){b.classList.toggle('active',b.getAttribute('data-imtheme')===p);});}
+  var saved=localStorage.getItem('im-theme')||'system';apply(saved);
+  document.addEventListener('DOMContentLoaded',function(){upd(saved);document.querySelectorAll('.im-theme-btn').forEach(function(b){b.addEventListener('click',function(){var t=this.getAttribute('data-imtheme');localStorage.setItem('im-theme',t);apply(t);upd(t);});});});
+  window.matchMedia('(prefers-color-scheme: light)').addEventListener('change',function(){if((localStorage.getItem('im-theme')||'system')==='system')apply('system');});
+})();
+</script>
+<script src="/js/longview-charts.js"></script>
+<script>
+(function(){
+  function init(){
+    var id=new URLSearchParams(location.search).get('c');
+    var d=LV.DETAILS&&LV.DETAILS[id];
+    if(!d){location.replace('/the-long-view.html');return;}
+    document.title=d.title+' — The Long View | ImpactMojo';
+    document.getElementById('d-tag').textContent=d.tag;
+    document.getElementById('d-title').textContent=d.title;
+    document.getElementById('d-takeaway').textContent=d.takeaway;
+    document.getElementById('d-why').textContent=d.why;
+    document.getElementById('d-how').textContent=d.how;
+    document.getElementById('d-look').textContent=d.look;
+    document.getElementById('d-source').textContent=d.source;
+    var holder=document.getElementById('chart-holder');
+    holder.innerHTML='<svg id="'+id+'" role="img" aria-label="'+d.title+'"></svg>';
+    LV.renderAll();
+    var order=LV.ORDER,i=order.indexOf(id),n=order.length;
+    var pv=order[(i-1+n)%n],nx=order[(i+1)%n];
+    var pe=document.getElementById('d-prev'),ne=document.getElementById('d-next');
+    pe.href='/the-long-view/chart.html?c='+pv; pe.querySelector('strong').textContent=LV.DETAILS[pv].title;
+    ne.href='/the-long-view/chart.html?c='+nx; ne.querySelector('strong').textContent=LV.DETAILS[nx].title;
+    new MutationObserver(function(ms){ms.forEach(function(m){if(m.attributeName==='data-theme')LV.renderAll();});}).observe(document.documentElement,{attributes:true});
+  }
+  if(document.readyState!=='loading')init();else document.addEventListener('DOMContentLoaded',init);
+})();
+</script>
+</body>
+</html>

--- a/the-long-view/gallery.html
+++ b/the-long-view/gallery.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-JRCMEB9TBW');</script>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="The classics rebuilt and the greats — famous data visualizations rebuilt in code, and modern masterworks worth studying. A companion to ImpactMojo's The Long View.">
+<title>The classics &amp; the greats — The Long View | ImpactMojo</title>
+<link href="/assets/images/favicon.png" rel="icon" type="image/png">
+<meta name="theme-color" content="#667eea">
+<link href="https://fonts.googleapis.com" rel="preconnect">
+<link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&amp;family=Inter:wght@400;500;600;700;800&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/css/longview.css">
+</head>
+<body>
+<a href="#main-content" class="skip-link">Skip to content</a>
+<div class="im-topbar" id="imTopbar">
+  <div class="im-topbar-left">
+    <a href="/index.html" class="im-topbar-home"><img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="28" height="28" style="border-radius:6px;"><span>ImpactMojo</span></a>
+  </div>
+  <div class="im-topbar-right">
+    <a href="/the-long-view.html" class="im-premium-btn" style="background:rgba(255,255,255,0.08);">← The Long View</a>
+    <div class="im-theme-selector" aria-label="Theme selection">
+      <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="Use system theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Use light theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Use dark theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+    </div>
+  </div>
+</div>
+<header class="hero" style="padding:4.5rem 1.5rem 3.5rem;">
+  <div class="hero-inner">
+    <span class="eyebrow">A companion to The Long View</span>
+    <h1 style="font-size:clamp(2.2rem,6vw,3.6rem);">The classics, <span class="accent">rebuilt</span> &amp; the greats</h1>
+    <p class="sub">Famous old charts rebuilt in code so you can see how they work, and a shelf of modern work by other people on the same themes.</p>
+  </div>
+</header>
+<main id="main-content">
+
+<!-- ===== MASTERS' WING (recreated classics) ===== -->
+<section class="section" id="masters">
+  <div class="wrap">
+    <div class="section-head">
+      <span class="kicker">The Masters' Wing</span>
+      <h2>The greats, rebuilt by hand</h2>
+      <p>Famous old charts, all out of copyright, rebuilt here in code so you can see how they were put together.</p>
+    </div>
+    <div class="masters">
+
+      <article class="plate" data-plate>
+        <div class="plate-canvas"><svg id="viz-rose" viewBox="0 0 400 320" role="img" aria-label="A recreation of Florence Nightingale's rose diagram showing that most soldier deaths in the Crimean War came from preventable disease, not wounds."></svg></div>
+        <div class="plate-caption">
+          <span class="tag">Public Health</span>
+          <h3>The Rose of Mortality</h3>
+          <div class="meta">Florence Nightingale · 1858</div>
+          <p>Her polar-area "coxcomb" showed that the great blue wedges — soldiers killed by <em>preventable</em> disease in the Crimean War — dwarfed the red of battle wounds. Area, not radius, carries the count.</p>
+          <p class="why">One of the first charts made to change policy. Sanitation reforms followed.</p>
+          <a class="source" href="https://en.wikipedia.org/wiki/Florence_Nightingale#Statistics_and_sanitary_reform" target="_blank" rel="noopener">About the original →</a>
+        </div>
+      </article>
+
+      <article class="plate" data-plate>
+        <div class="plate-canvas"><svg id="viz-minard" viewBox="0 0 400 320" role="img" aria-label="A recreation of Charles Minard's flow map of Napoleon's 1812 march on Moscow, the thinning band showing an army of 422,000 reduced to 10,000."></svg></div>
+        <div class="plate-caption">
+          <span class="tag">War &amp; Loss</span>
+          <h3>Napoleon's March</h3>
+          <div class="meta">Charles Joseph Minard · 1869</div>
+          <p>The width of the band is the size of the army; tan advancing on Moscow, black in retreat, with the freezing temperature traced below. 422,000 marched out. 10,000 came home.</p>
+          <p class="why">Tufte called it perhaps the best statistical graphic ever drawn: six variables on one flat page.</p>
+          <a class="source" href="https://en.wikipedia.org/wiki/Charles_Joseph_Minard#The_map_of_Napoleon's_Russian_campaign" target="_blank" rel="noopener">About the original →</a>
+        </div>
+      </article>
+
+      <article class="plate" data-plate>
+        <div class="plate-canvas"><svg id="viz-snow" viewBox="0 0 400 320" role="img" aria-label="A recreation of John Snow's 1854 cholera map, with death markers clustered tightly around the Broad Street water pump."></svg></div>
+        <div class="plate-caption">
+          <span class="tag">Public Health</span>
+          <h3>The Broad Street Pump</h3>
+          <div class="meta">Dr. John Snow · 1854</div>
+          <p>Each mark is a cholera death. Plotted on a street map of Soho, they swarm around a single water pump — the evidence that cholera travelled through water, not "bad air".</p>
+          <p class="why">An early landmark in epidemiology: the map pointed to the source, and the pump was shut off.</p>
+          <a class="source" href="https://en.wikipedia.org/wiki/1854_Broad_Street_cholera_outbreak" target="_blank" rel="noopener">About the original →</a>
+        </div>
+      </article>
+
+      <article class="plate plate--dubois" data-plate>
+        <div class="plate-canvas"><svg id="viz-dubois" viewBox="0 0 400 320" role="img" aria-label="A recreation in the style of W. E. B. Du Bois's 1900 data portraits: a spiral of growing bars on a cream ground, charting the rising value of property owned by Black Americans in Georgia."></svg></div>
+        <div class="plate-caption">
+          <span class="tag">Race &amp; Equity</span>
+          <h3>A Du Bois Data Portrait</h3>
+          <div class="meta">W. E. B. Du Bois &amp; team · 1900</div>
+          <p>For the 1900 Paris Exposition, Du Bois hand-drew dozens of radical, modernist charts of Black American life. This spiral — rising property values against the odds — is rebuilt in his palette.</p>
+          <p class="why">Charts made as an argument for dignity, decades ahead of their design time.</p>
+          <a class="source" href="https://www.loc.gov/pictures/collection/anedub/" target="_blank" rel="noopener">See the originals (Library of Congress) →</a>
+        </div>
+      </article>
+
+    </div>
+  </div>
+</section>
+
+<!-- ===== THE GREATS (curated gallery, links out) ===== -->
+<section class="section frameworks-bg" id="greats">
+  <div class="wrap">
+    <div class="section-head">
+      <span class="kicker">The Greats</span>
+      <h2>Masterworks worth studying</h2>
+      <p>Modern work on the same themes, by other people. We can't reprint it, so each card links to the original. Filter by topic.</p>
+    </div>
+
+    <div class="filters" id="filters" role="group" aria-label="Filter visualizations by theme">
+      <button class="filter-chip active" data-filter="all">All</button>
+      <button class="filter-chip" data-filter="poverty">Poverty &amp; Inequality</button>
+      <button class="filter-chip" data-filter="gender">Gender</button>
+      <button class="filter-chip" data-filter="race">Race &amp; Caste</button>
+      <button class="filter-chip" data-filter="health">Public Health</button>
+      <button class="filter-chip" data-filter="climate">Climate</button>
+      <button class="filter-chip" data-filter="migration">Migration</button>
+      <button class="filter-chip" data-filter="education">Education</button>
+      <button class="filter-chip" data-filter="india">India &amp; South Asia</button>
+      <button class="filter-chip" data-filter="justice">Justice &amp; Rights</button>
+    </div>
+
+    <div class="cards-gallery" id="cards"><!-- cards injected by JS --></div>
+  </div>
+</section>
+</main>
+<footer class="site-footer">
+  <div class="footer-grid">
+    <div class="footer-col"><h4>The Long View</h4><a href="/the-long-view.html">Our original charts</a><a href="/the-long-view/gallery.html">The classics &amp; greats</a></div>
+    <div class="footer-col"><h4>ImpactMojo</h4><a href="/about.html">About</a><a href="/dataverse.html">Dataverse</a><a href="/blog.html">Blog</a></div>
+    <div class="footer-col"><h4>Legal</h4><a href="/privacy-policy.html">Privacy</a><a href="/terms-of-service.html">Terms</a></div>
+    <div class="footer-col"><h4>More</h4><a href="/catalog.html">Courses</a><a href="https://github.com/ImpactMojo/ImpactMojo">GitHub</a></div>
+  </div>
+  <div class="footer-bottom"><p>© 2026 ImpactMojo. Recreations are our own; linked works belong to their creators.</p></div>
+</footer>
+<script>
+(function(){function gs(){return window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark';}function ap(t){document.documentElement.setAttribute('data-theme',t==='system'?gs():t);document.body.classList.remove('dark-mode','light-mode');document.body.classList.add((t==='system'?gs():t)==='light'?'light-mode':'dark-mode');}function ub(p){document.querySelectorAll('.im-theme-btn').forEach(function(b){b.classList.toggle('active',b.getAttribute('data-imtheme')===p);});}var sv=localStorage.getItem('im-theme')||'system';ap(sv);document.addEventListener('DOMContentLoaded',function(){ub(sv);document.querySelectorAll('.im-theme-btn').forEach(function(b){b.addEventListener('click',function(){var t=this.getAttribute('data-imtheme');localStorage.setItem('im-theme',t);ap(t);ub(t);});});});window.matchMedia('(prefers-color-scheme: light)').addEventListener('change',function(){if((localStorage.getItem('im-theme')||'system')==='system')ap('system');});})();
+</script>
+<script src="/js/longview-charts.js"></script>
+<script>
+(function(){function init(){LV.reveal&&LV.reveal();LV.drawMasters();LV.buildCards();LV.wireFilters();new MutationObserver(function(ms){ms.forEach(function(m){if(m.attributeName==='data-theme')LV.drawMasters();});}).observe(document.documentElement,{attributes:true});}if(document.readyState!=='loading')init();else document.addEventListener('DOMContentLoaded',init);})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Stage 2 of the redesign, per the direction you chose (this page = our originals; masters/greats split out; each original opens its own explainer).

**New architecture**
- Extracted the chart engine into a shared module (`js/longview-charts.js`) and the styles into `css/longview.css`, so a chart can render both as a small tile *and* large on its own page. Added per-chart explainer metadata.
- **`the-long-view.html`** is now purely our original charts — each one a **clickable tile**.
- **`/the-long-view/chart.html?c=<id>`** (new) — renders any original large with its explainer: *what it shows, why that chart type, how it's built, what to look for,* and the data source, plus prev/next navigation through the set.
- **`/the-long-view/gallery.html`** (new) — the recreated masters + the curated greats, moved off the main page and linked from it.

**Verified:** all three pages render in light and dark with the real fonts; charts, tiles, explainer text, prev/next, and theme switching all work programmatically. mojibake PASS, JS valid, sitemap updated.

**Honest caveat:** I verified the *chart rendering* and the *page wiring* programmatically (jsdom), but there's no browser in the build env, so I couldn't screenshot the full HTML/CSS page layout (tile grid spacing, detail-page columns, hover states). Please click around the live pages — if any layout looks off, tell me which page and I'll fix it fast.

https://claude.ai/code/session_01Xpta1BU7c52vLx8u7BEaDj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xpta1BU7c52vLx8u7BEaDj)_