### PR TITLE
Add Logframe 101 — the logical framework, built from the results chain up

### DIFF
--- a/101-courses/index.html
+++ b/101-courses/index.html
@@ -3,19 +3,19 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>ImpactMojo 101 Series — 45 Free Foundational Courses for Development Practitioners</title>
-<meta name="description" content="The ImpactMojo 101 Series — 45 free foundational courses on development methods, theory, and practice. Native interactive slide decks plus curated reading lists. CC BY-NC-ND, free forever.">
+<title>ImpactMojo 101 Series — 47 Free Foundational Courses for Development Practitioners</title>
+<meta name="description" content="The ImpactMojo 101 Series — 47 free foundational courses on development methods, theory, and practice. Native interactive slide decks plus curated reading lists. CC BY-NC-ND, free forever.">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://www.impactmojo.in/101-courses/">
 <meta property="og:type" content="website">
-<meta property="og:title" content="ImpactMojo 101 Series — 45 Free Foundational Courses">
-<meta property="og:description" content="45 free foundational courses on development methods, theory, and practice. Free forever, CC BY-NC-ND.">
+<meta property="og:title" content="ImpactMojo 101 Series — 47 Free Foundational Courses">
+<meta property="og:description" content="47 free foundational courses on development methods, theory, and practice. Free forever, CC BY-NC-ND.">
 <meta property="og:url" content="https://www.impactmojo.in/101-courses/">
 <meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
 <meta property="og:site_name" content="ImpactMojo">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="ImpactMojo 101 Series">
-<meta name="twitter:description" content="45 free foundational courses on development methods, theory, and practice.">
+<meta name="twitter:description" content="47 free foundational courses on development methods, theory, and practice.">
 <meta name="twitter:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
 
 <!-- Google Analytics -->
@@ -138,15 +138,15 @@ html,body{font-family:var(--font-body);color:var(--ink);background:var(--paper);
 <section class="hero">
   <div class="hero-inner">
     <div class="hero-eyebrow">ImpactMojo 101 Series &middot; Free Forever</div>
-    <h1 class="hero-title">46 Foundational Courses for South Asian Development Practitioners</h1>
+    <h1 class="hero-title">47 Foundational Courses for South Asian Development Practitioners</h1>
     <p class="hero-sub">A free, open-access, CC BY-NC-ND library of foundational primers on development methods, theory, and practice. Covering MEL, data, ethics, gender, climate, public finance, identity, and more &mdash; built specifically for the South Asian context. Native interactive slide decks plus curated reading lists.</p>
     <div class="hero-stats">
       <div class="hero-stat">
-        <div class="hero-stat-num">46</div>
+        <div class="hero-stat-num">47</div>
         <div class="hero-stat-lbl">Native Course Decks</div>
       </div>
       <div class="hero-stat">
-        <div class="hero-stat-num">3,800</div>
+        <div class="hero-stat-num">3,900</div>
         <div class="hero-stat-lbl">Slides of Learning</div>
       </div>
       <div class="hero-stat">
@@ -159,8 +159,8 @@ html,body{font-family:var(--font-body);color:var(--ink);background:var(--paper);
 
 <div class="filter-bar">
   <span class="filter-label">Filter:</span>
-  <button class="filter-chip active" data-filter="all">All (46)</button>
-  <button class="filter-chip" data-filter="native">Native HTML (46)</button>
+  <button class="filter-chip active" data-filter="all">All (47)</button>
+  <button class="filter-chip" data-filter="native">Native HTML (47)</button>
   <input type="search" class="filter-search" placeholder="Search courses by title or description..." aria-label="Search courses">
 </div>
 
@@ -291,6 +291,12 @@ html,body{font-family:var(--font-body);color:var(--ink);background:var(--paper);
   <span class="card-badge card-badge-native">Native HTML · 100 slides</span>
   <div class="card-title">Item Response Theory 101</div>
   <div class="card-desc">Learn advanced psychometric techniques for developing measurement instruments.</div>
+  <div class="card-cta">Open Course →</div>
+</a>
+<a class="course-card" href="/101-courses/logframe-101.html">
+  <span class="card-badge card-badge-native">Native HTML · 100 slides</span>
+  <div class="card-title">Logframe 101</div>
+  <div class="card-desc">The logical framework, built from the results chain up — inputs to impact, indicators and SMART targets, means of verification, assumptions and risk, and how to build, test and critique the matrix.</div>
   <div class="card-cta">Open Course →</div>
 </a>
 <a class="course-card" href="/101-courses/mel-basics.html">

--- a/101-courses/logframe-101.html
+++ b/101-courses/logframe-101.html
@@ -1,0 +1,1020 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Logframe 101 | ImpactMojo</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Amaranth:ital,wght@0,400;0,700;1,400&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+<style>
+:root {
+  --cyan:#0EA5E9; --indigo:#6366F1; --green:#10B981; --amber:#F59E0B;
+  --red:#EF4444; --cream:#FDF8F2; --ink:#1C1917; --ink-mid:#44403C;
+  --ink-light:#78716C; --header-h:52px; --footer-h:36px;
+  --font-head:'Inter',sans-serif; --font-body:'Amaranth',sans-serif;
+  --font-mono:'JetBrains Mono',monospace;
+}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html,body{width:100%;height:100%;background:#111;font-family:var(--font-body);overflow:hidden}
+#deck{position:fixed;inset:0;display:flex;align-items:center;justify-content:center}
+.slide-viewport{position:relative;flex-shrink:0;width:1280px;height:720px;transform-origin:center center}
+.slide{position:absolute;inset:0;background:var(--cream);overflow:hidden;display:none;flex-direction:column}
+.slide.active{display:flex}
+
+/* HEADER */
+.slide-header{position:absolute;top:0;left:0;right:0;height:var(--header-h);background:var(--ink);display:flex;align-items:center;justify-content:space-between;padding:0 28px;z-index:10}
+.logo-mark{display:flex;align-items:center;gap:10px;text-decoration:none}
+.logo-plane{width:28px;height:28px}
+.logo-wordmark{font-family:var(--font-head);font-weight:800;font-size:17px;background:linear-gradient(90deg,#0EA5E9,#6366F1);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;letter-spacing:-0.3px}
+.header-center{font-family:var(--font-head);font-size:11px;font-weight:500;color:rgba(255,255,255,0.5);letter-spacing:1.5px;text-transform:uppercase}
+.header-url{font-family:var(--font-mono);font-size:10px;color:rgba(255,255,255,0.4)}
+
+/* FOOTER */
+.slide-footer{position:absolute;bottom:0;left:0;right:0;height:var(--footer-h);background:var(--ink);display:flex;align-items:center;justify-content:space-between;padding:0 28px;z-index:10}
+.footer-left{font-family:var(--font-mono);font-size:9px;color:rgba(255,255,255,0.35);letter-spacing:1px;text-transform:uppercase}
+.footer-right{font-family:var(--font-mono);font-size:9px;color:rgba(255,255,255,0.35)}
+.slide-number{font-family:var(--font-mono);font-size:11px;font-weight:600;color:var(--cyan);background:rgba(14,165,233,0.1);padding:2px 8px;border-radius:3px}
+
+/* CONTENT */
+.slide-content{position:absolute;top:var(--header-h);bottom:var(--footer-h);left:0;right:0;padding:24px 40px 20px;overflow:hidden}
+
+/* SECTION LABEL */
+.section-label{font-family:var(--font-mono);font-size:9px;font-weight:600;letter-spacing:2.5px;text-transform:uppercase;color:var(--cyan);margin-bottom:8px;display:flex;align-items:center;gap:8px}
+.section-label::after{content:'';flex:1;height:1px;background:linear-gradient(90deg,var(--cyan) 0%,transparent 100%);opacity:0.3}
+
+/* TYPOGRAPHY */
+.slide-title{font-family:var(--font-head);font-weight:800;line-height:1.1;color:var(--ink);letter-spacing:-0.5px}
+.slide-title.xl{font-size:48px}.slide-title.lg{font-size:34px}.slide-title.md{font-size:30px}.slide-title.sm{font-size:24px}
+.slide-body{font-family:var(--font-body);font-size:15px;line-height:1.65;color:var(--ink-mid)}
+.slide-body.sm{font-size:13px}
+
+/* BULLETS */
+.bullet-list{list-style:none;display:flex;flex-direction:column;gap:10px;margin-top:14px}
+.bullet-list li{position:relative;padding-left:19px;font-family:var(--font-body);font-size:15px;line-height:1.55;color:var(--ink-mid)}
+.bullet-list li::before{content:'';position:absolute;left:0;top:9px;width:7px;height:7px;border-radius:50%;background:var(--cyan)}
+.bullet-list.green li::before{background:var(--green)}
+.bullet-list.amber li::before{background:var(--amber)}
+.bullet-list.indigo li::before{background:var(--indigo)}
+.bullet-list.red li::before{background:var(--red)}
+.bullet-list.sm li{font-size:14px}
+
+/* STAT CARDS */
+.stat-grid{display:grid;gap:14px;margin-top:16px}
+.stat-grid.c2{grid-template-columns:repeat(2,1fr)}.stat-grid.c3{grid-template-columns:repeat(3,1fr)}.stat-grid.c4{grid-template-columns:repeat(4,1fr)}
+.stat-card{background:white;border-radius:10px;padding:18px 20px;border-top:3px solid var(--cyan);box-shadow:0 2px 8px rgba(0,0,0,0.06)}
+.stat-card.green{border-top-color:var(--green)}.stat-card.amber{border-top-color:var(--amber)}.stat-card.indigo{border-top-color:var(--indigo)}.stat-card.red{border-top-color:var(--red)}
+.stat-number{font-family:var(--font-head);font-size:34px;font-weight:800;color:var(--ink);line-height:1;margin-bottom:4px}
+.stat-label{font-family:var(--font-body);font-size:13px;color:var(--ink-light);line-height:1.4}
+.stat-source{font-family:var(--font-mono);font-size:9px;color:var(--ink-light);margin-top:5px;opacity:0.7}
+
+/* TWO COLUMN */
+.two-col{display:grid;gap:28px;margin-top:14px}
+.two-col.half{grid-template-columns:1fr 1fr}
+.two-col.a32{grid-template-columns:3fr 2fr}
+.two-col.a23{grid-template-columns:2fr 3fr}
+
+/* PANELS */
+.col-panel{background:white;border-radius:10px;padding:20px 18px;border-left:3px solid var(--cyan);box-shadow:0 2px 6px rgba(0,0,0,0.05)}
+.col-panel.green{border-left-color:var(--green)}.col-panel.amber{border-left-color:var(--amber)}.col-panel.indigo{border-left-color:var(--indigo)}.col-panel.red{border-left-color:var(--red)}
+.col-panel-title{font-family:var(--font-head);font-size:12px;font-weight:700;color:var(--ink);margin-bottom:10px;text-transform:uppercase;letter-spacing:0.5px}
+
+/* HIGHLIGHT BOX */
+.hbox{border-left:4px solid var(--cyan);background:rgba(14,165,233,0.06);border-radius:0 8px 8px 0;padding:14px 18px;margin-top:14px}
+.hbox.green{border-left-color:var(--green);background:rgba(16,185,129,0.06)}
+.hbox.amber{border-left-color:var(--amber);background:rgba(245,158,11,0.06)}
+.hbox.indigo{border-left-color:var(--indigo);background:rgba(99,102,241,0.06)}
+.hbox.red{border-left-color:var(--red);background:rgba(239,68,68,0.06)}
+.hbox-text{font-family:var(--font-body);font-size:14px;line-height:1.55;color:var(--ink-mid)}
+
+/* TERM BOX */
+.term-box{background:linear-gradient(135deg,#F0E6D6 0%,white 100%);border:1px solid #C4A882;border-radius:12px;padding:18px 22px;margin-top:14px}
+.term-word{font-family:var(--font-head);font-size:22px;font-weight:800;color:#4A3728;margin-bottom:6px}
+.term-def{font-family:var(--font-body);font-size:14px;line-height:1.6;color:var(--ink-mid)}
+
+/* QUOTE */
+.quote-block{background:var(--ink);border-radius:12px;padding:34px 40px;margin-top:16px;position:relative;overflow:hidden}
+.quote-block::before{content:'"';position:absolute;top:-10px;left:18px;font-size:100px;font-family:Georgia,serif;color:var(--cyan);opacity:0.12;line-height:1}
+.quote-text{font-family:var(--font-body);font-size:19px;line-height:1.7;color:white;font-style:italic;position:relative;z-index:1}
+.quote-attr{font-family:var(--font-mono);font-size:10px;color:var(--cyan);margin-top:14px;letter-spacing:0.5px}
+
+/* COMPARE TABLE */
+.ctable{width:100%;border-collapse:collapse;margin-top:12px;font-family:var(--font-body)}
+.ctable th{background:var(--ink);color:white;padding:10px 14px;text-align:left;font-family:var(--font-head);font-size:12px;font-weight:700;letter-spacing:0.5px}
+.ctable td{padding:10px 14px;font-size:13px;color:var(--ink-mid);border-bottom:1px solid #EDE8E0;line-height:1.4}
+.ctable tr:nth-child(even) td{background:white}
+.ctable tr:nth-child(odd) td{background:#F9F6F1}
+.ctable{border:1px solid #D9D2C5}
+.ctable th,.ctable td{vertical-align:top;border-right:1px solid #EDE8E0}
+.ctable th{border-right-color:rgba(255,255,255,0.18)}
+.ctable th:last-child,.ctable td:last-child{border-right:none}
+.ctable tr:last-child td{border-bottom:none}
+
+/* CHART */
+.chart-wrap{background:white;border-radius:10px;padding:14px 16px;box-shadow:0 2px 8px rgba(0,0,0,0.06)}
+.chart-wrap canvas{display:block;width:100%!important;height:220px!important;max-height:220px}
+.chart-title{font-family:var(--font-head);font-size:11px;font-weight:700;color:var(--ink-mid);margin-bottom:10px;text-transform:uppercase;letter-spacing:0.5px}
+.chart-source{font-family:var(--font-mono);font-size:9px;color:var(--ink-light);margin-top:6px}
+
+/* DARK CARD */
+.dark-card{background:var(--ink);border-radius:12px;padding:22px 20px;color:white}
+.dark-card-label{font-family:var(--font-mono);font-size:9px;color:var(--cyan);letter-spacing:2px;margin-bottom:8px;text-transform:uppercase}
+.dark-card-title{font-family:var(--font-head);font-weight:800;font-size:17px;margin-bottom:8px;color:white}
+.dark-card-body{font-family:var(--font-body);font-size:13px;color:rgba(255,255,255,0.65);line-height:1.5}
+
+/* PROCESS FLOW */
+.flow{display:flex;align-items:center;gap:6px;margin-top:14px;flex-wrap:wrap}
+.flow-step{background:var(--ink);color:white;border-radius:8px;padding:10px 12px;flex:1;min-width:80px;text-align:center}
+.flow-num{font-family:var(--font-mono);font-size:9px;color:var(--cyan);letter-spacing:1px;margin-bottom:3px}
+.flow-label{font-family:var(--font-body);font-size:11px;line-height:1.3;color:white}
+.flow-arrow{font-size:16px;color:var(--cyan);flex-shrink:0}
+
+/* SECTION DIVIDER */
+.section-divider{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;flex-direction:column;background:var(--ink);text-align:center}
+.div-num{font-family:var(--font-mono);font-size:100px;font-weight:700;color:rgba(255,255,255,0.04);line-height:1;position:absolute}
+.div-label{font-family:var(--font-mono);font-size:11px;letter-spacing:3px;text-transform:uppercase;color:var(--cyan);margin-bottom:14px;position:relative}
+.div-title{font-family:var(--font-head);font-size:44px;font-weight:800;color:white;line-height:1.1;letter-spacing:-1px;max-width:700px;position:relative}
+.div-accent{width:60px;height:4px;background:linear-gradient(90deg,var(--cyan),var(--indigo));border-radius:2px;margin:18px auto 0;position:relative}
+
+/* TITLE SLIDE */
+.title-screen{position:absolute;inset:0;background:var(--ink);overflow:hidden}
+.title-bg{position:absolute;inset:0;opacity:0.04;background-image:repeating-linear-gradient(45deg,#fff 0,#fff 1px,transparent 0,transparent 50%);background-size:20px 20px}
+.title-bar{position:absolute;left:0;top:0;bottom:0;width:6px;background:linear-gradient(180deg,#0EA5E9,#6366F1,#10B981)}
+.title-content{padding:0 72px;position:relative;z-index:2;margin-top:90px}
+.title-series{font-family:var(--font-mono);font-size:11px;letter-spacing:3px;text-transform:uppercase;color:var(--cyan);margin-bottom:18px}
+.title-main{font-family:var(--font-head);font-size:54px;font-weight:800;color:white;line-height:1.05;letter-spacing:-1.5px;margin-bottom:14px}
+.title-sub{font-family:var(--font-body);font-size:17px;color:rgba(255,255,255,0.55);line-height:1.5;max-width:600px;margin-bottom:30px}
+.title-tags{display:flex;gap:10px;flex-wrap:wrap}
+.title-tag{font-family:var(--font-mono);font-size:10px;letter-spacing:1px;text-transform:uppercase;padding:5px 12px;border-radius:4px;border:1px solid rgba(255,255,255,0.2);color:rgba(255,255,255,0.55)}
+.title-geo{position:absolute;right:60px;top:var(--header-h);bottom:var(--footer-h);width:300px;overflow:hidden;opacity:0.06}
+
+/* TOC */
+.toc-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-top:14px}
+.toc-item{background:white;border-radius:8px;padding:10px 12px;border-left:3px solid transparent;box-shadow:0 1px 4px rgba(0,0,0,0.06)}
+.toc-item:nth-child(3n+1){border-left-color:var(--cyan)}.toc-item:nth-child(3n+2){border-left-color:var(--indigo)}.toc-item:nth-child(3n+3){border-left-color:var(--green)}
+.toc-num{font-family:var(--font-mono);font-size:9px;color:var(--ink-light);letter-spacing:1px;margin-bottom:3px}
+.toc-name{font-family:var(--font-head);font-size:13px;font-weight:700;color:var(--ink);line-height:1.3}
+.toc-slides{font-family:var(--font-mono);font-size:9px;color:var(--ink-light);margin-top:3px}
+
+/* THANK YOU */
+.ty-screen{position:absolute;inset:0;background:var(--ink);display:flex;align-items:center;justify-content:center;flex-direction:column;text-align:center;overflow:hidden}
+.ty-title{font-family:var(--font-head);font-size:50px;font-weight:800;color:white;margin-bottom:10px;letter-spacing:-1px}
+.ty-sub{font-family:var(--font-body);font-size:15px;color:rgba(255,255,255,0.45);max-width:480px;line-height:1.6;margin-bottom:32px}
+.ty-ctas{display:flex;gap:12px}
+.cta-btn{font-family:var(--font-head);font-size:12px;font-weight:700;padding:11px 26px;border-radius:8px;text-decoration:none;letter-spacing:0.3px}
+.cta-btn.primary{background:linear-gradient(135deg,var(--cyan),var(--indigo));color:white}
+.cta-btn.secondary{border:1.5px solid rgba(255,255,255,0.2);color:rgba(255,255,255,0.75)}
+
+/* SARGAM INLINE ICON */
+.si{display:inline-block;vertical-align:middle}
+
+/* NAV */
+#nav{position:fixed;bottom:16px;left:50%;transform:translateX(-50%);display:flex;align-items:center;gap:10px;background:rgba(0,0,0,0.75);backdrop-filter:blur(8px);border-radius:40px;padding:7px 16px;z-index:1000;opacity:1}
+
+.nav-btn{background:rgba(255,255,255,0.1);border:none;cursor:pointer;color:white;width:30px;height:30px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:14px;transition:background 0.2s}
+.nav-btn:hover{background:rgba(255,255,255,0.25)}
+.nav-btn:disabled{opacity:0.3;cursor:default}
+#prog-text{font-family:var(--font-mono);font-size:11px;color:rgba(255,255,255,0.55);min-width:55px;text-align:center}
+#progress-bar{position:fixed;top:0;left:0;height:3px;background:linear-gradient(90deg,var(--cyan),var(--indigo));z-index:2000;transition:width 0.3s}
+#fs-hint{position:fixed;top:10px;right:14px;font-family:var(--font-mono);font-size:9px;color:rgba(255,255,255,0.25);cursor:pointer;z-index:2000;letter-spacing:1px;text-transform:uppercase}
+
+/* SARGAM SPRITE (hidden) */
+svg.sprites{display:none}
+
+/* THEME SWITCHER */
+#theme-bar{position:fixed;top:58px;right:14px;display:flex;gap:4px;z-index:2000;background:rgba(0,0,0,0.6);backdrop-filter:blur(8px);border-radius:20px;padding:4px 6px}
+.theme-btn{font-family:var(--font-mono);font-size:9px;letter-spacing:0.5px;text-transform:uppercase;padding:4px 10px;border-radius:12px;border:none;cursor:pointer;color:rgba(255,255,255,0.55);background:transparent;transition:all 0.2s}
+.theme-btn.active{background:rgba(255,255,255,0.2);color:white}
+
+/* LIGHT MODE (default) */
+body.light .slide{background:#FDF8F2}
+body.light{background:#e8e2da}
+
+/* DARK MODE */
+body.dark .slide{background:#1C1917}
+body.dark .slide-content{color:#FDF8F2}
+body.dark .slide-title{color:#FDF8F2}
+body.dark .slide-body{color:rgba(255,255,255,0.7)}
+body.dark .stat-card{background:#2C2926;border-top-color:var(--cyan)}
+body.dark .stat-card.green{border-top-color:var(--green)}
+body.dark .stat-card.amber{border-top-color:var(--amber)}
+body.dark .stat-card.indigo{border-top-color:var(--indigo)}
+body.dark .stat-card.red{border-top-color:var(--red)}
+body.dark .stat-number{color:#FDF8F2}
+body.dark .stat-label{color:rgba(255,255,255,0.55)}
+body.dark .col-panel{background:#2C2926;border-left-color:var(--cyan)}
+body.dark .col-panel.green{border-left-color:var(--green)}
+body.dark .col-panel.amber{border-left-color:var(--amber)}
+body.dark .col-panel.indigo{border-left-color:var(--indigo)}
+body.dark .col-panel.red{border-left-color:var(--red)}
+body.dark .col-panel-title{color:rgba(255,255,255,0.8)}
+body.dark .chart-wrap{background:#2C2926}
+body.dark .chart-title{color:rgba(255,255,255,0.6)}
+body.dark .hbox{background:rgba(14,165,233,0.1);border-left-color:var(--cyan)}
+body.dark .hbox.green{background:rgba(16,185,129,0.1);border-left-color:var(--green)}
+body.dark .hbox.amber{background:rgba(245,158,11,0.1);border-left-color:var(--amber)}
+body.dark .hbox.indigo{background:rgba(99,102,241,0.1);border-left-color:var(--indigo)}
+body.dark .hbox.red{background:rgba(239,68,68,0.1);border-left-color:var(--red)}
+body.dark .hbox-text{color:rgba(255,255,255,0.7)}
+body.dark .term-box{background:linear-gradient(135deg,#2C2926 0%,#383230 100%);border-color:#5C4A3A}
+body.dark .term-word{color:#E8D5C0}
+body.dark .term-def{color:rgba(255,255,255,0.65)}
+body.dark .ctable th{background:#111}
+body.dark .ctable td{color:rgba(255,255,255,0.65);border-bottom-color:rgba(255,255,255,0.08)}
+body.dark .ctable tr:nth-child(even) td{background:#2C2926}
+body.dark .ctable tr:nth-child(odd) td{background:#242120}
+body.dark .ctable{border-color:rgba(255,255,255,0.1)}
+body.dark .ctable td{border-right-color:rgba(255,255,255,0.08)}
+body.dark .ctable th{border-right-color:rgba(255,255,255,0.18)}
+body.dark .toc-item{background:#2C2926}
+body.dark .toc-name{color:#FDF8F2}
+body.dark .toc-num,.toc-slides{color:rgba(255,255,255,0.4)}
+body.dark{background:#111}
+body.dark .bullet-list li{color:rgba(255,255,255,0.7)}
+body.dark .two-col .slide-body{color:rgba(255,255,255,0.7)}
+
+
+
+
+/* ── FILL RULES: make components use full slide area naturally ── */
+
+/* Tables: bigger rows, more breathing room */
+.ctable{margin-top:16px;margin-bottom:16px}
+.ctable td{padding:12px 16px;font-size:14px;line-height:1.5}
+.ctable th{padding:12px 16px;font-size:13px;letter-spacing:0.6px}
+
+/* Stat grids: cards breathe more */
+.stat-grid{gap:16px;margin-top:20px}
+.stat-card{padding:20px 22px;border-radius:12px}
+.stat-number{font-size:36px;margin-bottom:6px}
+.stat-label{font-size:14px;line-height:1.5}
+
+/* Highlight boxes: generous spacing */
+.hbox{padding:16px 20px;margin-top:16px;border-radius:0 10px 10px 0}
+.hbox-text{font-size:15px;line-height:1.6}
+
+/* Term boxes */
+.term-box{padding:20px 24px;margin-top:16px;border-radius:12px}
+.term-word{font-size:24px;margin-bottom:8px}
+.term-def{font-size:15px;line-height:1.65}
+
+/* Titles and body */
+.slide-title.md{font-size:32px}
+.slide-title.sm{font-size:26px}
+.slide-body{font-size:16px;line-height:1.7}
+.slide-body.sm{font-size:14px;line-height:1.65}
+
+/* Bullets: roomier */
+.bullet-list{gap:12px;margin-top:16px}
+.bullet-list li{font-size:16px;line-height:1.6}
+.bullet-list li::before{width:8px;height:8px;top:8px}
+.bullet-list.sm li{font-size:15px}
+
+/* Dark cards */
+.dark-card{padding:24px 22px;border-radius:14px}
+.dark-card-title{font-size:18px;margin-bottom:10px}
+.dark-card-body{font-size:14px;line-height:1.55}
+.dark-card-label{margin-bottom:10px}
+
+/* Panels */
+.col-panel{padding:22px 20px;border-radius:12px}
+.col-panel-title{font-size:13px;margin-bottom:12px}
+
+/* Quotes */
+.quote-block{padding:36px 44px;border-radius:14px;margin-top:20px}
+.quote-text{font-size:20px;line-height:1.75}
+.quote-attr{font-size:11px;margin-top:18px}
+
+/* Two-col layout */
+.two-col{gap:30px;margin-top:16px}
+
+/* Charts */
+.chart-wrap{padding:18px 20px;border-radius:12px}
+.chart-wrap canvas{height:230px!important;max-height:230px}
+.chart-title{font-size:12px;margin-bottom:12px}
+.chart-source{margin-top:8px}
+
+/* TOC */
+.toc-grid{gap:12px;margin-top:16px}
+.toc-item{padding:14px 16px;border-radius:10px}
+.toc-name{font-size:14px;line-height:1.35}
+.toc-num{font-size:10px;margin-bottom:4px}
+.toc-slides{margin-top:4px}
+
+/* Section dividers */
+.div-title{font-size:48px}
+.div-label{font-size:12px;margin-bottom:18px;letter-spacing:3.5px}
+.div-accent{width:70px;height:5px;margin-top:22px}
+
+/* Flow steps */
+.flow{gap:8px;margin-top:18px}
+.flow-step{padding:14px 16px;border-radius:10px}
+.flow-label{font-size:13px;line-height:1.35}
+.flow-num{margin-bottom:4px}
+
+/* Section label */
+.section-label{margin-bottom:12px;font-size:10px;letter-spacing:2.8px}
+
+/* Title slide */
+.title-main{font-size:58px}
+.title-sub{font-size:18px;line-height:1.55;margin-bottom:34px}
+.title-series{font-size:12px;margin-bottom:22px}
+.title-tag{font-size:11px;padding:6px 14px}
+
+/* Thank you slide */
+.ty-title{font-size:54px}
+.ty-sub{font-size:16px;line-height:1.65;margin-bottom:36px}
+
+
+/* === STANDARDISED END SLIDE === */
+.end-screen{position:absolute;inset:0;background:linear-gradient(135deg,#0F172A 0%,#1E293B 50%,#0F172A 100%);overflow:hidden;display:flex;align-items:center;justify-content:center;padding:60px 80px}
+.end-bar{position:absolute;left:0;top:0;bottom:0;width:6px;background:linear-gradient(180deg,#0EA5E9,#6366F1,#10B981);z-index:3}
+.end-pattern{position:absolute;inset:0;opacity:0.05;background-image:radial-gradient(circle at 25% 30%,#fff 1px,transparent 1px),radial-gradient(circle at 75% 70%,#fff 1px,transparent 1px);background-size:60px 60px;z-index:1}
+.end-glow{position:absolute;width:600px;height:600px;border-radius:50%;background:radial-gradient(circle,rgba(99,102,241,0.15) 0%,transparent 70%);top:-200px;right:-100px;z-index:1}
+.end-content{position:relative;z-index:2;max-width:880px;text-align:center}
+.end-eyebrow{font-family:var(--font-mono);font-size:11px;font-weight:600;letter-spacing:3px;text-transform:uppercase;color:#0EA5E9;margin-bottom:24px}
+.end-headline{font-family:var(--font-head);font-size:84px;font-weight:800;color:white;line-height:0.95;letter-spacing:-2.5px;margin-bottom:28px;background:linear-gradient(135deg,#fff 0%,#CBD5E1 100%);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
+.end-byline{font-family:var(--font-body);font-size:17px;color:rgba(255,255,255,0.72);line-height:1.6;margin:0 auto 36px;max-width:680px}
+.end-cta{display:flex;gap:14px;justify-content:center;flex-wrap:wrap;margin-bottom:34px}
+.end-btn{font-family:var(--font-head);font-size:13px;font-weight:700;padding:13px 28px;border-radius:9px;text-decoration:none;letter-spacing:0.4px;transition:transform 0.15s ease,box-shadow 0.15s ease;display:inline-block}
+.end-btn-primary{background:linear-gradient(135deg,#0EA5E9 0%,#6366F1 100%);color:white;box-shadow:0 4px 14px rgba(14,165,233,0.32)}
+.end-btn-secondary{background:rgba(255,255,255,0.08);border:1.5px solid rgba(255,255,255,0.18);color:rgba(255,255,255,0.95)}
+.end-btn-tertiary{background:transparent;border:1.5px solid rgba(255,255,255,0.12);color:rgba(255,255,255,0.7)}
+.end-btn:hover{transform:translateY(-2px);box-shadow:0 6px 22px rgba(14,165,233,0.45)}
+.end-meta{display:flex;gap:10px;justify-content:center;align-items:center;font-family:var(--font-mono);font-size:11px;color:rgba(255,255,255,0.42);letter-spacing:1px;flex-wrap:wrap}
+.end-meta-divider{opacity:0.4}
+
+
+/* === COMPACT MODE for dense slides === */
+.slide.compact .bullet-list{gap:6px;margin-top:8px}
+.slide.compact .bullet-list li{font-size:12.5px;line-height:1.4}
+.slide.compact .bullet-list.sm li{font-size:11.5px;line-height:1.4}
+.slide.compact .bullet-list li::before{width:5px;height:5px;margin-top:5px}
+.slide.compact .col-panel{padding:14px 14px}
+.slide.compact .col-panel-title{font-size:11px;margin-bottom:6px}
+.slide.compact .slide-body{font-size:13px;line-height:1.5}
+.slide.compact .slide-title.md{font-size:24px;margin-bottom:6px !important}
+.slide.compact .hbox{padding:8px 12px;margin-top:8px !important}
+.slide.compact .hbox-text{font-size:12px;line-height:1.45}
+
+
+/* === ECHARTS CHART SLIDES === */
+.chart-slide-frame{display:flex;flex-direction:column;height:100%;padding:0 8px}
+.chart-context{font-family:var(--font-body);font-size:14px;color:var(--ink-mid);line-height:1.55;margin-bottom:10px}
+.chart-canvas{flex:1;min-height:0;width:100%;border:1px solid rgba(99,102,241,0.10);border-radius:8px;background:linear-gradient(135deg,rgba(14,165,233,0.02),rgba(99,102,241,0.02))}
+.chart-takeaway{font-family:var(--font-body);font-size:13px;color:var(--ink-mid);font-style:italic;margin-top:10px;padding:8px 12px;background:rgba(245,158,11,0.06);border-left:3px solid var(--amber);border-radius:4px}
+.chart-takeaway strong{color:var(--ink);font-style:normal}
+
+/* ========== POLISH FIX BLOCK (v10.23.19) ========== */
+#fs-hint{top:14px !important;right:18px !important;font-size:10px !important;color:rgba(255,255,255,0.85) !important;background:rgba(0,0,0,0.55);padding:6px 12px;border-radius:14px;letter-spacing:0.6px;z-index:3000 !important}
+body.dark #fs-hint{background:rgba(255,255,255,0.14)}
+#nav{opacity:0.18;transition:opacity 0.25s ease;bottom:18px}
+#nav:hover, body.nav-active #nav{opacity:1}
+.slide-content{padding-bottom:46px}
+.slide.compact .slide-content{padding-top:18px;padding-bottom:42px}
+.slide.compact .slide-body{font-size:12.5px;line-height:1.45}
+.slide.compact .ctable td{padding:6px 10px;font-size:12px;line-height:1.35}
+.slide.compact .ctable th{padding:7px 10px;font-size:11px}
+.slide.compact .hbox{padding:10px 14px;margin-top:8px}
+.slide.compact .hbox-text{font-size:12.5px;line-height:1.4}
+.slide.compact .two-col{gap:14px}
+/* fs-hint no longer covers header-url */
+.slide-header{padding-right:120px}
+/* spacious mode for slides with very little content */
+.slide.spacious .slide-title.sm{font-size:30px}
+.slide.spacious .slide-title.md{font-size:38px}
+.slide.spacious .slide-body{font-size:17px;line-height:1.7}
+.slide.spacious .bullet-list li{font-size:16px;line-height:1.6}
+.slide.spacious .hbox{padding:18px 22px;margin-top:14px}
+.slide.spacious .hbox-text{font-size:16px;line-height:1.6}
+.slide.spacious .slide-content{padding-top:42px}
+/* pseudo-table alignment: stat-grids + col-panels + inline grids */
+.stat-grid{align-items:start}
+.col-panel{display:flex;flex-direction:column}
+.col-panel-title{flex:0 0 auto}
+.two-col,.two-col.half,.two-col.a32,.two-col.a23{align-items:start}
+/* inline grids inside slide-content default to top-align */
+/* ultra-compact: applied at runtime if slide still overflows after .compact */
+.slide.ultra-compact .slide-content{padding-top:14px;padding-bottom:38px}
+.slide.ultra-compact .slide-title.sm{font-size:20px;margin-bottom:6px !important}
+.slide.ultra-compact .slide-title.md{font-size:22px;margin-bottom:6px !important}
+.slide.ultra-compact .slide-body,
+.slide.ultra-compact .slide-body.sm{font-size:11.5px;line-height:1.4}
+.slide.ultra-compact .bullet-list{gap:4px;margin-top:6px}
+.slide.ultra-compact .bullet-list li{font-size:11.5px;line-height:1.35}
+.slide.ultra-compact .ctable td{padding:4px 8px;font-size:11px;line-height:1.3}
+.slide.ultra-compact .ctable th{padding:5px 8px;font-size:10px}
+.slide.ultra-compact .hbox{padding:8px 12px;margin-top:6px}
+.slide.ultra-compact .hbox-text{font-size:11.5px;line-height:1.35}
+.slide.ultra-compact .term-box{padding:12px 16px;margin-top:8px}
+.slide.ultra-compact .term-word{font-size:18px}
+.slide.ultra-compact .term-def{font-size:12px;line-height:1.4}
+.slide.ultra-compact .stat-card{padding:12px 14px}
+.slide.ultra-compact .col-panel{padding:12px 14px}
+.slide.ultra-compact .col-panel-title{font-size:10px;margin-bottom:4px}
+.slide.ultra-compact .two-col{gap:10px}
+/* end polish fix block */
+
+/* ========== UNIVERSAL FIT TIGHTENING (v10.23.34) ========== */
+/* Apply consistent slightly-tighter spacing across all slides so most content
+   fits naturally. No font-size changes — only padding, margins, gaps. */
+.slide-content{padding:18px 36px 16px !important}
+.slide-title.md{margin-bottom:6px !important}
+.slide-title.sm{margin-bottom:4px !important}
+.bullet-list{gap:7px;margin-top:10px}
+.bullet-list li{line-height:1.5}
+.hbox{padding:11px 14px;margin-top:8px}
+.hbox-text{line-height:1.45}
+.term-box{padding:14px 18px;margin-top:10px}
+.term-def{line-height:1.5}
+.dark-card{padding:16px 16px;margin-bottom:8px}
+.dark-card-body{line-height:1.45}
+.col-panel{padding:14px 14px}
+.stat-card{padding:14px 16px}
+.section-label{margin-bottom:8px}
+.ctable td{padding:8px 12px;line-height:1.4}
+.ctable th{padding:9px 12px}
+/* ========== /UNIVERSAL FIT TIGHTENING ========== */
+
+/* ===== MOBILE READING MODE (v10.63) — reflow the fixed 16:9 stage into a
+   full-width vertical layout on phones/tablets so slides fill the screen
+   instead of letterboxing to a small centred rectangle. ===== */
+@media (max-width: 820px){
+  html,body{overflow-x:hidden;overflow-y:auto;height:auto;background:var(--cream)}
+  body.dark, body.dark html{background:#1C1917}
+  #deck{position:static;display:block;min-height:100svh}
+  .slide-viewport{width:100%!important;height:auto!important;transform:none!important;position:relative;left:auto;top:auto}
+  .slide{position:relative;inset:auto;display:none;height:auto;min-height:100svh;box-shadow:none}
+  .slide.active{display:flex;flex-direction:column}
+  .slide-header{position:relative;height:auto;min-height:var(--header-h);padding:10px 16px}
+  .header-url{display:none}
+  .slide-content{position:relative!important;top:auto!important;bottom:auto!important;left:auto!important;right:auto!important;height:auto!important;overflow:visible!important;padding:18px 16px 90px!important;zoom:1!important;flex:1}
+  .slide-footer{position:relative;height:auto;min-height:var(--footer-h);padding:8px 16px}
+  /* one column everywhere */
+  .two-col,.two-col.half,.two-col.a32,.two-col.a23{grid-template-columns:1fr!important;gap:14px!important}
+  .stat-grid.c3,.stat-grid.c4{grid-template-columns:1fr 1fr!important}
+  .toc-grid{grid-template-columns:1fr 1fr!important}
+  .flow{flex-direction:column;align-items:stretch}
+  .flow-arrow{transform:rotate(90deg);align-self:center}
+  .chart-wrap canvas,.chart-canvas{height:260px!important;max-height:260px!important}
+  /* readable type */
+  .section-label{font-size:11px!important}
+  .slide-title.xl{font-size:30px!important}.slide-title.lg{font-size:27px!important}
+  .slide-title.md{font-size:23px!important}.slide-title.sm{font-size:20px!important}
+  .slide-body{font-size:15.5px!important;line-height:1.6!important}
+  .slide-body.sm{font-size:14px!important}
+  .bullet-list li,.bullet-list.sm li{font-size:15px!important;line-height:1.55!important}
+  .stat-number{font-size:30px!important}.stat-label{font-size:13px!important}
+  .ctable td{font-size:13px!important}.ctable th{font-size:12px!important}
+  .hbox-text{font-size:14.5px!important}.term-word{font-size:21px!important}.term-def{font-size:14.5px!important}
+  .quote-text{font-size:18px!important}
+  /* full-screen slide types: give them height, not absolute fill */
+  .title-screen,.section-divider,.end-screen{position:relative!important;inset:auto!important;min-height:86svh;height:auto}
+  .title-content{padding:32px 20px!important;margin-top:0!important}
+  .title-main{font-size:40px!important}.title-sub{font-size:16px!important}
+  .title-geo{display:none}
+  .div-title{font-size:32px!important}.div-num{font-size:64px!important}
+  .end-headline{font-size:40px!important}.end-byline{font-size:15px!important}
+  .end-cta{flex-direction:column}.end-content{padding:28px 18px}
+  /* floating nav: keep clear of content */
+  #nav{bottom:14px;opacity:1}
+  #theme-bar{top:auto;bottom:60px;right:10px}
+  #fs-hint{display:none}
+}
+
+</style>
+<!-- Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-JRCMEB9TBW');</script>
+<!-- SEO meta -->
+<meta name="description" content="Logframe 101 - a free foundational course for development practitioners in South Asia. The logical framework, built from the results chain up: inputs, activities, outputs, outcomes and impact; indicators and SMART targets; means of verification; assumptions and risk; building and testing the matrix, its critiques, and donor formats. ImpactMojo, CC BY-NC-ND.">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://www.impactmojo.in/101-courses/logframe-101.html">
+<meta property="og:title" content="Logframe 101">
+<meta property="og:description" content="Logframe 101 - a free foundational course for development practitioners in South Asia. The logical framework, built from the results chain up: inputs, activities, outputs, outcomes and impact; indicators and SMART targets; means of verification; assumptions and risk; building and testing the matrix, its critiques, and donor formats. ImpactMojo, CC BY-NC-ND.">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<meta property="og:url" content="https://www.impactmojo.in/101-courses/logframe-101.html">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="ImpactMojo">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Logframe 101">
+<meta name="twitter:description" content="Logframe 101 - a free foundational course for development practitioners in South Asia. The logical framework, built from the results chain up: inputs, activities, outputs, outcomes and impact; indicators and SMART targets; means of verification; assumptions and risk; building and testing the matrix, its critiques, and donor formats. ImpactMojo, CC BY-NC-ND.">
+<meta name="twitter:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<link rel="icon" type="image/png" href="/assets/images/favicon.png">
+<link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">
+</head>
+<body>
+
+<div id="theme-bar">
+ <button class="theme-btn" onclick="setTheme('system')">System</button>
+ <button class="theme-btn active" onclick="setTheme('light')">Light</button>
+ <button class="theme-btn" onclick="setTheme('dark')">Dark</button>
+</div>
+
+<svg class="sprites" xmlns="http://www.w3.org/2000/svg">
+  <symbol id="si_Heart" viewBox="0 0 24 24" fill="none"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 21C12 21 3 14.5 3 8.5a4.5 4.5 0 0 1 9-0.5 4.5 4.5 0 0 1 9 .5C21 14.5 12 21 12 21Z"/></symbol>
+  <symbol id="si_Book" viewBox="0 0 24 24" fill="none"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" d="M12 7.333C12 5.5 10.5 4 8.667 4H2v12h6.708C12 16 12 19.334 12 19.334m0-12C12 5.5 13.5 4 15.333 4H22v12h-6.667C12 16 12 19.334 12 19.334m0-12v12"/></symbol>
+  <symbol id="si_Wallet" viewBox="0 0 24 24" fill="none"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" d="M2 8.4V17c0 1.657 1.343 3 3 3h14c1.657 0 3-1.343 3-3V11c0-1.657-1.343-3-3-3H5c-1.657 0-3-1.343-3-3V6c0-1.105.895-2 2-2h13c1.105 0 2 .895 2 2v2M16 15h2"/></symbol>
+  <symbol id="si_Flag" viewBox="0 0 24 24" fill="none"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" d="M4 22V4m0 0 16 6-16 6"/></symbol>
+  <symbol id="si_Chat" viewBox="0 0 24 24" fill="none"><path stroke="currentColor" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" d="M19 16h-2.525a.99.99 0 0 0-.775.375l-2.925 3.65c-.4.5-1.162.5-1.562 0l-2.925-3.65A.99.99 0 0 0 7.512 16H5c-1.662 0-3-1.338-3-3V6c0-1.662 1.338-3 3-3h14c1.663 0 3 1.338 3 3v7c0 1.662-1.337 3-3 3Z"/></symbol>
+  <symbol id="si_Lightning" viewBox="0 0 24 24" fill="none"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M13 2 4 14h8l-1 8 9-12h-8l1-8Z"/></symbol>
+  <symbol id="si_Lock" viewBox="0 0 24 24" fill="none"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" d="M7 10V7a5 5 0 0 1 10 0v3m-1.4 1H8.4A2.4 2.4 0 0 0 6 13.4v5.2A2.4 2.4 0 0 0 8.4 21h7.2a2.4 2.4 0 0 0 2.4-2.4v-5.2A2.4 2.4 0 0 0 15.6 11Z"/></symbol>
+  <symbol id="si_Activity" viewBox="0 0 24 24" fill="none"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M1 12h4l4 9 7-18 3 9h4"/></symbol>
+  <symbol id="si_Bar_chart" viewBox="0 0 24 24" fill="none"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" d="M2 22h20M9 8.6A1.6 1.6 0 0 0 7.4 7H4.6A1.6 1.6 0 0 0 3 8.6V22m6 0V3.6A1.6 1.6 0 0 1 10.6 2h2.8A1.6 1.6 0 0 1 15 3.6V22m6 0v-8.4a1.6 1.6 0 0 0-1.6-1.6h-2.8a1.6 1.6 0 0 0-1.6 1.6"/></symbol>
+  <symbol id="si_Globe_detailed" viewBox="0 0 24 24" fill="none"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10Z"/><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" d="M12 22c-3 0-5-4.477-5-10S9 2 12 2s5 4.477 5 10-2 10-5 10ZM2 12h20"/></symbol>
+  <symbol id="si_Leaf" viewBox="0 0 24 24" fill="none"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 3c-8 0-14 4-16 12 4-2 8-3 11-1s4 6 4 10C22 14 19 7 21 3Z"/><path stroke="currentColor" stroke-linecap="round" stroke-width="1.5" d="M5 15c2 2 3 4 2 7"/></symbol>
+  <symbol id="si_Target" viewBox="0 0 24 24" fill="none"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10Zm0-5a5 5 0 1 0 0-10 5 5 0 0 0 0 10Zm0-3a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z"/></symbol>
+  <symbol id="si_Briefcase" viewBox="0 0 24 24" fill="none"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" d="M15 21V4.8a.8.8 0 0 0-.8-.8H9.8a.8.8 0 0 0-.8.8V21M4.4 7h15.2A2.4 2.4 0 0 1 22 9.4v9.2a2.4 2.4 0 0 1-2.4 2.4H4.4A2.4 2.4 0 0 1 2 18.6V9.4A2.4 2.4 0 0 1 4.4 7"/></symbol>
+  <symbol id="si_Database" viewBox="0 0 24 24" fill="none"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" d="M12 8c4.97 0 9-1.343 9-3S16.97 2 12 2 3 3.343 3 5s4.03 3 9 3Zm9 6c0 1.657-4.03 3-9 3s-9-1.343-9-3M3 5v14c0 1.657 4.03 3 9 3s9-1.343 9-3V5"/></symbol>
+  <symbol id="si_Info" viewBox="0 0 24 24" fill="none"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10Zm0-6v-4m0-2V9"/></symbol>
+  <symbol id="si_Check_circle" viewBox="0 0 24 24" fill="none"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m8 13 3 3 5-7m6 3c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2s10 4.477 10 10"/></symbol>
+  <symbol id="si_Arrow_right" viewBox="0 0 24 24" fill="none"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" d="m14 16 4-4m0 0-4-4m4 4H6"/></symbol>
+  <symbol id="si_Flare" viewBox="0 0 24 24" fill="none"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v2m0 14v2M3 12H5m14 0h2m-2.636-6.364-1.414 1.414M7.05 16.95l-1.414 1.414m0-11.314 1.414 1.414m9.9 9.9-1.414-1.414M12 8a4 4 0 1 0 0 8 4 4 0 0 0 0-8Z"/></symbol>
+  <symbol id="si_Library_books" viewBox="0 0 24 24" fill="none"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" d="M4 19V7.4A2.4 2.4 0 0 1 6.4 5H20v14H6.4A2.4 2.4 0 0 1 4 16.6ZM4 17H2M8 5V2m4 3V2m4 3V2"/></symbol>
+  <symbol id="si_Fact_check" viewBox="0 0 24 24" fill="none"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" d="M9 12h6m-6 3h6m-6-6h2M5.4 3h13.2A2.4 2.4 0 0 1 21 5.4v13.2a2.4 2.4 0 0 1-2.4 2.4H5.4A2.4 2.4 0 0 1 3 18.6V5.4A2.4 2.4 0 0 1 5.4 3Z"/><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m7 15.5 1.5 1.5 3-3.5"/></symbol>
+</svg>
+
+<div id="progress-bar"></div>
+<div id="fs-hint" onclick="toggleFS()">fullscreen</div>
+<div id="deck">
+ <div class="slide-viewport" id="viewport">
+
+<div class="slide active" id="s1"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="title-screen"><div class="title-bg"></div><div class="title-bar"></div><div class="title-content"><div class="title-series">ImpactMojo 101 Series &middot; Free Forever</div><div class="title-main">Logframe<br>101</div><div class="title-sub">The logical framework, built from the results chain up &mdash; results, indicators, means of verification and assumptions, for development practitioners in South Asia.</div><div class="title-tags"><span class="title-tag">Practical</span><span class="title-tag">Donor-Ready</span><span class="title-tag">100 Slides</span><span class="title-tag">Free Access</span></div></div><div class="title-geo"><svg viewBox="0 0 300 620" xmlns="http://www.w3.org/2000/svg" style="width:100%;height:100%"><defs><pattern id="hex" x="0" y="0" width="40" height="46" patternUnits="userSpaceOnUse"><polygon points="20,2 38,12 38,34 20,44 2,34 2,12" fill="none" stroke="white" stroke-width="1"/></pattern></defs><rect width="300" height="620" fill="url(#hex)"/></svg></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">01</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s2"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Agenda</div><div class="slide-title md" style="margin-bottom:8px">What We Cover</div><div class="toc-grid"><div class="toc-item"><div class="toc-num">01</div><div class="toc-name">What a Logframe Is</div><div class="toc-slides">Slides 3&ndash;9</div></div><div class="toc-item"><div class="toc-num">02</div><div class="toc-name">The Results Chain</div><div class="toc-slides">Slides 10&ndash;18</div></div><div class="toc-item"><div class="toc-num">03</div><div class="toc-name">Inputs, Activities, Outputs</div><div class="toc-slides">Slides 19&ndash;29</div></div><div class="toc-item"><div class="toc-num">04</div><div class="toc-name">Outcomes &amp; Impact</div><div class="toc-slides">Slides 30&ndash;40</div></div><div class="toc-item"><div class="toc-num">05</div><div class="toc-name">Indicators</div><div class="toc-slides">Slides 41&ndash;49</div></div><div class="toc-item"><div class="toc-num">06</div><div class="toc-name">Means of Verification</div><div class="toc-slides">Slides 50&ndash;57</div></div><div class="toc-item"><div class="toc-num">07</div><div class="toc-name">Assumptions</div><div class="toc-slides">Slides 58&ndash;64</div></div><div class="toc-item"><div class="toc-num">08</div><div class="toc-name">Risk</div><div class="toc-slides">Slides 65&ndash;73</div></div><div class="toc-item"><div class="toc-num">09</div><div class="toc-name">Building the Matrix</div><div class="toc-slides">Slides 74&ndash;81</div></div><div class="toc-item"><div class="toc-num">10</div><div class="toc-name">Critiques &amp; Limits</div><div class="toc-slides">Slides 82&ndash;89</div></div><div class="toc-item"><div class="toc-num">11</div><div class="toc-name">Tools &amp; Practice</div><div class="toc-slides">Slides 90&ndash;98</div></div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">02</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s3"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="section-divider"><div class="div-num">01</div><div class="div-label">Section One</div><div class="div-title">What a Logframe Is</div><div class="div-accent"></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">03</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s4"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Definition</div><div class="term-box"><div class="term-word">Logical framework (logframe)</div><div class="term-def">A one-page matrix that lays out what a project is trying to achieve, how it will get there, how you will know if it worked, and what has to hold true for the logic to run. Rows are levels of result; columns are the indicator, its source, and the assumptions.</div></div><div class="slide-body">It is two things at once: a <strong>planning</strong> tool that forces you to think through your logic, and a <strong>management</strong> tool you return to as the project runs.</div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">04</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s5"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">The shape</div><div class="slide-title md">A 4&times;4 grid, read two ways</div><table class="ctable"><thead><tr><th>Results level</th><th>Indicator</th><th>Means of verification</th><th>Assumptions</th></tr></thead><tbody><tr><td><strong>Impact / Goal</strong></td><td>How measured</td><td>Where the data comes from</td><td>What must hold</td></tr><tr><td><strong>Outcome / Purpose</strong></td><td>How measured</td><td>Source</td><td>Assumption</td></tr><tr><td><strong>Outputs</strong></td><td>How measured</td><td>Source</td><td>Assumption</td></tr><tr><td><strong>Activities</strong> (&amp; inputs)</td><td>How measured</td><td>Source</td><td>Assumption</td></tr></tbody></table><div class="hbox"><div class="hbox-text">Read <strong>down</strong> the first column for the story of change; read <strong>across</strong> a row to see how each result is measured and what it depends on.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">05</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s6"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Where it came from</div><div class="slide-title md">A short history</div><div class="slide-body">The logframe was developed for <strong>USAID in 1969</strong> by Leon Rosenberg and colleagues, to bring discipline to vague project plans. It spread through bilateral and UN agencies, was adapted by GTZ into the participatory <strong>ZOPP / objectives-oriented planning</strong> method, and remains a near-universal donor requirement today &mdash; the EU, DFID/FCDO, GIZ, the UN and most large NGOs all use a version.</div><div class="hbox amber"><div class="hbox-text">Because so many donors mandate it, the logframe is often the first formal document a funded project produces. Knowing it well is a practical survival skill.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">06</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s7"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Why bother</div><div class="slide-title md">What a good logframe gives you</div><ul class="bullet-list green"><li><strong>A testable theory.</strong> It states, on one page, the if&ndash;then logic your project is betting on.</li><li><strong>Shared language.</strong> Funder, manager and field team mean the same thing by &ldquo;outcome&rdquo;.</li><li><strong>A monitoring spine.</strong> The indicators column tells you exactly what to collect.</li><li><strong>Honesty about risk.</strong> The assumptions column makes you name what could break.</li></ul></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">07</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s8"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">What it is not</div><div class="slide-title md">A logframe is not the whole plan</div><div class="slide-body">The matrix is a summary, not a substitute for a theory of change, a work plan, a budget or a risk register. It compresses a rich design into a grid &mdash; useful for discipline and reporting, dangerous if mistaken for the full picture.</div><div class="hbox red"><div class="hbox-text">Filling in the boxes is not the same as having a sound design. A neat logframe over a weak theory is just tidy wishful thinking.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">08</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s9"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">The family</div><div class="slide-title md">Logframe, theory of change, results framework</div><table class="ctable"><thead><tr><th>Tool</th><th>What it is</th><th>Strength</th></tr></thead><tbody><tr><td>Theory of change</td><td>A narrative + diagram of how and why change happens</td><td>Rich, shows pathways &amp; mechanisms</td></tr><tr><td>Results framework</td><td>A hierarchy of objectives and sub-objectives</td><td>Good for portfolios / strategy</td></tr><tr><td>Logframe</td><td>A matrix of results, indicators, sources, assumptions</td><td>Compact, measurable, donor-ready</td></tr></tbody></table><div class="hbox indigo"><div class="hbox-text">Best practice: build the <strong>theory of change first</strong>, then summarise its causal spine into the logframe. The logframe is the ToC, disciplined into a grid.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">09</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s10"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="section-divider"><div class="div-num">02</div><div class="div-label">Section Two</div><div class="div-title">The Results Chain</div><div class="div-accent"></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">10</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s11"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">The spine</div><div class="slide-title md">The results chain</div><div class="flow"><div class="flow-step"><div class="flow-num">IN</div><div class="flow-label">Inputs</div></div><div class="flow-arrow">&rarr;</div><div class="flow-step"><div class="flow-num">ACT</div><div class="flow-label">Activities</div></div><div class="flow-arrow">&rarr;</div><div class="flow-step"><div class="flow-num">OUT</div><div class="flow-label">Outputs</div></div><div class="flow-arrow">&rarr;</div><div class="flow-step"><div class="flow-num">OC</div><div class="flow-label">Outcomes</div></div><div class="flow-arrow">&rarr;</div><div class="flow-step"><div class="flow-num">IMP</div><div class="flow-label">Impact</div></div></div><div class="hbox"><div class="hbox-text">Everything in a logframe hangs on this chain. The first job is to know exactly which link a given result belongs to &mdash; that is where most logframes go wrong.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">11</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s12"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">The dividing line</div><div class="slide-title md">What you control vs. what you influence</div><div class="two-col half"><div class="col-panel green"><div class="col-panel-title">Your sphere of control</div><div class="slide-body sm">Inputs, activities and outputs. If you do the work, these happen. You are <strong>accountable</strong> for them.</div></div><div class="col-panel amber"><div class="col-panel-title">Your sphere of influence</div><div class="slide-body sm">Outcomes and impact. These depend on how others respond &mdash; participants, systems, the wider world. You <strong>contribute</strong>; you do not solely cause them.</div></div></div><div class="hbox red"><div class="hbox-text">The single most common logframe error is promising an <em>outcome</em> as if it were an <em>output</em> &mdash; claiming control over something you can only influence.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">12</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s13"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">If&ndash;then</div><div class="slide-title md">The chain is a stack of hypotheses</div><div class="slide-body">Read upward, each level is an <em>if&ndash;then</em> claim: <em>if</em> we combine these inputs, <em>then</em> we can run these activities; <em>if</em> the activities happen, <em>then</em> we get these outputs; and so on. Each step is a bet that can fail.</div><div class="hbox"><div class="hbox-text">The assumptions column (later) holds the &ldquo;and these other things also have to be true&rdquo; that each <em>if&ndash;then</em> quietly depends on.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">13</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s14"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Direction</div><div class="slide-title md">Plan top-down, deliver bottom-up</div><div class="slide-body">When you <strong>design</strong>, start from the impact you want and work down: what outcome would contribute to it, what outputs would produce that outcome, what activities make those outputs. When you <strong>implement</strong>, you move the other way: inputs fund activities that yield outputs.</div><div class="hbox green"><div class="hbox-text">Designing downward keeps you honest &mdash; every activity has to earn its place by pointing at the result above it. Activities with no result above them are busywork.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">14</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s15"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">A worked chain</div><div class="slide-title md">One example, all the way up</div><table class="ctable"><thead><tr><th>Level</th><th>Example (girls&rsquo; education programme)</th></tr></thead><tbody><tr><td>Impact</td><td>Women&rsquo;s economic and social participation rises in the district</td></tr><tr><td>Outcome</td><td>More girls complete secondary school</td></tr><tr><td>Output</td><td>2,000 girls receive scholarships and after-school tutoring</td></tr><tr><td>Activity</td><td>Recruit tutors; disburse scholarships; run classes</td></tr><tr><td>Input</td><td>Funds, teachers, classrooms, materials</td></tr></tbody></table><div class="hbox"><div class="hbox-text">Notice the jump from output (girls enrolled and tutored) to outcome (girls completing school): that gap is where families, schools and the economy must cooperate.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">15</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s16"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Common confusion</div><div class="slide-title md">Output or outcome? A quick test</div><ul class="bullet-list sm"><li><strong>Output</strong> = the goods and services you deliver. &ldquo;500 health workers trained.&rdquo; It is done when you have done it.</li><li><strong>Outcome</strong> = the change in others&rsquo; behaviour, knowledge or condition. &ldquo;Health workers correctly manage childhood illness.&rdquo; It depends on whether the training took.</li></ul><div class="hbox amber"><div class="hbox-text">Test: <em>could you report this complete the day you finish delivery?</em> If yes, it is an output. If it needs someone else to change, it is an outcome.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">16</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s17"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Attribution</div><div class="slide-title md">The higher you climb, the less it is just you</div><div class="slide-body">At output level, your project is the cause. At outcome level, you are one of several forces. At impact level, you are a small contributor among many &mdash; economic conditions, government policy, other programmes. This is the <strong>attribution gap</strong>.</div><div class="hbox red"><div class="hbox-text">Claim <em>contribution</em>, not sole credit, for outcomes and impact. Over-claiming at the top of the chain is both dishonest and, when measured, easily disproved.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">17</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s18"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">See it drawn</div><div class="slide-title md">The chain, visualised</div><div class="slide-body">ImpactMojo&rsquo;s <strong>The Long View</strong> includes an original diagram of the results chain and the attribution gap &mdash; the widening distance between what a project delivers and the change it hopes to see. It is the picture behind this whole section.</div><div class="hbox indigo"><div class="hbox-text">A logframe is the results chain, written as a table. Keep the picture in your head as you fill in the rows.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">18</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s19"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="section-divider"><div class="div-num">03</div><div class="div-label">Section Three</div><div class="div-title">Inputs, Activities, Outputs</div><div class="div-accent"></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">19</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s20"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Inputs</div><div class="slide-title md">Inputs: what you put in</div><div class="slide-body">Inputs are the resources a project consumes: money, staff time, equipment, vehicles, training materials, partner contributions. In many logframe formats inputs sit alongside activities on the bottom row, often linked to the budget.</div><ul class="bullet-list sm"><li>Be specific enough to cost: &ldquo;12 community mobilisers for 18 months&rdquo;, not &ldquo;staff&rdquo;.</li><li>Include partner and community contributions (land, volunteer time) &mdash; they are real inputs.</li></ul></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">20</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s21"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Activities</div><div class="slide-title md">Activities: what you do</div><div class="slide-body">Activities are the actions that convert inputs into outputs: train, build, distribute, mobilise, advise. Write them as verbs. Each activity should connect clearly to an output above it.</div><div class="hbox amber"><div class="hbox-text">Keep the logframe to a manageable set of activity <em>clusters</em> (say 3&ndash;6 per output). The detailed task list belongs in the work plan, not the matrix.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">21</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s22"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Outputs</div><div class="slide-title md">Outputs: what you produce</div><div class="slide-body">Outputs are the direct, countable products of your activities &mdash; the goods and services in the hands of participants. They are fully within your control, so they are written as <strong>completed deliverables</strong>.</div><ul class="bullet-list green"><li>&ldquo;1,500 farmers trained in drip irrigation&rdquo;</li><li>&ldquo;20 village water committees formed and functional&rdquo;</li><li>&ldquo;A district nutrition dashboard built and handed over&rdquo;</li></ul></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">22</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s23"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Verbs &amp; tense</div><div class="slide-title md">Phrase each level in its own grammar</div><table class="ctable"><thead><tr><th>Level</th><th>Phrasing</th><th>Example</th></tr></thead><tbody><tr><td>Activity</td><td>Verb (the doing)</td><td>Train health workers</td></tr><tr><td>Output</td><td>Delivered / completed</td><td>500 health workers trained</td></tr><tr><td>Outcome</td><td>Change of state in others</td><td>Health workers apply IMNCI protocols</td></tr><tr><td>Impact</td><td>Higher-order condition</td><td>Under-5 mortality falls</td></tr></tbody></table><div class="hbox"><div class="hbox-text">Consistent phrasing is not pedantry &mdash; mixing an activity verb into an outcome row is the surface sign of muddled logic underneath.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">23</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s24"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">One result per box</div><div class="slide-title md">No smuggling with &ldquo;and&rdquo;</div><div class="slide-body">A statement with an &ldquo;and&rdquo; in it is usually two results hiding in one box: &ldquo;farmers trained <em>and</em> adopting new methods&rdquo; bundles an output with an outcome. Split them.</div><div class="hbox red"><div class="hbox-text">Each box should carry exactly one result, measurable on its own. If you cannot put a single indicator on it, it is doing too many jobs.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">24</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s25"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">How many?</div><div class="slide-title md">Keep the matrix small</div><div class="slide-body">A workable logframe has <strong>one impact, one (sometimes two) outcomes, and a handful of outputs</strong> &mdash; rarely more than five or six. More than that and the matrix stops being a one-page summary and becomes an unreadable spreadsheet nobody returns to.</div><div class="hbox amber"><div class="hbox-text">If you have ten outputs, you probably have two projects, or you have listed activities in the output row. Consolidate.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">25</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s26"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">The vertical test</div><div class="slide-title md">Read the logic upward and challenge it</div><div class="slide-body">Once the left column is drafted, test it: at each step, ask <em>&ldquo;is this enough to plausibly produce the level above?&rdquo;</em> If outputs alone clearly will not deliver the outcome, the design has a gap &mdash; or there is an assumption you have not yet named.</div><div class="hbox green"><div class="hbox-text">This upward read is the heart of the &ldquo;logical&rdquo; in logical framework. A logframe that fails it is just a list.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">26</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s27"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Worked rows</div><div class="slide-title md">Inputs to outputs, filled in</div><table class="ctable"><thead><tr><th>Level</th><th>Statement</th></tr></thead><tbody><tr><td>Output 1</td><td>800 adolescent girls enrolled in after-school STEM clubs</td></tr><tr><td>Activities</td><td>Set up 40 clubs; recruit &amp; train 40 facilitators; supply kits</td></tr><tr><td>Inputs</td><td>40 facilitators, club kits, venue agreements, &#8377;X budget</td></tr></tbody></table><div class="hbox"><div class="hbox-text">Notice the output is countable (800 girls, 40 clubs) and complete on delivery &mdash; exactly what makes it an output and not an outcome.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">27</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s28"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Costing the chain</div><div class="slide-title md">Tie inputs to the budget</div><div class="slide-body">Inputs are the bridge between the logframe and the budget. A well-built logframe lets a reader trace money to activity to output: this is what makes it a management tool, not just a planning artefact. Donors increasingly ask for cost per output (unit economics).</div><div class="hbox indigo"><div class="hbox-text">For more on cost per result, see ImpactMojo&rsquo;s <strong>Cost-Effectiveness 101</strong> and <strong>Public Finance &amp; Budgeting</strong> courses.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">28</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s29"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Section recap</div><div class="slide-title md">The bottom half, in one line</div><div class="hbox green"><div class="hbox-text"><strong>Inputs</strong> fund <strong>activities</strong> that produce <strong>outputs</strong> &mdash; all within your control, all written as you-did-it deliverables. The interesting, riskier half of the chain comes next.</div></div><div class="slide-body">Get this half tight and countable, and the monitoring almost writes itself. Get it muddled, and no amount of indicator-crafting upstream will save the matrix.</div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">29</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s30"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="section-divider"><div class="div-num">04</div><div class="div-label">Section Four</div><div class="div-title">Outcomes &amp; Impact</div><div class="div-accent"></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">30</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s31"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Outcomes</div><div class="slide-title md">Outcomes: the change you are really after</div><div class="slide-body">An outcome is the change in behaviour, knowledge, relationships or condition that your outputs are meant to bring about. It is usually the <strong>purpose</strong> of the project &mdash; the single most important row in the matrix, and the hardest to write well.</div><div class="hbox"><div class="hbox-text">If the impact is the destination and outputs are what you hand over, the outcome is the <em>uptake</em> &mdash; what people actually do differently because of what you delivered.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">31</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s32"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Impact</div><div class="slide-title md">Impact: the higher purpose</div><div class="slide-body">Impact (or goal) is the long-term, higher-level change your project contributes to: lower mortality, higher incomes, greater equality. It is usually shared with other actors and other programmes, realised over years, and beyond any single project to deliver alone.</div><div class="hbox amber"><div class="hbox-text">State the impact you contribute to, but do not pretend to own it. &ldquo;Contributes to reduced child stunting in the district&rdquo; is honest; &ldquo;reduces stunting&rdquo; alone over-claims.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">32</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s33"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">One purpose</div><div class="slide-title md">Why most logframes allow only one outcome</div><div class="slide-body">Classic logframe discipline insists on a <strong>single purpose / outcome</strong>. The reason is focus: a project chasing three outcomes usually does none well, and the matrix can no longer show a clean line of logic. If you genuinely have two, ask whether they are really two projects.</div><div class="hbox red"><div class="hbox-text">Multiple outcomes are a warning sign, not an achievement. They often hide a lack of decision about what the project is actually for.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">33</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s34"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Writing an outcome</div><div class="slide-title md">A good outcome statement</div><ul class="bullet-list green"><li>Describes a change in <strong>someone other than the project</strong> (participants, institutions).</li><li>Is realistic given the outputs &mdash; reachable within the project, not a wish.</li><li>Is measurable: you can name an indicator that would move if it were true.</li><li>Names the target group: <em>whose</em> behaviour or condition changes.</li></ul><div class="hbox"><div class="hbox-text">&ldquo;Smallholder farmers in 40 villages adopt and sustain drip irrigation&rdquo; &mdash; change, in named others, plausibly caused by the outputs, and measurable.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">34</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s35"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">The big jump</div><div class="slide-title md">Mind the output&ndash;outcome gap</div><div class="slide-body">The leap from output to outcome is where projects most often fail &mdash; and where the assumptions matter most. Training delivered (output) does not guarantee practice changed (outcome); a clinic built does not guarantee it is used. Name what has to happen in between.</div><div class="hbox amber"><div class="hbox-text">If you cannot explain <em>why</em> the outputs would lead to the outcome, you do not yet have a theory of change &mdash; you have a list of hopes.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">35</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s36"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Behaviour</div><div class="slide-title md">Most outcomes are behaviour change</div><div class="slide-body">In development work, the outcome is usually that some group <em>does something differently</em>: farmers adopt, mothers attend, officials enforce, girls stay in school. Behaviour is influenced by far more than your project, which is exactly why outcomes sit in the sphere of influence.</div><div class="hbox indigo"><div class="hbox-text">Designing for behaviour change is its own craft &mdash; see ImpactMojo&rsquo;s <strong>Behaviour-Change Communication</strong> course and BCT repository.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">36</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s37"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Time</div><div class="slide-title md">Results take time to appear</div><div class="slide-body">Outputs land during the project; outcomes often emerge near or after its end; impact may take years. A logframe measured only at project close can miss the outcomes it was built to create &mdash; and credit impacts that have not yet had time to form.</div><div class="hbox"><div class="hbox-text">Match your measurement timing to where each result sits in time. Some outcomes need a follow-up survey months after the last activity.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">37</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s38"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Worked top rows</div><div class="slide-title md">Outcome and impact, filled in</div><table class="ctable"><thead><tr><th>Level</th><th>Statement</th></tr></thead><tbody><tr><td>Impact</td><td>Contributes to higher and more resilient incomes for smallholder households</td></tr><tr><td>Outcome</td><td>Farmers in 40 villages adopt and sustain water-efficient irrigation</td></tr><tr><td>Output</td><td>1,500 farmers trained and equipped with drip-irrigation kits</td></tr></tbody></table><div class="hbox green"><div class="hbox-text">&ldquo;Contributes to&rdquo; at impact, a behaviour change at outcome, a countable deliverable at output &mdash; each row in its proper grammar.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">38</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s39"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Sustainability</div><div class="slide-title md">Will it last past the project?</div><div class="slide-body">A strong outcome statement often carries a hint of durability &mdash; &ldquo;adopt <em>and sustain</em>&rdquo;. Donors increasingly ask not just whether change happened, but whether it will hold once funding ends. That depends on systems, ownership and incentives, not just your outputs.</div><div class="hbox amber"><div class="hbox-text">Sustainability usually lives in the assumptions and in the exit strategy. Name who keeps the change alive after you leave.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">39</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s40"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Section recap</div><div class="slide-title md">The top half, in one line</div><div class="hbox green"><div class="hbox-text"><strong>Outputs</strong> are taken up as <strong>outcomes</strong> (behaviour change in others) which <strong>contribute to</strong> <strong>impact</strong> (higher-order change). You control the first, influence the second, and merely contribute to the third.</div></div><div class="slide-body">With the left column complete, the next job is to make each row measurable. That is the indicators column.</div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">40</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s41"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="section-divider"><div class="div-num">05</div><div class="div-label">Section Five</div><div class="div-title">Indicators</div><div class="div-accent"></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">41</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s42"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Definition</div><div class="term-box"><div class="term-word">Indicator (OVI)</div><div class="term-def">An <strong>objectively verifiable indicator</strong> is a specific, measurable sign that a result has been achieved. It answers: &ldquo;how would we know?&rdquo; For each row of the chain you name at least one indicator that would move if that result were real.</div></div><div class="slide-body">&ldquo;Objectively verifiable&rdquo; means two people measuring it independently would get the same answer &mdash; no judgement call required.</div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">42</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s43"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">SMART</div><div class="slide-title md">Make every indicator SMART</div><div class="stat-grid c3"><div class="stat-card"><div class="stat-number">S&middot;M</div><div class="stat-label"><strong>Specific</strong> &amp; <strong>Measurable</strong> &mdash; clear what, countable how</div></div><div class="stat-card indigo"><div class="stat-number">A&middot;R</div><div class="stat-label"><strong>Achievable</strong> &amp; <strong>Relevant</strong> &mdash; realistic, and tied to the result</div></div><div class="stat-card green"><div class="stat-number">T</div><div class="stat-label"><strong>Time-bound</strong> &mdash; by when</div></div></div><div class="hbox"><div class="hbox-text">&ldquo;% of trained midwives correctly performing newborn resuscitation, measured by observation, rising from 40% to 80% by end of year 2.&rdquo;</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">43</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s44"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Anatomy</div><div class="slide-title md">A full indicator has four parts</div><ul class="bullet-list"><li><strong>Unit / what</strong> &mdash; % of women, number of villages, rate per 1,000.</li><li><strong>Baseline</strong> &mdash; the value at the start. Without it you cannot show change.</li><li><strong>Target</strong> &mdash; the value you commit to reach, by a date.</li><li><strong>Disaggregation</strong> &mdash; by sex, age, caste, location, disability.</li></ul><div class="hbox red"><div class="hbox-text">An indicator with no baseline is the most common logframe fault. A target without a starting point measures nothing.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">44</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s45"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Quant &amp; qual</div><div class="slide-title md">Numbers and judgements both count</div><div class="two-col half"><div class="col-panel"><div class="col-panel-title">Quantitative</div><div class="slide-body sm">Counts, rates, percentages, scores. Easy to verify, easy to aggregate &mdash; but can miss the &ldquo;why&rdquo;.</div></div><div class="col-panel green"><div class="col-panel-title">Qualitative</div><div class="slide-body sm">Quality of participation, perceived fairness, case stories. Harder to verify; use a defined scale or rubric so it stays objective.</div></div></div><div class="hbox"><div class="hbox-text">The best logframes mix both: a number for &ldquo;how much&rdquo; and a qualitative measure for &ldquo;how well&rdquo;.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">45</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s46"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Proxies</div><div class="slide-title md">When you can&rsquo;t measure it directly</div><div class="slide-body">Some results &mdash; empowerment, resilience, trust &mdash; have no direct meter. A <strong>proxy indicator</strong> stands in: e.g. women&rsquo;s control over household spending as a proxy for empowerment. Choose proxies carefully and state that they are proxies.</div><div class="hbox amber"><div class="hbox-text">Beware Goodhart&rsquo;s law: <em>when a measure becomes a target, it stops being a good measure.</em> People optimise the proxy, not the thing you cared about.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">46</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s47"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Too many</div><div class="slide-title md">A few good indicators beat many weak ones</div><div class="slide-body">Every indicator is a data-collection commitment. One or two strong indicators per result is usually enough; a logframe with forty indicators becomes a monitoring burden that crowds out actually running the project.</div><div class="hbox red"><div class="hbox-text">Before adding an indicator, ask: <em>who will collect this, how often, and what decision will it inform?</em> If there is no answer, drop it.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">47</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s48"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Standard sets</div><div class="slide-title md">Borrow indicators where you can</div><div class="slide-body">Many sectors have agreed indicator sets &mdash; the SDG indicators, WHO and DHS health indicators, education access measures, IRIS+ for impact investing. Using standard definitions makes your results comparable and saves you re-inventing measurement.</div><div class="hbox indigo"><div class="hbox-text">Match to national data where you can (NFHS, Census, PLFS) so your baseline and target sit in a context readers already know.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">48</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s49"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Worked indicators</div><div class="slide-title md">Indicators across the chain</div><table class="ctable"><thead><tr><th>Result</th><th>Indicator (with baseline &rarr; target)</th></tr></thead><tbody><tr><td>Output</td><td>No. of farmers trained: 0 &rarr; 1,500 by Q6 (disagg. by sex)</td></tr><tr><td>Outcome</td><td>% of trained farmers still using drip at 12 months: &ndash; &rarr; 60%</td></tr><tr><td>Impact</td><td>Mean kharif income of participant households: baseline survey &rarr; +20%</td></tr></tbody></table><div class="hbox green"><div class="hbox-text">Each indicator carries a unit, a baseline, a target and a date &mdash; and gets harder to attribute the higher you go. That is honest measurement.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">49</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s50"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="section-divider"><div class="div-num">06</div><div class="div-label">Section Six</div><div class="div-title">Means of Verification</div><div class="div-accent"></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">50</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s51"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Definition</div><div class="term-box"><div class="term-word">Means of verification (MoV)</div><div class="term-def">The third column: <strong>where the data for each indicator comes from</strong>, who collects it, how often, and how. If the indicator says &ldquo;what we measure&rdquo;, the MoV says &ldquo;how we will actually get that number&rdquo;.</div></div><div class="slide-body">An indicator with no realistic means of verification is a promise you cannot keep. The two columns must be designed together.</div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">51</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s52"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Sources</div><div class="slide-title md">Where verification data comes from</div><ul class="bullet-list sm"><li><strong>Project records</strong> &mdash; attendance sheets, distribution logs, training registers (cheap, for outputs).</li><li><strong>Surveys</strong> &mdash; baseline / midline / endline of participants (for outcomes).</li><li><strong>Observation</strong> &mdash; direct checks of practice or quality.</li><li><strong>Official statistics</strong> &mdash; NFHS, Census, administrative data (for impact / context).</li><li><strong>Independent reports</strong> &mdash; third-party evaluations, audits.</li></ul></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">52</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s53"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">The reality check</div><div class="slide-title md">MoV is where ambition meets the budget</div><div class="slide-body">Filling in the MoV column is a cost test. A fancy outcome indicator that needs a 5,000-household panel survey may be unaffordable. If you cannot pay to verify it, you cannot claim it &mdash; so revise the indicator to something you can actually measure.</div><div class="hbox red"><div class="hbox-text">Every indicator&rsquo;s MoV has a price. The monitoring budget is set, in effect, in this column &mdash; plan for it (often 5&ndash;10% of project cost).</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">53</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s54"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Frequency</div><div class="slide-title md">How often, and who</div><div class="slide-body">A good MoV entry names the <strong>method</strong>, the <strong>frequency</strong> and the <strong>responsible person</strong>: &ldquo;observation checklist, quarterly, by the M&amp;E officer&rdquo;. Output data is usually continuous; outcome surveys are periodic; impact data may come once, at endline or after.</div><div class="hbox"><div class="hbox-text">Tie the frequency to decisions: collect output data often enough to course-correct, but do not survey outcomes so often that measurement disrupts the work.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">54</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s55"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Quality</div><div class="slide-title md">Verifiable means trustworthy</div><div class="slide-body">The point of the MoV column is credibility: a sceptical reader (or auditor, or evaluator) should be able to follow it to the same conclusion. That means the source must be reliable, the method consistent, and the data retained.</div><ul class="bullet-list sm"><li>Prefer sources someone else could independently check.</li><li>Keep the raw data, not just the summary, so claims can be re-verified.</li><li>For self-reported data, note the bias and triangulate where it matters.</li></ul></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">55</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s56"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Worked MoV</div><div class="slide-title md">Indicator and its verification, paired</div><table class="ctable"><thead><tr><th>Indicator</th><th>Means of verification</th></tr></thead><tbody><tr><td>1,500 farmers trained</td><td>Training registers, ongoing, M&amp;E officer</td></tr><tr><td>60% still using drip at 12 months</td><td>Follow-up sample survey of 300 farmers, year 2, external enumerators</td></tr><tr><td>+20% kharif income</td><td>Baseline &amp; endline household survey; cross-checked with mandi records</td></tr></tbody></table><div class="hbox green"><div class="hbox-text">Cheap records for outputs, a sample survey for the outcome, a before/after survey for impact &mdash; cost rising with the level, as it should.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">56</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s57"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Connecting M&amp;E</div><div class="slide-title md">The logframe is your M&amp;E plan&rsquo;s backbone</div><div class="slide-body">Columns two and three &mdash; indicators and means of verification &mdash; are, in effect, your monitoring plan. A fuller M&amp;E plan just adds detail: tools, sampling, responsibilities, timing, analysis and use.</div><div class="hbox indigo"><div class="hbox-text">For the wider system around the matrix, see ImpactMojo&rsquo;s <strong>MEL Basics 101</strong> and <strong>The Evidence Question</strong> flagship.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">57</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s58"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="section-divider"><div class="div-num">07</div><div class="div-label">Section Seven</div><div class="div-title">Assumptions</div><div class="div-accent"></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">58</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s59"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Definition</div><div class="term-box"><div class="term-word">Assumptions</div><div class="term-def">The fourth column: the <strong>external conditions that must hold</strong> for each step of the logic to work, but which are outside your control. They are the &ldquo;and also&rdquo; that every if&ndash;then quietly relies on.</div></div><div class="slide-body">Assumptions are where a logframe gets honest. They name the things that could break your chain even if you do everything right.</div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">59</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s60"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">The if&ndash;and&ndash;then logic</div><div class="slide-title md">How assumptions complete the chain</div><div class="slide-body">Read vertically <em>with</em> the assumptions: <em>IF</em> we deliver the outputs <em>AND</em> the assumptions at that level hold, <em>THEN</em> we reach the outcome. The assumption column sits to the side of each step, carrying the conditions that step depends on.</div><div class="flow"><div class="flow-step"><div class="flow-num">IF</div><div class="flow-label">Outputs delivered</div></div><div class="flow-arrow">+</div><div class="flow-step"><div class="flow-num">AND</div><div class="flow-label">Assumptions hold</div></div><div class="flow-arrow">&rarr;</div><div class="flow-step"><div class="flow-num">THEN</div><div class="flow-label">Outcome reached</div></div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">60</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s61"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Examples</div><div class="slide-title md">What assumptions look like</div><ul class="bullet-list amber"><li>&ldquo;Monsoon rainfall is within normal range&rdquo; (for an agriculture outcome).</li><li>&ldquo;The government does not cut the teacher-recruitment budget&rdquo; (for an education outcome).</li><li>&ldquo;Trained staff are not transferred out within the year&rdquo; (for a health-quality outcome).</li><li>&ldquo;Market prices for the crop stay stable&rdquo; (for an income impact).</li></ul><div class="hbox"><div class="hbox-text">Each is plausible, outside your control, and capable of breaking the logic. That is exactly what belongs in this column.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">61</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s62"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">The assumptions algorithm</div><div class="slide-title md">Decide what to do with each one</div><div class="slide-body">For every assumption, ask two questions: <em>how likely is it to hold?</em> and <em>how important is it?</em></div><table class="ctable"><thead><tr><th>Likely to hold?</th><th>Action</th></tr></thead><tbody><tr><td>Almost certain</td><td>Note it, move on &mdash; not a real risk</td></tr><tr><td>Likely but not sure</td><td>Keep in the logframe; monitor it</td></tr><tr><td>Unlikely &amp; important</td><td>Redesign the project to remove the dependency, or add an activity to secure it</td></tr><tr><td>Will not hold &amp; fatal</td><td>A &ldquo;killer assumption&rdquo; &mdash; the project may not be viable</td></tr></tbody></table></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">62</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s63"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Killer assumptions</div><div class="slide-title md">When an assumption sinks the project</div><div class="slide-body">A <strong>killer assumption</strong> is one that is both essential and unlikely to hold. If your whole outcome depends on a policy passing that almost certainly will not, no amount of good delivery will save you. Better to find this on paper than two years in.</div><div class="hbox red"><div class="hbox-text">The discipline of writing assumptions exists largely to surface killer assumptions early &mdash; while you can still redesign or walk away.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">63</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s64"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Not an excuse</div><div class="slide-title md">Assumptions are to manage, not to hide behind</div><div class="slide-body">Assumptions are not a place to park everything that might go wrong so you can blame them later. Anything you can influence belongs in your activities, not your assumptions. Reserve the column for genuinely external conditions &mdash; and then actively monitor them.</div><div class="hbox amber"><div class="hbox-text">Revisit assumptions at every review. An assumption that has started to fail is an early warning the outcome is at risk.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">64</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s65"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="section-divider"><div class="div-num">08</div><div class="div-label">Section Eight</div><div class="div-title">Risk</div><div class="div-accent"></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">65</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s66"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">From assumptions to risk</div><div class="slide-title md">A risk is an assumption that might fail</div><div class="slide-body">Flip an assumption to its negative and you have a risk: &ldquo;rainfall is normal&rdquo; &rarr; &ldquo;drought reduces yields&rdquo;. Modern donor formats often pair the logframe with a <strong>risk register</strong> that goes further: naming, scoring and assigning each risk.</div><div class="hbox"><div class="hbox-text">Same underlying reality, two lenses: the assumption is what you hope holds; the risk is what happens if it does not.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">66</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s67"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Scoring</div><div class="slide-title md">Likelihood &times; impact</div><div class="slide-body">Risks are usually scored on two axes &mdash; how <strong>likely</strong> they are and how big the <strong>impact</strong> would be &mdash; often on a 1&ndash;5 scale each. The product (or a colour grid) gives a rough priority so attention goes to the high&ndash;high corner.</div><div class="hbox indigo"><div class="hbox-text">A 5&times;5 likelihood&ndash;impact grid is the standard picture. It is a small heatmap &mdash; and, like any heatmap, it is a rough sort, not a precise number.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">67</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s68"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">The 4 Ts</div><div class="slide-title md">Four ways to handle a risk</div><div class="stat-grid c4"><div class="stat-card"><div class="stat-number">Treat</div><div class="stat-label">Act to reduce likelihood or impact</div></div><div class="stat-card indigo"><div class="stat-number">Transfer</div><div class="stat-label">Shift it &mdash; insurance, partner, contract</div></div><div class="stat-card amber"><div class="stat-number">Tolerate</div><div class="stat-label">Accept it; monitor; have a plan B</div></div><div class="stat-card red"><div class="stat-number">Terminate</div><div class="stat-label">Avoid it &mdash; change or drop the activity</div></div></div><div class="hbox"><div class="hbox-text">Most risks are <em>treated</em> or <em>tolerated</em>. The value is in deciding deliberately, not in the label.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">68</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s69"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Types</div><div class="slide-title md">Common risk categories</div><ul class="bullet-list sm"><li><strong>Contextual</strong> &mdash; politics, economy, climate, conflict, policy shifts.</li><li><strong>Programmatic</strong> &mdash; the intervention fails to work as designed; low uptake.</li><li><strong>Institutional / fiduciary</strong> &mdash; partner capacity, fraud, financial mismanagement.</li><li><strong>Reputational &amp; safeguarding</strong> &mdash; harm to participants, loss of trust.</li></ul><div class="hbox red"><div class="hbox-text">Safeguarding risk &mdash; the risk that a project harms the people it serves &mdash; is now a non-negotiable category for most funders. Never leave it out.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">69</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s70"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Owners</div><div class="slide-title md">Every risk needs a name against it</div><div class="slide-body">A risk register with no owners is a list nobody acts on. Each significant risk should have a named <strong>owner</strong> responsible for monitoring it and triggering the response, plus a <strong>trigger</strong> &mdash; the sign that the risk is materialising.</div><div class="hbox amber"><div class="hbox-text">&ldquo;If enrolment is below 60% of target by month 3, the programme manager escalates and we activate the community-mobilisation contingency.&rdquo;</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">70</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s71"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Living document</div><div class="slide-title md">Review risk on a schedule</div><div class="slide-body">Risk is not a one-time annex. New risks appear, old ones fade, scores change. A useful register is reviewed at every project board or quarterly review, with changes logged. A risk register written once and filed is theatre.</div><div class="hbox"><div class="hbox-text">Tie the risk review to the same cadence as your logframe review, so assumptions and risks &mdash; two views of the same uncertainty &mdash; move together.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">71</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s72"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Worked register</div><div class="slide-title md">A risk register row</div><table class="ctable"><thead><tr><th>Risk</th><th>L&times;I</th><th>Response</th><th>Owner</th></tr></thead><tbody><tr><td>Drought cuts yields, weakening the income case</td><td>3&times;4</td><td>Treat: promote water-efficient varieties; tolerate residual</td><td>Field lead</td></tr><tr><td>Trained staff transferred out</td><td>4&times;3</td><td>Treat: train a wider pool; brief supervisors</td><td>M&amp;E officer</td></tr><tr><td>Partner financial controls weak</td><td>2&times;5</td><td>Transfer/treat: audits, milestone disbursement</td><td>Finance</td></tr></tbody></table></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">72</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s73"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Section recap</div><div class="slide-title md">Assumptions and risk, together</div><div class="hbox green"><div class="hbox-text">The <strong>assumptions</strong> column names what must hold; the <strong>risk register</strong> names what happens if it does not, scores it, and assigns a response and an owner. Both make the logframe honest about uncertainty.</div></div><div class="slide-body">With all four columns understood, you are ready to assemble the full matrix &mdash; and to test it as a whole.</div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">73</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s74"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="section-divider"><div class="div-num">09</div><div class="div-label">Section Nine</div><div class="div-title">Building the Matrix</div><div class="div-accent"></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">74</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s75"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Order of work</div><div class="slide-title md">Build it in the right sequence</div><div class="flow"><div class="flow-step"><div class="flow-num">1</div><div class="flow-label">Theory of change first</div></div><div class="flow-arrow">&rarr;</div><div class="flow-step"><div class="flow-num">2</div><div class="flow-label">Left column (results)</div></div><div class="flow-arrow">&rarr;</div><div class="flow-step"><div class="flow-num">3</div><div class="flow-label">Assumptions</div></div><div class="flow-arrow">&rarr;</div><div class="flow-step"><div class="flow-num">4</div><div class="flow-label">Indicators</div></div><div class="flow-arrow">&rarr;</div><div class="flow-step"><div class="flow-num">5</div><div class="flow-label">Means of verification</div></div></div><div class="hbox"><div class="hbox-text">Resist the urge to start with indicators. If the logic is wrong, beautiful indicators measure the wrong thing.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">75</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s76"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Do it with people</div><div class="slide-title md">A logframe is better built in a room</div><div class="slide-body">The participatory tradition (ZOPP) builds the logframe in a workshop with the people who will deliver it and, ideally, those it serves. The matrix that results is usually weaker on paper but far stronger in practice, because the team owns the logic and has stress-tested it.</div><div class="hbox green"><div class="hbox-text">The conversation is the point. A logframe handed down from a consultant who never met the team is a compliance document, not a plan.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">76</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s77"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Vertical logic</div><div class="slide-title md">Test 1: does the column make sense going up?</div><div class="slide-body">Read the results column from the bottom: activities &rarr; outputs &rarr; outcome &rarr; impact. At each arrow ask whether the lower level, plus its assumptions, is genuinely enough to reach the next. Gaps mean a missing output, a missing assumption, or an over-reach.</div><div class="hbox amber"><div class="hbox-text">If you find yourself saying &ldquo;and then a miracle happens&rdquo; between two rows, you have found the gap.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">77</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s78"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Horizontal logic</div><div class="slide-title md">Test 2: does each row hang together?</div><div class="slide-body">Read each row across: result &rarr; indicator &rarr; means of verification &rarr; assumption. Does the indicator actually measure the result? Can the MoV realistically supply it? Is the assumption truly external? A row that fails this is internally inconsistent.</div><div class="hbox"><div class="hbox-text">Vertical logic tests the <em>theory</em>; horizontal logic tests the <em>measurement</em>. A strong logframe passes both.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">78</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s79"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Common faults</div><div class="slide-title md">What reviewers look for</div><ul class="bullet-list red"><li>Activities dressed up as outputs; outputs dressed up as outcomes.</li><li>Indicators with no baseline, or no realistic data source.</li><li>Too many outcomes; a fuzzy, unmeasurable purpose.</li><li>Assumptions that are really things the project controls.</li><li>A matrix that contradicts the budget or the work plan.</li></ul></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">79</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s80"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Keep it alive</div><div class="slide-title md">Revise the logframe as you learn</div><div class="slide-body">A logframe is a hypothesis, and hypotheses get updated. Most donors allow &mdash; and expect &mdash; revisions at review points: refined targets, corrected assumptions, dropped indicators. A frozen logframe is a sign nobody is using it.</div><div class="hbox green"><div class="hbox-text">Log every change and why. The trail of revisions is itself evidence of adaptive, learning-oriented management.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">80</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s81"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Full example</div><div class="slide-title md">One complete row of the matrix</div><table class="ctable"><thead><tr><th>Result</th><th>Indicator</th><th>MoV</th><th>Assumption</th></tr></thead><tbody><tr><td>Outcome: farmers adopt &amp; sustain drip irrigation</td><td>60% of trained farmers still using drip at 12 months</td><td>Follow-up survey of 300, year 2</td><td>Water availability and crop prices stay viable</td></tr></tbody></table><div class="hbox indigo"><div class="hbox-text">A single row, read across, contains a whole small theory: what changes, how we will know, where the number comes from, and what it depends on.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">81</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s82"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="section-divider"><div class="div-num">10</div><div class="div-label">Section Ten</div><div class="div-title">Critiques &amp; Limits</div><div class="div-accent"></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">82</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s83"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Honest about the tool</div><div class="slide-title md">The logframe has real critics</div><div class="slide-body">For all its usefulness, the logframe has been criticised for decades &mdash; by practitioners, evaluators and scholars. Knowing the critiques makes you a better user: you keep the discipline while avoiding the traps.</div><div class="hbox"><div class="hbox-text">The goal is not to abandon the logframe but to hold it lightly &mdash; as a useful summary, not a description of how change really works.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">83</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s84"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Critique 1</div><div class="slide-title md">Change is rarely linear</div><div class="slide-body">The results chain implies a tidy, one-directional flow. Real change is messy, looping, full of feedback and unintended effects. Complex problems &mdash; governance, social norms, systems &mdash; do not move in a straight line from activity to impact.</div><div class="hbox amber"><div class="hbox-text">For complex settings, pair the logframe with systems thinking and outcome-mapping approaches that allow for non-linear, emergent change.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">84</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s85"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Critique 2</div><div class="slide-title md">It can crowd out what it can&rsquo;t count</div><div class="slide-body">Because the logframe rewards the measurable, teams can drift toward what is easy to count &mdash; outputs, numbers trained &mdash; and away from harder, more important changes in power, relationships or dignity. The map starts to shape the territory.</div><div class="hbox red"><div class="hbox-text">&ldquo;Not everything that counts can be counted.&rdquo; Guard against measuring the trivial precisely while ignoring the vital.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">85</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s86"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Critique 3</div><div class="slide-title md">It can lock in a plan that should flex</div><div class="slide-body">A logframe agreed at the start, then treated as a contract, can punish teams for adapting &mdash; even when learning shows the original plan was wrong. Rigidly enforced, it discourages exactly the responsiveness good development needs.</div><div class="hbox amber"><div class="hbox-text">This is what &ldquo;adaptive management&rdquo; and Doing Development Differently push back on: keep the logframe, but let it be revised as you learn.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">86</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s87"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Critique 4</div><div class="slide-title md">It serves the donor more than the community</div><div class="slide-body">Logframes are written upward, in the donor&rsquo;s language and categories. Critics note this can centre the funder&rsquo;s accountability over the priorities and knowledge of the people the project serves &mdash; a power dynamic worth naming.</div><div class="hbox indigo"><div class="hbox-text">Building the logframe <em>with</em> communities, and including indicators they care about, pushes back against this. See <strong>Decolonial Development 101</strong>.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">87</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s88"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Alternatives</div><div class="slide-title md">Complements and alternatives</div><table class="ctable"><thead><tr><th>Approach</th><th>Good when&hellip;</th></tr></thead><tbody><tr><td>Outcome Mapping</td><td>Change runs through many actors&rsquo; behaviour; boundaries are fuzzy</td></tr><tr><td>Outcome Harvesting</td><td>Outcomes can&rsquo;t be predicted in advance; you work backwards</td></tr><tr><td>Most Significant Change</td><td>You want participant-defined, story-based evidence</td></tr><tr><td>Adaptive / DDD</td><td>The problem is complex and the path must be discovered</td></tr></tbody></table><div class="hbox"><div class="hbox-text">These are not rivals so much as companions. Many strong M&amp;E systems use a logframe for accountability and one of these for learning.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">88</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s89"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Balanced view</div><div class="slide-title md">Use it well, hold it lightly</div><div class="slide-body">The logframe endures because, used well, it does something valuable: it forces a team to state its logic, commit to measurement, and name its risks, on one honest page. Its failures are mostly failures of <em>how</em> it is used &mdash; rigidly, upward, as compliance.</div><div class="hbox green"><div class="hbox-text">A good practitioner knows both the discipline and the limits. The matrix is a servant, not a master.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">89</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s90"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="section-divider"><div class="div-num">11</div><div class="div-label">Section Eleven</div><div class="div-title">Tools &amp; Practice</div><div class="div-accent"></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">90</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s91"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Donor formats</div><div class="slide-title md">Every funder wants it slightly differently</div><ul class="bullet-list sm"><li><strong>EU</strong> &mdash; intervention logic + indicators, baselines, targets, sources, assumptions.</li><li><strong>FCDO (ex-DFID)</strong> &mdash; logframe with milestones per year, plus a separate theory of change.</li><li><strong>USAID</strong> &mdash; results framework + activity MEL plans.</li><li><strong>UN agencies</strong> &mdash; results-based management; results &amp; resources frameworks.</li><li><strong>GIZ</strong> &mdash; results model / results matrix in the ZOPP tradition.</li></ul><div class="hbox"><div class="hbox-text">The logic underneath is the same. Learn the structure once and you can fill any donor&rsquo;s template.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">91</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s92"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Software</div><div class="slide-title md">What people actually build them in</div><ul class="bullet-list sm"><li><strong>A spreadsheet</strong> &mdash; honestly, most logframes live in Excel or Sheets. Fine.</li><li><strong>Word tables</strong> &mdash; for the narrative proposal annex.</li><li><strong>M&amp;E platforms</strong> &mdash; DevResults, TolaData, Logalto, Kobo + a dashboard, for live tracking.</li></ul><div class="hbox amber"><div class="hbox-text">The tool matters far less than the thinking. A sound logframe in a plain spreadsheet beats a muddled one in expensive software.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">92</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s93"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Templates</div><div class="slide-title md">A reusable column checklist</div><table class="ctable"><thead><tr><th>Column</th><th>Must contain</th></tr></thead><tbody><tr><td>Results</td><td>One result per row, in the right grammar for its level</td></tr><tr><td>Indicators</td><td>Unit, baseline, target, date, disaggregation</td></tr><tr><td>MoV</td><td>Source, method, frequency, responsible person</td></tr><tr><td>Assumptions</td><td>External conditions, monitored, not things you control</td></tr></tbody></table><div class="hbox green"><div class="hbox-text">Print this checklist next to your draft. If any cell is empty or vague, the logframe is not finished.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">93</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s94"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Quality check</div><div class="slide-title md">A reviewer&rsquo;s ten-minute test</div><ul class="bullet-list"><li>Can I read the left column as a believable story of change?</li><li>Is there exactly one clear outcome?</li><li>Does every indicator have a baseline and a source I trust?</li><li>Are the assumptions genuinely external &mdash; and any killers flagged?</li><li>Does the matrix agree with the budget and work plan?</li></ul><div class="hbox"><div class="hbox-text">Five yeses and you have a logframe worth funding. Any no is where the next revision starts.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">94</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s95"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Practice</div><div class="slide-title md">Build one from a project you know</div><div class="slide-body">The fastest way to learn the logframe is to draft one for a real or imagined project in your own field. Start from the impact, work down to activities, then fill the other three columns. Show it to a colleague and have them attack the logic.</div><div class="hbox indigo"><div class="hbox-text">Try ImpactMojo&rsquo;s <strong>Theory of Change Workbench</strong> to build the causal story first, then summarise it into your logframe.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">95</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s96"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Connected courses</div><div class="slide-title md">Where to go next at ImpactMojo</div><ul class="bullet-list sm"><li><strong>Theory of Change 101</strong> &mdash; the narrative your logframe summarises.</li><li><strong>MEL Basics 101</strong> &mdash; the wider monitoring, evaluation &amp; learning system.</li><li><strong>Impact Evaluation 101</strong> &amp; <strong>Causal Inference</strong> &mdash; proving the outcome.</li><li><strong>Cost-Effectiveness 101</strong> &mdash; cost per result, tied to your inputs row.</li><li><strong>Data Visualization 101</strong> &mdash; turning your indicators into honest charts.</li></ul></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">96</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s97"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">Further reading</div><div class="slide-title md">Reading &amp; references</div><ul class="bullet-list sm"><li>EuropeAid / EU &mdash; <em>Project Cycle Management Guidelines</em></li><li>Bond &amp; FCDO &mdash; logframe and theory-of-change guidance notes</li><li>Rosalind Eyben et al. &mdash; <em>The Politics of Evidence</em> (the critique)</li><li>Patricia Rogers &mdash; work on complexity and theory-based evaluation</li><li>BetterEvaluation.org &mdash; methods, including alternatives to the logframe</li></ul></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">97</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s98"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">The whole tool</div><div class="slide-title md">Logframe 101 in one sentence</div><div class="hbox green"><div class="hbox-text">A logframe states, on one page, the change you are betting on (results), how you will know it happened (indicators), where the proof comes from (means of verification), and what has to hold true for the bet to pay (assumptions).</div></div><div class="slide-body">Built with the team, tested up and across, and revised as you learn, it is one of the most useful disciplines in development practice &mdash; as long as you remember it is a summary of reality, not reality itself.</div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">98</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s99"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="slide-content"><div class="section-label">In one slide</div><div class="slide-title md">The logframe, recapped</div><div class="two-col half"><div class="col-panel green"><div class="col-panel-title">The rows (results)</div><div class="slide-body sm">&bull; Inputs &rarr; Activities &rarr; Outputs (you control)<br>&bull; Outcome (you influence)<br>&bull; Impact (you contribute to)<br>&bull; One outcome; a handful of outputs</div></div><div class="col-panel"><div class="col-panel-title">The columns</div><div class="slide-body sm">&bull; Indicator: unit, baseline, target, date<br>&bull; MoV: source, method, frequency, who<br>&bull; Assumptions: external, monitored<br>&bull; Test vertically <em>and</em> horizontally</div></div></div><div class="hbox"><div class="hbox-text">Build the theory of change first; hold the matrix lightly; revise as you learn.</div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">99</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+<div class="slide" id="s100"><div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" target="_blank"><svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/><circle cx="150" cy="50" r="4" fill="#10B981"/></svg><span class="logo-wordmark">ImpactMojo</span></a><span class="header-center">Logframe 101</span><span class="header-url">www.impactmojo.in</span></div><div class="end-screen"><div class="end-bar"></div><div class="end-pattern"></div><div class="end-glow"></div><div class="end-content"><div class="end-eyebrow">ImpactMojo 101 Series</div><div class="end-headline">One honest<br>page.</div><div class="end-byline">You can now read, build, test and critique a logframe &mdash; the results chain, the four columns, and the assumptions that keep it honest. Next: build one for a project you know.</div><div class="end-cta"><a class="end-btn end-btn-primary" href="https://www.impactmojo.in/101-courses/" target="_blank">More 101 Courses</a><a class="end-btn end-btn-secondary" href="https://www.impactmojo.in/" target="_blank">ImpactMojo Home</a><a class="end-btn end-btn-tertiary" href="https://www.impactmojo.in/catalog.html" target="_blank">Full Catalog</a></div><div class="end-meta"><span>Free Forever</span><span class="end-meta-divider">&middot;</span><span>CC BY-NC-ND 4.0</span><span class="end-meta-divider">&middot;</span><span>www.impactmojo.in</span></div></div></div><div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series</span><span class="slide-number">100</span><span class="footer-right">www.impactmojo.in</span></div></div>
+
+ </div>
+</div><!-- /deck -->
+
+<div id="nav">
+ <button class="nav-btn" id="prevBtn" onclick="changeSlide(-1)">&#8249;</button>
+ <span id="prog-text">1 / 100</span>
+ <button class="nav-btn" id="nextBtn" onclick="changeSlide(1)">&#8250;</button>
+</div>
+
+<script>
+
+const SLIDE_IDS = ['s1','s2','s3','s4','s5','s6','s7','s8','s9','s10','s11','s12','s13','s14','s15','s16','s17','s18','s19','s20','s21','s22','s23','s24','s25','s26','s27','s28','s29','s30','s31','s32','s33','s34','s35','s36','s37','s38','s39','s40','s41','s42','s43','s44','s45','s46','s47','s48','s49','s50','s51','s52','s53','s54','s55','s56','s57','s58','s59','s60','s61','s62','s63','s64','s65','s66','s67','s68','s69','s70','s71','s72','s73','s74','s75','s76','s77','s78','s79','s80','s81','s82','s83','s84','s85','s86','s87','s88','s89','s90','s91','s92','s93','s94','s95','s96','s97','s98','s99','s100'];
+
+let cur = 0;
+const TOTAL = SLIDE_IDS.length;
+
+const chartsInit = {};
+
+function showSlide(n) {
+  document.getElementById(SLIDE_IDS[cur])?.classList.remove('active');
+  cur = Math.max(0, Math.min(n, TOTAL - 1));
+  document.getElementById(SLIDE_IDS[cur])?.classList.add('active');
+  document.getElementById('prog-text').textContent = (cur+1) + ' / ' + TOTAL;
+  document.getElementById('prevBtn').disabled = cur === 0;
+  document.getElementById('nextBtn').disabled = cur === TOTAL - 1;
+  document.getElementById('progress-bar').style.width = ((cur+1)/TOTAL*100) + '%';
+  if (!chartsInit[cur]) { initChart(cur); chartsInit[cur] = true; }
+  showNav();
+}
+
+function changeSlide(d) { showSlide(cur + d); }
+
+document.addEventListener('keydown', e => {
+  if (e.key === 'ArrowRight' || e.key === 'ArrowDown') changeSlide(1);
+  if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') changeSlide(-1);
+});
+
+let ts = 0;
+document.addEventListener('touchstart', e => ts = e.touches[0].clientX);
+document.addEventListener('touchend', e => {
+  const d = ts - e.changedTouches[0].clientX;
+  if (Math.abs(d) > 50) changeSlide(d > 0 ? 1 : -1);
+});
+
+function showNav() {}
+
+function toggleFS() {
+  if (!document.fullscreenElement) document.documentElement.requestFullscreen();
+  else document.exitFullscreen();
+}
+document.addEventListener('fullscreenchange', () => {
+  document.getElementById('fs-hint').textContent = document.fullscreenElement ? 'exit fullscreen' : 'fullscreen';
+});
+
+// Viewport scaling — fit the 1280x720 stage to any screen. Re-runs on load,
+// orientation change and visual-viewport resize so mobile (where innerHeight
+// can be ~0 during parse) settles to the correct full-width fit instead of a
+// shrunken sliver.
+function scaleViewport() {
+  const vp = document.getElementById('viewport');
+  if (!vp) return;
+  const s = Math.min(window.innerWidth / 1280, window.innerHeight / 720);
+  if (s > 0) vp.style.transform = 'scale(' + s + ')';
+}
+window.addEventListener('resize', scaleViewport);
+window.addEventListener('orientationchange', function(){ setTimeout(scaleViewport, 150); });
+window.addEventListener('load', scaleViewport);
+if (window.visualViewport) window.visualViewport.addEventListener('resize', scaleViewport);
+scaleViewport();
+[50, 200, 500, 1000].forEach(function(t){ setTimeout(scaleViewport, t); });
+
+// Charts
+function initChart(slideIdx) {}
+
+
+// Theme
+function setTheme(t) {
+  document.body.classList.remove('light','dark');
+  if (t === 'light') document.body.classList.add('light');
+  else if (t === 'dark') document.body.classList.add('dark');
+  document.querySelectorAll('.theme-btn').forEach(b => {
+    b.classList.toggle('active', b.textContent.toLowerCase() === t);
+  });
+  localStorage.setItem('im-theme', t);
+}
+(function(){
+  const saved = localStorage.getItem('im-theme') || 'light';
+  setTheme(saved);
+})();
+
+showSlide(0);
+
+// ========== CHART RESIZE-ON-ACTIVATE (v10.23.32) ==========
+// ECharts canvases initialize with 0 width when their parent slide is
+// display:none. When a slide first becomes active, the canvas now has
+// dimensions but the chart hasn't redrawn. Force resize on activation.
+(function chartResize(){
+  function resizeIn(slide){
+    if (!slide || !window.echarts) return;
+    slide.querySelectorAll(".chart-canvas").forEach(function(c){
+      var inst = echarts.getInstanceByDom(c);
+      if (inst) {
+        try { inst.resize(); } catch(e){}
+      }
+    });
+  }
+  function resizeActive(){
+    document.querySelectorAll(".slide.active").forEach(resizeIn);
+  }
+  var vp = document.getElementById("viewport") || document.querySelector(".slide-viewport");
+  if (vp && window.MutationObserver) {
+    new MutationObserver(resizeActive).observe(vp, {subtree:true, attributes:true, attributeFilter:["class"]});
+  }
+  // Initial pass after charts have had time to init
+  setTimeout(resizeActive, 400);
+})();
+// ========== /CHART RESIZE-ON-ACTIVATE ==========
+</script>
+
+<script>
+
+// Init ECharts on slide change (lazy init when slide becomes active)
+(function(){
+  const initECharts = () => {
+
+  };
+  // Defer until DOM ready + ECharts loaded
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    setTimeout(initECharts, 80);
+  } else {
+    document.addEventListener('DOMContentLoaded', () => setTimeout(initECharts, 80));
+  }
+})();
+
+// ========== POLISH FIX BLOCK (v10.23.22) — runtime overflow detection ==========
+(function ensureFit(){
+  // v10.23.29: auto-compact disabled per user — no font shrinking
+  // Original logic preserved below as comments for reference
+  /* DISABLED:
+
+  function checkSlide(slide){
+    if (!slide || slide.classList.contains("compact")) return;
+    if (slide.querySelector(".end-screen, .title-screen, .section-divider, .toc-grid")) return;
+    var content = slide.querySelector(".slide-content");
+    if (!content) return;
+    // Slide must be active (display:flex) to measure
+    if (slide.offsetHeight === 0) return;
+    if (content.scrollHeight > content.clientHeight + 4) {
+      slide.classList.add("compact");
+      // Re-check after compact applied; if still overflowing, escalate
+      requestAnimationFrame(function(){
+        if (content.scrollHeight > content.clientHeight + 4) {
+          slide.classList.add("ultra-compact");
+        }
+      });
+    }
+  }
+  function checkAll(){
+    document.querySelectorAll(".slide.active").forEach(checkSlide);
+  }
+  // Watch slide-viewport for class changes (new active slide)
+  var vp = document.getElementById("viewport") || document.querySelector(".slide-viewport");
+  if (vp && window.MutationObserver) {
+    new MutationObserver(checkAll).observe(vp, {subtree:true, attributes:true, attributeFilter:["class"]});
+  }
+  window.addEventListener("resize", function(){
+    setTimeout(checkAll, 50);
+  });
+  // Initial pass after a brief delay (let scaleViewport run first)
+  setTimeout(checkAll, 200);
+
+  */
+})();
+(function autoSpacious(){
+  document.querySelectorAll(".slide").forEach(function(slide){
+    if (slide.classList.contains("compact")) return;
+    if (slide.querySelector(".end-screen, .title-screen, .section-divider, .toc-grid, .chart-canvas, .chart-wrap, table, svg.diagram")) return;
+    var text = (slide.textContent||"").length;
+    if (text > 0 && text < 420) {
+      slide.classList.add("spacious");
+    }
+  });
+})();
+(function navIdle(){
+  var t;
+  function ping(){
+    document.body.classList.add("nav-active");
+    clearTimeout(t);
+    t = setTimeout(function(){document.body.classList.remove("nav-active");}, 2200);
+  }
+  ["mousemove","keydown","touchstart","click"].forEach(function(e){
+    document.addEventListener(e, ping, {passive:true});
+  });
+  ping();
+})();
+// end polish fix block
+
+// ========== SLIDE DEEP-LINKING (v10.23.30) ==========
+(function slideDeepLinking(){
+  function syncHashFromActive(){
+    var active = document.querySelector(".slide.active");
+    if (active && active.id) {
+      var newHash = "#" + active.id;
+      if (location.hash !== newHash) {
+        history.replaceState(null, "", newHash);
+      }
+    }
+  }
+  function jumpToHash(){
+    if (!location.hash || !/^#s\d+$/.test(location.hash)) return;
+    var targetId = location.hash.slice(1);
+    var target = document.getElementById(targetId);
+    if (!target || !target.classList.contains("slide")) return;
+    if (target.classList.contains("active")) return;
+    var slides = Array.prototype.slice.call(document.querySelectorAll(".slide"));
+    var idx = slides.indexOf(target);
+    if (idx < 0) return;
+    var success = false;
+    if (typeof showSlide === "function") {
+      try { showSlide(idx + 1); if (target.classList.contains("active")) success = true; } catch(e){}
+      if (!success) { try { showSlide(idx); if (target.classList.contains("active")) success = true; } catch(e){} }
+    }
+    if (!success && typeof show === "function") {
+      try { show(idx + 1); if (target.classList.contains("active")) success = true; } catch(e){}
+    }
+    if (!success) {
+      slides.forEach(function(s){ s.classList.remove("active"); });
+      target.classList.add("active");
+      var prog = document.getElementById("prog-text");
+      if (prog) prog.textContent = (idx + 1) + " / " + slides.length;
+      var bar = document.getElementById("progress-bar");
+      if (bar) bar.style.width = ((idx + 1) / slides.length * 100) + "%";
+      var pb = document.getElementById("prevBtn");
+      var nb = document.getElementById("nextBtn");
+      if (pb) pb.disabled = (idx === 0);
+      if (nb) nb.disabled = (idx === slides.length - 1);
+    }
+  }
+  var vp = document.getElementById("viewport") || document.querySelector(".slide-viewport");
+  if (vp && window.MutationObserver) {
+    new MutationObserver(syncHashFromActive).observe(vp, {subtree:true, attributes:true, attributeFilter:["class"]});
+  }
+  if (location.hash && /^#s\d+$/.test(location.hash)) {
+    setTimeout(jumpToHash, 250);
+  }
+  window.addEventListener("hashchange", jumpToHash);
+})();
+// ========== /SLIDE DEEP-LINKING ==========
+
+// ========== PROPORTIONAL AUTO-FIT (v10.23.34) ==========
+(function autoFit(){
+  function fit(slide){
+    if (!slide) return;
+    var content = slide.querySelector(".slide-content");
+    if (!content) return;
+    content.style.zoom = "";
+    if (slide.querySelector(".title-screen, .section-divider, .end-screen")) return;
+    var natural = content.scrollHeight;
+    var avail = content.clientHeight;
+    if (natural <= avail + 4) return;
+    var scale = avail / natural;
+    if (scale < 0.78) return;
+    content.style.zoom = scale;
+  }
+  function fitActive(){
+    document.querySelectorAll(".slide.active").forEach(fit);
+  }
+  var vp = document.getElementById("viewport") || document.querySelector(".slide-viewport");
+  if (vp && window.MutationObserver) {
+    new MutationObserver(fitActive).observe(vp, {subtree:true, attributes:true, attributeFilter:["class"]});
+  }
+  window.addEventListener("resize", function(){ setTimeout(fitActive, 50); });
+  setTimeout(fitActive, 250);
+})();
+// ========== /PROPORTIONAL AUTO-FIT ==========</script>
+
+<script src="/js/translate-sarvam.js" defer></script>
+</body>
+</html>

--- a/catalog_data.json
+++ b/catalog_data.json
@@ -205,6 +205,13 @@
       "link": "/101-courses/data-viz.html"
     },
     {
+      "title": "Logframe 101",
+      "type": "Course",
+      "track": "Monitoring, Evaluation & Learning",
+      "level": "Core",
+      "link": "/101-courses/logframe-101.html"
+    },
+    {
       "title": "Sexual Rights and Health Basics",
       "type": "Course",
       "track": "Gender, Equity & Inclusion",

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -8392,6 +8392,23 @@
     "category": "101 Foundational Courses"
   },
   {
+    "id": "101-logframe-101",
+    "title": "Logframe 101",
+    "description": "Logframe 101 — a free foundational course for development practitioners in South Asia. The logical framework, built from the results chain up: inputs, activities, outputs, outcomes and impact; indicators and SMART targets; means of verification; assumptions and risk; building and testing the matrix, its critiques, and donor formats. ImpactMojo, CC BY-NC-ND.",
+    "url": "/101-courses/logframe-101.html",
+    "tags": [
+      "logframe",
+      "logical framework",
+      "results chain",
+      "theory of change",
+      "monitoring evaluation",
+      "101",
+      "foundational course"
+    ],
+    "type": "course",
+    "category": "101 Foundational Courses"
+  },
+  {
     "id": "101-bi-analysis",
     "title": "Bivariate Analysis 101",
     "description": "Bivariate Analysis 101 — a free foundational course for development practitioners and researchers in South Asia. The step after describing one variable: cross-tabulation, correlation, comparing groups, chi-square, simple regression and the pitfalls of reading two variables together, with India-centric examples. ImpactMojo, CC BY-NC-ND.",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.57.0 — June 7, 2026 (Logframe 101 — the logical framework, built from the results chain up)
+
+### For Learners
+
+- **Logframe 101** — a new free, 100-slide course on the logical framework, the matrix nearly every funder asks for. It builds the tool from the results chain up: inputs, activities and outputs (what you control) through outcomes (what you influence) to impact (what you contribute to), with the output-to-outcome gap and attribution made plain. Then it works through the four columns — results, indicators (SMART, with baselines and disaggregation), means of verification, and the assumptions and risk that keep the matrix honest — before showing how to build it, test it vertically and horizontally, and weigh its real critiques and alternatives (outcome mapping, adaptive management). Practical throughout, with donor formats and worked examples. Find it under **101 Courses**.
+
 ## v10.56.0 — June 7, 2026 (Data Visualization 101 — the companion course to The Long View)
 
 ### For Learners

--- a/scripts/deck_builder.py
+++ b/scripts/deck_builder.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Reusable builder for ImpactMojo 101-series slide decks.
+
+Extracts the CSS / sprite / nav-JS chrome from an existing deck
+(101-courses/data-lit.html) so every generated deck is visually and
+behaviourally identical to the rest of the series. Per-deck scripts supply
+only content, meta, the title/end screens and (optionally) chart code.
+"""
+import re, os
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TPL = os.path.join(ROOT, '101-courses', 'data-lit.html')
+
+_src = open(TPL).read()
+CSS = _src[_src.index('<style>'):_src.index('</style>') + len('</style>')]
+_sp = _src.index('<svg class="sprites"')
+_spend = _src.index('</svg>\n\n<div id="progress-bar"')
+SPRITE = _src[_sp:_spend + len('</svg>')]
+_mj0 = _src.index('<script>\nconst SLIDE_IDS')
+_mj1 = _src.index('</script>', _mj0)
+MAINJS = _src[_mj0 + len('<script>'):_mj1]
+_pj0 = _src.index('<script>', _mj1)
+_pj1 = _src.index('</script>', _pj0)
+POLISHJS = _src[_pj0 + len('<script>'):_pj1]
+
+LOGO = ('<svg class="logo-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">'
+        '<path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" '
+        'stroke-linecap="round" stroke-linejoin="round"/>'
+        '<path d="M80,130 L150,50" stroke="#6366F1" stroke-width="2" stroke-dasharray="4,4"/>'
+        '<circle cx="150" cy="50" r="4" fill="#10B981"/></svg>')
+
+TITLE_GEO = ('<div class="title-geo"><svg viewBox="0 0 300 620" xmlns="http://www.w3.org/2000/svg" '
+             'style="width:100%;height:100%"><defs><pattern id="hex" x="0" y="0" width="40" height="46" '
+             'patternUnits="userSpaceOnUse"><polygon points="20,2 38,12 38,34 20,44 2,34 2,12" fill="none" '
+             'stroke="white" stroke-width="1"/></pattern></defs><rect width="300" height="620" fill="url(#hex)"/>'
+             '</svg></div>')
+
+NO_CHARTS = """// Charts
+function initChart(slideIdx) {}
+
+"""
+
+
+def _header(course):
+    return ('<div class="slide-header"><a href="https://www.impactmojo.in/101-courses/" class="logo-mark" '
+            'target="_blank">' + LOGO + '<span class="logo-wordmark">ImpactMojo</span></a>'
+            '<span class="header-center">' + course + '</span>'
+            '<span class="header-url">www.impactmojo.in</span></div>')
+
+
+def _footer(n):
+    return ('<div class="slide-footer"><span class="footer-left">CC BY-NC-ND 4.0 &middot; ImpactMojo 101 Series'
+            '</span><span class="slide-number">' + ('%02d' % n) + '</span>'
+            '<span class="footer-right">www.impactmojo.in</span></div>')
+
+
+def build(course, out_name, meta_desc, title_main_html, title_sub_html, title_tags,
+          toc, slides, end_headline_html, end_byline, charts_js=NO_CHARTS,
+          extra_head_scripts=''):
+    """slides: list of (kind, payload). kinds: 'title','toc','divider','content','end'.
+    The caller supplies the list already containing title/toc/dividers/end placeholders
+    in order; payloads: title->None, toc->list[(name,range)], divider->(num,label,title),
+    content->inner_html, end->None.
+    """
+    parts = []
+    for i, (kind, payload) in enumerate(slides):
+        n = i + 1
+        sid = 's%d' % n
+        active = ' active' if n == 1 else ''
+        if kind == 'title':
+            tags = ''.join('<span class="title-tag">%s</span>' % t for t in title_tags)
+            body = ('<div class="title-screen"><div class="title-bg"></div><div class="title-bar"></div>'
+                    '<div class="title-content"><div class="title-series">ImpactMojo 101 Series &middot; Free Forever</div>'
+                    '<div class="title-main">' + title_main_html + '</div>'
+                    '<div class="title-sub">' + title_sub_html + '</div>'
+                    '<div class="title-tags">' + tags + '</div></div>' + TITLE_GEO + '</div>')
+        elif kind == 'toc':
+            items = ''
+            for j, (name, rng) in enumerate(payload):
+                items += ('<div class="toc-item"><div class="toc-num">%02d</div><div class="toc-name">%s</div>'
+                          '<div class="toc-slides">Slides %s</div></div>' % (j + 1, name, rng))
+            body = ('<div class="slide-content"><div class="section-label">Agenda</div>'
+                    '<div class="slide-title md" style="margin-bottom:8px">What We Cover</div>'
+                    '<div class="toc-grid">' + items + '</div></div>')
+        elif kind == 'divider':
+            num, label, title = payload
+            body = ('<div class="section-divider"><div class="div-num">%02d</div>'
+                    '<div class="div-label">%s</div><div class="div-title">%s</div>'
+                    '<div class="div-accent"></div></div>' % (num, label, title))
+        elif kind == 'end':
+            body = ('<div class="end-screen"><div class="end-bar"></div><div class="end-pattern"></div>'
+                    '<div class="end-glow"></div><div class="end-content">'
+                    '<div class="end-eyebrow">ImpactMojo 101 Series</div>'
+                    '<div class="end-headline">' + end_headline_html + '</div>'
+                    '<div class="end-byline">' + end_byline + '</div>'
+                    '<div class="end-cta">'
+                    '<a class="end-btn end-btn-primary" href="https://www.impactmojo.in/101-courses/" target="_blank">More 101 Courses</a>'
+                    '<a class="end-btn end-btn-secondary" href="https://www.impactmojo.in/" target="_blank">ImpactMojo Home</a>'
+                    '<a class="end-btn end-btn-tertiary" href="https://www.impactmojo.in/catalog.html" target="_blank">Full Catalog</a>'
+                    '</div>'
+                    '<div class="end-meta"><span>Free Forever</span><span class="end-meta-divider">&middot;</span>'
+                    '<span>CC BY-NC-ND 4.0</span><span class="end-meta-divider">&middot;</span>'
+                    '<span>www.impactmojo.in</span></div></div></div>')
+        else:
+            body = '<div class="slide-content">' + payload + '</div>'
+        parts.append('<div class="slide%s" id="%s">%s%s%s</div>' % (active, sid, _header(course), body, _footer(n)))
+
+    slides_html = '\n\n'.join(parts)
+    total = len(slides)
+
+    ids = "['" + "','".join('s%d' % k for k in range(1, total + 1)) + "']"
+    mainjs = re.sub(r"const SLIDE_IDS = \[[^\]]*\];", "const SLIDE_IDS = " + ids + ";", MAINJS, count=1)
+    head = mainjs[:mainjs.index('// Charts')]
+    tail = mainjs[mainjs.index('// Theme'):]
+    mainjs = head + charts_js + '\n' + tail
+
+    title_short = course
+    HEAD = ('<!DOCTYPE html>\n<html lang="en">\n<head>\n<meta charset="UTF-8">\n'
+            '<meta name="viewport" content="width=device-width, initial-scale=1.0">\n'
+            '<title>' + course + ' | ImpactMojo</title>\n'
+            '<link rel="preconnect" href="https://fonts.googleapis.com">\n'
+            '<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Amaranth:ital,wght@0,400;0,700;1,400&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">\n'
+            '<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>\n'
+            + CSS + '\n'
+            '<!-- Google Analytics -->\n'
+            '<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>\n'
+            "<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-JRCMEB9TBW');</script>\n"
+            '<!-- SEO meta -->\n'
+            '<meta name="description" content="' + meta_desc + '">\n'
+            '<meta name="robots" content="index, follow">\n'
+            '<link rel="canonical" href="https://www.impactmojo.in/101-courses/' + out_name + '">\n'
+            '<meta property="og:title" content="' + title_short + '">\n'
+            '<meta property="og:description" content="' + meta_desc + '">\n'
+            '<meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">\n'
+            '<meta property="og:url" content="https://www.impactmojo.in/101-courses/' + out_name + '">\n'
+            '<meta property="og:type" content="website">\n'
+            '<meta property="og:site_name" content="ImpactMojo">\n'
+            '<meta name="twitter:card" content="summary_large_image">\n'
+            '<meta name="twitter:title" content="' + title_short + '">\n'
+            '<meta name="twitter:description" content="' + meta_desc + '">\n'
+            '<meta name="twitter:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">\n'
+            '<link rel="icon" type="image/png" href="/assets/images/favicon.png">\n'
+            '<link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">\n'
+            + extra_head_scripts +
+            '</head>\n<body>\n\n')
+
+    THEMEBAR = ('<div id="theme-bar">\n <button class="theme-btn" onclick="setTheme(\'system\')">System</button>\n'
+                ' <button class="theme-btn active" onclick="setTheme(\'light\')">Light</button>\n'
+                ' <button class="theme-btn" onclick="setTheme(\'dark\')">Dark</button>\n</div>\n\n')
+
+    NAV = ('<div id="nav">\n <button class="nav-btn" id="prevBtn" onclick="changeSlide(-1)">&#8249;</button>\n'
+           ' <span id="prog-text">1 / ' + str(total) + '</span>\n'
+           ' <button class="nav-btn" id="nextBtn" onclick="changeSlide(1)">&#8250;</button>\n</div>\n\n')
+
+    doc = (HEAD + THEMEBAR + SPRITE + '\n\n'
+           '<div id="progress-bar"></div>\n<div id="fs-hint" onclick="toggleFS()">fullscreen</div>\n'
+           '<div id="deck">\n <div class="slide-viewport" id="viewport">\n\n'
+           + slides_html +
+           '\n\n </div>\n</div><!-- /deck -->\n\n'
+           + NAV +
+           '<script>\n' + mainjs + '</script>\n\n'
+           '<script>\n' + POLISHJS + '</script>\n\n'
+           '<script src="/js/translate-sarvam.js" defer></script>\n</body>\n</html>\n')
+
+    out_path = os.path.join(ROOT, '101-courses', out_name)
+    open(out_path, 'w').write(doc)
+    return out_path, len(doc), total

--- a/scripts/gen_logframe_deck.py
+++ b/scripts/gen_logframe_deck.py
@@ -1,0 +1,897 @@
+#!/usr/bin/env python3
+"""Logframe 101 - the logical framework, built from the results chain up."""
+import deck_builder as db
+
+slides = []
+
+
+def content(inner):
+    slides.append(('content', inner))
+
+
+def divider(num, label, title):
+    slides.append(('divider', (num, label, title)))
+
+
+slides.append(('title', None))
+TOC = [
+    ("What a Logframe Is", "3&ndash;9"),
+    ("The Results Chain", "10&ndash;18"),
+    ("Inputs, Activities, Outputs", "19&ndash;29"),
+    ("Outcomes &amp; Impact", "30&ndash;40"),
+    ("Indicators", "41&ndash;49"),
+    ("Means of Verification", "50&ndash;57"),
+    ("Assumptions", "58&ndash;64"),
+    ("Risk", "65&ndash;73"),
+    ("Building the Matrix", "74&ndash;81"),
+    ("Critiques &amp; Limits", "82&ndash;89"),
+    ("Tools &amp; Practice", "90&ndash;98"),
+]
+slides.append(('toc', TOC))
+
+# ============ SECTION 1: What a Logframe Is (6) ============
+divider(1, "Section One", "What a Logframe Is")
+
+content('<div class="section-label">Definition</div>'
+        '<div class="term-box"><div class="term-word">Logical framework (logframe)</div>'
+        '<div class="term-def">A one-page matrix that lays out what a project is trying to achieve, how it will get '
+        'there, how you will know if it worked, and what has to hold true for the logic to run. Rows are levels of '
+        'result; columns are the indicator, its source, and the assumptions.</div></div>'
+        '<div class="slide-body">It is two things at once: a <strong>planning</strong> tool that forces you to think '
+        'through your logic, and a <strong>management</strong> tool you return to as the project runs.</div>')
+
+content('<div class="section-label">The shape</div>'
+        '<div class="slide-title md">A 4&times;4 grid, read two ways</div>'
+        '<table class="ctable"><thead><tr><th>Results level</th><th>Indicator</th><th>Means of verification</th><th>Assumptions</th></tr></thead>'
+        '<tbody>'
+        '<tr><td><strong>Impact / Goal</strong></td><td>How measured</td><td>Where the data comes from</td><td>What must hold</td></tr>'
+        '<tr><td><strong>Outcome / Purpose</strong></td><td>How measured</td><td>Source</td><td>Assumption</td></tr>'
+        '<tr><td><strong>Outputs</strong></td><td>How measured</td><td>Source</td><td>Assumption</td></tr>'
+        '<tr><td><strong>Activities</strong> (&amp; inputs)</td><td>How measured</td><td>Source</td><td>Assumption</td></tr>'
+        '</tbody></table>'
+        '<div class="hbox"><div class="hbox-text">Read <strong>down</strong> the first column for the story of change; '
+        'read <strong>across</strong> a row to see how each result is measured and what it depends on.</div></div>')
+
+content('<div class="section-label">Where it came from</div>'
+        '<div class="slide-title md">A short history</div>'
+        '<div class="slide-body">The logframe was developed for <strong>USAID in 1969</strong> by Leon Rosenberg and '
+        'colleagues, to bring discipline to vague project plans. It spread through bilateral and UN agencies, was '
+        'adapted by GTZ into the participatory <strong>ZOPP / objectives-oriented planning</strong> method, and '
+        'remains a near-universal donor requirement today &mdash; the EU, DFID/FCDO, GIZ, the UN and most large '
+        'NGOs all use a version.</div>'
+        '<div class="hbox amber"><div class="hbox-text">Because so many donors mandate it, the logframe is often the '
+        'first formal document a funded project produces. Knowing it well is a practical survival skill.</div></div>')
+
+content('<div class="section-label">Why bother</div>'
+        '<div class="slide-title md">What a good logframe gives you</div>'
+        '<ul class="bullet-list green">'
+        '<li><strong>A testable theory.</strong> It states, on one page, the if&ndash;then logic your project is betting on.</li>'
+        '<li><strong>Shared language.</strong> Funder, manager and field team mean the same thing by &ldquo;outcome&rdquo;.</li>'
+        '<li><strong>A monitoring spine.</strong> The indicators column tells you exactly what to collect.</li>'
+        '<li><strong>Honesty about risk.</strong> The assumptions column makes you name what could break.</li>'
+        '</ul>')
+
+content('<div class="section-label">What it is not</div>'
+        '<div class="slide-title md">A logframe is not the whole plan</div>'
+        '<div class="slide-body">The matrix is a summary, not a substitute for a theory of change, a work plan, a '
+        'budget or a risk register. It compresses a rich design into a grid &mdash; useful for discipline and '
+        'reporting, dangerous if mistaken for the full picture.</div>'
+        '<div class="hbox red"><div class="hbox-text">Filling in the boxes is not the same as having a sound design. '
+        'A neat logframe over a weak theory is just tidy wishful thinking.</div></div>')
+
+content('<div class="section-label">The family</div>'
+        '<div class="slide-title md">Logframe, theory of change, results framework</div>'
+        '<table class="ctable"><thead><tr><th>Tool</th><th>What it is</th><th>Strength</th></tr></thead><tbody>'
+        '<tr><td>Theory of change</td><td>A narrative + diagram of how and why change happens</td><td>Rich, shows pathways &amp; mechanisms</td></tr>'
+        '<tr><td>Results framework</td><td>A hierarchy of objectives and sub-objectives</td><td>Good for portfolios / strategy</td></tr>'
+        '<tr><td>Logframe</td><td>A matrix of results, indicators, sources, assumptions</td><td>Compact, measurable, donor-ready</td></tr>'
+        '</tbody></table>'
+        '<div class="hbox indigo"><div class="hbox-text">Best practice: build the <strong>theory of change first</strong>, '
+        'then summarise its causal spine into the logframe. The logframe is the ToC, disciplined into a grid.</div></div>')
+
+# ============ SECTION 2: The Results Chain (8) ============
+divider(2, "Section Two", "The Results Chain")
+
+content('<div class="section-label">The spine</div>'
+        '<div class="slide-title md">The results chain</div>'
+        '<div class="flow">'
+        '<div class="flow-step"><div class="flow-num">IN</div><div class="flow-label">Inputs</div></div>'
+        '<div class="flow-arrow">&rarr;</div>'
+        '<div class="flow-step"><div class="flow-num">ACT</div><div class="flow-label">Activities</div></div>'
+        '<div class="flow-arrow">&rarr;</div>'
+        '<div class="flow-step"><div class="flow-num">OUT</div><div class="flow-label">Outputs</div></div>'
+        '<div class="flow-arrow">&rarr;</div>'
+        '<div class="flow-step"><div class="flow-num">OC</div><div class="flow-label">Outcomes</div></div>'
+        '<div class="flow-arrow">&rarr;</div>'
+        '<div class="flow-step"><div class="flow-num">IMP</div><div class="flow-label">Impact</div></div>'
+        '</div>'
+        '<div class="hbox"><div class="hbox-text">Everything in a logframe hangs on this chain. The first job is to '
+        'know exactly which link a given result belongs to &mdash; that is where most logframes go wrong.</div></div>')
+
+content('<div class="section-label">The dividing line</div>'
+        '<div class="slide-title md">What you control vs. what you influence</div>'
+        '<div class="two-col half">'
+        '<div class="col-panel green"><div class="col-panel-title">Your sphere of control</div>'
+        '<div class="slide-body sm">Inputs, activities and outputs. If you do the work, these happen. You are '
+        '<strong>accountable</strong> for them.</div></div>'
+        '<div class="col-panel amber"><div class="col-panel-title">Your sphere of influence</div>'
+        '<div class="slide-body sm">Outcomes and impact. These depend on how others respond &mdash; participants, '
+        'systems, the wider world. You <strong>contribute</strong>; you do not solely cause them.</div></div></div>'
+        '<div class="hbox red"><div class="hbox-text">The single most common logframe error is promising an '
+        '<em>outcome</em> as if it were an <em>output</em> &mdash; claiming control over something you can only influence.</div></div>')
+
+content('<div class="section-label">If&ndash;then</div>'
+        '<div class="slide-title md">The chain is a stack of hypotheses</div>'
+        '<div class="slide-body">Read upward, each level is an <em>if&ndash;then</em> claim: <em>if</em> we combine these '
+        'inputs, <em>then</em> we can run these activities; <em>if</em> the activities happen, <em>then</em> we get '
+        'these outputs; and so on. Each step is a bet that can fail.</div>'
+        '<div class="hbox"><div class="hbox-text">The assumptions column (later) holds the &ldquo;and these other things '
+        'also have to be true&rdquo; that each <em>if&ndash;then</em> quietly depends on.</div></div>')
+
+content('<div class="section-label">Direction</div>'
+        '<div class="slide-title md">Plan top-down, deliver bottom-up</div>'
+        '<div class="slide-body">When you <strong>design</strong>, start from the impact you want and work down: what '
+        'outcome would contribute to it, what outputs would produce that outcome, what activities make those outputs. '
+        'When you <strong>implement</strong>, you move the other way: inputs fund activities that yield outputs.</div>'
+        '<div class="hbox green"><div class="hbox-text">Designing downward keeps you honest &mdash; every activity has '
+        'to earn its place by pointing at the result above it. Activities with no result above them are busywork.</div></div>')
+
+content('<div class="section-label">A worked chain</div>'
+        '<div class="slide-title md">One example, all the way up</div>'
+        '<table class="ctable"><thead><tr><th>Level</th><th>Example (girls&rsquo; education programme)</th></tr></thead><tbody>'
+        '<tr><td>Impact</td><td>Women&rsquo;s economic and social participation rises in the district</td></tr>'
+        '<tr><td>Outcome</td><td>More girls complete secondary school</td></tr>'
+        '<tr><td>Output</td><td>2,000 girls receive scholarships and after-school tutoring</td></tr>'
+        '<tr><td>Activity</td><td>Recruit tutors; disburse scholarships; run classes</td></tr>'
+        '<tr><td>Input</td><td>Funds, teachers, classrooms, materials</td></tr>'
+        '</tbody></table>'
+        '<div class="hbox"><div class="hbox-text">Notice the jump from output (girls enrolled and tutored) to outcome '
+        '(girls completing school): that gap is where families, schools and the economy must cooperate.</div></div>')
+
+content('<div class="section-label">Common confusion</div>'
+        '<div class="slide-title md">Output or outcome? A quick test</div>'
+        '<ul class="bullet-list sm">'
+        '<li><strong>Output</strong> = the goods and services you deliver. &ldquo;500 health workers trained.&rdquo; '
+        'It is done when you have done it.</li>'
+        '<li><strong>Outcome</strong> = the change in others&rsquo; behaviour, knowledge or condition. &ldquo;Health '
+        'workers correctly manage childhood illness.&rdquo; It depends on whether the training took.</li>'
+        '</ul>'
+        '<div class="hbox amber"><div class="hbox-text">Test: <em>could you report this complete the day you finish '
+        'delivery?</em> If yes, it is an output. If it needs someone else to change, it is an outcome.</div></div>')
+
+content('<div class="section-label">Attribution</div>'
+        '<div class="slide-title md">The higher you climb, the less it is just you</div>'
+        '<div class="slide-body">At output level, your project is the cause. At outcome level, you are one of several '
+        'forces. At impact level, you are a small contributor among many &mdash; economic conditions, government policy, '
+        'other programmes. This is the <strong>attribution gap</strong>.</div>'
+        '<div class="hbox red"><div class="hbox-text">Claim <em>contribution</em>, not sole credit, for outcomes and '
+        'impact. Over-claiming at the top of the chain is both dishonest and, when measured, easily disproved.</div></div>')
+
+content('<div class="section-label">See it drawn</div>'
+        '<div class="slide-title md">The chain, visualised</div>'
+        '<div class="slide-body">ImpactMojo&rsquo;s <strong>The Long View</strong> includes an original diagram of the '
+        'results chain and the attribution gap &mdash; the widening distance between what a project delivers and the '
+        'change it hopes to see. It is the picture behind this whole section.</div>'
+        '<div class="hbox indigo"><div class="hbox-text">A logframe is the results chain, written as a table. Keep the '
+        'picture in your head as you fill in the rows.</div></div>')
+
+# ============ SECTION 3: Inputs, Activities, Outputs (10) ============
+divider(3, "Section Three", "Inputs, Activities, Outputs")
+
+content('<div class="section-label">Inputs</div>'
+        '<div class="slide-title md">Inputs: what you put in</div>'
+        '<div class="slide-body">Inputs are the resources a project consumes: money, staff time, equipment, vehicles, '
+        'training materials, partner contributions. In many logframe formats inputs sit alongside activities on the '
+        'bottom row, often linked to the budget.</div>'
+        '<ul class="bullet-list sm">'
+        '<li>Be specific enough to cost: &ldquo;12 community mobilisers for 18 months&rdquo;, not &ldquo;staff&rdquo;.</li>'
+        '<li>Include partner and community contributions (land, volunteer time) &mdash; they are real inputs.</li>'
+        '</ul>')
+
+content('<div class="section-label">Activities</div>'
+        '<div class="slide-title md">Activities: what you do</div>'
+        '<div class="slide-body">Activities are the actions that convert inputs into outputs: train, build, distribute, '
+        'mobilise, advise. Write them as verbs. Each activity should connect clearly to an output above it.</div>'
+        '<div class="hbox amber"><div class="hbox-text">Keep the logframe to a manageable set of activity <em>clusters</em> '
+        '(say 3&ndash;6 per output). The detailed task list belongs in the work plan, not the matrix.</div></div>')
+
+content('<div class="section-label">Outputs</div>'
+        '<div class="slide-title md">Outputs: what you produce</div>'
+        '<div class="slide-body">Outputs are the direct, countable products of your activities &mdash; the goods and '
+        'services in the hands of participants. They are fully within your control, so they are written as '
+        '<strong>completed deliverables</strong>.</div>'
+        '<ul class="bullet-list green">'
+        '<li>&ldquo;1,500 farmers trained in drip irrigation&rdquo;</li>'
+        '<li>&ldquo;20 village water committees formed and functional&rdquo;</li>'
+        '<li>&ldquo;A district nutrition dashboard built and handed over&rdquo;</li>'
+        '</ul>')
+
+content('<div class="section-label">Verbs &amp; tense</div>'
+        '<div class="slide-title md">Phrase each level in its own grammar</div>'
+        '<table class="ctable"><thead><tr><th>Level</th><th>Phrasing</th><th>Example</th></tr></thead><tbody>'
+        '<tr><td>Activity</td><td>Verb (the doing)</td><td>Train health workers</td></tr>'
+        '<tr><td>Output</td><td>Delivered / completed</td><td>500 health workers trained</td></tr>'
+        '<tr><td>Outcome</td><td>Change of state in others</td><td>Health workers apply IMNCI protocols</td></tr>'
+        '<tr><td>Impact</td><td>Higher-order condition</td><td>Under-5 mortality falls</td></tr>'
+        '</tbody></table>'
+        '<div class="hbox"><div class="hbox-text">Consistent phrasing is not pedantry &mdash; mixing an activity verb '
+        'into an outcome row is the surface sign of muddled logic underneath.</div></div>')
+
+content('<div class="section-label">One result per box</div>'
+        '<div class="slide-title md">No smuggling with &ldquo;and&rdquo;</div>'
+        '<div class="slide-body">A statement with an &ldquo;and&rdquo; in it is usually two results hiding in one box: '
+        '&ldquo;farmers trained <em>and</em> adopting new methods&rdquo; bundles an output with an outcome. Split them.</div>'
+        '<div class="hbox red"><div class="hbox-text">Each box should carry exactly one result, measurable on its own. '
+        'If you cannot put a single indicator on it, it is doing too many jobs.</div></div>')
+
+content('<div class="section-label">How many?</div>'
+        '<div class="slide-title md">Keep the matrix small</div>'
+        '<div class="slide-body">A workable logframe has <strong>one impact, one (sometimes two) outcomes, and a '
+        'handful of outputs</strong> &mdash; rarely more than five or six. More than that and the matrix stops being a '
+        'one-page summary and becomes an unreadable spreadsheet nobody returns to.</div>'
+        '<div class="hbox amber"><div class="hbox-text">If you have ten outputs, you probably have two projects, or you '
+        'have listed activities in the output row. Consolidate.</div></div>')
+
+content('<div class="section-label">The vertical test</div>'
+        '<div class="slide-title md">Read the logic upward and challenge it</div>'
+        '<div class="slide-body">Once the left column is drafted, test it: at each step, ask <em>&ldquo;is this enough '
+        'to plausibly produce the level above?&rdquo;</em> If outputs alone clearly will not deliver the outcome, the '
+        'design has a gap &mdash; or there is an assumption you have not yet named.</div>'
+        '<div class="hbox green"><div class="hbox-text">This upward read is the heart of the &ldquo;logical&rdquo; in '
+        'logical framework. A logframe that fails it is just a list.</div></div>')
+
+content('<div class="section-label">Worked rows</div>'
+        '<div class="slide-title md">Inputs to outputs, filled in</div>'
+        '<table class="ctable"><thead><tr><th>Level</th><th>Statement</th></tr></thead><tbody>'
+        '<tr><td>Output 1</td><td>800 adolescent girls enrolled in after-school STEM clubs</td></tr>'
+        '<tr><td>Activities</td><td>Set up 40 clubs; recruit &amp; train 40 facilitators; supply kits</td></tr>'
+        '<tr><td>Inputs</td><td>40 facilitators, club kits, venue agreements, &#8377;X budget</td></tr>'
+        '</tbody></table>'
+        '<div class="hbox"><div class="hbox-text">Notice the output is countable (800 girls, 40 clubs) and complete on '
+        'delivery &mdash; exactly what makes it an output and not an outcome.</div></div>')
+
+content('<div class="section-label">Costing the chain</div>'
+        '<div class="slide-title md">Tie inputs to the budget</div>'
+        '<div class="slide-body">Inputs are the bridge between the logframe and the budget. A well-built logframe lets '
+        'a reader trace money to activity to output: this is what makes it a management tool, not just a planning '
+        'artefact. Donors increasingly ask for cost per output (unit economics).</div>'
+        '<div class="hbox indigo"><div class="hbox-text">For more on cost per result, see ImpactMojo&rsquo;s '
+        '<strong>Cost-Effectiveness 101</strong> and <strong>Public Finance &amp; Budgeting</strong> courses.</div></div>')
+
+content('<div class="section-label">Section recap</div>'
+        '<div class="slide-title md">The bottom half, in one line</div>'
+        '<div class="hbox green"><div class="hbox-text"><strong>Inputs</strong> fund <strong>activities</strong> that '
+        'produce <strong>outputs</strong> &mdash; all within your control, all written as you-did-it deliverables. The '
+        'interesting, riskier half of the chain comes next.</div></div>'
+        '<div class="slide-body">Get this half tight and countable, and the monitoring almost writes itself. Get it '
+        'muddled, and no amount of indicator-crafting upstream will save the matrix.</div>')
+
+# ============ SECTION 4: Outcomes & Impact (10) ============
+divider(4, "Section Four", "Outcomes &amp; Impact")
+
+content('<div class="section-label">Outcomes</div>'
+        '<div class="slide-title md">Outcomes: the change you are really after</div>'
+        '<div class="slide-body">An outcome is the change in behaviour, knowledge, relationships or condition that your '
+        'outputs are meant to bring about. It is usually the <strong>purpose</strong> of the project &mdash; the single '
+        'most important row in the matrix, and the hardest to write well.</div>'
+        '<div class="hbox"><div class="hbox-text">If the impact is the destination and outputs are what you hand over, '
+        'the outcome is the <em>uptake</em> &mdash; what people actually do differently because of what you delivered.</div></div>')
+
+content('<div class="section-label">Impact</div>'
+        '<div class="slide-title md">Impact: the higher purpose</div>'
+        '<div class="slide-body">Impact (or goal) is the long-term, higher-level change your project contributes to: '
+        'lower mortality, higher incomes, greater equality. It is usually shared with other actors and other '
+        'programmes, realised over years, and beyond any single project to deliver alone.</div>'
+        '<div class="hbox amber"><div class="hbox-text">State the impact you contribute to, but do not pretend to own '
+        'it. &ldquo;Contributes to reduced child stunting in the district&rdquo; is honest; &ldquo;reduces stunting&rdquo; '
+        'alone over-claims.</div></div>')
+
+content('<div class="section-label">One purpose</div>'
+        '<div class="slide-title md">Why most logframes allow only one outcome</div>'
+        '<div class="slide-body">Classic logframe discipline insists on a <strong>single purpose / outcome</strong>. The '
+        'reason is focus: a project chasing three outcomes usually does none well, and the matrix can no longer show a '
+        'clean line of logic. If you genuinely have two, ask whether they are really two projects.</div>'
+        '<div class="hbox red"><div class="hbox-text">Multiple outcomes are a warning sign, not an achievement. They '
+        'often hide a lack of decision about what the project is actually for.</div></div>')
+
+content('<div class="section-label">Writing an outcome</div>'
+        '<div class="slide-title md">A good outcome statement</div>'
+        '<ul class="bullet-list green">'
+        '<li>Describes a change in <strong>someone other than the project</strong> (participants, institutions).</li>'
+        '<li>Is realistic given the outputs &mdash; reachable within the project, not a wish.</li>'
+        '<li>Is measurable: you can name an indicator that would move if it were true.</li>'
+        '<li>Names the target group: <em>whose</em> behaviour or condition changes.</li>'
+        '</ul>'
+        '<div class="hbox"><div class="hbox-text">&ldquo;Smallholder farmers in 40 villages adopt and sustain drip '
+        'irrigation&rdquo; &mdash; change, in named others, plausibly caused by the outputs, and measurable.</div></div>')
+
+content('<div class="section-label">The big jump</div>'
+        '<div class="slide-title md">Mind the output&ndash;outcome gap</div>'
+        '<div class="slide-body">The leap from output to outcome is where projects most often fail &mdash; and where the '
+        'assumptions matter most. Training delivered (output) does not guarantee practice changed (outcome); a clinic '
+        'built does not guarantee it is used. Name what has to happen in between.</div>'
+        '<div class="hbox amber"><div class="hbox-text">If you cannot explain <em>why</em> the outputs would lead to the '
+        'outcome, you do not yet have a theory of change &mdash; you have a list of hopes.</div></div>')
+
+content('<div class="section-label">Behaviour</div>'
+        '<div class="slide-title md">Most outcomes are behaviour change</div>'
+        '<div class="slide-body">In development work, the outcome is usually that some group <em>does something '
+        'differently</em>: farmers adopt, mothers attend, officials enforce, girls stay in school. Behaviour is '
+        'influenced by far more than your project, which is exactly why outcomes sit in the sphere of influence.</div>'
+        '<div class="hbox indigo"><div class="hbox-text">Designing for behaviour change is its own craft &mdash; see '
+        'ImpactMojo&rsquo;s <strong>Behaviour-Change Communication</strong> course and BCT repository.</div></div>')
+
+content('<div class="section-label">Time</div>'
+        '<div class="slide-title md">Results take time to appear</div>'
+        '<div class="slide-body">Outputs land during the project; outcomes often emerge near or after its end; impact '
+        'may take years. A logframe measured only at project close can miss the outcomes it was built to create &mdash; '
+        'and credit impacts that have not yet had time to form.</div>'
+        '<div class="hbox"><div class="hbox-text">Match your measurement timing to where each result sits in time. '
+        'Some outcomes need a follow-up survey months after the last activity.</div></div>')
+
+content('<div class="section-label">Worked top rows</div>'
+        '<div class="slide-title md">Outcome and impact, filled in</div>'
+        '<table class="ctable"><thead><tr><th>Level</th><th>Statement</th></tr></thead><tbody>'
+        '<tr><td>Impact</td><td>Contributes to higher and more resilient incomes for smallholder households</td></tr>'
+        '<tr><td>Outcome</td><td>Farmers in 40 villages adopt and sustain water-efficient irrigation</td></tr>'
+        '<tr><td>Output</td><td>1,500 farmers trained and equipped with drip-irrigation kits</td></tr>'
+        '</tbody></table>'
+        '<div class="hbox green"><div class="hbox-text">&ldquo;Contributes to&rdquo; at impact, a behaviour change at '
+        'outcome, a countable deliverable at output &mdash; each row in its proper grammar.</div></div>')
+
+content('<div class="section-label">Sustainability</div>'
+        '<div class="slide-title md">Will it last past the project?</div>'
+        '<div class="slide-body">A strong outcome statement often carries a hint of durability &mdash; &ldquo;adopt '
+        '<em>and sustain</em>&rdquo;. Donors increasingly ask not just whether change happened, but whether it will '
+        'hold once funding ends. That depends on systems, ownership and incentives, not just your outputs.</div>'
+        '<div class="hbox amber"><div class="hbox-text">Sustainability usually lives in the assumptions and in the exit '
+        'strategy. Name who keeps the change alive after you leave.</div></div>')
+
+content('<div class="section-label">Section recap</div>'
+        '<div class="slide-title md">The top half, in one line</div>'
+        '<div class="hbox green"><div class="hbox-text"><strong>Outputs</strong> are taken up as <strong>outcomes</strong> '
+        '(behaviour change in others) which <strong>contribute to</strong> <strong>impact</strong> (higher-order '
+        'change). You control the first, influence the second, and merely contribute to the third.</div></div>'
+        '<div class="slide-body">With the left column complete, the next job is to make each row measurable. That is '
+        'the indicators column.</div>')
+
+# ============ SECTION 5: Indicators (8) ============
+divider(5, "Section Five", "Indicators")
+
+content('<div class="section-label">Definition</div>'
+        '<div class="term-box"><div class="term-word">Indicator (OVI)</div>'
+        '<div class="term-def">An <strong>objectively verifiable indicator</strong> is a specific, measurable sign that '
+        'a result has been achieved. It answers: &ldquo;how would we know?&rdquo; For each row of the chain you name at '
+        'least one indicator that would move if that result were real.</div></div>'
+        '<div class="slide-body">&ldquo;Objectively verifiable&rdquo; means two people measuring it independently would '
+        'get the same answer &mdash; no judgement call required.</div>')
+
+content('<div class="section-label">SMART</div>'
+        '<div class="slide-title md">Make every indicator SMART</div>'
+        '<div class="stat-grid c3">'
+        '<div class="stat-card"><div class="stat-number">S&middot;M</div><div class="stat-label"><strong>Specific</strong> &amp; '
+        '<strong>Measurable</strong> &mdash; clear what, countable how</div></div>'
+        '<div class="stat-card indigo"><div class="stat-number">A&middot;R</div><div class="stat-label"><strong>Achievable</strong> &amp; '
+        '<strong>Relevant</strong> &mdash; realistic, and tied to the result</div></div>'
+        '<div class="stat-card green"><div class="stat-number">T</div><div class="stat-label"><strong>Time-bound</strong> '
+        '&mdash; by when</div></div>'
+        '</div>'
+        '<div class="hbox"><div class="hbox-text">&ldquo;% of trained midwives correctly performing newborn '
+        'resuscitation, measured by observation, rising from 40% to 80% by end of year 2.&rdquo;</div></div>')
+
+content('<div class="section-label">Anatomy</div>'
+        '<div class="slide-title md">A full indicator has four parts</div>'
+        '<ul class="bullet-list">'
+        '<li><strong>Unit / what</strong> &mdash; % of women, number of villages, rate per 1,000.</li>'
+        '<li><strong>Baseline</strong> &mdash; the value at the start. Without it you cannot show change.</li>'
+        '<li><strong>Target</strong> &mdash; the value you commit to reach, by a date.</li>'
+        '<li><strong>Disaggregation</strong> &mdash; by sex, age, caste, location, disability.</li>'
+        '</ul>'
+        '<div class="hbox red"><div class="hbox-text">An indicator with no baseline is the most common logframe fault. '
+        'A target without a starting point measures nothing.</div></div>')
+
+content('<div class="section-label">Quant &amp; qual</div>'
+        '<div class="slide-title md">Numbers and judgements both count</div>'
+        '<div class="two-col half">'
+        '<div class="col-panel"><div class="col-panel-title">Quantitative</div>'
+        '<div class="slide-body sm">Counts, rates, percentages, scores. Easy to verify, easy to aggregate &mdash; but '
+        'can miss the &ldquo;why&rdquo;.</div></div>'
+        '<div class="col-panel green"><div class="col-panel-title">Qualitative</div>'
+        '<div class="slide-body sm">Quality of participation, perceived fairness, case stories. Harder to verify; use '
+        'a defined scale or rubric so it stays objective.</div></div></div>'
+        '<div class="hbox"><div class="hbox-text">The best logframes mix both: a number for &ldquo;how much&rdquo; and a '
+        'qualitative measure for &ldquo;how well&rdquo;.</div></div>')
+
+content('<div class="section-label">Proxies</div>'
+        '<div class="slide-title md">When you can&rsquo;t measure it directly</div>'
+        '<div class="slide-body">Some results &mdash; empowerment, resilience, trust &mdash; have no direct meter. A '
+        '<strong>proxy indicator</strong> stands in: e.g. women&rsquo;s control over household spending as a proxy for '
+        'empowerment. Choose proxies carefully and state that they are proxies.</div>'
+        '<div class="hbox amber"><div class="hbox-text">Beware Goodhart&rsquo;s law: <em>when a measure becomes a target, '
+        'it stops being a good measure.</em> People optimise the proxy, not the thing you cared about.</div></div>')
+
+content('<div class="section-label">Too many</div>'
+        '<div class="slide-title md">A few good indicators beat many weak ones</div>'
+        '<div class="slide-body">Every indicator is a data-collection commitment. One or two strong indicators per '
+        'result is usually enough; a logframe with forty indicators becomes a monitoring burden that crowds out '
+        'actually running the project.</div>'
+        '<div class="hbox red"><div class="hbox-text">Before adding an indicator, ask: <em>who will collect this, how '
+        'often, and what decision will it inform?</em> If there is no answer, drop it.</div></div>')
+
+content('<div class="section-label">Standard sets</div>'
+        '<div class="slide-title md">Borrow indicators where you can</div>'
+        '<div class="slide-body">Many sectors have agreed indicator sets &mdash; the SDG indicators, WHO and DHS health '
+        'indicators, education access measures, IRIS+ for impact investing. Using standard definitions makes your '
+        'results comparable and saves you re-inventing measurement.</div>'
+        '<div class="hbox indigo"><div class="hbox-text">Match to national data where you can (NFHS, Census, PLFS) so '
+        'your baseline and target sit in a context readers already know.</div></div>')
+
+content('<div class="section-label">Worked indicators</div>'
+        '<div class="slide-title md">Indicators across the chain</div>'
+        '<table class="ctable"><thead><tr><th>Result</th><th>Indicator (with baseline &rarr; target)</th></tr></thead><tbody>'
+        '<tr><td>Output</td><td>No. of farmers trained: 0 &rarr; 1,500 by Q6 (disagg. by sex)</td></tr>'
+        '<tr><td>Outcome</td><td>% of trained farmers still using drip at 12 months: &ndash; &rarr; 60%</td></tr>'
+        '<tr><td>Impact</td><td>Mean kharif income of participant households: baseline survey &rarr; +20%</td></tr>'
+        '</tbody></table>'
+        '<div class="hbox green"><div class="hbox-text">Each indicator carries a unit, a baseline, a target and a date '
+        '&mdash; and gets harder to attribute the higher you go. That is honest measurement.</div></div>')
+
+# ============ SECTION 6: Means of Verification (7) ============
+divider(6, "Section Six", "Means of Verification")
+
+content('<div class="section-label">Definition</div>'
+        '<div class="term-box"><div class="term-word">Means of verification (MoV)</div>'
+        '<div class="term-def">The third column: <strong>where the data for each indicator comes from</strong>, who '
+        'collects it, how often, and how. If the indicator says &ldquo;what we measure&rdquo;, the MoV says &ldquo;how '
+        'we will actually get that number&rdquo;.</div></div>'
+        '<div class="slide-body">An indicator with no realistic means of verification is a promise you cannot keep. '
+        'The two columns must be designed together.</div>')
+
+content('<div class="section-label">Sources</div>'
+        '<div class="slide-title md">Where verification data comes from</div>'
+        '<ul class="bullet-list sm">'
+        '<li><strong>Project records</strong> &mdash; attendance sheets, distribution logs, training registers (cheap, for outputs).</li>'
+        '<li><strong>Surveys</strong> &mdash; baseline / midline / endline of participants (for outcomes).</li>'
+        '<li><strong>Observation</strong> &mdash; direct checks of practice or quality.</li>'
+        '<li><strong>Official statistics</strong> &mdash; NFHS, Census, administrative data (for impact / context).</li>'
+        '<li><strong>Independent reports</strong> &mdash; third-party evaluations, audits.</li>'
+        '</ul>')
+
+content('<div class="section-label">The reality check</div>'
+        '<div class="slide-title md">MoV is where ambition meets the budget</div>'
+        '<div class="slide-body">Filling in the MoV column is a cost test. A fancy outcome indicator that needs a '
+        '5,000-household panel survey may be unaffordable. If you cannot pay to verify it, you cannot claim it &mdash; '
+        'so revise the indicator to something you can actually measure.</div>'
+        '<div class="hbox red"><div class="hbox-text">Every indicator&rsquo;s MoV has a price. The monitoring budget is '
+        'set, in effect, in this column &mdash; plan for it (often 5&ndash;10% of project cost).</div></div>')
+
+content('<div class="section-label">Frequency</div>'
+        '<div class="slide-title md">How often, and who</div>'
+        '<div class="slide-body">A good MoV entry names the <strong>method</strong>, the <strong>frequency</strong> and '
+        'the <strong>responsible person</strong>: &ldquo;observation checklist, quarterly, by the M&amp;E officer&rdquo;. '
+        'Output data is usually continuous; outcome surveys are periodic; impact data may come once, at endline or '
+        'after.</div>'
+        '<div class="hbox"><div class="hbox-text">Tie the frequency to decisions: collect output data often enough to '
+        'course-correct, but do not survey outcomes so often that measurement disrupts the work.</div></div>')
+
+content('<div class="section-label">Quality</div>'
+        '<div class="slide-title md">Verifiable means trustworthy</div>'
+        '<div class="slide-body">The point of the MoV column is credibility: a sceptical reader (or auditor, or '
+        'evaluator) should be able to follow it to the same conclusion. That means the source must be reliable, the '
+        'method consistent, and the data retained.</div>'
+        '<ul class="bullet-list sm">'
+        '<li>Prefer sources someone else could independently check.</li>'
+        '<li>Keep the raw data, not just the summary, so claims can be re-verified.</li>'
+        '<li>For self-reported data, note the bias and triangulate where it matters.</li>'
+        '</ul>')
+
+content('<div class="section-label">Worked MoV</div>'
+        '<div class="slide-title md">Indicator and its verification, paired</div>'
+        '<table class="ctable"><thead><tr><th>Indicator</th><th>Means of verification</th></tr></thead><tbody>'
+        '<tr><td>1,500 farmers trained</td><td>Training registers, ongoing, M&amp;E officer</td></tr>'
+        '<tr><td>60% still using drip at 12 months</td><td>Follow-up sample survey of 300 farmers, year 2, external enumerators</td></tr>'
+        '<tr><td>+20% kharif income</td><td>Baseline &amp; endline household survey; cross-checked with mandi records</td></tr>'
+        '</tbody></table>'
+        '<div class="hbox green"><div class="hbox-text">Cheap records for outputs, a sample survey for the outcome, a '
+        'before/after survey for impact &mdash; cost rising with the level, as it should.</div></div>')
+
+content('<div class="section-label">Connecting M&amp;E</div>'
+        '<div class="slide-title md">The logframe is your M&amp;E plan&rsquo;s backbone</div>'
+        '<div class="slide-body">Columns two and three &mdash; indicators and means of verification &mdash; are, in '
+        'effect, your monitoring plan. A fuller M&amp;E plan just adds detail: tools, sampling, responsibilities, '
+        'timing, analysis and use.</div>'
+        '<div class="hbox indigo"><div class="hbox-text">For the wider system around the matrix, see ImpactMojo&rsquo;s '
+        '<strong>MEL Basics 101</strong> and <strong>The Evidence Question</strong> flagship.</div></div>')
+
+# ============ SECTION 7: Assumptions (6) ============
+divider(7, "Section Seven", "Assumptions")
+
+content('<div class="section-label">Definition</div>'
+        '<div class="term-box"><div class="term-word">Assumptions</div>'
+        '<div class="term-def">The fourth column: the <strong>external conditions that must hold</strong> for each '
+        'step of the logic to work, but which are outside your control. They are the &ldquo;and also&rdquo; that every '
+        'if&ndash;then quietly relies on.</div></div>'
+        '<div class="slide-body">Assumptions are where a logframe gets honest. They name the things that could break '
+        'your chain even if you do everything right.</div>')
+
+content('<div class="section-label">The if&ndash;and&ndash;then logic</div>'
+        '<div class="slide-title md">How assumptions complete the chain</div>'
+        '<div class="slide-body">Read vertically <em>with</em> the assumptions: <em>IF</em> we deliver the outputs '
+        '<em>AND</em> the assumptions at that level hold, <em>THEN</em> we reach the outcome. The assumption column '
+        'sits to the side of each step, carrying the conditions that step depends on.</div>'
+        '<div class="flow">'
+        '<div class="flow-step"><div class="flow-num">IF</div><div class="flow-label">Outputs delivered</div></div>'
+        '<div class="flow-arrow">+</div>'
+        '<div class="flow-step"><div class="flow-num">AND</div><div class="flow-label">Assumptions hold</div></div>'
+        '<div class="flow-arrow">&rarr;</div>'
+        '<div class="flow-step"><div class="flow-num">THEN</div><div class="flow-label">Outcome reached</div></div>'
+        '</div>')
+
+content('<div class="section-label">Examples</div>'
+        '<div class="slide-title md">What assumptions look like</div>'
+        '<ul class="bullet-list amber">'
+        '<li>&ldquo;Monsoon rainfall is within normal range&rdquo; (for an agriculture outcome).</li>'
+        '<li>&ldquo;The government does not cut the teacher-recruitment budget&rdquo; (for an education outcome).</li>'
+        '<li>&ldquo;Trained staff are not transferred out within the year&rdquo; (for a health-quality outcome).</li>'
+        '<li>&ldquo;Market prices for the crop stay stable&rdquo; (for an income impact).</li>'
+        '</ul>'
+        '<div class="hbox"><div class="hbox-text">Each is plausible, outside your control, and capable of breaking the '
+        'logic. That is exactly what belongs in this column.</div></div>')
+
+content('<div class="section-label">The assumptions algorithm</div>'
+        '<div class="slide-title md">Decide what to do with each one</div>'
+        '<div class="slide-body">For every assumption, ask two questions: <em>how likely is it to hold?</em> and '
+        '<em>how important is it?</em></div>'
+        '<table class="ctable"><thead><tr><th>Likely to hold?</th><th>Action</th></tr></thead><tbody>'
+        '<tr><td>Almost certain</td><td>Note it, move on &mdash; not a real risk</td></tr>'
+        '<tr><td>Likely but not sure</td><td>Keep in the logframe; monitor it</td></tr>'
+        '<tr><td>Unlikely &amp; important</td><td>Redesign the project to remove the dependency, or add an activity to secure it</td></tr>'
+        '<tr><td>Will not hold &amp; fatal</td><td>A &ldquo;killer assumption&rdquo; &mdash; the project may not be viable</td></tr>'
+        '</tbody></table>')
+
+content('<div class="section-label">Killer assumptions</div>'
+        '<div class="slide-title md">When an assumption sinks the project</div>'
+        '<div class="slide-body">A <strong>killer assumption</strong> is one that is both essential and unlikely to '
+        'hold. If your whole outcome depends on a policy passing that almost certainly will not, no amount of good '
+        'delivery will save you. Better to find this on paper than two years in.</div>'
+        '<div class="hbox red"><div class="hbox-text">The discipline of writing assumptions exists largely to surface '
+        'killer assumptions early &mdash; while you can still redesign or walk away.</div></div>')
+
+content('<div class="section-label">Not an excuse</div>'
+        '<div class="slide-title md">Assumptions are to manage, not to hide behind</div>'
+        '<div class="slide-body">Assumptions are not a place to park everything that might go wrong so you can blame '
+        'them later. Anything you can influence belongs in your activities, not your assumptions. Reserve the column '
+        'for genuinely external conditions &mdash; and then actively monitor them.</div>'
+        '<div class="hbox amber"><div class="hbox-text">Revisit assumptions at every review. An assumption that has '
+        'started to fail is an early warning the outcome is at risk.</div></div>')
+
+# ============ SECTION 8: Risk (8) ============
+divider(8, "Section Eight", "Risk")
+
+content('<div class="section-label">From assumptions to risk</div>'
+        '<div class="slide-title md">A risk is an assumption that might fail</div>'
+        '<div class="slide-body">Flip an assumption to its negative and you have a risk: &ldquo;rainfall is normal&rdquo; '
+        '&rarr; &ldquo;drought reduces yields&rdquo;. Modern donor formats often pair the logframe with a '
+        '<strong>risk register</strong> that goes further: naming, scoring and assigning each risk.</div>'
+        '<div class="hbox"><div class="hbox-text">Same underlying reality, two lenses: the assumption is what you hope '
+        'holds; the risk is what happens if it does not.</div></div>')
+
+content('<div class="section-label">Scoring</div>'
+        '<div class="slide-title md">Likelihood &times; impact</div>'
+        '<div class="slide-body">Risks are usually scored on two axes &mdash; how <strong>likely</strong> they are and '
+        'how big the <strong>impact</strong> would be &mdash; often on a 1&ndash;5 scale each. The product (or a colour '
+        'grid) gives a rough priority so attention goes to the high&ndash;high corner.</div>'
+        '<div class="hbox indigo"><div class="hbox-text">A 5&times;5 likelihood&ndash;impact grid is the standard '
+        'picture. It is a small heatmap &mdash; and, like any heatmap, it is a rough sort, not a precise number.</div></div>')
+
+content('<div class="section-label">The 4 Ts</div>'
+        '<div class="slide-title md">Four ways to handle a risk</div>'
+        '<div class="stat-grid c4">'
+        '<div class="stat-card"><div class="stat-number">Treat</div><div class="stat-label">Act to reduce likelihood or impact</div></div>'
+        '<div class="stat-card indigo"><div class="stat-number">Transfer</div><div class="stat-label">Shift it &mdash; insurance, partner, contract</div></div>'
+        '<div class="stat-card amber"><div class="stat-number">Tolerate</div><div class="stat-label">Accept it; monitor; have a plan B</div></div>'
+        '<div class="stat-card red"><div class="stat-number">Terminate</div><div class="stat-label">Avoid it &mdash; change or drop the activity</div></div>'
+        '</div>'
+        '<div class="hbox"><div class="hbox-text">Most risks are <em>treated</em> or <em>tolerated</em>. The value is '
+        'in deciding deliberately, not in the label.</div></div>')
+
+content('<div class="section-label">Types</div>'
+        '<div class="slide-title md">Common risk categories</div>'
+        '<ul class="bullet-list sm">'
+        '<li><strong>Contextual</strong> &mdash; politics, economy, climate, conflict, policy shifts.</li>'
+        '<li><strong>Programmatic</strong> &mdash; the intervention fails to work as designed; low uptake.</li>'
+        '<li><strong>Institutional / fiduciary</strong> &mdash; partner capacity, fraud, financial mismanagement.</li>'
+        '<li><strong>Reputational &amp; safeguarding</strong> &mdash; harm to participants, loss of trust.</li>'
+        '</ul>'
+        '<div class="hbox red"><div class="hbox-text">Safeguarding risk &mdash; the risk that a project harms the people '
+        'it serves &mdash; is now a non-negotiable category for most funders. Never leave it out.</div></div>')
+
+content('<div class="section-label">Owners</div>'
+        '<div class="slide-title md">Every risk needs a name against it</div>'
+        '<div class="slide-body">A risk register with no owners is a list nobody acts on. Each significant risk should '
+        'have a named <strong>owner</strong> responsible for monitoring it and triggering the response, plus a '
+        '<strong>trigger</strong> &mdash; the sign that the risk is materialising.</div>'
+        '<div class="hbox amber"><div class="hbox-text">&ldquo;If enrolment is below 60% of target by month 3, the '
+        'programme manager escalates and we activate the community-mobilisation contingency.&rdquo;</div></div>')
+
+content('<div class="section-label">Living document</div>'
+        '<div class="slide-title md">Review risk on a schedule</div>'
+        '<div class="slide-body">Risk is not a one-time annex. New risks appear, old ones fade, scores change. A '
+        'useful register is reviewed at every project board or quarterly review, with changes logged. A risk register '
+        'written once and filed is theatre.</div>'
+        '<div class="hbox"><div class="hbox-text">Tie the risk review to the same cadence as your logframe review, so '
+        'assumptions and risks &mdash; two views of the same uncertainty &mdash; move together.</div></div>')
+
+content('<div class="section-label">Worked register</div>'
+        '<div class="slide-title md">A risk register row</div>'
+        '<table class="ctable"><thead><tr><th>Risk</th><th>L&times;I</th><th>Response</th><th>Owner</th></tr></thead><tbody>'
+        '<tr><td>Drought cuts yields, weakening the income case</td><td>3&times;4</td><td>Treat: promote water-efficient varieties; tolerate residual</td><td>Field lead</td></tr>'
+        '<tr><td>Trained staff transferred out</td><td>4&times;3</td><td>Treat: train a wider pool; brief supervisors</td><td>M&amp;E officer</td></tr>'
+        '<tr><td>Partner financial controls weak</td><td>2&times;5</td><td>Transfer/treat: audits, milestone disbursement</td><td>Finance</td></tr>'
+        '</tbody></table>')
+
+content('<div class="section-label">Section recap</div>'
+        '<div class="slide-title md">Assumptions and risk, together</div>'
+        '<div class="hbox green"><div class="hbox-text">The <strong>assumptions</strong> column names what must hold; the '
+        '<strong>risk register</strong> names what happens if it does not, scores it, and assigns a response and an '
+        'owner. Both make the logframe honest about uncertainty.</div></div>'
+        '<div class="slide-body">With all four columns understood, you are ready to assemble the full matrix &mdash; and '
+        'to test it as a whole.</div>')
+
+# ============ SECTION 9: Building the Matrix (7) ============
+divider(9, "Section Nine", "Building the Matrix")
+
+content('<div class="section-label">Order of work</div>'
+        '<div class="slide-title md">Build it in the right sequence</div>'
+        '<div class="flow">'
+        '<div class="flow-step"><div class="flow-num">1</div><div class="flow-label">Theory of change first</div></div>'
+        '<div class="flow-arrow">&rarr;</div>'
+        '<div class="flow-step"><div class="flow-num">2</div><div class="flow-label">Left column (results)</div></div>'
+        '<div class="flow-arrow">&rarr;</div>'
+        '<div class="flow-step"><div class="flow-num">3</div><div class="flow-label">Assumptions</div></div>'
+        '<div class="flow-arrow">&rarr;</div>'
+        '<div class="flow-step"><div class="flow-num">4</div><div class="flow-label">Indicators</div></div>'
+        '<div class="flow-arrow">&rarr;</div>'
+        '<div class="flow-step"><div class="flow-num">5</div><div class="flow-label">Means of verification</div></div>'
+        '</div>'
+        '<div class="hbox"><div class="hbox-text">Resist the urge to start with indicators. If the logic is wrong, '
+        'beautiful indicators measure the wrong thing.</div></div>')
+
+content('<div class="section-label">Do it with people</div>'
+        '<div class="slide-title md">A logframe is better built in a room</div>'
+        '<div class="slide-body">The participatory tradition (ZOPP) builds the logframe in a workshop with the people '
+        'who will deliver it and, ideally, those it serves. The matrix that results is usually weaker on paper but far '
+        'stronger in practice, because the team owns the logic and has stress-tested it.</div>'
+        '<div class="hbox green"><div class="hbox-text">The conversation is the point. A logframe handed down from a '
+        'consultant who never met the team is a compliance document, not a plan.</div></div>')
+
+content('<div class="section-label">Vertical logic</div>'
+        '<div class="slide-title md">Test 1: does the column make sense going up?</div>'
+        '<div class="slide-body">Read the results column from the bottom: activities &rarr; outputs &rarr; outcome '
+        '&rarr; impact. At each arrow ask whether the lower level, plus its assumptions, is genuinely enough to reach '
+        'the next. Gaps mean a missing output, a missing assumption, or an over-reach.</div>'
+        '<div class="hbox amber"><div class="hbox-text">If you find yourself saying &ldquo;and then a miracle '
+        'happens&rdquo; between two rows, you have found the gap.</div></div>')
+
+content('<div class="section-label">Horizontal logic</div>'
+        '<div class="slide-title md">Test 2: does each row hang together?</div>'
+        '<div class="slide-body">Read each row across: result &rarr; indicator &rarr; means of verification &rarr; '
+        'assumption. Does the indicator actually measure the result? Can the MoV realistically supply it? Is the '
+        'assumption truly external? A row that fails this is internally inconsistent.</div>'
+        '<div class="hbox"><div class="hbox-text">Vertical logic tests the <em>theory</em>; horizontal logic tests the '
+        '<em>measurement</em>. A strong logframe passes both.</div></div>')
+
+content('<div class="section-label">Common faults</div>'
+        '<div class="slide-title md">What reviewers look for</div>'
+        '<ul class="bullet-list red">'
+        '<li>Activities dressed up as outputs; outputs dressed up as outcomes.</li>'
+        '<li>Indicators with no baseline, or no realistic data source.</li>'
+        '<li>Too many outcomes; a fuzzy, unmeasurable purpose.</li>'
+        '<li>Assumptions that are really things the project controls.</li>'
+        '<li>A matrix that contradicts the budget or the work plan.</li>'
+        '</ul>')
+
+content('<div class="section-label">Keep it alive</div>'
+        '<div class="slide-title md">Revise the logframe as you learn</div>'
+        '<div class="slide-body">A logframe is a hypothesis, and hypotheses get updated. Most donors allow &mdash; and '
+        'expect &mdash; revisions at review points: refined targets, corrected assumptions, dropped indicators. A frozen '
+        'logframe is a sign nobody is using it.</div>'
+        '<div class="hbox green"><div class="hbox-text">Log every change and why. The trail of revisions is itself '
+        'evidence of adaptive, learning-oriented management.</div></div>')
+
+content('<div class="section-label">Full example</div>'
+        '<div class="slide-title md">One complete row of the matrix</div>'
+        '<table class="ctable"><thead><tr><th>Result</th><th>Indicator</th><th>MoV</th><th>Assumption</th></tr></thead><tbody>'
+        '<tr><td>Outcome: farmers adopt &amp; sustain drip irrigation</td>'
+        '<td>60% of trained farmers still using drip at 12 months</td>'
+        '<td>Follow-up survey of 300, year 2</td>'
+        '<td>Water availability and crop prices stay viable</td></tr>'
+        '</tbody></table>'
+        '<div class="hbox indigo"><div class="hbox-text">A single row, read across, contains a whole small theory: '
+        'what changes, how we will know, where the number comes from, and what it depends on.</div></div>')
+
+# ============ SECTION 10: Critiques & Limits (7) ============
+divider(10, "Section Ten", "Critiques &amp; Limits")
+
+content('<div class="section-label">Honest about the tool</div>'
+        '<div class="slide-title md">The logframe has real critics</div>'
+        '<div class="slide-body">For all its usefulness, the logframe has been criticised for decades &mdash; by '
+        'practitioners, evaluators and scholars. Knowing the critiques makes you a better user: you keep the '
+        'discipline while avoiding the traps.</div>'
+        '<div class="hbox"><div class="hbox-text">The goal is not to abandon the logframe but to hold it lightly &mdash; '
+        'as a useful summary, not a description of how change really works.</div></div>')
+
+content('<div class="section-label">Critique 1</div>'
+        '<div class="slide-title md">Change is rarely linear</div>'
+        '<div class="slide-body">The results chain implies a tidy, one-directional flow. Real change is messy, '
+        'looping, full of feedback and unintended effects. Complex problems &mdash; governance, social norms, systems '
+        '&mdash; do not move in a straight line from activity to impact.</div>'
+        '<div class="hbox amber"><div class="hbox-text">For complex settings, pair the logframe with systems thinking '
+        'and outcome-mapping approaches that allow for non-linear, emergent change.</div></div>')
+
+content('<div class="section-label">Critique 2</div>'
+        '<div class="slide-title md">It can crowd out what it can&rsquo;t count</div>'
+        '<div class="slide-body">Because the logframe rewards the measurable, teams can drift toward what is easy to '
+        'count &mdash; outputs, numbers trained &mdash; and away from harder, more important changes in power, '
+        'relationships or dignity. The map starts to shape the territory.</div>'
+        '<div class="hbox red"><div class="hbox-text">&ldquo;Not everything that counts can be counted.&rdquo; Guard '
+        'against measuring the trivial precisely while ignoring the vital.</div></div>')
+
+content('<div class="section-label">Critique 3</div>'
+        '<div class="slide-title md">It can lock in a plan that should flex</div>'
+        '<div class="slide-body">A logframe agreed at the start, then treated as a contract, can punish teams for '
+        'adapting &mdash; even when learning shows the original plan was wrong. Rigidly enforced, it discourages exactly '
+        'the responsiveness good development needs.</div>'
+        '<div class="hbox amber"><div class="hbox-text">This is what &ldquo;adaptive management&rdquo; and Doing '
+        'Development Differently push back on: keep the logframe, but let it be revised as you learn.</div></div>')
+
+content('<div class="section-label">Critique 4</div>'
+        '<div class="slide-title md">It serves the donor more than the community</div>'
+        '<div class="slide-body">Logframes are written upward, in the donor&rsquo;s language and categories. Critics '
+        'note this can centre the funder&rsquo;s accountability over the priorities and knowledge of the people the '
+        'project serves &mdash; a power dynamic worth naming.</div>'
+        '<div class="hbox indigo"><div class="hbox-text">Building the logframe <em>with</em> communities, and including '
+        'indicators they care about, pushes back against this. See <strong>Decolonial Development 101</strong>.</div></div>')
+
+content('<div class="section-label">Alternatives</div>'
+        '<div class="slide-title md">Complements and alternatives</div>'
+        '<table class="ctable"><thead><tr><th>Approach</th><th>Good when&hellip;</th></tr></thead><tbody>'
+        '<tr><td>Outcome Mapping</td><td>Change runs through many actors&rsquo; behaviour; boundaries are fuzzy</td></tr>'
+        '<tr><td>Outcome Harvesting</td><td>Outcomes can&rsquo;t be predicted in advance; you work backwards</td></tr>'
+        '<tr><td>Most Significant Change</td><td>You want participant-defined, story-based evidence</td></tr>'
+        '<tr><td>Adaptive / DDD</td><td>The problem is complex and the path must be discovered</td></tr>'
+        '</tbody></table>'
+        '<div class="hbox"><div class="hbox-text">These are not rivals so much as companions. Many strong M&amp;E '
+        'systems use a logframe for accountability and one of these for learning.</div></div>')
+
+content('<div class="section-label">Balanced view</div>'
+        '<div class="slide-title md">Use it well, hold it lightly</div>'
+        '<div class="slide-body">The logframe endures because, used well, it does something valuable: it forces a team '
+        'to state its logic, commit to measurement, and name its risks, on one honest page. Its failures are mostly '
+        'failures of <em>how</em> it is used &mdash; rigidly, upward, as compliance.</div>'
+        '<div class="hbox green"><div class="hbox-text">A good practitioner knows both the discipline and the limits. '
+        'The matrix is a servant, not a master.</div></div>')
+
+# ============ SECTION 11: Tools & Practice (8) ============
+divider(11, "Section Eleven", "Tools &amp; Practice")
+
+content('<div class="section-label">Donor formats</div>'
+        '<div class="slide-title md">Every funder wants it slightly differently</div>'
+        '<ul class="bullet-list sm">'
+        '<li><strong>EU</strong> &mdash; intervention logic + indicators, baselines, targets, sources, assumptions.</li>'
+        '<li><strong>FCDO (ex-DFID)</strong> &mdash; logframe with milestones per year, plus a separate theory of change.</li>'
+        '<li><strong>USAID</strong> &mdash; results framework + activity MEL plans.</li>'
+        '<li><strong>UN agencies</strong> &mdash; results-based management; results &amp; resources frameworks.</li>'
+        '<li><strong>GIZ</strong> &mdash; results model / results matrix in the ZOPP tradition.</li>'
+        '</ul>'
+        '<div class="hbox"><div class="hbox-text">The logic underneath is the same. Learn the structure once and you '
+        'can fill any donor&rsquo;s template.</div></div>')
+
+content('<div class="section-label">Software</div>'
+        '<div class="slide-title md">What people actually build them in</div>'
+        '<ul class="bullet-list sm">'
+        '<li><strong>A spreadsheet</strong> &mdash; honestly, most logframes live in Excel or Sheets. Fine.</li>'
+        '<li><strong>Word tables</strong> &mdash; for the narrative proposal annex.</li>'
+        '<li><strong>M&amp;E platforms</strong> &mdash; DevResults, TolaData, Logalto, Kobo + a dashboard, for live tracking.</li>'
+        '</ul>'
+        '<div class="hbox amber"><div class="hbox-text">The tool matters far less than the thinking. A sound logframe '
+        'in a plain spreadsheet beats a muddled one in expensive software.</div></div>')
+
+content('<div class="section-label">Templates</div>'
+        '<div class="slide-title md">A reusable column checklist</div>'
+        '<table class="ctable"><thead><tr><th>Column</th><th>Must contain</th></tr></thead><tbody>'
+        '<tr><td>Results</td><td>One result per row, in the right grammar for its level</td></tr>'
+        '<tr><td>Indicators</td><td>Unit, baseline, target, date, disaggregation</td></tr>'
+        '<tr><td>MoV</td><td>Source, method, frequency, responsible person</td></tr>'
+        '<tr><td>Assumptions</td><td>External conditions, monitored, not things you control</td></tr>'
+        '</tbody></table>'
+        '<div class="hbox green"><div class="hbox-text">Print this checklist next to your draft. If any cell is empty '
+        'or vague, the logframe is not finished.</div></div>')
+
+content('<div class="section-label">Quality check</div>'
+        '<div class="slide-title md">A reviewer&rsquo;s ten-minute test</div>'
+        '<ul class="bullet-list">'
+        '<li>Can I read the left column as a believable story of change?</li>'
+        '<li>Is there exactly one clear outcome?</li>'
+        '<li>Does every indicator have a baseline and a source I trust?</li>'
+        '<li>Are the assumptions genuinely external &mdash; and any killers flagged?</li>'
+        '<li>Does the matrix agree with the budget and work plan?</li>'
+        '</ul>'
+        '<div class="hbox"><div class="hbox-text">Five yeses and you have a logframe worth funding. Any no is where '
+        'the next revision starts.</div></div>')
+
+content('<div class="section-label">Practice</div>'
+        '<div class="slide-title md">Build one from a project you know</div>'
+        '<div class="slide-body">The fastest way to learn the logframe is to draft one for a real or imagined project '
+        'in your own field. Start from the impact, work down to activities, then fill the other three columns. Show it '
+        'to a colleague and have them attack the logic.</div>'
+        '<div class="hbox indigo"><div class="hbox-text">Try ImpactMojo&rsquo;s <strong>Theory of Change Workbench</strong> '
+        'to build the causal story first, then summarise it into your logframe.</div></div>')
+
+content('<div class="section-label">Connected courses</div>'
+        '<div class="slide-title md">Where to go next at ImpactMojo</div>'
+        '<ul class="bullet-list sm">'
+        '<li><strong>Theory of Change 101</strong> &mdash; the narrative your logframe summarises.</li>'
+        '<li><strong>MEL Basics 101</strong> &mdash; the wider monitoring, evaluation &amp; learning system.</li>'
+        '<li><strong>Impact Evaluation 101</strong> &amp; <strong>Causal Inference</strong> &mdash; proving the outcome.</li>'
+        '<li><strong>Cost-Effectiveness 101</strong> &mdash; cost per result, tied to your inputs row.</li>'
+        '<li><strong>Data Visualization 101</strong> &mdash; turning your indicators into honest charts.</li>'
+        '</ul>')
+
+content('<div class="section-label">Further reading</div>'
+        '<div class="slide-title md">Reading &amp; references</div>'
+        '<ul class="bullet-list sm">'
+        '<li>EuropeAid / EU &mdash; <em>Project Cycle Management Guidelines</em></li>'
+        '<li>Bond &amp; FCDO &mdash; logframe and theory-of-change guidance notes</li>'
+        '<li>Rosalind Eyben et al. &mdash; <em>The Politics of Evidence</em> (the critique)</li>'
+        '<li>Patricia Rogers &mdash; work on complexity and theory-based evaluation</li>'
+        '<li>BetterEvaluation.org &mdash; methods, including alternatives to the logframe</li>'
+        '</ul>')
+
+content('<div class="section-label">The whole tool</div>'
+        '<div class="slide-title md">Logframe 101 in one sentence</div>'
+        '<div class="hbox green"><div class="hbox-text">A logframe states, on one page, the change you are betting on '
+        '(results), how you will know it happened (indicators), where the proof comes from (means of verification), '
+        'and what has to hold true for the bet to pay (assumptions).</div></div>'
+        '<div class="slide-body">Built with the team, tested up and across, and revised as you learn, it is one of the '
+        'most useful disciplines in development practice &mdash; as long as you remember it is a summary of reality, '
+        'not reality itself.</div>')
+
+# ---- s99 recap ----
+content('<div class="section-label">In one slide</div>'
+        '<div class="slide-title md">The logframe, recapped</div>'
+        '<div class="two-col half">'
+        '<div class="col-panel green"><div class="col-panel-title">The rows (results)</div>'
+        '<div class="slide-body sm">&bull; Inputs &rarr; Activities &rarr; Outputs (you control)<br>'
+        '&bull; Outcome (you influence)<br>&bull; Impact (you contribute to)<br>'
+        '&bull; One outcome; a handful of outputs</div></div>'
+        '<div class="col-panel"><div class="col-panel-title">The columns</div>'
+        '<div class="slide-body sm">&bull; Indicator: unit, baseline, target, date<br>'
+        '&bull; MoV: source, method, frequency, who<br>&bull; Assumptions: external, monitored<br>'
+        '&bull; Test vertically <em>and</em> horizontally</div></div>'
+        '</div>'
+        '<div class="hbox"><div class="hbox-text">Build the theory of change first; hold the matrix lightly; revise as '
+        'you learn.</div></div>')
+
+slides.append(('end', None))
+
+assert len(slides) == 100, "got %d" % len(slides)
+
+path, size, total = db.build(
+    course="Logframe 101",
+    out_name="logframe-101.html",
+    meta_desc=("Logframe 101 - a free foundational course for development practitioners in South Asia. The logical "
+               "framework, built from the results chain up: inputs, activities, outputs, outcomes and impact; "
+               "indicators and SMART targets; means of verification; assumptions and risk; building and testing the "
+               "matrix, its critiques, and donor formats. ImpactMojo, CC BY-NC-ND."),
+    title_main_html="Logframe<br>101",
+    title_sub_html=("The logical framework, built from the results chain up &mdash; results, indicators, means of "
+                    "verification and assumptions, for development practitioners in South Asia."),
+    title_tags=["Practical", "Donor-Ready", "100 Slides", "Free Access"],
+    toc=TOC,
+    slides=slides,
+    end_headline_html="One honest<br>page.",
+    end_byline=("You can now read, build, test and critique a logframe &mdash; the results chain, the four columns, "
+                "and the assumptions that keep it honest. Next: build one for a project you know."),
+)
+print("Wrote", path, "-", size, "bytes,", total, "slides")

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -998,6 +998,12 @@
         <priority>0.7</priority>
     </url>
     <url>
+        <loc>https://www.impactmojo.in/101-courses/logframe-101.html</loc>
+        <lastmod>2026-06-07</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.7</priority>
+    </url>
+    <url>
         <loc>https://www.impactmojo.in/101-courses/child-development.html</loc>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>


### PR DESCRIPTION
A new 100-slide 101-series deck on the **logical framework** — the matrix nearly every funder requires.

## What's in it
11 sections, built from the results chain up, in a plain practitioner voice:
1. What a logframe is (and isn't)
2. The results chain — control vs influence, the output→outcome gap, attribution
3. Inputs, activities, outputs
4. Outcomes & impact
5. Indicators — SMART, baselines, disaggregation, proxies, Goodhart's law
6. Means of verification — sources, cost, frequency
7. Assumptions — the if–and–then logic, killer assumptions
8. Risk — likelihood×impact, the 4 Ts, registers
9. Building the matrix — order of work, vertical & horizontal logic tests
10. Critiques & limits — linearity, measurability, rigidity, power; alternatives
11. Tools & practice — donor formats, software, checklists, further reading

Built on a new reusable engine, `scripts/deck_builder.py`, which extracts the exact CSS / sprite / nav-JS chrome from `data-lit.html` so the deck matches the series. Content in `scripts/gen_logframe_deck.py`.

## Registration
- `101-courses/index.html` — card added, counts 46 → 47 (incl. stale head-meta fixed)
- `data/search-index.json`, `catalog_data.json` (MEL track), `sitemap.xml`
- `docs/changelog.md` — v10.57.0 with a For Learners bullet

## Validation
- mojibake: PASS · JSON valid · sitemap well-formed · inline JS passes `node --check`
- 100 slide divs, 1 active

https://claude.ai/code/session_01Xpta1BU7c52vLx8u7BEaDj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xpta1BU7c52vLx8u7BEaDj)_