### PR TITLE
Add two data-literacy pages to The Long View: Numbers in the News & The Evidence Map

### DIFF
--- a/data/search-index.json
+++ b/data/search-index.json
@@ -9064,5 +9064,41 @@
     ],
     "type": "showcase",
     "category": "Showcase"
+  },
+  {
+    "id": "lv-numbers-in-the-news",
+    "title": "Numbers in the News — a reader's field guide",
+    "description": "A reader's field guide to the statistics in the news — the missing denominator, percent vs percentage points, base rates and false positives, truncated axes, cherry-picked baselines, margin of error, correlation vs causation, and survivorship bias — each with an interactive example.",
+    "url": "/the-long-view/numbers-in-the-news.html",
+    "tags": [
+      "data literacy",
+      "statistics",
+      "numbers",
+      "news",
+      "media literacy",
+      "the long view",
+      "interactive",
+      "critical thinking"
+    ],
+    "type": "page",
+    "category": "The Long View"
+  },
+  {
+    "id": "lv-evidence-map",
+    "title": "The Evidence Map — what works, and what we don't know",
+    "description": "An interactive guide to evidence gap maps — how to read what works in development, how strong the evidence is, and where the gaps are. With an illustrative education map and links to the authoritative maps from 3ie, Cochrane, Campbell and J-PAL.",
+    "url": "/the-long-view/evidence-map.html",
+    "tags": [
+      "evidence",
+      "evidence gap map",
+      "what works",
+      "systematic review",
+      "impact evaluation",
+      "3ie",
+      "the long view",
+      "interactive"
+    ],
+    "type": "page",
+    "category": "The Long View"
   }
 ]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,13 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.62.0 — June 7, 2026 (Two new data-literacy pages for The Long View)
+
+### For Learners
+
+- **Numbers in the News** — a reader's field guide to the statistics that pass for facts. Eight ways numbers mislead — the missing denominator, percent vs percentage points, base rates and false positives, the truncated axis, the cherry-picked baseline, margin of error, correlation vs causation, and survivorship bias — each with a small interactive example you can poke at, plus a pocket checklist of questions to ask any number. Find it under **The Long View**.
+- **The Evidence Map** — an interactive guide to evidence gap maps: how to read what works in development, how strong the evidence is, and where the gaps are. Includes a clickable illustrative map for the education sector and links straight to the authoritative, continuously-updated maps from 3ie, Cochrane, the Campbell Collaboration and J-PAL. Find it under **The Long View**.
+
 ## v10.61.0 — June 7, 2026 (AI and Development — a new Deep Dive)
 
 ### For Learners

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1256,6 +1256,18 @@
         <priority>0.5</priority>
     </url>
     <url>
+        <loc>https://www.impactmojo.in/the-long-view/numbers-in-the-news.html</loc>
+        <lastmod>2026-06-07</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.6</priority>
+    </url>
+    <url>
+        <loc>https://www.impactmojo.in/the-long-view/evidence-map.html</loc>
+        <lastmod>2026-06-07</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.6</priority>
+    </url>
+    <url>
         <loc>https://www.impactmojo.in/portfolio.html</loc>
         <lastmod>2026-03-21</lastmod>
         <changefreq>monthly</changefreq>

--- a/the-long-view.html
+++ b/the-long-view.html
@@ -374,9 +374,11 @@
     </ul>
 
     <div class="tools-grid">
+      <a class="tool-link" href="/the-long-view/numbers-in-the-news.html"><h4>Numbers in the News →</h4><span>A reader's field guide to the statistics that mislead — with interactive examples.</span></a>
+      <a class="tool-link" href="/the-long-view/evidence-map.html"><h4>The Evidence Map →</h4><span>How to read an evidence gap map: what works, and what we don't know.</span></a>
       <a class="tool-link" href="/dataverse.html"><h4>Dataverse →</h4><span>The datasets and tools we drew on, in one place.</span></a>
       <a class="tool-link" href="/Labs/"><h4>Interactive Labs →</h4><span>Browser tools to explore and chart data without code.</span></a>
-      <a class="tool-link" href="/catalog.html"><h4>Data Visualization course →</h4><span>How to build charts that are clear and honest.</span></a>
+      <a class="tool-link" href="/101-courses/data-viz.html"><h4>Data Visualization 101 →</h4><span>How to build charts that are clear and honest.</span></a>
       <a class="tool-link" href="/blog.html"><h4>Learning Loops →</h4><span>Notes on measurement and working with numbers.</span></a>
     </div>
 

--- a/the-long-view/evidence-map.html
+++ b/the-long-view/evidence-map.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-JRCMEB9TBW');</script>
+<meta name="description" content="What is an evidence gap map, and how do you read one? An interactive, illustrative evidence map of what works in education for development — with links to the authoritative maps from 3ie, Cochrane, Campbell and J-PAL. A companion to ImpactMojo's The Long View.">
+<title>The Evidence Map — what works, and what we don't know | The Long View</title>
+<link href="/assets/images/favicon.png" rel="icon" type="image/png">
+<meta name="theme-color" content="#667eea">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://www.impactmojo.in/the-long-view/evidence-map.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="The Evidence Map — what works, and what we don't know">
+<meta property="og:description" content="An interactive guide to evidence gap maps — what works in development, how strong the evidence is, and where the gaps are. With links to the real maps from 3ie, Cochrane and J-PAL.">
+<meta property="og:url" content="https://www.impactmojo.in/the-long-view/evidence-map.html">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<link href="https://fonts.googleapis.com" rel="preconnect">
+<link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&amp;family=Inter:wght@400;500;600;700;800&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/css/longview.css">
+<style>
+/* Evidence Map — page-specific */
+.em-note { background: var(--color-bg-card); border: 1px solid var(--color-border); border-left: 3px solid var(--color-accent-pink); border-radius: 0 12px 12px 0; padding: 1.1rem 1.4rem; margin: 1.5rem 0; font-size: .95rem; color: var(--color-text); }
+.em-note b { color: var(--color-accent-pink); }
+.em-legend { display: flex; flex-wrap: wrap; gap: 1.4rem; align-items: center; margin: 1.5rem 0; font-family: var(--font-mono); font-size: .78rem; color: var(--color-text-muted); }
+.em-legend .grp { display: flex; align-items: center; gap: .5rem; }
+.em-dot { display: inline-block; border-radius: 50%; }
+.em-c-high { background: #1A9E6B; } .em-c-med { background: #E8A33D; } .em-c-low { background: #C95D6B; } .em-c-none { background: transparent; border: 1.5px dashed var(--color-border); }
+.em-scroll { overflow-x: auto; border: 1px solid var(--color-border); border-radius: 16px; background: var(--color-bg-card); }
+.em-grid { border-collapse: collapse; min-width: 640px; width: 100%; font-family: var(--font-body); }
+.em-grid th { font-family: var(--font-mono); font-size: .76rem; font-weight: 600; color: var(--color-text-muted); padding: .9rem .6rem; text-align: center; vertical-align: bottom; border-bottom: 1px solid var(--color-border); line-height: 1.25; }
+.em-grid th.em-rowhead { text-align: left; min-width: 180px; position: sticky; left: 0; background: var(--color-bg-card); z-index: 2; }
+.em-grid td.em-rowhead { font-family: var(--font-heading); font-weight: 600; font-size: .92rem; padding: .7rem .8rem; text-align: left; min-width: 180px; border-bottom: 1px solid var(--color-border); position: sticky; left: 0; background: var(--color-bg-card); z-index: 1; }
+.em-grid td.em-cell { text-align: center; border-bottom: 1px solid var(--color-border); padding: .4rem; }
+.em-bub { display: inline-flex; align-items: center; justify-content: center; border-radius: 50%; cursor: pointer; transition: transform .15s, box-shadow .15s; color: #fff; font-family: var(--font-mono); font-weight: 700; font-size: .72rem; border: none; }
+.em-bub:hover { transform: scale(1.12); box-shadow: 0 0 0 3px rgba(102,126,234,.3); }
+.em-bub:focus-visible { outline: 3px solid var(--color-primary); outline-offset: 2px; }
+.em-gap { display: inline-block; width: 12px; height: 12px; border-radius: 50%; border: 1.5px dashed var(--color-border); opacity: .6; }
+.em-panel { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: 16px; padding: 1.6rem; margin-top: 1.5rem; min-height: 120px; }
+.em-panel .em-ph { color: var(--color-text-muted); font-style: italic; }
+.em-panel h3 { font-family: var(--font-heading); font-size: 1.25rem; margin: 0 0 .2rem; }
+.em-panel .em-pair { font-family: var(--font-mono); font-size: .78rem; color: var(--color-text-muted); margin-bottom: .8rem; }
+.em-conf { display: inline-block; font-family: var(--font-mono); font-size: .72rem; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; padding: .2rem .6rem; border-radius: 5px; color: #fff; margin-bottom: .8rem; }
+.em-panel p { font-size: 1rem; line-height: 1.6; margin: 0 0 .8rem; }
+.em-sources a { font-family: var(--font-mono); font-size: .8rem; color: var(--color-primary); text-decoration: none; border-bottom: 1px solid transparent; }
+.em-sources a:hover { border-bottom-color: var(--color-primary); }
+.em-steps { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit,minmax(220px,1fr)); margin-top: 1rem; }
+.em-step { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: 14px; padding: 1.2rem; }
+.em-step .n { font-family: var(--font-mono); color: var(--color-accent-pink); font-weight: 700; font-size: .8rem; }
+.em-step h4 { font-family: var(--font-heading); font-size: 1.05rem; margin: .3rem 0 .4rem; }
+.em-step p { font-size: .9rem; color: var(--color-text-muted); margin: 0; line-height: 1.5; }
+.em-real { display: grid; gap: .8rem; grid-template-columns: repeat(auto-fit,minmax(220px,1fr)); margin-top: 1rem; }
+.em-real a { display: block; background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: 12px; padding: 1rem 1.1rem; text-decoration: none; color: var(--color-text); transition: border-color .15s; }
+.em-real a:hover { border-color: var(--color-primary); }
+.em-real h4 { font-family: var(--font-heading); font-size: 1rem; margin: 0 0 .25rem; color: var(--color-primary); }
+.em-real span { font-size: .85rem; color: var(--color-text-muted); }
+.em-related { margin-top: 1.5rem; display: flex; flex-wrap: wrap; gap: .6rem; }
+.em-related a { font-family: var(--font-mono); font-size: .8rem; padding: .5rem .9rem; border-radius: 8px; border: 1px solid var(--color-border); background: var(--color-bg-card); color: var(--color-text); text-decoration: none; transition: all .15s; }
+.em-related a:hover { border-color: var(--color-primary); color: var(--color-primary); }
+</style>
+</head>
+<body>
+<a href="#main-content" class="skip-link">Skip to content</a>
+<div class="im-topbar" id="imTopbar">
+  <div class="im-topbar-left">
+    <a href="/index.html" class="im-topbar-home"><img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="28" height="28" style="border-radius:6px;"><span>ImpactMojo</span></a>
+  </div>
+  <div class="im-topbar-right">
+    <a href="/the-long-view.html" class="im-premium-btn" style="background:rgba(255,255,255,0.08);">← The Long View</a>
+    <div class="im-theme-selector" aria-label="Theme selection">
+      <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="Use system theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Use light theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Use dark theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+    </div>
+  </div>
+</div>
+
+<header class="hero" style="padding:4.5rem 1.5rem 3.5rem;">
+  <div class="hero-inner">
+    <span class="eyebrow">A companion to The Long View</span>
+    <h1 style="font-size:clamp(2.2rem,6vw,3.6rem);">The Evidence <span class="accent">Map</span></h1>
+    <p class="sub">Development is full of confident claims about "what works." An evidence gap map asks a harder question: how strong is the evidence, and where is it missing? Here's how to read one — and an interactive map you can click through.</p>
+  </div>
+</header>
+
+<main id="main-content">
+<section class="section">
+  <div class="wrap" style="max-width:920px;">
+    <div class="section-head" style="text-align:left;">
+      <span class="kicker">What it is</span>
+      <h2 style="text-align:left;">A map of what we know — and what we don't</h2>
+      <p style="margin-left:0;text-align:left;">An <b>evidence gap map</b> (EGM) is a grid. Down the side: the things you could <em>do</em> — interventions. Across the top: the things you might <em>change</em> — outcomes. In each cell, a bubble shows how much rigorous evidence exists for that pairing, and how confident we can be in it. Big confident bubbles mean "well studied, works." Empty cells — the <em>gaps</em> — mean "nobody really knows yet." The empty cells are often the most important thing on the map.</p>
+    </div>
+
+    <div class="em-note">
+      <b>Read this first.</b> The map below is an <b>illustrative teaching example</b> for the education-and-development sector. The pattern of confidence reflects the broad direction of well-known evidence syntheses, but the bubble sizes are simplified for clarity — they are not exact study counts. For the real, continuously-updated maps, use the authoritative sources linked at the bottom (3ie, Cochrane, the Campbell Collaboration, J-PAL).
+    </div>
+
+    <div class="em-legend">
+      <span class="grp"><b style="color:var(--color-text)">Colour = confidence:</b></span>
+      <span class="grp"><span class="em-dot em-c-high" style="width:14px;height:14px;"></span> High</span>
+      <span class="grp"><span class="em-dot em-c-med" style="width:14px;height:14px;"></span> Mixed / moderate</span>
+      <span class="grp"><span class="em-dot em-c-low" style="width:14px;height:14px;"></span> Weak / contested</span>
+      <span class="grp"><span class="em-dot em-c-none" style="width:14px;height:14px;"></span> Evidence gap</span>
+      <span class="grp" style="margin-left:auto;"><b style="color:var(--color-text)">Size = volume of evidence.</b> Click a bubble.</span>
+    </div>
+
+    <div class="em-scroll">
+      <table class="em-grid" id="emGrid" aria-label="Illustrative evidence gap map: interventions by outcomes in education for development"></table>
+    </div>
+
+    <div class="em-panel" id="emPanel" aria-live="polite">
+      <p class="em-ph">Click any bubble in the map above to see what the evidence says about that intervention–outcome pairing, how confident we can be, and where to read more.</p>
+    </div>
+
+    <div class="section-head" style="text-align:left;margin-top:3rem;">
+      <span class="kicker">How to read it</span>
+      <h2 style="text-align:left;">Four moves of a careful reader</h2>
+    </div>
+    <div class="em-steps">
+      <div class="em-step"><div class="n">01</div><h4>Find the big green bubbles</h4><p>Well-studied pairings with consistent effects. This is where "what works" is on solid ground — act here with confidence.</p></div>
+      <div class="em-step"><div class="n">02</div><h4>Distrust a single study</h4><p>A small bubble is one or two trials. One striking result is a hypothesis, not a finding. Confidence comes from replication.</p></div>
+      <div class="em-step"><div class="n">03</div><h4>Hunt for the empty cells</h4><p>The gaps are where confident claims outrun the evidence. "Everyone knows X works" over an empty cell is a research agenda, not a fact.</p></div>
+      <div class="em-step"><div class="n">04</div><h4>Mind the context</h4><p>Evidence travels imperfectly. What worked in one country, scale, or population may not transfer. The map narrows uncertainty; it never removes it.</p></div>
+    </div>
+
+    <div class="section-head" style="text-align:left;margin-top:3rem;">
+      <span class="kicker">The real thing</span>
+      <h2 style="text-align:left;">Authoritative, continuously-updated maps</h2>
+      <p style="margin-left:0;text-align:left;">This page teaches the idea. For live evidence on a real decision, go to the source — these institutions build and maintain rigorous evidence gap maps and systematic reviews.</p>
+    </div>
+    <div class="em-real">
+      <a href="https://developmentevidence.3ieimpact.org/" target="_blank" rel="noopener"><h4>3ie Development Evidence Portal →</h4><span>The largest collection of evidence gap maps and impact evaluations for international development.</span></a>
+      <a href="https://www.cochranelibrary.com/" target="_blank" rel="noopener"><h4>Cochrane Library →</h4><span>The gold standard for systematic reviews in health and beyond.</span></a>
+      <a href="https://www.campbellcollaboration.org/" target="_blank" rel="noopener"><h4>Campbell Collaboration →</h4><span>Systematic reviews in education, social welfare, crime and justice.</span></a>
+      <a href="https://www.povertyactionlab.org/policy-insights" target="_blank" rel="noopener"><h4>J-PAL Policy Insights →</h4><span>What randomised evaluations tell us, summarised for decision-makers.</span></a>
+    </div>
+
+    <div class="em-related">
+      <a href="/the-long-view.html">← The Long View: our charts</a>
+      <a href="/the-long-view/numbers-in-the-news.html">Numbers in the News</a>
+      <a href="/101-courses/impact-eval.html">Impact Evaluation 101</a>
+      <a href="/101-courses/mel-basics.html">MEL Basics 101</a>
+      <a href="/DeepDives/the-learning-crisis.html">Deep Dive: The Learning Crisis</a>
+    </div>
+  </div>
+</section>
+</main>
+
+<footer class="site-footer">
+  <div class="footer-grid">
+    <div class="footer-col"><h4>The Long View</h4><a href="/the-long-view.html">Our original charts</a><a href="/the-long-view/gallery.html">The classics &amp; greats</a><a href="/the-long-view/evidence-map.html">The Evidence Map</a></div>
+    <div class="footer-col"><h4>ImpactMojo</h4><a href="/about.html">About</a><a href="/dataverse.html">Dataverse</a><a href="/blog.html">Blog</a></div>
+    <div class="footer-col"><h4>Legal</h4><a href="/privacy-policy.html">Privacy</a><a href="/terms-of-service.html">Terms</a></div>
+    <div class="footer-col"><h4>More</h4><a href="/catalog.html">Courses</a><a href="https://github.com/ImpactMojo/ImpactMojo">GitHub</a></div>
+  </div>
+  <div class="footer-bottom"><p>© 2026 ImpactMojo. The illustrative map is a teaching aid; for real evidence use the linked sources. Free forever, CC BY-NC-ND.</p></div>
+</footer>
+
+<script>
+/* theme (shared pattern) */
+(function(){function gs(){return window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark';}function ap(t){document.documentElement.setAttribute('data-theme',t==='system'?gs():t);document.body.classList.remove('dark-mode','light-mode');document.body.classList.add((t==='system'?gs():t)==='light'?'light-mode':'dark-mode');}function ub(p){document.querySelectorAll('.im-theme-btn').forEach(function(b){b.classList.toggle('active',b.getAttribute('data-imtheme')===p);});}var sv=localStorage.getItem('im-theme')||'system';ap(sv);document.addEventListener('DOMContentLoaded',function(){ub(sv);document.querySelectorAll('.im-theme-btn').forEach(function(b){b.addEventListener('click',function(){var t=this.getAttribute('data-imtheme');localStorage.setItem('im-theme',t);ap(t);ub(t);});});});window.matchMedia('(prefers-color-scheme: light)').addEventListener('change',function(){if((localStorage.getItem('im-theme')||'system')==='system')ap('system');});})();
+</script>
+<script>
+/* ===== Illustrative Evidence Gap Map — education for development =====
+   confidence: high | med | low | null(gap). volume: 0-3 (bubble size). */
+var EM_OUTCOMES = ["Enrolment &amp; attendance","Learning (test scores)","Completion / dropout","Equity (girls &amp; poorest)"];
+var EM_ROWS = [
+  {name:"Conditional cash transfers", cells:[
+    {c:"high",v:3,note:"One of the most-studied interventions in development. Cash tied to school attendance reliably raises enrolment and attendance across many countries."},
+    {c:"low",v:2,note:"Strong on getting children <em>into</em> school, but effects on actual learning are small and inconsistent — attendance is not the same as learning."},
+    {c:"med",v:2,note:"Reduces dropout and raises grade completion in many settings, though effects fade without complementary quality improvements."},
+    {c:"high",v:2,note:"Often targeted at girls and poor households, with clear gains in their enrolment — a frequent equity success story."}
+  ]},
+  {name:"Structured pedagogy / TaRL", cells:[
+    {c:"med",v:1,note:"Designed to improve learning rather than access, so enrolment effects are modest and indirect."},
+    {c:"high",v:3,note:"Teaching at the Right Level and structured-pedagogy programmes are among the best-evidenced ways to raise foundational learning, validated across multiple randomised trials in South Asia and Africa."},
+    {c:"med",v:1,note:"Better learning can reduce dropout over time, but this is less directly measured than the test-score gains."},
+    {c:"med",v:2,note:"Grouping by ability helps the children furthest behind most — promising for equity, with growing evidence."}
+  ]},
+  {name:"School meals", cells:[
+    {c:"high",v:2,note:"Free school meals are a consistent draw, raising enrolment and especially attendance — a well-established finding, including India's mid-day meal scheme."},
+    {c:"med",v:2,note:"Effects on learning are real but modest, working mainly through attendance and, where children are undernourished, nutrition and concentration."},
+    {c:"med",v:1,note:"Some evidence of reduced dropout, particularly for poorer children for whom the meal is a meaningful transfer."},
+    {c:"high",v:1,note:"Disproportionately benefits poor and food-insecure households — a strong equity rationale."}
+  ]},
+  {name:"Smaller classes / more teachers", cells:[
+    {c:"low",v:1,note:"Little direct effect on enrolment — this is a quality input, not an access one."},
+    {c:"low",v:2,note:"The evidence is famously mixed: simply adding teachers or cutting class size, without changing how teaching happens, often yields disappointing learning gains."},
+    {c:null,v:0,note:"Surprisingly thin direct evidence on completion — an evidence gap."},
+    {c:"med",v:1,note:"Can help disadvantaged students when paired with accountability, but effects depend heavily on implementation."}
+  ]},
+  {name:"Computers &amp; hardware", cells:[
+    {c:"low",v:1,note:"Providing devices rarely changes whether children attend school."},
+    {c:"low",v:2,note:"Hardware alone (one-laptop-per-child style) has a weak and inconsistent record on learning; software and pedagogy matter far more than the device."},
+    {c:null,v:0,note:"Very little rigorous evidence on completion effects — a clear gap."},
+    {c:"low",v:1,note:"Risk of widening gaps if access and support are uneven; equity effects are uncertain."}
+  ]},
+  {name:"Information to parents", cells:[
+    {c:"med",v:1,note:"Telling parents about the returns to schooling, or their child's results, can nudge enrolment and attendance at very low cost in some settings."},
+    {c:"med",v:1,note:"Modest learning effects in several trials — cheap, but not transformative on its own."},
+    {c:"low",v:1,note:"Limited and mixed evidence on dropout."},
+    {c:null,v:0,note:"Equity effects under-studied — an evidence gap worth filling."}
+  ]},
+  {name:"Merit scholarships", cells:[
+    {c:"med",v:1,note:"Can raise attendance and effort among students within reach of the award."},
+    {c:"med",v:1,note:"Some positive effects on test scores via increased effort, though gains can concentrate among already-stronger students."},
+    {c:"low",v:1,note:"Thin evidence on completion."},
+    {c:"low",v:1,note:"Equity is a concern: merit awards can favour the already-advantaged rather than the poorest."}
+  ]},
+  {name:"Deworming &amp; child health", cells:[
+    {c:"med",v:2,note:"In high-infection settings, treating intestinal worms has been linked to better attendance — though the size and generalisability of the effect is one of development economics' most public debates."},
+    {c:"low",v:2,note:"Direct effects on test scores are contested; the most-discussed long-run benefits run through health and later earnings rather than immediate learning."},
+    {c:null,v:0,note:"Limited direct evidence on school completion — a gap."},
+    {c:"med",v:1,note:"Cheap and broad, so often pro-poor where worm burden is high, but context-dependent."}
+  ]}
+];
+var EM_CONF = {high:{c:"#1A9E6B",l:"High confidence"}, med:{c:"#E8A33D",l:"Mixed / moderate"}, low:{c:"#C95D6B",l:"Weak / contested"}};
+var EM_SIZE = {0:0, 1:24, 2:34, 3:46};
+
+function emBuild(){
+  var t=document.getElementById('emGrid');
+  var head='<thead><tr><th class="em-rowhead">Intervention &darr; / Outcome &rarr;</th>';
+  EM_OUTCOMES.forEach(function(o){head+='<th>'+o+'</th>';});
+  head+='</tr></thead>';
+  var body='<tbody>';
+  EM_ROWS.forEach(function(row,ri){
+    body+='<tr><td class="em-rowhead">'+row.name+'</td>';
+    row.cells.forEach(function(cell,ci){
+      if(!cell.c || cell.v===0){
+        body+='<td class="em-cell"><span class="em-gap" title="Evidence gap — little or no rigorous evidence"></span></td>';
+      } else {
+        var sz=EM_SIZE[cell.v];
+        body+='<td class="em-cell"><button class="em-bub" style="width:'+sz+'px;height:'+sz+'px;background:'+EM_CONF[cell.c].c+'" '+
+          'data-r="'+ri+'" data-c="'+ci+'" aria-label="'+row.name+', '+EM_OUTCOMES[ci].replace(/&amp;/g,'and')+', '+EM_CONF[cell.c].l+'" '+
+          'onclick="emShow('+ri+','+ci+')">'+cell.v+'</button></td>';
+      }
+    });
+    body+='</tr>';
+  });
+  body+='</tbody>';
+  t.innerHTML=head+body;
+}
+function emShow(ri,ci){
+  var row=EM_ROWS[ri], cell=row.cells[ci], out=EM_OUTCOMES[ci];
+  var p=document.getElementById('emPanel');
+  if(!cell.c){ p.innerHTML='<h3>'+row.name+' &times; '+out+'</h3><span class="em-conf" style="background:var(--color-text-muted)">Evidence gap</span><p>Little or no rigorous evidence exists for this pairing yet. On the map, that is not a verdict of "doesn\'t work" — it is a research agenda.</p>'; return; }
+  var cf=EM_CONF[cell.c];
+  var vol=["","one or two studies (treat as preliminary)","a moderate body of studies","a large, well-replicated body of studies"][cell.v];
+  p.innerHTML='<h3>'+row.name+' &times; '+out+'</h3>'+
+    '<div class="em-pair">Evidence volume: '+vol+'</div>'+
+    '<span class="em-conf" style="background:'+cf.c+'">'+cf.l+'</span>'+
+    '<p>'+cell.note+'</p>'+
+    '<div class="em-sources"><a href="https://developmentevidence.3ieimpact.org/" target="_blank" rel="noopener">See the real evidence on 3ie →</a></div>';
+}
+document.addEventListener('DOMContentLoaded',function(){emBuild();});
+</script>
+</body>
+</html>

--- a/the-long-view/gallery.html
+++ b/the-long-view/gallery.html
@@ -129,7 +129,7 @@
 </main>
 <footer class="site-footer">
   <div class="footer-grid">
-    <div class="footer-col"><h4>The Long View</h4><a href="/the-long-view.html">Our original charts</a><a href="/the-long-view/gallery.html">The classics &amp; greats</a></div>
+    <div class="footer-col"><h4>The Long View</h4><a href="/the-long-view.html">Our original charts</a><a href="/the-long-view/gallery.html">The classics &amp; greats</a><a href="/the-long-view/numbers-in-the-news.html">Numbers in the News</a><a href="/the-long-view/evidence-map.html">The Evidence Map</a></div>
     <div class="footer-col"><h4>ImpactMojo</h4><a href="/about.html">About</a><a href="/dataverse.html">Dataverse</a><a href="/blog.html">Blog</a></div>
     <div class="footer-col"><h4>Legal</h4><a href="/privacy-policy.html">Privacy</a><a href="/terms-of-service.html">Terms</a></div>
     <div class="footer-col"><h4>More</h4><a href="/catalog.html">Courses</a><a href="https://github.com/ImpactMojo/ImpactMojo">GitHub</a></div>

--- a/the-long-view/numbers-in-the-news.html
+++ b/the-long-view/numbers-in-the-news.html
@@ -1,0 +1,375 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-JRCMEB9TBW');</script>
+<meta name="description" content="A reader's field guide to the statistics in the news — the missing denominator, percent vs percentage points, base rates, truncated axes, cherry-picked baselines and more, with interactive examples. A companion to ImpactMojo's The Long View.">
+<title>Numbers in the News — a reader's field guide | The Long View</title>
+<link href="/assets/images/favicon.png" rel="icon" type="image/png">
+<meta name="theme-color" content="#667eea">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://www.impactmojo.in/the-long-view/numbers-in-the-news.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Numbers in the News — a reader's field guide">
+<meta property="og:description" content="The statistics in the news, decoded — missing denominators, percent vs percentage points, base rates, truncated axes and more, with interactive examples.">
+<meta property="og:url" content="https://www.impactmojo.in/the-long-view/numbers-in-the-news.html">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<link href="https://fonts.googleapis.com" rel="preconnect">
+<link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&amp;family=Inter:wght@400;500;600;700;800&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/css/longview.css">
+<style>
+/* Numbers in the News — page-specific */
+.nn-list { counter-reset: nn; }
+.nn-card { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: 16px; padding: 1.75rem 1.75rem 1.9rem; margin-bottom: 1.5rem; }
+.nn-card .nn-kicker { font-family: var(--font-mono); font-size: .72rem; letter-spacing: .14em; text-transform: uppercase; color: var(--color-accent-pink); font-weight: 600; }
+.nn-card h3 { font-family: var(--font-heading); font-size: clamp(1.25rem, 3vw, 1.6rem); margin: .35rem 0 .35rem; line-height: 1.2; }
+.nn-card h3::before { counter-increment: nn; content: counter(nn, decimal-leading-zero); font-family: var(--font-mono); color: var(--color-text-muted); font-size: .9rem; margin-right: .6rem; }
+.nn-card .nn-trap { font-size: 1.02rem; color: var(--color-text); margin: 0 0 1rem; }
+.nn-widget { background: var(--color-bg); border: 1px solid var(--color-border); border-radius: 12px; padding: 1.25rem; margin: 1.1rem 0; }
+.nn-controls { display: flex; flex-wrap: wrap; gap: .6rem; align-items: center; margin-bottom: 1rem; }
+.nn-btn { font-family: var(--font-mono); font-size: .8rem; font-weight: 600; padding: .5rem .9rem; border-radius: 8px; border: 1px solid var(--color-border); background: var(--color-bg-card); color: var(--color-text); cursor: pointer; transition: all .15s; }
+.nn-btn:hover { border-color: var(--color-primary); }
+.nn-btn.active { background: var(--color-primary); color: #fff; border-color: var(--color-primary); }
+.nn-input { font-family: var(--font-mono); font-size: .9rem; width: 5.5rem; padding: .45rem .55rem; border-radius: 8px; border: 1px solid var(--color-border); background: var(--color-bg-card); color: var(--color-text); }
+.nn-label { font-family: var(--font-mono); font-size: .78rem; color: var(--color-text-muted); }
+.nn-range { width: 100%; max-width: 360px; accent-color: var(--color-primary); }
+.nn-readout { font-family: var(--font-mono); font-size: .95rem; line-height: 1.7; background: var(--color-bg-card); border-radius: 8px; padding: .85rem 1rem; border: 1px dashed var(--color-border); }
+.nn-readout b { color: var(--color-primary); }
+.nn-readout .flip { color: var(--color-accent-pink); }
+.nn-bars { display: flex; align-items: flex-end; gap: 1.5rem; height: 190px; padding: .5rem 0 0; }
+.nn-bar-wrap { display: flex; flex-direction: column; align-items: center; gap: .4rem; flex: 1; max-width: 90px; height: 100%; justify-content: flex-end; }
+.nn-bar { width: 100%; border-radius: 6px 6px 0 0; background: linear-gradient(180deg, var(--color-accent-blue), var(--color-primary)); transition: height .5s cubic-bezier(.22,1,.36,1); min-height: 2px; }
+.nn-bar.alt { background: linear-gradient(180deg, var(--color-accent-pink), #d6336c); }
+.nn-bar-val { font-family: var(--font-mono); font-size: .8rem; font-weight: 600; }
+.nn-bar-lbl { font-family: var(--font-mono); font-size: .72rem; color: var(--color-text-muted); text-align: center; }
+.nn-axisnote { font-family: var(--font-mono); font-size: .72rem; color: var(--color-text-muted); margin-top: .5rem; }
+.nn-takeaway { font-size: .98rem; border-left: 3px solid var(--color-accent-pink); padding: .2rem 0 .2rem 1rem; margin: 1.1rem 0 0; color: var(--color-text); }
+.nn-takeaway b { color: var(--color-accent-pink); }
+.nn-illus { font-family: var(--font-mono); font-size: .68rem; letter-spacing: .08em; text-transform: uppercase; color: var(--color-text-muted); opacity: .8; }
+.nn-checklist { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: 16px; padding: 1.75rem; }
+.nn-checklist ul { list-style: none; padding: 0; margin: .5rem 0 0; display: grid; gap: .7rem; }
+.nn-checklist li { padding-left: 1.9rem; position: relative; font-size: 1.02rem; }
+.nn-checklist li::before { content: "?"; position: absolute; left: 0; top: -1px; width: 1.4rem; height: 1.4rem; border-radius: 50%; background: var(--color-primary); color: #fff; font-family: var(--font-mono); font-weight: 700; font-size: .8rem; display: flex; align-items: center; justify-content: center; }
+.nn-related { margin-top: 1.5rem; display: flex; flex-wrap: wrap; gap: .6rem; }
+.nn-related a { font-family: var(--font-mono); font-size: .8rem; padding: .5rem .9rem; border-radius: 8px; border: 1px solid var(--color-border); background: var(--color-bg-card); color: var(--color-text); text-decoration: none; transition: all .15s; }
+.nn-related a:hover { border-color: var(--color-primary); color: var(--color-primary); }
+</style>
+</head>
+<body>
+<a href="#main-content" class="skip-link">Skip to content</a>
+<div class="im-topbar" id="imTopbar">
+  <div class="im-topbar-left">
+    <a href="/index.html" class="im-topbar-home"><img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="28" height="28" style="border-radius:6px;"><span>ImpactMojo</span></a>
+  </div>
+  <div class="im-topbar-right">
+    <a href="/the-long-view.html" class="im-premium-btn" style="background:rgba(255,255,255,0.08);">← The Long View</a>
+    <div class="im-theme-selector" aria-label="Theme selection">
+      <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="Use system theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Use light theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Use dark theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+    </div>
+  </div>
+</div>
+
+<header class="hero" style="padding:4.5rem 1.5rem 3.5rem;">
+  <div class="hero-inner">
+    <span class="eyebrow">A companion to The Long View</span>
+    <h1 style="font-size:clamp(2.2rem,6vw,3.6rem);">Numbers in the <span class="accent">News</span></h1>
+    <p class="sub">A reader's field guide to the statistics that pass for facts. Eight ways numbers mislead — each with a small interactive example you can poke at. Learn to spot them, and you read the news more honestly.</p>
+  </div>
+</header>
+
+<main id="main-content">
+<section class="section">
+  <div class="wrap" style="max-width:820px;">
+    <div class="section-head" style="text-align:left;">
+      <span class="kicker">How to read this</span>
+      <h2 style="text-align:left;">Most misleading numbers aren't lies</h2>
+      <p style="margin-left:0;text-align:left;">They are true numbers framed to point the wrong way. A real count, a real percentage, a real chart — arranged so the obvious reading is the wrong one. You don't need statistics to defend yourself; you need a handful of questions. Here are the eight that catch most of it. <span class="nn-illus">All figures below are illustrative, chosen to make the mechanism visible.</span></p>
+    </div>
+
+    <div class="nn-list">
+
+      <!-- 1. DENOMINATOR -->
+      <article class="nn-card">
+        <div class="nn-kicker">The missing denominator</div>
+        <h3>A big number out of what?</h3>
+        <p class="nn-trap">"State A had 5,000 road deaths last year; State B had 1,200." So State A is more dangerous? Only if the two states are the same size. A count means nothing without the population it came from. Switch the view.</p>
+        <div class="nn-widget">
+          <div class="nn-controls">
+            <button class="nn-btn active" data-den="count" onclick="nnDen('count',this)">Raw count</button>
+            <button class="nn-btn" data-den="rate" onclick="nnDen('rate',this)">Per 100,000 people</button>
+          </div>
+          <div class="nn-bars" id="nnDenBars"></div>
+          <div class="nn-axisnote" id="nnDenNote"></div>
+        </div>
+        <p class="nn-takeaway"><b>Ask:</b> out of how many? A count tells you size; a rate tells you risk. The news loves counts because they sound bigger.</p>
+      </article>
+
+      <!-- 2. PERCENT vs PERCENTAGE POINTS -->
+      <article class="nn-card">
+        <div class="nn-kicker">Percent vs percentage points</div>
+        <h3>"Risk doubled" — from what to what?</h3>
+        <p class="nn-trap">A drug that takes your risk from 2% to 4% has <em>doubled</em> your risk (+100%, relative) and raised it by <em>2 percentage points</em> (absolute). Both are true. One sells papers. Enter any two rates and see both framings.</p>
+        <div class="nn-widget">
+          <div class="nn-controls">
+            <span class="nn-label">from</span><input class="nn-input" id="nnPctA" type="number" value="2" min="0" max="100" step="0.1" oninput="nnPct()"><span class="nn-label">%</span>
+            <span class="nn-label">to</span><input class="nn-input" id="nnPctB" type="number" value="4" min="0" max="100" step="0.1" oninput="nnPct()"><span class="nn-label">%</span>
+          </div>
+          <div class="nn-readout" id="nnPctOut"></div>
+        </div>
+        <p class="nn-takeaway"><b>Ask:</b> percent <em>of what base?</em> A scary relative rise on a tiny base is a tiny absolute change.</p>
+      </article>
+
+      <!-- 3. BASE RATES -->
+      <article class="nn-card">
+        <div class="nn-kicker">Base rates &amp; false positives</div>
+        <h3>A "99% accurate" test that's usually wrong</h3>
+        <p class="nn-trap">A test for a rare condition is 99% accurate. You test positive. Your chance of actually having it can still be under 1-in-2 — because when the condition is rare, false positives outnumber true ones. Drag the prevalence and watch.</p>
+        <div class="nn-widget">
+          <div class="nn-controls" style="flex-direction:column;align-items:flex-start;gap:.4rem;">
+            <span class="nn-label">How common the condition is: <b id="nnBasePrevLbl" style="color:var(--color-primary)">1 in 1,000</b> &middot; test sensitivity &amp; specificity fixed at 99%</span>
+            <input class="nn-range" id="nnBaseRange" type="range" min="0" max="100" value="20" oninput="nnBase()">
+          </div>
+          <div class="nn-readout" id="nnBaseOut"></div>
+        </div>
+        <p class="nn-takeaway"><b>Ask:</b> how common is it to begin with? Accuracy without the base rate is half the story — this is Bayes' theorem in everyday clothes.</p>
+      </article>
+
+      <!-- 4. TRUNCATED AXIS -->
+      <article class="nn-card">
+        <div class="nn-kicker">The truncated axis</div>
+        <h3>A cliff that's really a gentle slope</h3>
+        <p class="nn-trap">The same four numbers — 48, 49, 50, 52 — can look like a dramatic surge or a near-flat line, depending only on where the y-axis starts. Toggle the baseline.</p>
+        <div class="nn-widget">
+          <div class="nn-controls">
+            <button class="nn-btn" data-ax="trunc" onclick="nnAxis('trunc',this)">Axis starts at 47</button>
+            <button class="nn-btn active" data-ax="zero" onclick="nnAxis('zero',this)">Axis starts at 0</button>
+          </div>
+          <div class="nn-bars" id="nnAxisBars"></div>
+          <div class="nn-axisnote" id="nnAxisNote"></div>
+        </div>
+        <p class="nn-takeaway"><b>Ask:</b> where does the axis start? A bar chart should almost always start at zero. When it doesn't, someone is amplifying a small difference.</p>
+      </article>
+
+      <!-- 5. CHERRY-PICKED BASELINE -->
+      <article class="nn-card">
+        <div class="nn-kicker">The cherry-picked baseline</div>
+        <h3>"Since 20XX, things have..." — pick the X</h3>
+        <p class="nn-trap">Give me the freedom to choose the starting year and I can make this wobbly series look like steady progress or steady decline — without changing a single data point. Slide the start year.</p>
+        <div class="nn-widget">
+          <div class="nn-controls" style="flex-direction:column;align-items:flex-start;gap:.4rem;">
+            <span class="nn-label">Start the story in: <b id="nnCherryYrLbl" style="color:var(--color-primary)">2009</b></span>
+            <input class="nn-range" id="nnCherryRange" type="range" min="0" max="13" value="0" oninput="nnCherry()">
+          </div>
+          <div class="nn-readout" id="nnCherryOut"></div>
+        </div>
+        <p class="nn-takeaway"><b>Ask:</b> why <em>that</em> start year? An honest trend shows the whole series, not the slice that flatters the argument.</p>
+      </article>
+
+      <!-- 6. MARGIN OF ERROR -->
+      <article class="nn-card">
+        <div class="nn-kicker">Sample size &amp; margin of error</div>
+        <h3>A "2-point lead" that's really a tie</h3>
+        <p class="nn-trap">A poll says 51% to 49%. With a small sample, the margin of error swamps the gap — the "lead" is noise. Grow the sample and watch the uncertainty shrink.</p>
+        <div class="nn-widget">
+          <div class="nn-controls" style="flex-direction:column;align-items:flex-start;gap:.4rem;">
+            <span class="nn-label">People surveyed: <b id="nnMoeNLbl" style="color:var(--color-primary)">400</b></span>
+            <input class="nn-range" id="nnMoeRange" type="range" min="0" max="100" value="20" oninput="nnMoe()">
+          </div>
+          <div class="nn-readout" id="nnMoeOut"></div>
+        </div>
+        <p class="nn-takeaway"><b>Ask:</b> how many people, and what's the margin of error? If the gap is smaller than the margin, there is no gap.</p>
+      </article>
+
+      <!-- 7. CORRELATION -->
+      <article class="nn-card">
+        <div class="nn-kicker">Correlation isn't causation</div>
+        <h3>The third thing nobody mentioned</h3>
+        <p class="nn-trap">"Children who own more books score higher" — so buy books? Maybe. But richer, more-educated households have both more books <em>and</em> higher scores. The books may be a marker, not a cause. The hidden third variable — the confounder — is where most "X causes Y" headlines quietly fail.</p>
+        <div class="nn-widget" style="display:grid;grid-template-columns:1fr auto 1fr;gap:.5rem;align-items:center;text-align:center;">
+          <div style="font-family:var(--font-mono);font-size:.85rem;padding:.7rem;border:1px solid var(--color-border);border-radius:8px;">Books at home</div>
+          <div style="font-family:var(--font-mono);color:var(--color-text-muted);">&harr;?</div>
+          <div style="font-family:var(--font-mono);font-size:.85rem;padding:.7rem;border:1px solid var(--color-border);border-radius:8px;">Test scores</div>
+          <div style="grid-column:1/4;font-family:var(--font-mono);color:var(--color-accent-pink);font-size:.8rem;margin-top:.3rem;">&uarr; both driven by household income &amp; parental education &uarr;</div>
+        </div>
+        <p class="nn-takeaway"><b>Ask:</b> what else could explain both? A genuine cause survives the question "what's the confounder?" — see ImpactMojo's work on causal inference.</p>
+      </article>
+
+      <!-- 8. SURVIVORSHIP -->
+      <article class="nn-card">
+        <div class="nn-kicker">Survivorship &amp; selection</div>
+        <h3>Counting only the winners</h3>
+        <p class="nn-trap">"Most successful founders dropped out of college." But you only hear about the founders who succeeded — the far larger number of dropouts who failed never make the article. When the sample is "those who survived to be counted," the lesson is usually wrong. The planes that came back from war were the ones that <em>could</em>.</p>
+        <p class="nn-takeaway"><b>Ask:</b> who's missing from this data? The failures, the dropouts, the silent — selection decides the story before the numbers do.</p>
+      </article>
+
+    </div>
+
+    <div class="nn-checklist" style="margin-top:2.5rem;">
+      <span class="kicker" style="color:var(--color-accent-pink);font-family:var(--font-mono);font-size:.72rem;letter-spacing:.14em;text-transform:uppercase;">The pocket checklist</span>
+      <h2 style="font-family:var(--font-heading);font-size:1.5rem;margin:.4rem 0 .3rem;">Eight questions for any number</h2>
+      <ul>
+        <li><b>Out of how many?</b> — a count needs a denominator to mean anything.</li>
+        <li><b>Percent of what base?</b> — relative vs absolute change are different stories.</li>
+        <li><b>How common is it to begin with?</b> — accuracy without the base rate misleads.</li>
+        <li><b>Where does the axis start?</b> — a truncated axis amplifies small gaps.</li>
+        <li><b>Why that start year?</b> — a cherry-picked baseline manufactures trends.</li>
+        <li><b>How big is the sample?</b> — if the gap is under the margin of error, it's noise.</li>
+        <li><b>What's the confounder?</b> — correlation rarely proves causation.</li>
+        <li><b>Who's missing from the data?</b> — selection and survivorship hide the failures.</li>
+      </ul>
+    </div>
+
+    <div class="nn-related">
+      <a href="/the-long-view.html">← The Long View: our charts</a>
+      <a href="/the-long-view/gallery.html">The classics &amp; greats</a>
+      <a href="/101-courses/data-viz.html">Data Visualization 101</a>
+      <a href="/101-courses/data-lit.html">Data Literacy 101</a>
+      <a href="/the-long-view/evidence-map.html">The Evidence Map →</a>
+    </div>
+  </div>
+</section>
+</main>
+
+<footer class="site-footer">
+  <div class="footer-grid">
+    <div class="footer-col"><h4>The Long View</h4><a href="/the-long-view.html">Our original charts</a><a href="/the-long-view/gallery.html">The classics &amp; greats</a><a href="/the-long-view/numbers-in-the-news.html">Numbers in the News</a></div>
+    <div class="footer-col"><h4>ImpactMojo</h4><a href="/about.html">About</a><a href="/dataverse.html">Dataverse</a><a href="/blog.html">Blog</a></div>
+    <div class="footer-col"><h4>Legal</h4><a href="/privacy-policy.html">Privacy</a><a href="/terms-of-service.html">Terms</a></div>
+    <div class="footer-col"><h4>More</h4><a href="/catalog.html">Courses</a><a href="https://github.com/ImpactMojo/ImpactMojo">GitHub</a></div>
+  </div>
+  <div class="footer-bottom"><p>© 2026 ImpactMojo. Examples are illustrative, built to show the mechanism. Free forever, CC BY-NC-ND.</p></div>
+</footer>
+
+<script>
+/* theme (shared pattern) */
+(function(){function gs(){return window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark';}function ap(t){document.documentElement.setAttribute('data-theme',t==='system'?gs():t);document.body.classList.remove('dark-mode','light-mode');document.body.classList.add((t==='system'?gs():t)==='light'?'light-mode':'dark-mode');}function ub(p){document.querySelectorAll('.im-theme-btn').forEach(function(b){b.classList.toggle('active',b.getAttribute('data-imtheme')===p);});}var sv=localStorage.getItem('im-theme')||'system';ap(sv);document.addEventListener('DOMContentLoaded',function(){ub(sv);document.querySelectorAll('.im-theme-btn').forEach(function(b){b.addEventListener('click',function(){var t=this.getAttribute('data-imtheme');localStorage.setItem('im-theme',t);ap(t);ub(t);});});});window.matchMedia('(prefers-color-scheme: light)').addEventListener('change',function(){if((localStorage.getItem('im-theme')||'system')==='system')ap('system');});})();
+</script>
+<script>
+/* ---- 1. Denominator ---- */
+var NN_DEN = [
+  {name:'State A', deaths:5000, pop:11000000},
+  {name:'State B', deaths:1200, pop:1300000}
+];
+function nnDen(mode, btn){
+  document.querySelectorAll('[data-den]').forEach(function(b){b.classList.toggle('active',b===btn);});
+  var vals = NN_DEN.map(function(d){ return mode==='count' ? d.deaths : d.deaths/d.pop*100000; });
+  var max = Math.max.apply(null, vals);
+  var host = document.getElementById('nnDenBars'); host.innerHTML='';
+  NN_DEN.forEach(function(d,i){
+    var v = vals[i];
+    var disp = mode==='count' ? Math.round(v).toLocaleString() : v.toFixed(1);
+    var w = document.createElement('div'); w.className='nn-bar-wrap';
+    w.innerHTML = '<div class="nn-bar-val">'+disp+'</div>'+
+      '<div class="nn-bar'+(i?' alt':'')+'" style="height:'+(v/max*100)+'%"></div>'+
+      '<div class="nn-bar-lbl">'+d.name+'</div>';
+    host.appendChild(w);
+  });
+  var lead = vals[0]>vals[1] ? 'State A' : 'State B';
+  document.getElementById('nnDenNote').innerHTML = mode==='count'
+    ? 'By raw count, <b>State A</b> looks far more dangerous. But it has ~8&times; the population.'
+    : 'Per 100,000 people, <span style="color:var(--color-accent-pink)"><b>'+lead+'</b> is actually higher</span> — the ranking flips.';
+}
+
+/* ---- 2. Percent vs percentage points ---- */
+function nnPct(){
+  var a=parseFloat(document.getElementById('nnPctA').value)||0;
+  var b=parseFloat(document.getElementById('nnPctB').value)||0;
+  var pp=(b-a);
+  var rel = a===0 ? null : (b-a)/a*100;
+  var relTxt = rel===null ? 'undefined (base is 0)' : (rel>=0?'+':'')+rel.toFixed(0)+'%';
+  document.getElementById('nnPctOut').innerHTML =
+    'Absolute change: <b>'+(pp>=0?'+':'')+pp.toFixed(1)+' percentage points</b><br>'+
+    'Relative change: <span class="flip">'+relTxt+'</span><br>'+
+    '<span style="color:var(--color-text-muted)">Headline writers reach for whichever sounds bigger.</span>';
+}
+
+/* ---- 3. Base rates (Bayes) ---- */
+function nnBase(){
+  var t=parseInt(document.getElementById('nnBaseRange').value,10); // 0..100
+  // map slider to prevalence from 1 in 10,000 (rare) to 1 in 5 (common), log scale
+  var minL=Math.log(1/10000), maxL=Math.log(1/5);
+  var prev=Math.exp(minL+(maxL-minL)*(t/100));
+  var sens=0.99, spec=0.99;
+  var pPos = prev*sens + (1-prev)*(1-spec);
+  var ppv = prev*sens / pPos; // P(disease|positive)
+  var oneIn = Math.round(1/prev);
+  document.getElementById('nnBasePrevLbl').textContent = '1 in '+oneIn.toLocaleString();
+  // illustrate per 100,000
+  var N=100000, have=Math.round(prev*N), dontHave=N-have;
+  var truePos=Math.round(have*sens), falsePos=Math.round(dontHave*(1-spec));
+  document.getElementById('nnBaseOut').innerHTML =
+    'Out of 100,000 people, about <b>'+have.toLocaleString()+'</b> have it.<br>'+
+    'True positives: <b>'+truePos.toLocaleString()+'</b> &nbsp;·&nbsp; False positives: <span class="flip">'+falsePos.toLocaleString()+'</span><br>'+
+    'So if you test positive, your real chance of having it is <b>'+(ppv*100).toFixed(ppv<0.1?1:0)+'%</b>'+
+    (ppv<0.5?' <span class="flip">— more likely a false alarm than the real thing.</span>':' — now the positive is trustworthy.');
+}
+
+/* ---- 4. Truncated axis ---- */
+var NN_AX=[48,49,50,52];
+function nnAxis(mode, btn){
+  document.querySelectorAll('[data-ax]').forEach(function(b){b.classList.toggle('active',b===btn);});
+  var base = mode==='zero' ? 0 : 47;
+  var top = 53;
+  var host=document.getElementById('nnAxisBars'); host.innerHTML='';
+  NN_AX.forEach(function(v,i){
+    var h = (v-base)/(top-base)*100;
+    var w=document.createElement('div'); w.className='nn-bar-wrap';
+    w.innerHTML='<div class="nn-bar-val">'+v+'</div>'+
+      '<div class="nn-bar" style="height:'+Math.max(h,1)+'%"></div>'+
+      '<div class="nn-bar-lbl">Q'+(i+1)+'</div>';
+    host.appendChild(w);
+  });
+  document.getElementById('nnAxisNote').innerHTML = mode==='zero'
+    ? 'Starting at zero: 48 to 52 is a barely-visible rise of about 8%.'
+    : '<span style="color:var(--color-accent-pink)">Starting at 47: the same 8% rise now looks like it <b>quadrupled</b>.</span>';
+}
+
+/* ---- 5. Cherry-picked baseline ---- */
+var NN_YEARS=[2009,2010,2011,2012,2013,2014,2015,2016,2017,2018,2019,2020,2021,2022];
+var NN_SERIES=[42,55,48,60,52,47,58,64,51,46,59,68,54,49]; // wobbly, illustrative
+function nnCherry(){
+  var s=parseInt(document.getElementById('nnCherryRange').value,10);
+  document.getElementById('nnCherryYrLbl').textContent=NN_YEARS[s];
+  var startV=NN_SERIES[s], endV=NN_SERIES[NN_SERIES.length-1];
+  var diff=endV-startV;
+  var dir = diff>3 ? 'risen' : (diff<-3 ? 'fallen' : 'barely moved');
+  var col = diff>3 ? 'var(--color-accent-blue)' : (diff<-3 ? 'var(--color-accent-pink)' : 'var(--color-text-muted)');
+  document.getElementById('nnCherryOut').innerHTML =
+    '"Since <b>'+NN_YEARS[s]+'</b>, the figure has <b style="color:'+col+'">'+dir+'</b>" &mdash; '+
+    'from '+startV+' to '+endV+' ('+(diff>=0?'+':'')+diff+').<br>'+
+    '<span style="color:var(--color-text-muted)">Same 14 data points every time. Only the start year changed.</span>';
+}
+
+/* ---- 6. Margin of error ---- */
+function nnMoe(){
+  var t=parseInt(document.getElementById('nnMoeRange').value,10); // 0..100
+  var n=Math.round(50*Math.pow(10, t/100*2.6)); // ~50 to ~20000
+  document.getElementById('nnMoeNLbl').textContent=n.toLocaleString();
+  var p=0.5;
+  var moe=1.96*Math.sqrt(p*(1-p)/n)*100; // percentage points
+  var gap=2; // the "51 vs 49" gap
+  var verdict = moe>gap
+    ? '<span class="flip">The &plusmn;'+moe.toFixed(1)+'pt margin is bigger than the 2-point gap &mdash; statistically a tie.</span>'
+    : '<b>The &plusmn;'+moe.toFixed(1)+'pt margin is now smaller than the gap &mdash; the lead is real.</b>';
+  document.getElementById('nnMoeOut').innerHTML =
+    'A 51%&ndash;49% result with this sample carries a margin of error of about <b>&plusmn;'+moe.toFixed(1)+' points</b>.<br>'+verdict;
+}
+
+/* init all */
+document.addEventListener('DOMContentLoaded',function(){
+  nnDen('count',document.querySelector('[data-den="count"]'));
+  nnPct();
+  nnBase();
+  nnAxis('zero',document.querySelector('[data-ax="zero"]'));
+  nnCherry();
+  nnMoe();
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
Two new interactive data-literacy pages for **The Long View**, completing the session's content program.

## 1. Numbers in the News
A reader's field guide to the statistics that pass for facts — eight ways numbers mislead, each with a small interactive widget:
1. The missing denominator (count vs rate — the ranking flips)
2. Percent vs percentage points (relative vs absolute)
3. Base rates & false positives (Bayes, with a prevalence slider)
4. The truncated axis (same data, zero vs truncated baseline)
5. The cherry-picked baseline (slide the start year, watch the "trend" flip)
6. Sample size & margin of error
7. Correlation ≠ causation (the confounder)
8. Survivorship & selection bias

Plus a pocket checklist of eight questions. **All figures are clearly labelled illustrative** — the widgets teach the mechanism, they don't assert facts.

## 2. The Evidence Map
An interactive teaching tool on **evidence gap maps**: a clickable illustrative matrix (interventions × outcomes for the education sector, bubble colour = confidence, size = evidence volume), with a detail panel for each cell. Framed explicitly and repeatedly as an **illustrative teaching aid** whose confidence pattern reflects the broad direction of well-known syntheses — with prominent links to the real, continuously-updated maps from **3ie, Cochrane, the Campbell Collaboration, and J-PAL** for any actual decision.

## Integration
- Both built as native Long View siblings — `/css/longview.css` chrome, shared theme toggle, hero/section/footer patterns
- Linked from `the-long-view.html` (tools grid) and `gallery.html` (footer); they cross-link each other
- Registered in `data/search-index.json`, `sitemap.xml`, and `docs/changelog.md` (v10.62.0)

## Validation
- mojibake PASS · search-index valid JSON · sitemap well-formed · all inline JS passes `node --check`
- all related course/dive links confirmed to exist · responsive viewport meta present

---
This completes the full program shipped this session: **2 new 101 courses** (Data Visualization 101, Logframe 101), **4 new Deep Dives** (Stunting Puzzle, Care Economy, Climate Migration, AI & Development), and **2 new Long View pages** — eight merged PRs in all.

https://claude.ai/code/session_01Xpta1BU7c52vLx8u7BEaDj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xpta1BU7c52vLx8u7BEaDj)_