### PR TITLE
Polish Numbers in the News & The Evidence Map

### DIFF
--- a/the-long-view/evidence-map.html
+++ b/the-long-view/evidence-map.html
@@ -29,16 +29,31 @@
 .em-legend .grp { display: flex; align-items: center; gap: .5rem; }
 .em-dot { display: inline-block; border-radius: 50%; }
 .em-c-high { background: #1A9E6B; } .em-c-med { background: #E8A33D; } .em-c-low { background: #C95D6B; } .em-c-none { background: transparent; border: 1.5px dashed var(--color-border); }
+/* summary stat strip */
+.em-stats { display:flex; flex-wrap:wrap; gap:.8rem; margin:1.4rem 0; }
+.em-stat { flex:1; min-width:130px; background:var(--color-bg-card); border:1px solid var(--color-border); border-radius:14px; padding:1rem 1.1rem; }
+.em-stat .num { font-family:var(--font-heading); font-weight:800; font-size:1.7rem; line-height:1; }
+.em-stat .lbl { font-family:var(--font-mono); font-size:.72rem; color:var(--color-text-muted); margin-top:.35rem; text-transform:uppercase; letter-spacing:.06em; }
+.em-stat.s-high .num{color:#1A9E6B;} .em-stat.s-med .num{color:#E8A33D;} .em-stat.s-low .num{color:#C95D6B;} .em-stat.s-gap .num{color:var(--color-text-muted);}
+/* gap-highlight toggle */
+.em-toolbar { display:flex; flex-wrap:wrap; align-items:center; gap:.6rem; margin:.4rem 0 1.1rem; }
+.em-toggle { font-family:var(--font-mono); font-size:.78rem; font-weight:600; padding:.5rem .95rem; border-radius:999px; border:1px solid var(--color-border); background:var(--color-bg-card); color:var(--color-text); cursor:pointer; transition:all .15s; }
+.em-toggle:hover { border-color:var(--color-primary); }
+.em-toggle.active { background:linear-gradient(135deg,var(--color-primary),var(--color-primary-2)); color:#fff; border-color:transparent; }
+
 .em-scroll { overflow-x: auto; border: 1px solid var(--color-border); border-radius: 16px; background: var(--color-bg-card); }
 .em-grid { border-collapse: collapse; min-width: 640px; width: 100%; font-family: var(--font-body); }
 .em-grid th { font-family: var(--font-mono); font-size: .76rem; font-weight: 600; color: var(--color-text-muted); padding: .9rem .6rem; text-align: center; vertical-align: bottom; border-bottom: 1px solid var(--color-border); line-height: 1.25; }
 .em-grid th.em-rowhead { text-align: left; min-width: 180px; position: sticky; left: 0; background: var(--color-bg-card); z-index: 2; }
 .em-grid td.em-rowhead { font-family: var(--font-heading); font-weight: 600; font-size: .92rem; padding: .7rem .8rem; text-align: left; min-width: 180px; border-bottom: 1px solid var(--color-border); position: sticky; left: 0; background: var(--color-bg-card); z-index: 1; }
-.em-grid td.em-cell { text-align: center; border-bottom: 1px solid var(--color-border); padding: .4rem; }
-.em-bub { display: inline-flex; align-items: center; justify-content: center; border-radius: 50%; cursor: pointer; transition: transform .15s, box-shadow .15s; color: #fff; font-family: var(--font-mono); font-weight: 700; font-size: .72rem; border: none; }
-.em-bub:hover { transform: scale(1.12); box-shadow: 0 0 0 3px rgba(102,126,234,.3); }
+.em-grid td.em-cell { text-align: center; border-bottom: 1px solid var(--color-border); padding: .4rem; transition: background .2s; }
+.em-bub { position:relative; display: inline-flex; align-items: center; justify-content: center; border-radius: 50%; cursor: pointer; transition: transform .15s, box-shadow .15s, opacity .2s; border: 2px solid rgba(255,255,255,.55); box-shadow: 0 3px 8px rgba(15,23,42,.18); }
+.em-bub::after { content:""; position:absolute; inset:0; margin:auto; width:32%; height:32%; border-radius:50%; background:rgba(255,255,255,.85); }
+.em-bub:hover { transform: scale(1.15); box-shadow: 0 0 0 4px rgba(102,126,234,.28); }
 .em-bub:focus-visible { outline: 3px solid var(--color-primary); outline-offset: 2px; }
-.em-gap { display: inline-block; width: 12px; height: 12px; border-radius: 50%; border: 1.5px dashed var(--color-border); opacity: .6; }
+.em-bub.dim { opacity:.18; }
+.em-gap { display: inline-block; width: 13px; height: 13px; border-radius: 50%; border: 1.5px dashed var(--color-text-muted); opacity: .55; transition:all .2s; }
+.em-cell.gaphi .em-gap { opacity:1; border-color:var(--color-accent-pink); background:rgba(240,147,251,.18); transform:scale(1.25); }
 .em-panel { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: 16px; padding: 1.6rem; margin-top: 1.5rem; min-height: 120px; }
 .em-panel .em-ph { color: var(--color-text-muted); font-style: italic; }
 .em-panel h3 { font-family: var(--font-heading); font-size: 1.25rem; margin: 0 0 .2rem; }
@@ -99,6 +114,8 @@
       <b>Read this first.</b> The map below is an <b>illustrative teaching example</b> for the education-and-development sector. The pattern of confidence reflects the broad direction of well-known evidence syntheses, but the bubble sizes are simplified for clarity — they are not exact study counts. For the real, continuously-updated maps, use the authoritative sources linked at the bottom (3ie, Cochrane, the Campbell Collaboration, J-PAL).
     </div>
 
+    <div class="em-stats" id="emStats"></div>
+
     <div class="em-legend">
       <span class="grp"><b style="color:var(--color-text)">Colour = confidence:</b></span>
       <span class="grp"><span class="em-dot em-c-high" style="width:14px;height:14px;"></span> High</span>
@@ -106,6 +123,11 @@
       <span class="grp"><span class="em-dot em-c-low" style="width:14px;height:14px;"></span> Weak / contested</span>
       <span class="grp"><span class="em-dot em-c-none" style="width:14px;height:14px;"></span> Evidence gap</span>
       <span class="grp" style="margin-left:auto;"><b style="color:var(--color-text)">Size = volume of evidence.</b> Click a bubble.</span>
+    </div>
+
+    <div class="em-toolbar">
+      <button class="em-toggle" id="emGapBtn" onclick="emToggleGaps(this)" aria-pressed="false">⌖ Highlight the gaps</button>
+      <span class="em-note" style="margin:0;border:none;border-left:none;padding:.2rem 0;background:none;font-family:var(--font-mono);font-size:.76rem;color:var(--color-text-muted);">Tip: the empty cells are often the most important thing on the map.</span>
     </div>
 
     <div class="em-scroll">
@@ -221,6 +243,20 @@ var EM_ROWS = [
 var EM_CONF = {high:{c:"#1A9E6B",l:"High confidence"}, med:{c:"#E8A33D",l:"Mixed / moderate"}, low:{c:"#C95D6B",l:"Weak / contested"}};
 var EM_SIZE = {0:0, 1:24, 2:34, 3:46};
 
+function emStats(){
+  var n={high:0,med:0,low:0,gap:0,total:0};
+  EM_ROWS.forEach(function(r){r.cells.forEach(function(c){n.total++; if(!c.c||c.v===0)n.gap++; else n[c.c]++;});});
+  var cards=[
+    ['s-high',n.high,'High confidence'],
+    ['s-med',n.med,'Mixed / moderate'],
+    ['s-low',n.low,'Weak / contested'],
+    ['s-gap',n.gap,'Evidence gaps']
+  ];
+  document.getElementById('emStats').innerHTML=
+    '<div class="em-stat"><div class="num">'+n.total+'</div><div class="lbl">Pairings mapped</div></div>'+
+    cards.map(function(c){return '<div class="em-stat '+c[0]+'"><div class="num">'+c[1]+'</div><div class="lbl">'+c[2]+'</div></div>';}).join('');
+}
+
 function emBuild(){
   var t=document.getElementById('emGrid');
   var head='<thead><tr><th class="em-rowhead">Intervention &darr; / Outcome &rarr;</th>';
@@ -231,18 +267,27 @@ function emBuild(){
     body+='<tr><td class="em-rowhead">'+row.name+'</td>';
     row.cells.forEach(function(cell,ci){
       if(!cell.c || cell.v===0){
-        body+='<td class="em-cell"><span class="em-gap" title="Evidence gap — little or no rigorous evidence"></span></td>';
+        body+='<td class="em-cell em-isgap"><span class="em-gap" title="Evidence gap — little or no rigorous evidence"></span></td>';
       } else {
         var sz=EM_SIZE[cell.v];
         body+='<td class="em-cell"><button class="em-bub" style="width:'+sz+'px;height:'+sz+'px;background:'+EM_CONF[cell.c].c+'" '+
-          'data-r="'+ri+'" data-c="'+ci+'" aria-label="'+row.name+', '+EM_OUTCOMES[ci].replace(/&amp;/g,'and')+', '+EM_CONF[cell.c].l+'" '+
-          'onclick="emShow('+ri+','+ci+')">'+cell.v+'</button></td>';
+          'data-r="'+ri+'" data-c="'+ci+'" title="'+EM_CONF[cell.c].l+' · click for detail" aria-label="'+row.name+', '+EM_OUTCOMES[ci].replace(/&amp;/g,'and')+', '+EM_CONF[cell.c].l+', click for detail" '+
+          'onclick="emShow('+ri+','+ci+')"></button></td>';
       }
     });
     body+='</tr>';
   });
   body+='</tbody>';
   t.innerHTML=head+body;
+}
+
+function emToggleGaps(btn){
+  var on=btn.classList.toggle('active');
+  btn.setAttribute('aria-pressed',on?'true':'false');
+  document.querySelectorAll('#emGrid .em-cell').forEach(function(td){
+    td.classList.toggle('gaphi', on && td.classList.contains('em-isgap'));
+  });
+  document.querySelectorAll('#emGrid .em-bub').forEach(function(b){ b.classList.toggle('dim', on); });
 }
 function emShow(ri,ci){
   var row=EM_ROWS[ri], cell=row.cells[ci], out=EM_OUTCOMES[ci];
@@ -256,7 +301,7 @@ function emShow(ri,ci){
     '<p>'+cell.note+'</p>'+
     '<div class="em-sources"><a href="https://developmentevidence.3ieimpact.org/" target="_blank" rel="noopener">See the real evidence on 3ie →</a></div>';
 }
-document.addEventListener('DOMContentLoaded',function(){emBuild();});
+document.addEventListener('DOMContentLoaded',function(){emStats();emBuild();});
 </script>
 </body>
 </html>

--- a/the-long-view/numbers-in-the-news.html
+++ b/the-long-view/numbers-in-the-news.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-JRCMEB9TBW');</script>
-<meta name="description" content="A reader's field guide to the statistics in the news — the missing denominator, percent vs percentage points, base rates, truncated axes, cherry-picked baselines and more, with interactive examples. A companion to ImpactMojo's The Long View.">
+<meta name="description" content="A reader's field guide to the statistics in the news — the missing denominator, percent vs percentage points, base rates, truncated axes, cherry-picked baselines, margins of error, confounders and survivorship — each with a hands-on interactive example. A companion to ImpactMojo's The Long View.">
 <title>Numbers in the News — a reader's field guide | The Long View</title>
 <link href="/assets/images/favicon.png" rel="icon" type="image/png">
 <meta name="theme-color" content="#667eea">
@@ -13,7 +13,7 @@
 <link rel="canonical" href="https://www.impactmojo.in/the-long-view/numbers-in-the-news.html">
 <meta property="og:type" content="article">
 <meta property="og:title" content="Numbers in the News — a reader's field guide">
-<meta property="og:description" content="The statistics in the news, decoded — missing denominators, percent vs percentage points, base rates, truncated axes and more, with interactive examples.">
+<meta property="og:description" content="The statistics in the news, decoded — missing denominators, percent vs percentage points, base rates, truncated axes and more, with hands-on interactive examples.">
 <meta property="og:url" content="https://www.impactmojo.in/the-long-view/numbers-in-the-news.html">
 <meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
 <meta name="twitter:card" content="summary_large_image">
@@ -22,41 +22,78 @@
 <link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&amp;family=Inter:wght@400;500;600;700;800&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
 <link rel="stylesheet" href="/css/longview.css">
 <style>
-/* Numbers in the News — page-specific */
-.nn-list { counter-reset: nn; }
-.nn-card { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: 16px; padding: 1.75rem 1.75rem 1.9rem; margin-bottom: 1.5rem; }
-.nn-card .nn-kicker { font-family: var(--font-mono); font-size: .72rem; letter-spacing: .14em; text-transform: uppercase; color: var(--color-accent-pink); font-weight: 600; }
-.nn-card h3 { font-family: var(--font-heading); font-size: clamp(1.25rem, 3vw, 1.6rem); margin: .35rem 0 .35rem; line-height: 1.2; }
-.nn-card h3::before { counter-increment: nn; content: counter(nn, decimal-leading-zero); font-family: var(--font-mono); color: var(--color-text-muted); font-size: .9rem; margin-right: .6rem; }
-.nn-card .nn-trap { font-size: 1.02rem; color: var(--color-text); margin: 0 0 1rem; }
-.nn-widget { background: var(--color-bg); border: 1px solid var(--color-border); border-radius: 12px; padding: 1.25rem; margin: 1.1rem 0; }
-.nn-controls { display: flex; flex-wrap: wrap; gap: .6rem; align-items: center; margin-bottom: 1rem; }
-.nn-btn { font-family: var(--font-mono); font-size: .8rem; font-weight: 600; padding: .5rem .9rem; border-radius: 8px; border: 1px solid var(--color-border); background: var(--color-bg-card); color: var(--color-text); cursor: pointer; transition: all .15s; }
-.nn-btn:hover { border-color: var(--color-primary); }
-.nn-btn.active { background: var(--color-primary); color: #fff; border-color: var(--color-primary); }
-.nn-input { font-family: var(--font-mono); font-size: .9rem; width: 5.5rem; padding: .45rem .55rem; border-radius: 8px; border: 1px solid var(--color-border); background: var(--color-bg-card); color: var(--color-text); }
-.nn-label { font-family: var(--font-mono); font-size: .78rem; color: var(--color-text-muted); }
-.nn-range { width: 100%; max-width: 360px; accent-color: var(--color-primary); }
-.nn-readout { font-family: var(--font-mono); font-size: .95rem; line-height: 1.7; background: var(--color-bg-card); border-radius: 8px; padding: .85rem 1rem; border: 1px dashed var(--color-border); }
-.nn-readout b { color: var(--color-primary); }
-.nn-readout .flip { color: var(--color-accent-pink); }
-.nn-bars { display: flex; align-items: flex-end; gap: 1.5rem; height: 190px; padding: .5rem 0 0; }
-.nn-bar-wrap { display: flex; flex-direction: column; align-items: center; gap: .4rem; flex: 1; max-width: 90px; height: 100%; justify-content: flex-end; }
-.nn-bar { width: 100%; border-radius: 6px 6px 0 0; background: linear-gradient(180deg, var(--color-accent-blue), var(--color-primary)); transition: height .5s cubic-bezier(.22,1,.36,1); min-height: 2px; }
-.nn-bar.alt { background: linear-gradient(180deg, var(--color-accent-pink), #d6336c); }
-.nn-bar-val { font-family: var(--font-mono); font-size: .8rem; font-weight: 600; }
-.nn-bar-lbl { font-family: var(--font-mono); font-size: .72rem; color: var(--color-text-muted); text-align: center; }
-.nn-axisnote { font-family: var(--font-mono); font-size: .72rem; color: var(--color-text-muted); margin-top: .5rem; }
-.nn-takeaway { font-size: .98rem; border-left: 3px solid var(--color-accent-pink); padding: .2rem 0 .2rem 1rem; margin: 1.1rem 0 0; color: var(--color-text); }
-.nn-takeaway b { color: var(--color-accent-pink); }
-.nn-illus { font-family: var(--font-mono); font-size: .68rem; letter-spacing: .08em; text-transform: uppercase; color: var(--color-text-muted); opacity: .8; }
-.nn-checklist { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: 16px; padding: 1.75rem; }
-.nn-checklist ul { list-style: none; padding: 0; margin: .5rem 0 0; display: grid; gap: .7rem; }
-.nn-checklist li { padding-left: 1.9rem; position: relative; font-size: 1.02rem; }
-.nn-checklist li::before { content: "?"; position: absolute; left: 0; top: -1px; width: 1.4rem; height: 1.4rem; border-radius: 50%; background: var(--color-primary); color: #fff; font-family: var(--font-mono); font-weight: 700; font-size: .8rem; display: flex; align-items: center; justify-content: center; }
-.nn-related { margin-top: 1.5rem; display: flex; flex-wrap: wrap; gap: .6rem; }
-.nn-related a { font-family: var(--font-mono); font-size: .8rem; padding: .5rem .9rem; border-radius: 8px; border: 1px solid var(--color-border); background: var(--color-bg-card); color: var(--color-text); text-decoration: none; transition: all .15s; }
-.nn-related a:hover { border-color: var(--color-primary); color: var(--color-primary); }
+/* ===== Numbers in the News — page-specific ===== */
+.nn-intro-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(160px,1fr)); gap:.7rem; margin-top:1.6rem; }
+.nn-jump { display:flex; align-items:center; gap:.55rem; font-family:var(--font-mono); font-size:.78rem; color:var(--color-text); text-decoration:none; padding:.6rem .75rem; border:1px solid var(--color-border); border-radius:10px; background:var(--color-bg-card); transition:border-color .15s, transform .15s; }
+.nn-jump:hover { border-color:var(--color-primary); transform:translateY(-2px); }
+.nn-jump .nn-jnum { font-weight:700; color:var(--color-primary); }
+
+.nn-list { margin-top:.5rem; }
+.nn-card { position:relative; background:var(--color-bg-card); border:1px solid var(--color-border); border-radius:18px; padding:1.9rem 1.8rem 2rem; margin-bottom:1.6rem; box-shadow:0 10px 30px rgba(15,23,42,0.05); scroll-margin-top:64px; }
+.nn-card::before { content:""; position:absolute; left:0; top:1.9rem; bottom:1.9rem; width:4px; border-radius:4px; background:linear-gradient(180deg,var(--color-primary),var(--color-accent-pink)); }
+.nn-head { display:flex; align-items:flex-start; gap:1rem; margin-bottom:.6rem; }
+.nn-badge { flex:0 0 auto; width:46px; height:46px; border-radius:12px; background:linear-gradient(135deg,var(--color-primary),var(--color-primary-2)); color:#fff; font-family:var(--font-mono); font-weight:700; font-size:1.1rem; display:flex; align-items:center; justify-content:center; box-shadow:0 6px 16px rgba(102,126,234,.35); }
+.nn-htext { flex:1; }
+.nn-kicker { font-family:var(--font-mono); font-size:.7rem; letter-spacing:.14em; text-transform:uppercase; color:var(--color-accent-pink); font-weight:600; }
+.nn-card h3 { font-family:var(--font-heading); font-size:clamp(1.2rem,3vw,1.5rem); margin:.15rem 0 0; line-height:1.2; color:var(--color-text); }
+.nn-trap { font-size:1.02rem; color:var(--color-text); margin:.2rem 0 1.1rem; }
+.nn-trap em { color:var(--color-primary); font-style:normal; font-weight:700; }
+
+.nn-widget { background:var(--color-bg); border:1px solid var(--color-border); border-radius:14px; padding:1.3rem; margin:1.1rem 0; }
+.nn-controls { display:flex; flex-wrap:wrap; gap:.6rem; align-items:center; margin-bottom:1.1rem; }
+.nn-controls.col { flex-direction:column; align-items:stretch; gap:.55rem; }
+.nn-btn { font-family:var(--font-mono); font-size:.8rem; font-weight:600; padding:.5rem .95rem; border-radius:999px; border:1px solid var(--color-border); background:var(--color-bg-card); color:var(--color-text); cursor:pointer; transition:all .15s; }
+.nn-btn:hover { border-color:var(--color-primary); }
+.nn-btn.active { background:linear-gradient(135deg,var(--color-primary),var(--color-primary-2)); color:#fff; border-color:transparent; box-shadow:0 4px 12px rgba(102,126,234,.3); }
+.nn-input { font-family:var(--font-mono); font-size:.9rem; width:5rem; padding:.45rem .55rem; border-radius:8px; border:1px solid var(--color-border); background:var(--color-bg-card); color:var(--color-text); }
+.nn-label { font-family:var(--font-mono); font-size:.78rem; color:var(--color-text-muted); }
+.nn-label b { color:var(--color-primary); }
+.nn-range { width:100%; max-width:420px; accent-color:var(--color-primary); height:6px; }
+
+/* result panel (replaces dashed wireframe boxes) */
+.nn-result { display:flex; gap:.85rem; align-items:flex-start; background:var(--color-bg-card); border:1px solid var(--color-border); border-left:4px solid var(--color-primary); border-radius:10px; padding:.95rem 1.1rem; }
+.nn-result .ico { flex:0 0 auto; width:30px; height:30px; border-radius:8px; background:rgba(102,126,234,.12); color:var(--color-primary); display:flex; align-items:center; justify-content:center; }
+.nn-result .ico svg { width:17px; height:17px; }
+.nn-result .body { font-size:.96rem; line-height:1.6; color:var(--color-text); }
+.nn-result .body b { color:var(--color-primary); }
+.nn-result .body .flip { color:var(--color-accent-pink); font-weight:700; }
+.nn-result.warn { border-left-color:var(--color-accent-pink); }
+.nn-result.warn .ico { background:rgba(240,147,251,.16); color:#d6336c; }
+
+/* bar charts with baseline + gridlines */
+.nn-chart { position:relative; }
+.nn-bars { position:relative; display:flex; align-items:flex-end; gap:1.6rem; height:200px; padding:.5rem .2rem 0; z-index:1; }
+.nn-grid-lines { position:absolute; inset:.5rem .2rem 22px; z-index:0; pointer-events:none; }
+.nn-grid-lines span { position:absolute; left:0; right:0; height:1px; background:var(--color-border); opacity:.55; }
+.nn-bar-wrap { display:flex; flex-direction:column; align-items:center; gap:.45rem; flex:1; max-width:96px; height:100%; justify-content:flex-end; }
+.nn-bar { width:100%; border-radius:7px 7px 0 0; background:linear-gradient(180deg,var(--color-accent-blue),var(--color-primary)); transition:height .55s cubic-bezier(.22,1,.36,1); min-height:2px; box-shadow:0 4px 14px rgba(102,126,234,.25); }
+.nn-bar.alt { background:linear-gradient(180deg,var(--color-accent-pink),#d6336c); box-shadow:0 4px 14px rgba(214,51,108,.25); }
+.nn-bar.mut { background:linear-gradient(180deg,#94a3b8,#64748b); box-shadow:none; }
+.nn-bar-val { font-family:var(--font-mono); font-size:.82rem; font-weight:700; color:var(--color-text); }
+.nn-bar-lbl { font-family:var(--font-mono); font-size:.72rem; color:var(--color-text-muted); text-align:center; line-height:1.25; }
+.nn-baseline { height:2px; background:var(--color-text-muted); opacity:.5; margin:0 .2rem; border-radius:2px; }
+.nn-axisnote { font-family:var(--font-mono); font-size:.74rem; color:var(--color-text-muted); margin-top:.7rem; line-height:1.55; }
+.nn-axisnote .flip { color:var(--color-accent-pink); }
+
+.nn-takeaway { font-size:.98rem; border-left:3px solid var(--color-accent-pink); padding:.25rem 0 .25rem 1.05rem; margin:1.2rem 0 0; color:var(--color-text); }
+.nn-takeaway b { color:var(--color-accent-pink); }
+.nn-note { font-family:var(--font-mono); font-size:.72rem; color:var(--color-text-muted); }
+
+/* survivorship plane */
+.nn-plane { display:block; width:100%; max-width:420px; margin:.4rem auto .2rem; }
+.nn-plane .hit { transition:opacity .4s, fill .4s; }
+
+/* checklist */
+.nn-checklist { background:linear-gradient(135deg,rgba(102,126,234,.06),rgba(240,147,251,.06)); border:1px solid var(--color-border); border-radius:18px; padding:1.9rem; }
+.nn-checklist ul { list-style:none; padding:0; margin:.8rem 0 0; display:grid; gap:.7rem; }
+.nn-checklist li { padding-left:2.4rem; position:relative; font-size:1.02rem; color:var(--color-text); line-height:1.5; }
+.nn-checklist li .qn { position:absolute; left:0; top:0; width:1.7rem; height:1.7rem; border-radius:8px; background:linear-gradient(135deg,var(--color-primary),var(--color-primary-2)); color:#fff; font-family:var(--font-mono); font-weight:700; font-size:.78rem; display:flex; align-items:center; justify-content:center; }
+.nn-checklist li b { color:var(--color-primary); }
+
+.nn-related { margin-top:1.6rem; display:flex; flex-wrap:wrap; gap:.6rem; }
+.nn-related a { font-family:var(--font-mono); font-size:.8rem; padding:.55rem .95rem; border-radius:999px; border:1px solid var(--color-border); background:var(--color-bg-card); color:var(--color-text); text-decoration:none; transition:all .15s; }
+.nn-related a:hover { border-color:var(--color-primary); color:var(--color-primary); }
+@media (max-width:560px){ .nn-card{padding:1.5rem 1.2rem 1.6rem;} .nn-bars{gap:1rem;} }
 </style>
 </head>
 <body>
@@ -79,149 +116,167 @@
   <div class="hero-inner">
     <span class="eyebrow">A companion to The Long View</span>
     <h1 style="font-size:clamp(2.2rem,6vw,3.6rem);">Numbers in the <span class="accent">News</span></h1>
-    <p class="sub">A reader's field guide to the statistics that pass for facts. Eight ways numbers mislead — each with a small interactive example you can poke at. Learn to spot them, and you read the news more honestly.</p>
+    <p class="sub">A reader's field guide to the statistics that pass for facts. Eight ways numbers mislead — each with a small interactive you can actually poke at. Learn to spot them, and you read the news more honestly.</p>
   </div>
 </header>
 
 <main id="main-content">
 <section class="section">
-  <div class="wrap" style="max-width:820px;">
+  <div class="wrap" style="max-width:840px;">
     <div class="section-head" style="text-align:left;">
       <span class="kicker">How to read this</span>
       <h2 style="text-align:left;">Most misleading numbers aren't lies</h2>
-      <p style="margin-left:0;text-align:left;">They are true numbers framed to point the wrong way. A real count, a real percentage, a real chart — arranged so the obvious reading is the wrong one. You don't need statistics to defend yourself; you need a handful of questions. Here are the eight that catch most of it. <span class="nn-illus">All figures below are illustrative, chosen to make the mechanism visible.</span></p>
+      <p style="margin-left:0;text-align:left;">They are true numbers framed to point the wrong way — a real count, a real percentage, a real chart, arranged so the obvious reading is the wrong one. You don't need statistics to defend yourself; you need a handful of questions. Here are the eight that catch most of it. <span class="nn-note">All figures below are illustrative, chosen to make the mechanism visible.</span></p>
+      <nav class="nn-intro-grid" aria-label="Jump to a trap">
+        <a class="nn-jump" href="#t1"><span class="nn-jnum">01</span> Missing denominator</a>
+        <a class="nn-jump" href="#t2"><span class="nn-jnum">02</span> Percent vs points</a>
+        <a class="nn-jump" href="#t3"><span class="nn-jnum">03</span> Base rates</a>
+        <a class="nn-jump" href="#t4"><span class="nn-jnum">04</span> Truncated axis</a>
+        <a class="nn-jump" href="#t5"><span class="nn-jnum">05</span> Cherry-picked start</a>
+        <a class="nn-jump" href="#t6"><span class="nn-jnum">06</span> Margin of error</a>
+        <a class="nn-jump" href="#t7"><span class="nn-jnum">07</span> Confounders</a>
+        <a class="nn-jump" href="#t8"><span class="nn-jnum">08</span> Survivorship</a>
+      </nav>
     </div>
 
     <div class="nn-list">
 
       <!-- 1. DENOMINATOR -->
-      <article class="nn-card">
-        <div class="nn-kicker">The missing denominator</div>
-        <h3>A big number out of what?</h3>
+      <article class="nn-card" id="t1">
+        <div class="nn-head"><div class="nn-badge">01</div><div class="nn-htext"><div class="nn-kicker">The missing denominator</div><h3>A big number out of what?</h3></div></div>
         <p class="nn-trap">"State A had 5,000 road deaths last year; State B had 1,200." So State A is more dangerous? Only if the two states are the same size. A count means nothing without the population it came from. Switch the view.</p>
         <div class="nn-widget">
           <div class="nn-controls">
             <button class="nn-btn active" data-den="count" onclick="nnDen('count',this)">Raw count</button>
             <button class="nn-btn" data-den="rate" onclick="nnDen('rate',this)">Per 100,000 people</button>
           </div>
-          <div class="nn-bars" id="nnDenBars"></div>
+          <div class="nn-chart"><div class="nn-grid-lines" id="nnDenGrid"></div><div class="nn-bars" id="nnDenBars"></div></div>
+          <div class="nn-baseline"></div>
           <div class="nn-axisnote" id="nnDenNote"></div>
         </div>
         <p class="nn-takeaway"><b>Ask:</b> out of how many? A count tells you size; a rate tells you risk. The news loves counts because they sound bigger.</p>
       </article>
 
       <!-- 2. PERCENT vs PERCENTAGE POINTS -->
-      <article class="nn-card">
-        <div class="nn-kicker">Percent vs percentage points</div>
-        <h3>"Risk doubled" — from what to what?</h3>
-        <p class="nn-trap">A drug that takes your risk from 2% to 4% has <em>doubled</em> your risk (+100%, relative) and raised it by <em>2 percentage points</em> (absolute). Both are true. One sells papers. Enter any two rates and see both framings.</p>
+      <article class="nn-card" id="t2">
+        <div class="nn-head"><div class="nn-badge">02</div><div class="nn-htext"><div class="nn-kicker">Percent vs percentage points</div><h3>"Risk doubled" — from what to what?</h3></div></div>
+        <p class="nn-trap">A drug that takes your risk from 2% to 4% has <em>doubled</em> it (+100%, relative) and raised it by <em>2 percentage points</em> (absolute). Both are true. One sells papers. Enter any two rates and see both framings.</p>
         <div class="nn-widget">
           <div class="nn-controls">
             <span class="nn-label">from</span><input class="nn-input" id="nnPctA" type="number" value="2" min="0" max="100" step="0.1" oninput="nnPct()"><span class="nn-label">%</span>
             <span class="nn-label">to</span><input class="nn-input" id="nnPctB" type="number" value="4" min="0" max="100" step="0.1" oninput="nnPct()"><span class="nn-label">%</span>
           </div>
-          <div class="nn-readout" id="nnPctOut"></div>
+          <div class="nn-result" id="nnPctOut"></div>
         </div>
         <p class="nn-takeaway"><b>Ask:</b> percent <em>of what base?</em> A scary relative rise on a tiny base is a tiny absolute change.</p>
       </article>
 
       <!-- 3. BASE RATES -->
-      <article class="nn-card">
-        <div class="nn-kicker">Base rates &amp; false positives</div>
-        <h3>A "99% accurate" test that's usually wrong</h3>
+      <article class="nn-card" id="t3">
+        <div class="nn-head"><div class="nn-badge">03</div><div class="nn-htext"><div class="nn-kicker">Base rates &amp; false positives</div><h3>A "99% accurate" test that's usually wrong</h3></div></div>
         <p class="nn-trap">A test for a rare condition is 99% accurate. You test positive. Your chance of actually having it can still be under 1-in-2 — because when the condition is rare, false positives outnumber true ones. Drag the prevalence and watch.</p>
         <div class="nn-widget">
-          <div class="nn-controls" style="flex-direction:column;align-items:flex-start;gap:.4rem;">
-            <span class="nn-label">How common the condition is: <b id="nnBasePrevLbl" style="color:var(--color-primary)">1 in 1,000</b> &middot; test sensitivity &amp; specificity fixed at 99%</span>
-            <input class="nn-range" id="nnBaseRange" type="range" min="0" max="100" value="20" oninput="nnBase()">
+          <div class="nn-controls col">
+            <span class="nn-label">How common the condition is: <b id="nnBasePrevLbl">1 in 1,000</b> &middot; test sensitivity &amp; specificity fixed at 99%</span>
+            <input class="nn-range" id="nnBaseRange" type="range" min="0" max="100" value="20" oninput="nnBase()" aria-label="Condition prevalence">
           </div>
-          <div class="nn-readout" id="nnBaseOut"></div>
+          <div class="nn-chart"><div class="nn-bars" id="nnBaseBars" style="height:120px;"></div></div>
+          <div class="nn-result" id="nnBaseOut" style="margin-top:.9rem;"></div>
         </div>
         <p class="nn-takeaway"><b>Ask:</b> how common is it to begin with? Accuracy without the base rate is half the story — this is Bayes' theorem in everyday clothes.</p>
       </article>
 
       <!-- 4. TRUNCATED AXIS -->
-      <article class="nn-card">
-        <div class="nn-kicker">The truncated axis</div>
-        <h3>A cliff that's really a gentle slope</h3>
+      <article class="nn-card" id="t4">
+        <div class="nn-head"><div class="nn-badge">04</div><div class="nn-htext"><div class="nn-kicker">The truncated axis</div><h3>A cliff that's really a gentle slope</h3></div></div>
         <p class="nn-trap">The same four numbers — 48, 49, 50, 52 — can look like a dramatic surge or a near-flat line, depending only on where the y-axis starts. Toggle the baseline.</p>
         <div class="nn-widget">
           <div class="nn-controls">
             <button class="nn-btn" data-ax="trunc" onclick="nnAxis('trunc',this)">Axis starts at 47</button>
             <button class="nn-btn active" data-ax="zero" onclick="nnAxis('zero',this)">Axis starts at 0</button>
           </div>
-          <div class="nn-bars" id="nnAxisBars"></div>
+          <div class="nn-chart"><div class="nn-grid-lines" id="nnAxisGrid"></div><div class="nn-bars" id="nnAxisBars"></div></div>
+          <div class="nn-baseline"></div>
           <div class="nn-axisnote" id="nnAxisNote"></div>
         </div>
         <p class="nn-takeaway"><b>Ask:</b> where does the axis start? A bar chart should almost always start at zero. When it doesn't, someone is amplifying a small difference.</p>
       </article>
 
       <!-- 5. CHERRY-PICKED BASELINE -->
-      <article class="nn-card">
-        <div class="nn-kicker">The cherry-picked baseline</div>
-        <h3>"Since 20XX, things have..." — pick the X</h3>
-        <p class="nn-trap">Give me the freedom to choose the starting year and I can make this wobbly series look like steady progress or steady decline — without changing a single data point. Slide the start year.</p>
+      <article class="nn-card" id="t5">
+        <div class="nn-head"><div class="nn-badge">05</div><div class="nn-htext"><div class="nn-kicker">The cherry-picked baseline</div><h3>"Since 20XX, things have…" — pick the X</h3></div></div>
+        <p class="nn-trap">Give me the freedom to choose the starting year and I can make this wobbly series look like steady progress or steady decline — without changing a single data point. Slide the start year and watch the line that's kept fixed.</p>
         <div class="nn-widget">
-          <div class="nn-controls" style="flex-direction:column;align-items:flex-start;gap:.4rem;">
-            <span class="nn-label">Start the story in: <b id="nnCherryYrLbl" style="color:var(--color-primary)">2009</b></span>
-            <input class="nn-range" id="nnCherryRange" type="range" min="0" max="13" value="0" oninput="nnCherry()">
+          <div class="nn-controls col">
+            <span class="nn-label">Start the story in: <b id="nnCherryYrLbl">2009</b></span>
+            <input class="nn-range" id="nnCherryRange" type="range" min="0" max="13" value="0" oninput="nnCherry()" aria-label="Start year">
           </div>
-          <div class="nn-readout" id="nnCherryOut"></div>
+          <div class="nn-chart"><svg id="nnCherrySvg" viewBox="0 0 460 150" width="100%" height="150" preserveAspectRatio="none" aria-hidden="true"></svg></div>
+          <div class="nn-result" id="nnCherryOut" style="margin-top:.6rem;"></div>
         </div>
         <p class="nn-takeaway"><b>Ask:</b> why <em>that</em> start year? An honest trend shows the whole series, not the slice that flatters the argument.</p>
       </article>
 
       <!-- 6. MARGIN OF ERROR -->
-      <article class="nn-card">
-        <div class="nn-kicker">Sample size &amp; margin of error</div>
-        <h3>A "2-point lead" that's really a tie</h3>
-        <p class="nn-trap">A poll says 51% to 49%. With a small sample, the margin of error swamps the gap — the "lead" is noise. Grow the sample and watch the uncertainty shrink.</p>
+      <article class="nn-card" id="t6">
+        <div class="nn-head"><div class="nn-badge">06</div><div class="nn-htext"><div class="nn-kicker">Sample size &amp; margin of error</div><h3>A "2-point lead" that's really a tie</h3></div></div>
+        <p class="nn-trap">A poll says 51% to 49%. With a small sample, the margin of error swamps the gap — the "lead" is noise. Grow the sample and watch the uncertainty bands shrink until they finally separate.</p>
         <div class="nn-widget">
-          <div class="nn-controls" style="flex-direction:column;align-items:flex-start;gap:.4rem;">
-            <span class="nn-label">People surveyed: <b id="nnMoeNLbl" style="color:var(--color-primary)">400</b></span>
-            <input class="nn-range" id="nnMoeRange" type="range" min="0" max="100" value="20" oninput="nnMoe()">
+          <div class="nn-controls col">
+            <span class="nn-label">People surveyed: <b id="nnMoeNLbl">400</b></span>
+            <input class="nn-range" id="nnMoeRange" type="range" min="0" max="100" value="20" oninput="nnMoe()" aria-label="Sample size">
           </div>
-          <div class="nn-readout" id="nnMoeOut"></div>
+          <div class="nn-chart"><svg id="nnMoeSvg" viewBox="0 0 460 96" width="100%" height="96" aria-hidden="true"></svg></div>
+          <div class="nn-result" id="nnMoeOut" style="margin-top:.6rem;"></div>
         </div>
         <p class="nn-takeaway"><b>Ask:</b> how many people, and what's the margin of error? If the gap is smaller than the margin, there is no gap.</p>
       </article>
 
-      <!-- 7. CORRELATION -->
-      <article class="nn-card">
-        <div class="nn-kicker">Correlation isn't causation</div>
-        <h3>The third thing nobody mentioned</h3>
-        <p class="nn-trap">"Children who own more books score higher" — so buy books? Maybe. But richer, more-educated households have both more books <em>and</em> higher scores. The books may be a marker, not a cause. The hidden third variable — the confounder — is where most "X causes Y" headlines quietly fail.</p>
-        <div class="nn-widget" style="display:grid;grid-template-columns:1fr auto 1fr;gap:.5rem;align-items:center;text-align:center;">
-          <div style="font-family:var(--font-mono);font-size:.85rem;padding:.7rem;border:1px solid var(--color-border);border-radius:8px;">Books at home</div>
-          <div style="font-family:var(--font-mono);color:var(--color-text-muted);">&harr;?</div>
-          <div style="font-family:var(--font-mono);font-size:.85rem;padding:.7rem;border:1px solid var(--color-border);border-radius:8px;">Test scores</div>
-          <div style="grid-column:1/4;font-family:var(--font-mono);color:var(--color-accent-pink);font-size:.8rem;margin-top:.3rem;">&uarr; both driven by household income &amp; parental education &uarr;</div>
+      <!-- 7. CONFOUNDER -->
+      <article class="nn-card" id="t7">
+        <div class="nn-head"><div class="nn-badge">07</div><div class="nn-htext"><div class="nn-kicker">Correlation isn't causation</div><h3>The third thing nobody mentioned</h3></div></div>
+        <p class="nn-trap">"Children with more books at home score higher — so buy books!" Maybe. But richer, more-educated households have both more books <em>and</em> higher scores. Compare all children and the slope is steep. Then compare only children <em>within the same income group</em> — and watch it melt.</p>
+        <div class="nn-widget">
+          <div class="nn-controls">
+            <button class="nn-btn active" data-cf="raw" onclick="nnConf('raw',this)">All children</button>
+            <button class="nn-btn" data-cf="ctrl" onclick="nnConf('ctrl',this)">Same income group only</button>
+          </div>
+          <div class="nn-chart"><div class="nn-grid-lines" id="nnConfGrid"></div><div class="nn-bars" id="nnConfBars"></div></div>
+          <div class="nn-baseline"></div>
+          <div class="nn-axisnote" id="nnConfNote"></div>
         </div>
         <p class="nn-takeaway"><b>Ask:</b> what else could explain both? A genuine cause survives the question "what's the confounder?" — see ImpactMojo's work on causal inference.</p>
       </article>
 
       <!-- 8. SURVIVORSHIP -->
-      <article class="nn-card">
-        <div class="nn-kicker">Survivorship &amp; selection</div>
-        <h3>Counting only the winners</h3>
-        <p class="nn-trap">"Most successful founders dropped out of college." But you only hear about the founders who succeeded — the far larger number of dropouts who failed never make the article. When the sample is "those who survived to be counted," the lesson is usually wrong. The planes that came back from war were the ones that <em>could</em>.</p>
-        <p class="nn-takeaway"><b>Ask:</b> who's missing from this data? The failures, the dropouts, the silent — selection decides the story before the numbers do.</p>
+      <article class="nn-card" id="t8">
+        <div class="nn-head"><div class="nn-badge">08</div><div class="nn-htext"><div class="nn-kicker">Survivorship &amp; selection</div><h3>Counting only the planes that came back</h3></div></div>
+        <p class="nn-trap">In WWII, analysts mapped the bullet holes on returning bombers and proposed armouring the spots that were hit most. The statistician Abraham Wald saw the trap: those planes <em>survived</em>. Armour belongs where the holes <em>aren't</em> — the engines and cockpit — because planes hit there never came back to be counted. Toggle what the data shows.</p>
+        <div class="nn-widget">
+          <div class="nn-controls">
+            <button class="nn-btn active" data-sv="seen" onclick="nnSurv('seen',this)">Holes on returning planes</button>
+            <button class="nn-btn" data-sv="armor" onclick="nnSurv('armor',this)">Where the armour should go</button>
+          </div>
+          <svg class="nn-plane" id="nnPlaneSvg" viewBox="0 0 360 200" role="img" aria-label="Diagram of a bomber, top view, showing where damage appears on returning planes versus where armour should actually go"></svg>
+          <div class="nn-result" id="nnSurvOut"></div>
+        </div>
+        <p class="nn-takeaway"><b>Ask:</b> who's missing from this data? "Most successful founders dropped out" forgets the far larger crowd of dropouts who failed. Selection decides the story before the numbers do.</p>
       </article>
 
     </div>
 
     <div class="nn-checklist" style="margin-top:2.5rem;">
       <span class="kicker" style="color:var(--color-accent-pink);font-family:var(--font-mono);font-size:.72rem;letter-spacing:.14em;text-transform:uppercase;">The pocket checklist</span>
-      <h2 style="font-family:var(--font-heading);font-size:1.5rem;margin:.4rem 0 .3rem;">Eight questions for any number</h2>
+      <h2 style="font-family:var(--font-heading);font-size:1.5rem;margin:.4rem 0 .3rem;color:var(--color-text);">Eight questions for any number</h2>
       <ul>
-        <li><b>Out of how many?</b> — a count needs a denominator to mean anything.</li>
-        <li><b>Percent of what base?</b> — relative vs absolute change are different stories.</li>
-        <li><b>How common is it to begin with?</b> — accuracy without the base rate misleads.</li>
-        <li><b>Where does the axis start?</b> — a truncated axis amplifies small gaps.</li>
-        <li><b>Why that start year?</b> — a cherry-picked baseline manufactures trends.</li>
-        <li><b>How big is the sample?</b> — if the gap is under the margin of error, it's noise.</li>
-        <li><b>What's the confounder?</b> — correlation rarely proves causation.</li>
-        <li><b>Who's missing from the data?</b> — selection and survivorship hide the failures.</li>
+        <li><span class="qn">01</span><b>Out of how many?</b> — a count needs a denominator to mean anything.</li>
+        <li><span class="qn">02</span><b>Percent of what base?</b> — relative vs absolute change are different stories.</li>
+        <li><span class="qn">03</span><b>How common is it to begin with?</b> — accuracy without the base rate misleads.</li>
+        <li><span class="qn">04</span><b>Where does the axis start?</b> — a truncated axis amplifies small gaps.</li>
+        <li><span class="qn">05</span><b>Why that start year?</b> — a cherry-picked baseline manufactures trends.</li>
+        <li><span class="qn">06</span><b>How big is the sample?</b> — if the gap is under the margin of error, it's noise.</li>
+        <li><span class="qn">07</span><b>What's the confounder?</b> — correlation rarely proves causation.</li>
+        <li><span class="qn">08</span><b>Who's missing from the data?</b> — selection and survivorship hide the failures.</li>
       </ul>
     </div>
 
@@ -251,124 +306,183 @@
 (function(){function gs(){return window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark';}function ap(t){document.documentElement.setAttribute('data-theme',t==='system'?gs():t);document.body.classList.remove('dark-mode','light-mode');document.body.classList.add((t==='system'?gs():t)==='light'?'light-mode':'dark-mode');}function ub(p){document.querySelectorAll('.im-theme-btn').forEach(function(b){b.classList.toggle('active',b.getAttribute('data-imtheme')===p);});}var sv=localStorage.getItem('im-theme')||'system';ap(sv);document.addEventListener('DOMContentLoaded',function(){ub(sv);document.querySelectorAll('.im-theme-btn').forEach(function(b){b.addEventListener('click',function(){var t=this.getAttribute('data-imtheme');localStorage.setItem('im-theme',t);ap(t);ub(t);});});});window.matchMedia('(prefers-color-scheme: light)').addEventListener('change',function(){if((localStorage.getItem('im-theme')||'system')==='system')ap('system');});})();
 </script>
 <script>
+var ICO_INFO='<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>';
+var ICO_WARN='<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>';
+function res(host, warn, html){
+  host.className = 'nn-result' + (warn?' warn':'');
+  host.innerHTML = '<span class="ico">'+(warn?ICO_WARN:ICO_INFO)+'</span><span class="body">'+html+'</span>';
+}
+function gridlines(host,n){ host.innerHTML=''; for(var i=1;i<n;i++){var s=document.createElement('span'); s.style.top=(i/n*100)+'%'; host.appendChild(s);} }
+
 /* ---- 1. Denominator ---- */
-var NN_DEN = [
-  {name:'State A', deaths:5000, pop:11000000},
-  {name:'State B', deaths:1200, pop:1300000}
-];
-function nnDen(mode, btn){
+var NN_DEN=[{name:'State A',deaths:5000,pop:11000000},{name:'State B',deaths:1200,pop:1300000}];
+function nnDen(mode,btn){
   document.querySelectorAll('[data-den]').forEach(function(b){b.classList.toggle('active',b===btn);});
-  var vals = NN_DEN.map(function(d){ return mode==='count' ? d.deaths : d.deaths/d.pop*100000; });
-  var max = Math.max.apply(null, vals);
-  var host = document.getElementById('nnDenBars'); host.innerHTML='';
+  var vals=NN_DEN.map(function(d){return mode==='count'?d.deaths:d.deaths/d.pop*100000;});
+  var max=Math.max.apply(null,vals);
+  gridlines(document.getElementById('nnDenGrid'),4);
+  var host=document.getElementById('nnDenBars');host.innerHTML='';
   NN_DEN.forEach(function(d,i){
-    var v = vals[i];
-    var disp = mode==='count' ? Math.round(v).toLocaleString() : v.toFixed(1);
-    var w = document.createElement('div'); w.className='nn-bar-wrap';
-    w.innerHTML = '<div class="nn-bar-val">'+disp+'</div>'+
-      '<div class="nn-bar'+(i?' alt':'')+'" style="height:'+(v/max*100)+'%"></div>'+
-      '<div class="nn-bar-lbl">'+d.name+'</div>';
+    var v=vals[i],disp=mode==='count'?Math.round(v).toLocaleString():v.toFixed(1);
+    var w=document.createElement('div');w.className='nn-bar-wrap';
+    w.innerHTML='<div class="nn-bar-val">'+disp+'</div><div class="nn-bar'+(i?' alt':'')+'" style="height:'+(v/max*100)+'%"></div><div class="nn-bar-lbl">'+d.name+'<br>'+(mode==='count'?'deaths':'per 100k')+'</div>';
     host.appendChild(w);
   });
-  var lead = vals[0]>vals[1] ? 'State A' : 'State B';
-  document.getElementById('nnDenNote').innerHTML = mode==='count'
-    ? 'By raw count, <b>State A</b> looks far more dangerous. But it has ~8&times; the population.'
-    : 'Per 100,000 people, <span style="color:var(--color-accent-pink)"><b>'+lead+'</b> is actually higher</span> — the ranking flips.';
+  var lead=vals[0]>vals[1]?'State A':'State B';
+  document.getElementById('nnDenNote').innerHTML=mode==='count'
+    ?'By raw count, State A looks far more dangerous. But it has roughly 8&times; the population of State B.'
+    :'<span class="flip">Per 100,000 people, '+lead+' is actually higher — the ranking flips.</span>';
 }
 
-/* ---- 2. Percent vs percentage points ---- */
+/* ---- 2. Percent vs points ---- */
 function nnPct(){
-  var a=parseFloat(document.getElementById('nnPctA').value)||0;
-  var b=parseFloat(document.getElementById('nnPctB').value)||0;
-  var pp=(b-a);
-  var rel = a===0 ? null : (b-a)/a*100;
-  var relTxt = rel===null ? 'undefined (base is 0)' : (rel>=0?'+':'')+rel.toFixed(0)+'%';
-  document.getElementById('nnPctOut').innerHTML =
-    'Absolute change: <b>'+(pp>=0?'+':'')+pp.toFixed(1)+' percentage points</b><br>'+
-    'Relative change: <span class="flip">'+relTxt+'</span><br>'+
-    '<span style="color:var(--color-text-muted)">Headline writers reach for whichever sounds bigger.</span>';
+  var a=parseFloat(document.getElementById('nnPctA').value)||0,b=parseFloat(document.getElementById('nnPctB').value)||0;
+  var pp=b-a,rel=a===0?null:(b-a)/a*100;
+  var relTxt=rel===null?'undefined (base is 0)':(rel>=0?'+':'')+rel.toFixed(0)+'%';
+  res(document.getElementById('nnPctOut'),false,
+    'Absolute change: <b>'+(pp>=0?'+':'')+pp.toFixed(1)+' percentage points</b>. '+
+    'Relative change: <span class="flip">'+relTxt+'</span>. '+
+    'Same fact — headline writers reach for whichever sounds bigger.');
 }
 
-/* ---- 3. Base rates (Bayes) ---- */
+/* ---- 3. Base rates ---- */
 function nnBase(){
-  var t=parseInt(document.getElementById('nnBaseRange').value,10); // 0..100
-  // map slider to prevalence from 1 in 10,000 (rare) to 1 in 5 (common), log scale
-  var minL=Math.log(1/10000), maxL=Math.log(1/5);
-  var prev=Math.exp(minL+(maxL-minL)*(t/100));
-  var sens=0.99, spec=0.99;
-  var pPos = prev*sens + (1-prev)*(1-spec);
-  var ppv = prev*sens / pPos; // P(disease|positive)
-  var oneIn = Math.round(1/prev);
-  document.getElementById('nnBasePrevLbl').textContent = '1 in '+oneIn.toLocaleString();
-  // illustrate per 100,000
-  var N=100000, have=Math.round(prev*N), dontHave=N-have;
-  var truePos=Math.round(have*sens), falsePos=Math.round(dontHave*(1-spec));
-  document.getElementById('nnBaseOut').innerHTML =
-    'Out of 100,000 people, about <b>'+have.toLocaleString()+'</b> have it.<br>'+
-    'True positives: <b>'+truePos.toLocaleString()+'</b> &nbsp;·&nbsp; False positives: <span class="flip">'+falsePos.toLocaleString()+'</span><br>'+
-    'So if you test positive, your real chance of having it is <b>'+(ppv*100).toFixed(ppv<0.1?1:0)+'%</b>'+
-    (ppv<0.5?' <span class="flip">— more likely a false alarm than the real thing.</span>':' — now the positive is trustworthy.');
+  var t=parseInt(document.getElementById('nnBaseRange').value,10);
+  var minL=Math.log(1/10000),maxL=Math.log(1/5),prev=Math.exp(minL+(maxL-minL)*(t/100));
+  var sens=0.99,spec=0.99,N=100000,have=Math.round(prev*N),dont=N-have;
+  var truePos=Math.round(have*sens),falsePos=Math.round(dont*(1-spec));
+  var ppv=truePos/(truePos+falsePos||1);
+  document.getElementById('nnBasePrevLbl').textContent='1 in '+Math.round(1/prev).toLocaleString();
+  // two-bar viz: true vs false positives
+  var host=document.getElementById('nnBaseBars');host.innerHTML='';
+  var mx=Math.max(truePos,falsePos,1);
+  [['True positives',truePos,false],['False positives',falsePos,true]].forEach(function(p){
+    var w=document.createElement('div');w.className='nn-bar-wrap';
+    w.innerHTML='<div class="nn-bar-val">'+p[1].toLocaleString()+'</div><div class="nn-bar'+(p[2]?' alt':'')+'" style="height:'+(p[1]/mx*100)+'%"></div><div class="nn-bar-lbl">'+p[0]+'</div>';
+    host.appendChild(w);
+  });
+  res(document.getElementById('nnBaseOut'),ppv<0.5,
+    'Of 100,000 people, about <b>'+have.toLocaleString()+'</b> truly have it. A positive result then means a real chance of <b>'+(ppv*100).toFixed(ppv<0.1?1:0)+'%</b>'+
+    (ppv<0.5?' — <span class="flip">more likely a false alarm than the real thing.</span>':' — now the positive is trustworthy.'));
 }
 
 /* ---- 4. Truncated axis ---- */
 var NN_AX=[48,49,50,52];
-function nnAxis(mode, btn){
+function nnAxis(mode,btn){
   document.querySelectorAll('[data-ax]').forEach(function(b){b.classList.toggle('active',b===btn);});
-  var base = mode==='zero' ? 0 : 47;
-  var top = 53;
-  var host=document.getElementById('nnAxisBars'); host.innerHTML='';
+  var base=mode==='zero'?0:47,top=mode==='zero'?60:53;
+  gridlines(document.getElementById('nnAxisGrid'),mode==='zero'?6:6);
+  var host=document.getElementById('nnAxisBars');host.innerHTML='';
   NN_AX.forEach(function(v,i){
-    var h = (v-base)/(top-base)*100;
-    var w=document.createElement('div'); w.className='nn-bar-wrap';
-    w.innerHTML='<div class="nn-bar-val">'+v+'</div>'+
-      '<div class="nn-bar" style="height:'+Math.max(h,1)+'%"></div>'+
-      '<div class="nn-bar-lbl">Q'+(i+1)+'</div>';
+    var h=(v-base)/(top-base)*100;
+    var w=document.createElement('div');w.className='nn-bar-wrap';
+    w.innerHTML='<div class="nn-bar-val">'+v+'</div><div class="nn-bar" style="height:'+Math.max(h,1)+'%"></div><div class="nn-bar-lbl">Q'+(i+1)+'</div>';
     host.appendChild(w);
   });
-  document.getElementById('nnAxisNote').innerHTML = mode==='zero'
-    ? 'Starting at zero: 48 to 52 is a barely-visible rise of about 8%.'
-    : '<span style="color:var(--color-accent-pink)">Starting at 47: the same 8% rise now looks like it <b>quadrupled</b>.</span>';
+  document.getElementById('nnAxisNote').innerHTML=mode==='zero'
+    ?'Starting at zero: 48 to 52 is a barely-visible rise of about 8%.'
+    :'<span class="flip">Starting at 47: the same 8% rise now looks like it quadrupled.</span>';
 }
 
-/* ---- 5. Cherry-picked baseline ---- */
+/* ---- 5. Cherry-picked baseline (line chart) ---- */
 var NN_YEARS=[2009,2010,2011,2012,2013,2014,2015,2016,2017,2018,2019,2020,2021,2022];
-var NN_SERIES=[42,55,48,60,52,47,58,64,51,46,59,68,54,49]; // wobbly, illustrative
+var NN_SERIES=[42,55,48,60,52,47,58,64,51,46,59,68,54,49];
 function nnCherry(){
   var s=parseInt(document.getElementById('nnCherryRange').value,10);
   document.getElementById('nnCherryYrLbl').textContent=NN_YEARS[s];
-  var startV=NN_SERIES[s], endV=NN_SERIES[NN_SERIES.length-1];
-  var diff=endV-startV;
-  var dir = diff>3 ? 'risen' : (diff<-3 ? 'fallen' : 'barely moved');
-  var col = diff>3 ? 'var(--color-accent-blue)' : (diff<-3 ? 'var(--color-accent-pink)' : 'var(--color-text-muted)');
-  document.getElementById('nnCherryOut').innerHTML =
-    '"Since <b>'+NN_YEARS[s]+'</b>, the figure has <b style="color:'+col+'">'+dir+'</b>" &mdash; '+
-    'from '+startV+' to '+endV+' ('+(diff>=0?'+':'')+diff+').<br>'+
-    '<span style="color:var(--color-text-muted)">Same 14 data points every time. Only the start year changed.</span>';
+  var W=460,H=150,pad=10,n=NN_SERIES.length;
+  var mn=Math.min.apply(null,NN_SERIES)-5,mx=Math.max.apply(null,NN_SERIES)+5;
+  function X(i){return pad+i/(n-1)*(W-2*pad);}
+  function Y(v){return H-pad-(v-mn)/(mx-mn)*(H-2*pad);}
+  var full='',hi='';
+  for(var i=0;i<n;i++){full+=(i?'L':'M')+X(i).toFixed(1)+','+Y(NN_SERIES[i]).toFixed(1)+' ';}
+  for(var j=s;j<n;j++){hi+=(j===s?'M':'L')+X(j).toFixed(1)+','+Y(NN_SERIES[j]).toFixed(1)+' ';}
+  var startV=NN_SERIES[s],endV=NN_SERIES[n-1],diff=endV-startV;
+  var dir=diff>3?'risen':(diff<-3?'fallen':'barely moved');
+  var col=diff>3?'var(--color-accent-blue)':(diff<-3?'#d6336c':'var(--color-text-muted)');
+  var svg=document.getElementById('nnCherrySvg');
+  svg.innerHTML=
+    '<path d="'+full+'" fill="none" stroke="var(--color-border)" stroke-width="2"/>'+
+    '<path d="'+hi+'" fill="none" stroke="'+col+'" stroke-width="3" stroke-linejoin="round"/>'+
+    '<line x1="'+X(s)+'" y1="0" x2="'+X(s)+'" y2="'+H+'" stroke="var(--color-primary)" stroke-width="1.5" stroke-dasharray="4,4"/>'+
+    '<circle cx="'+X(s)+'" cy="'+Y(startV)+'" r="5" fill="var(--color-primary)"/>'+
+    '<circle cx="'+X(n-1)+'" cy="'+Y(endV)+'" r="5" fill="'+col+'"/>';
+  res(document.getElementById('nnCherryOut'),false,
+    '"Since <b>'+NN_YEARS[s]+'</b>, the figure has <b style="color:'+col+'">'+dir+'</b>" — from '+startV+' to '+endV+' ('+(diff>=0?'+':'')+diff+'). '+
+    '<span class="nn-note">Same 14 data points every time; only the start year moved.</span>');
 }
 
-/* ---- 6. Margin of error ---- */
+/* ---- 6. Margin of error (bands) ---- */
 function nnMoe(){
-  var t=parseInt(document.getElementById('nnMoeRange').value,10); // 0..100
-  var n=Math.round(50*Math.pow(10, t/100*2.6)); // ~50 to ~20000
+  var t=parseInt(document.getElementById('nnMoeRange').value,10);
+  var n=Math.round(50*Math.pow(10,t/100*2.6));
   document.getElementById('nnMoeNLbl').textContent=n.toLocaleString();
-  var p=0.5;
-  var moe=1.96*Math.sqrt(p*(1-p)/n)*100; // percentage points
-  var gap=2; // the "51 vs 49" gap
-  var verdict = moe>gap
-    ? '<span class="flip">The &plusmn;'+moe.toFixed(1)+'pt margin is bigger than the 2-point gap &mdash; statistically a tie.</span>'
-    : '<b>The &plusmn;'+moe.toFixed(1)+'pt margin is now smaller than the gap &mdash; the lead is real.</b>';
-  document.getElementById('nnMoeOut').innerHTML =
-    'A 51%&ndash;49% result with this sample carries a margin of error of about <b>&plusmn;'+moe.toFixed(1)+' points</b>.<br>'+verdict;
+  var moe=1.96*Math.sqrt(0.25/n)*100, gap=2;
+  var W=460,H=96,cx=W/2,scale=8; // px per point around 50
+  function bx(p){return cx+(p-50)*scale;}
+  var aL=bx(51-moe),aR=bx(51+moe),bL=bx(49-moe),bR=bx(49+moe);
+  var overlap=aL<bR;
+  var svg=document.getElementById('nnMoeSvg');
+  svg.innerHTML=
+    '<text x="6" y="24" font-family="JetBrains Mono" font-size="11" fill="var(--color-accent-blue)">Candidate A · 51%</text>'+
+    '<rect x="'+Math.min(aL,aR)+'" y="30" width="'+Math.abs(aR-aL)+'" height="12" rx="6" fill="var(--color-accent-blue)" opacity="0.85"/>'+
+    '<text x="6" y="62" font-family="JetBrains Mono" font-size="11" fill="#d6336c">Candidate B · 49%</text>'+
+    '<rect x="'+Math.min(bL,bR)+'" y="68" width="'+Math.abs(bR-bL)+'" height="12" rx="6" fill="#d6336c" opacity="0.85"/>'+
+    '<line x1="'+bx(50)+'" y1="26" x2="'+bx(50)+'" y2="86" stroke="var(--color-text-muted)" stroke-width="1" stroke-dasharray="3,3"/>';
+  res(document.getElementById('nnMoeOut'),overlap,
+    'Margin of error: about <b>&plusmn;'+moe.toFixed(1)+' points</b> each. '+
+    (overlap?'<span class="flip">The bands overlap — the 2-point "lead" is statistically a tie.</span>':'<b>The bands have separated — the lead is now real.</b>'));
 }
 
-/* init all */
+/* ---- 7. Confounder ---- */
+function nnConf(mode,btn){
+  document.querySelectorAll('[data-cf]').forEach(function(b){b.classList.toggle('active',b===btn);});
+  var raw=[58,68,80], ctrl=[70,72,74]; // scores by books: few/some/many
+  var vals=mode==='raw'?raw:ctrl;
+  gridlines(document.getElementById('nnConfGrid'),5);
+  var host=document.getElementById('nnConfBars');host.innerHTML='';
+  ['Few books','Some','Many books'].forEach(function(lbl,i){
+    var w=document.createElement('div');w.className='nn-bar-wrap';
+    w.innerHTML='<div class="nn-bar-val">'+vals[i]+'</div><div class="nn-bar'+(mode==='ctrl'?' mut':'')+'" style="height:'+vals[i]+'%"></div><div class="nn-bar-lbl">'+lbl+'</div>';
+    host.appendChild(w);
+  });
+  document.getElementById('nnConfNote').innerHTML=mode==='raw'
+    ?'Across all children, more books tracks a big jump in scores (58 &rarr; 80). Looks causal.'
+    :'<span class="flip">But within one income group, the gap nearly vanishes (70 &rarr; 74). Income drove most of it — books were a marker, not the cause.</span>';
+}
+
+/* ---- 8. Survivorship (Wald's plane) ---- */
+var NN_HOLES_SEEN=[[70,70],[95,60],[120,135],[160,72],[200,150],[235,66],[120,40],[260,120],[300,150],[150,160]];
+var NN_HOLES_GAP=[[180,100],[180,118],[150,95],[210,95]]; // engines + cockpit
+function planeBody(){
+  return '<path d="M180,12 C188,12 192,28 192,48 L250,70 320,84 320,104 192,96 L188,150 220,170 220,182 180,176 140,182 140,170 172,150 L168,96 40,104 40,84 110,70 168,48 C168,28 172,12 180,12 Z" fill="var(--color-border)" opacity="0.55" stroke="var(--color-text-muted)" stroke-width="1.5"/>';
+}
+function nnSurv(mode,btn){
+  document.querySelectorAll('[data-sv]').forEach(function(b){b.classList.toggle('active',b===btn);});
+  var svg=document.getElementById('nnPlaneSvg');
+  var dots='';
+  if(mode==='seen'){
+    NN_HOLES_SEEN.forEach(function(p){dots+='<circle class="hit" cx="'+p[0]+'" cy="'+p[1]+'" r="4.5" fill="#2d3748" stroke="#fff" stroke-width="1"/>';});
+  } else {
+    // faded survivor holes + highlighted armour zones
+    NN_HOLES_SEEN.forEach(function(p){dots+='<circle class="hit" cx="'+p[0]+'" cy="'+p[1]+'" r="3.5" fill="var(--color-text-muted)" opacity="0.35"/>';});
+    NN_HOLES_GAP.forEach(function(p){dots+='<circle class="hit" cx="'+p[0]+'" cy="'+p[1]+'" r="11" fill="none" stroke="#d6336c" stroke-width="2.5"/><circle cx="'+p[0]+'" cy="'+p[1]+'" r="3" fill="#d6336c"/>';});
+  }
+  svg.innerHTML=planeBody()+dots;
+  res(document.getElementById('nnSurvOut'),mode==='armor',
+    mode==='seen'
+    ?'These are the hits on planes that <b>made it home</b>. The instinct: armour where the dots cluster.'
+    :'<span class="flip">Wrong. Armour the empty spots — engines and cockpit.</span> Planes hit there never returned to be counted; the gaps are the danger.');
+}
+
+/* init */
 document.addEventListener('DOMContentLoaded',function(){
   nnDen('count',document.querySelector('[data-den="count"]'));
-  nnPct();
-  nnBase();
+  nnPct(); nnBase();
   nnAxis('zero',document.querySelector('[data-ax="zero"]'));
-  nnCherry();
-  nnMoe();
+  nnCherry(); nnMoe();
+  nnConf('raw',document.querySelector('[data-cf="raw"]'));
+  nnSurv('seen',document.querySelector('[data-sv="seen"]'));
 });
 </script>
 </body>


### PR DESCRIPTION
Follow-up to #594. The two Long View data-literacy pages had solid logic but genuinely sketchy execution — wireframe-style readouts, two of the eight "interactives" missing, and crude evidence-map bubbles. This pass finishes them. Verified with headless screenshots (light + dark, over HTTP so the stylesheet loads).

## Numbers in the News
- **Completed the two missing interactives:** #7 *confounder* (books-vs-scores bars with a steep slope that flattens when you switch to "same income group only") and #8 *survivorship* (Abraham Wald's bomber — toggle the holes on returning planes vs where the armour should actually go).
- **Replaced the wireframe dashed readouts** with finished result panels (icon + colored accent bar, warn state in pink).
- **Real charts:** bar baselines + gridlines; an SVG line chart for the cherry-picked-baseline demo (the kept segment highlighted against the full faded series); SVG confidence bands for margin-of-error that visibly overlap then separate.
- Numbered gradient badges per card, a jump-nav grid, and **fixed the checklist** (was rendering literal `?` glyphs → now numbered `01–08` tiles).

## The Evidence Map
- Bubbles **drop the naked `0–3` number** for a clean sized circle with a confidence ring.
- Added a **colored summary stat strip** (32 pairings · 5 high · 13 mixed · 10 weak · 4 gaps) and a **"Highlight the gaps"** toggle that dims the bubbles and foregrounds the empty cells.

## Validation
- mojibake PASS · both inline scripts pass `node --check` · every `getElementById` target resolves · viewport meta present
- Rendered both pages via Puppeteer over a local HTTP server and inspected the widgets directly (the only "white bars" earlier were a `file://` artifact where the absolute-path stylesheet 404s — confirmed correct over HTTP).

No new files, no registration changes — pure polish of the two existing pages.

https://claude.ai/code/session_01Xpta1BU7c52vLx8u7BEaDj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xpta1BU7c52vLx8u7BEaDj)_