### PR TITLE
Server-side status monitoring, auto-alerts, and site-wide footer link

### DIFF
--- a/404.html
+++ b/404.html
@@ -1743,6 +1743,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul class="footer-links">
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="catalog.html">Course Catalog</a></li>
                     <li><a href="handouts.html">Resource Library</a></li>
                     <li><a href="blog.html">Blog</a></li>

--- a/PAGE-TEMPLATE.html
+++ b/PAGE-TEMPLATE.html
@@ -1447,6 +1447,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/about.html
+++ b/about.html
@@ -2376,6 +2376,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/accessibility.html
+++ b/accessibility.html
@@ -1498,6 +1498,7 @@ body { padding-top: 70px; } /* clear fixed header */
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/account.html
+++ b/account.html
@@ -2850,6 +2850,7 @@ h1, h2, h3, h4, h5, h6 {
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/bct-repository.html
+++ b/bct-repository.html
@@ -1567,6 +1567,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="/handouts">Handouts</a></li>
                     <li><a href="/bct-repository">NudgeKit</a></li>
                     <li><a href="/dataverse">Dataverse</a></li>

--- a/blog.html
+++ b/blog.html
@@ -2696,6 +2696,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul class="footer-links">
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="catalog.html">Course Catalog</a></li>
                     <li><a href="handouts.html">Resource Library</a></li>
                     <li><a href="blog.html">Blog</a></li>

--- a/catalog.html
+++ b/catalog.html
@@ -2185,6 +2185,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href='/blog'>Blog</a></li>
                     <li><a href='/podcast'>Podcast</a></li>
                     <li><a href='/handouts'>Handouts</a></li>

--- a/challenges.html
+++ b/challenges.html
@@ -877,6 +877,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="/handouts">Handouts</a></li>
                     <li><a href="/bct-repository">NudgeKit</a></li>
                     <li><a href="/dataverse">Dataverse</a></li>

--- a/data-protection.html
+++ b/data-protection.html
@@ -1804,6 +1804,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/dataverse.html
+++ b/dataverse.html
@@ -1820,6 +1820,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="/handouts">Handouts</a></li>
                     <li><a href="/bct-repository">NudgeKit</a></li>
                     <li><a href="/dataverse">Dataverse</a></li>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -1259,6 +1259,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,22 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.64.0 — June 8, 2026 (Status monitoring: real uptime + auto-alerts)
+
+### For Learners
+
+- **Real 90-day uptime on the Status page** — the status page now shows true availability measured across all visitors (not just your own browser), backed by a server-side health check that runs every 15 minutes. A "System Status" link now appears in the site footer across the platform.
+
+### Added
+
+- Server-side status monitoring: `netlify/functions/status-probe.mjs` (scheduled every 15 min) probes all 11 components, stores a 90-day history in Netlify Blobs, and is flap-resistant (an outage is only declared after 2 consecutive failed checks). `netlify/functions/status-history.mjs` serves that history at `/api/status-history` for the page to render.
+- Automated incident alerts: on a confirmed outage the probe auto-opens a GitHub issue (auto-closed on recovery) and sends an email via a new self-contained `supabase/functions/status-alert` function (Resend). Light auto-remediation fires a Supabase keepalive when the backend looks down (the common free-tier auto-pause). Both alert paths degrade gracefully when their credentials are absent.
+- "System Status" footer link added across 33 top-level pages.
+
+### Fixed
+
+- Status page no longer reports the Supabase backend as "down": the probe now sends the public anon key to `/auth/v1/health` (which 401s without it) and treats any non-5xx response as reachable.
+
 ## v10.63.0 — June 8, 2026 (System Status page)
 
 ### For Learners

--- a/faq.html
+++ b/faq.html
@@ -1875,6 +1875,7 @@ body.dark-mode .badge-free, body.dark-mode .badge-status-live, body.dark-mode .s
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/forgot-password.html
+++ b/forgot-password.html
@@ -1956,6 +1956,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/grievance.html
+++ b/grievance.html
@@ -1685,6 +1685,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/handouts.html
+++ b/handouts.html
@@ -1431,6 +1431,7 @@ body.dark-mode .badge-free, body.dark-mode .badge-status-live, body.dark-mode .s
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="/handouts">Educational Handouts</a></li>
                     <li><a href="/blog">Learning Loops Blog</a></li>
                     <li><a href="/podcast">Between the Logframes</a></li>

--- a/index.html
+++ b/index.html
@@ -6359,7 +6359,7 @@ window.addEventListener('authStateChanged', function(e) {
 </div>
 <div class="footer-section">
 <h4>Resources</h4>
-<ul>
+<ul><li><a href="/status.html">System Status</a></li>
 <li><a href='/handouts'>Educational Handouts</a></li>
 <li><a href='/blog'>Learning Loops Blog</a></li>
 <li><a href='/podcast'>Between the Logframes</a></li>

--- a/login.html
+++ b/login.html
@@ -1811,6 +1811,7 @@ body.dark-mode .badge-free, body.dark-mode .badge-status-live, body.dark-mode .s
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/netlify/functions/status-history.mjs
+++ b/netlify/functions/status-history.mjs
@@ -1,0 +1,36 @@
+/**
+ * Netlify Function — Status History reader
+ *
+ * Serves the cross-visitor status history that status-probe.mjs writes to the
+ * "status" Netlify Blobs store, so /status.html can render a TRUE 90-day uptime
+ * view aggregated across all visitors (not just the viewer's localStorage).
+ *
+ * GET /api/status-history  ->  { updatedAt, days: {YYYY-MM-DD: {overall, components}}, components: {...} }
+ *
+ * Returns an empty payload (200) until the scheduled probe has run at least
+ * once, so the page can fall back to its local history without erroring.
+ */
+export default async () => {
+  const headers = {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+    "Cache-Control": "public, max-age=60, must-revalidate",
+  };
+  try {
+    const { getStore } = await import("@netlify/blobs");
+    const store = getStore("status");
+    const [history, state] = await Promise.all([
+      store.get("history", { type: "json" }),
+      store.get("state", { type: "json" }),
+    ]);
+    return new Response(JSON.stringify({
+      updatedAt: state?.updatedAt || null,
+      days: history || {},
+      components: state?.components || {},
+    }), { headers });
+  } catch (e) {
+    return new Response(JSON.stringify({ updatedAt: null, days: {}, components: {}, error: e.message }), { headers });
+  }
+};
+
+export const config = { path: "/api/status-history" };

--- a/netlify/functions/status-probe.mjs
+++ b/netlify/functions/status-probe.mjs
@@ -1,0 +1,240 @@
+/**
+ * Netlify Scheduled Function — Server-side Status Probe
+ *
+ * Runs every 15 minutes, probes every ImpactMojo component from the server
+ * (no CORS limits, real HTTP status codes), and persists results to a
+ * Netlify Blobs store ("status") so the public /status.html page can show a
+ * TRUE cross-visitor 90-day uptime history (not just per-browser localStorage).
+ *
+ * It is also the alerting brain:
+ *   - Flap-resistant: a component is only declared "down" after 2 consecutive
+ *     failed probes (~30 min), and "recovered" after 1 clean probe.
+ *   - On a confirmed outage it auto-opens a GitHub issue (which emails repo
+ *     watchers) and sends an email alert via the Supabase `status-alert`
+ *     function; on recovery it auto-closes the issue and sends an all-clear.
+ *   - Light auto-remediation: if Supabase looks down it fires a keepalive
+ *     ping (the #1 real cause is the free-tier project pausing).
+ *
+ * Storage keys in the "status" blob store:
+ *   history → { "YYYY-MM-DD": { overall, components: {id: level} } }   (~120d)
+ *   state   → { components: {id: {level, fails, since, issue}}, updatedAt }
+ *
+ * Optional environment variables (set in the Netlify dashboard):
+ *   URL / SITE_URL              — deploy URL (Netlify sets URL automatically)
+ *   SUPABASE_URL               — Supabase project URL
+ *   SUPABASE_ANON_KEY          — public anon key (for the auth health probe)
+ *   SUPABASE_SERVICE_ROLE_KEY  — for the Supabase auto-wake remediation
+ *   GITHUB_TOKEN               — repo-scoped PAT to auto-open/close issues
+ *   STATUS_ALERT_EMAIL         — where outage emails go (default below)
+ *
+ * Every alerting/remediation step degrades gracefully: a missing token just
+ * logs a notice and skips, it never breaks the probe loop.
+ */
+
+const SITE_URL = (process.env.URL || process.env.SITE_URL || "https://www.impactmojo.in").replace(/\/$/, "");
+const SUPABASE_URL = (process.env.SUPABASE_URL || "https://ddyszmfffyedolkcugld.supabase.co").replace(/\/$/, "");
+const SUPABASE_ANON = process.env.SUPABASE_ANON_KEY ||
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRkeXN6bWZmZnllZG9sa2N1Z2xkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQ3MzMxMzEsImV4cCI6MjA4MDMwOTEzMX0.vPLlFkC3pqOBtofZ8B6_FBLbRfOKwlyv3DzLvJBS16w";
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN || process.env.GITHUB_PAT;
+const ALERT_EMAIL = process.env.STATUS_ALERT_EMAIL || "hello@impactmojo.in";
+const REPO = "ImpactMojo/ImpactMojo";
+
+const SLOW_MS = 2000;     // slower than this = degraded
+const TIMEOUT_MS = 10000; // no response by this = down
+const DOWN_AFTER = 2;     // consecutive fails before declaring an outage
+const HISTORY_DAYS = 120; // keep ~4 months, page renders last 90
+
+const RANK = { up: 0, degraded: 1, down: 2 };
+const RANK_REV = ["up", "degraded", "down"];
+const LABELS = { up: "Operational", degraded: "Degraded", down: "Down" };
+
+const COMPONENTS = [
+  { id: "home",      name: "Website",            url: SITE_URL + "/",                          type: "page" },
+  { id: "catalog",   name: "Course Catalog",     url: SITE_URL + "/catalog.html",              type: "page" },
+  { id: "games",     name: "Game Library",       url: SITE_URL + "/game-library.html",         type: "page" },
+  { id: "handouts",  name: "Resource Library",   url: SITE_URL + "/handouts.html",             type: "page" },
+  { id: "blog",      name: "Blog",               url: SITE_URL + "/blog.html",                 type: "page" },
+  { id: "docs",      name: "Documentation",      url: SITE_URL + "/docs/",                     type: "page" },
+  { id: "search",    name: "Search Index",       url: SITE_URL + "/data/search-index.json",    type: "json" },
+  { id: "deploy",    name: "Hosting & CDN",      url: SITE_URL + "/version.json",              type: "json" },
+  { id: "translate", name: "Translation Service",url: SITE_URL + "/.netlify/functions/translate", type: "fn" },
+  { id: "supabase",  name: "Accounts & Backend", url: SUPABASE_URL + "/auth/v1/health",        type: "fn", headers: { apikey: SUPABASE_ANON } },
+  { id: "github",    name: "Source & Content",   url: "https://api.github.com/repos/" + REPO,  type: "fn",
+    headers: { "User-Agent": "impactmojo-status", ...(GITHUB_TOKEN ? { Authorization: `Bearer ${GITHUB_TOKEN}` } : {}) } },
+];
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+async function probe(c) {
+  const start = Date.now();
+  const headers = c.headers || {};
+  try {
+    let res, level;
+    const opts = { headers, signal: AbortSignal.timeout(TIMEOUT_MS), redirect: "follow" };
+    if (c.type === "page") {
+      res = await fetch(c.url, { ...opts, method: "HEAD" });
+      level = res.ok ? "up" : "down";
+    } else if (c.type === "json") {
+      res = await fetch(c.url, { ...opts, method: "GET" });
+      if (res.ok) { await res.json(); level = "up"; } else { level = "down"; }
+    } else { // fn — any non-5xx response means reachable
+      res = await fetch(c.url, { ...opts, method: "GET" });
+      level = res.status >= 500 ? "down" : "up";
+    }
+    const ms = Date.now() - start;
+    if (level === "up" && ms > SLOW_MS) level = "degraded";
+    return { level, ms, code: res.status };
+  } catch (e) {
+    return { level: "down", ms: Date.now() - start, code: e.name === "TimeoutError" ? "timeout" : "error" };
+  }
+}
+
+/* ---- Light auto-remediation (only for tractable, known failure modes) ---- */
+async function remediate(id) {
+  if (id === "supabase" && SERVICE_KEY) {
+    // The overwhelmingly common cause of a Supabase free-tier outage is the
+    // project auto-pausing after inactivity. A REST + auth ping counts as
+    // activity and nudges it back awake (same mechanism as supabase-keepalive).
+    try {
+      await fetch(`${SUPABASE_URL}/rest/v1/?select=1`, {
+        headers: { apikey: SERVICE_KEY, Authorization: `Bearer ${SERVICE_KEY}` },
+        signal: AbortSignal.timeout(8000),
+      });
+      await fetch(`${SUPABASE_URL}/auth/v1/settings`, {
+        headers: { apikey: SERVICE_KEY, Authorization: `Bearer ${SERVICE_KEY}` },
+        signal: AbortSignal.timeout(8000),
+      });
+      return "fired supabase keepalive (auto-wake)";
+    } catch (e) {
+      return "supabase auto-wake failed: " + e.message;
+    }
+  }
+  return null;
+}
+
+/* ---- GitHub issue alerting (emails repo watchers automatically) ---- */
+async function githubRequest(method, path, body) {
+  if (!GITHUB_TOKEN) return null;
+  const res = await fetch(`https://api.github.com${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${GITHUB_TOKEN}`,
+      Accept: "application/vnd.github+json",
+      "User-Agent": "impactmojo-status",
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) { console.log(`[status] GitHub ${method} ${path} -> ${res.status}`); return null; }
+  return res.json();
+}
+async function openIssue(c, r, note) {
+  const data = await githubRequest("POST", `/repos/${REPO}/issues`, {
+    title: `🔴 Status: ${c.name} is down`,
+    body: `Automated alert from the status monitor.\n\n` +
+          `- **Component:** ${c.name} (\`${c.id}\`)\n` +
+          `- **URL:** ${c.url}\n` +
+          `- **Result:** ${LABELS[r.level]} (code: ${r.code}, ${r.ms} ms)\n` +
+          `- **Detected:** ${new Date().toISOString()}\n` +
+          (note ? `- **Auto-remediation:** ${note}\n` : "") +
+          `\nThis issue will auto-close when the component recovers. ` +
+          `Live status: ${SITE_URL}/status.html`,
+    labels: ["status", "incident"],
+  });
+  return data ? data.number : null;
+}
+async function closeIssue(num, c) {
+  if (!num) return;
+  await githubRequest("POST", `/repos/${REPO}/issues/${num}/comments`, {
+    body: `✅ Recovered — ${c.name} is responding normally again as of ${new Date().toISOString()}. Auto-closing.`,
+  });
+  await githubRequest("PATCH", `/repos/${REPO}/issues/${num}`, { state: "closed" });
+}
+
+/* ---- Email alert via the Supabase status-alert function (uses Resend) ---- */
+async function sendAlertEmail(subject, html) {
+  if (!SERVICE_KEY) { console.log("[status] no service key — skipping email"); return; }
+  try {
+    const res = await fetch(`${SUPABASE_URL}/functions/v1/status-alert`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${SERVICE_KEY}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ to: ALERT_EMAIL, subject, html }),
+      signal: AbortSignal.timeout(8000),
+    });
+    console.log(`[status] alert email -> ${res.status}`);
+  } catch (e) {
+    console.log("[status] alert email failed:", e.message);
+  }
+}
+
+export default async () => {
+  const { getStore } = await import("@netlify/blobs");
+  const store = getStore("status");
+
+  const history = (await store.get("history", { type: "json" })) || {};
+  const state = (await store.get("state", { type: "json" })) || { components: {} };
+  const day = today();
+  history[day] = history[day] || { overall: 0, components: {} };
+
+  const results = await Promise.all(COMPONENTS.map(async (c) => ({ c, r: await probe(c) })));
+
+  for (const { c, r } of results) {
+    // roll today's worst observation per component + overall
+    history[day].components[c.id] = Math.max(history[day].components[c.id] ?? 0, RANK[r.level]);
+    history[day].overall = Math.max(history[day].overall, RANK[r.level]);
+
+    const prev = state.components[c.id] || { level: "up", fails: 0, since: null, issue: null };
+    const failing = r.level === "down";
+    const fails = failing ? prev.fails + 1 : 0;
+    const next = { level: r.level, fails, since: prev.since, issue: prev.issue, code: r.code, ms: r.ms };
+
+    // transition: healthy -> confirmed outage
+    if (failing && fails >= DOWN_AFTER && prev.level !== "down") {
+      const note = await remediate(c.id);
+      next.level = "down";
+      next.since = new Date().toISOString();
+      console.log(`[status] OUTAGE: ${c.name} (${r.code}) ${note || ""}`);
+      next.issue = await openIssue(c, r, note);
+      await sendAlertEmail(
+        `🔴 ImpactMojo status: ${c.name} is down`,
+        `<p><strong>${c.name}</strong> failed ${fails} consecutive checks (code ${r.code}, ${r.ms} ms).</strong></p>` +
+        (note ? `<p>Auto-remediation: ${note}.</p>` : "") +
+        `<p>Live status: <a href="${SITE_URL}/status.html">${SITE_URL}/status.html</a></p>`
+      );
+    } else if (failing && prev.level !== "down") {
+      next.level = prev.level; // not yet confirmed — hold previous level
+    }
+
+    // transition: was down -> recovered
+    if (!failing && prev.level === "down") {
+      console.log(`[status] RECOVERED: ${c.name}`);
+      await closeIssue(prev.issue, c);
+      await sendAlertEmail(
+        `✅ ImpactMojo status: ${c.name} recovered`,
+        `<p><strong>${c.name}</strong> is responding normally again (code ${r.code}, ${r.ms} ms).</p>`
+      );
+      next.issue = null;
+      next.since = null;
+    }
+
+    state.components[c.id] = next;
+  }
+
+  // prune history to HISTORY_DAYS
+  const cutoff = new Date(Date.now() - HISTORY_DAYS * 864e5).toISOString().slice(0, 10);
+  for (const k of Object.keys(history)) if (k < cutoff) delete history[k];
+
+  state.updatedAt = new Date().toISOString();
+  await store.setJSON("history", history);
+  await store.setJSON("state", state);
+
+  const summary = results.map(({ c, r }) => `${c.id}:${r.level}`).join(" ");
+  console.log(`[status] probed ${results.length} components — ${summary}`);
+  return new Response(JSON.stringify({ ok: true, updatedAt: state.updatedAt }), {
+    headers: { "Content-Type": "application/json" },
+  });
+};
+
+// Every 15 minutes
+export const config = { schedule: "*/15 * * * *" };

--- a/org-dashboard.html
+++ b/org-dashboard.html
@@ -2368,6 +2368,7 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/podcast.html
+++ b/podcast.html
@@ -1842,6 +1842,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/portfolio.html
+++ b/portfolio.html
@@ -892,7 +892,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
             <div class="footer-section"><h4>Quick Links</h4><ul><li><a href="catalog.html">Course Catalog</a></li><li><a href="premium.html">Premium Access</a></li><li><a href="faq.html">FAQ</a></li>
 <li><a href="/docs/" rel="noopener noreferrer" target="_blank">Documentation</a></li>
 </ul></div>
-            <div class="footer-section"><h4>Resources</h4><ul><li><a href="blog.html">Blog</a></li><li><a href="podcast.html">Podcast</a></li><li><a href="handouts.html">Handouts</a></li></ul></div>
+            <div class="footer-section"><h4>Resources</h4><ul><li><a href="/status.html">System Status</a></li><li><a href="blog.html">Blog</a></li><li><a href="podcast.html">Podcast</a></li><li><a href="handouts.html">Handouts</a></li></ul></div>
         </div>
         <div class="footer-bottom">
             <p class="footer-copyright">&copy; 2024-2026 ImpactMojo. All rights reserved. Made with &lt;3 in India.</p>

--- a/premium.html
+++ b/premium.html
@@ -2196,6 +2196,7 @@ body{padding-top:74px}
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1195,6 +1195,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/refund-policy.html
+++ b/refund-policy.html
@@ -1346,6 +1346,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/signup.html
+++ b/signup.html
@@ -2066,6 +2066,7 @@ body.dark-mode .badge-free, body.dark-mode .badge-status-live, body.dark-mode .s
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/status.html
+++ b/status.html
@@ -427,7 +427,7 @@ main .nav-links a, main .footer a, main a.refresh-btn { text-decoration: none; }
 
         <!-- 90-day overall uptime -->
         <div class="group">
-            <h3>90-Day Uptime (this browser)</h3>
+            <h3 id="uptimeHeading">90-Day Uptime</h3>
             <div class="component-list">
                 <div class="uptime-block">
                     <div class="uptime-head">
@@ -656,6 +656,24 @@ function loadHistory() {
     try { return JSON.parse(localStorage.getItem(HISTORY_KEY)) || {}; }
     catch (e) { return {}; }
 }
+/* Cross-visitor history written server-side by status-probe.mjs (every 15min).
+   Falls back to per-browser localStorage if the endpoint isn't live yet. */
+let usingServerHistory = false;
+async function loadServerHistory() {
+    try {
+        const res = await fetch('/api/status-history', { cache: 'no-store' });
+        if (!res.ok) return null;
+        const data = await res.json();
+        const days = data && data.days ? Object.keys(data.days) : [];
+        if (!days.length) return null;
+        const norm = {};
+        for (const d of days) {
+            const v = data.days[d];
+            norm[d] = (v && typeof v === 'object') ? (v.overall || 0) : (v || 0);
+        }
+        return { hist: norm, updatedAt: data.updatedAt };
+    } catch (e) { return null; }
+}
 function recordHistory(overallLevel) {
     const hist = loadHistory();
     const d = today();
@@ -702,8 +720,19 @@ async function runAllChecks() {
 
     paintBanner(results);
     const worst = RANK_REV[Math.max(...results.map(r => RANK[r.level]))];
-    const hist = recordHistory(worst);
-    renderUptime(hist);
+    const localHist = recordHistory(worst); // always keep a local fallback
+
+    // Prefer the cross-visitor server history; fall back to this browser's.
+    const server = await loadServerHistory();
+    const heading = document.getElementById('uptimeHeading');
+    if (server) {
+        usingServerHistory = true;
+        renderUptime(server.hist);
+        heading.textContent = '90-Day Uptime (all visitors)';
+    } else {
+        renderUptime(localHist);
+        heading.textContent = '90-Day Uptime (this browser)';
+    }
 
     document.getElementById('lastChecked').textContent =
         'Last checked: ' + new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });

--- a/supabase/functions/status-alert/index.ts
+++ b/supabase/functions/status-alert/index.ts
@@ -1,0 +1,79 @@
+// Supabase Edge Function — status-alert
+//
+// Sends an outage / recovery email for the ImpactMojo status monitor. Kept
+// deliberately separate from `send-notification` so the status pipeline can
+// never affect onboarding/newsletter email delivery.
+//
+// Called server-to-server by netlify/functions/status-probe.mjs:
+//   POST /functions/v1/status-alert
+//   Authorization: Bearer <SERVICE_ROLE_KEY>
+//   { "to": "hello@impactmojo.in", "subject": "...", "html": "..." }
+//
+// Environment:
+//   RESEND_API_KEY            — required for delivery (shared with send-notification)
+//   STATUS_ALERT_FROM         — optional From address (default below)
+//   SUPABASE_SERVICE_ROLE_KEY — used only to authorize the caller
+//
+// If RESEND_API_KEY is unset it returns 200 {skipped:true} so the probe never
+// breaks; auth failures return 401.
+
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+
+const FROM = Deno.env.get("STATUS_ALERT_FROM") || "ImpactMojo Status <status@impactmojo.in>";
+const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, content-type",
+  "Content-Type": "application/json",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "POST only" }), { status: 405, headers: corsHeaders });
+  }
+
+  // Only the service role may trigger alerts.
+  const auth = req.headers.get("Authorization") || "";
+  if (!SERVICE_KEY || auth !== `Bearer ${SERVICE_KEY}`) {
+    return new Response(JSON.stringify({ error: "unauthorized" }), { status: 401, headers: corsHeaders });
+  }
+
+  let body: { to?: string; subject?: string; html?: string };
+  try { body = await req.json(); } catch { return new Response(JSON.stringify({ error: "bad json" }), { status: 400, headers: corsHeaders }); }
+  const { to, subject, html } = body;
+  if (!to || !subject || !html) {
+    return new Response(JSON.stringify({ error: "to, subject, html required" }), { status: 400, headers: corsHeaders });
+  }
+
+  const resendKey = Deno.env.get("RESEND_API_KEY");
+  if (!resendKey) {
+    console.log("RESEND_API_KEY not set — skipping status email");
+    return new Response(JSON.stringify({ skipped: true, reason: "no RESEND_API_KEY" }), { headers: corsHeaders });
+  }
+
+  const wrapped = `<div style="font-family:Inter,Helvetica,Arial,sans-serif;max-width:560px;margin:0 auto;color:#0F172A">
+    <h2 style="font-size:18px;margin:0 0 12px">${subject}</h2>
+    <div style="font-size:15px;line-height:1.6;color:#334155">${html}</div>
+    <hr style="border:none;border-top:1px solid #E2E8F0;margin:20px 0">
+    <p style="font-size:12px;color:#94A3B8">Automated message from the ImpactMojo status monitor.</p>
+  </div>`;
+
+  try {
+    const resp = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${resendKey}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ from: FROM, to: [to], subject, html: wrapped }),
+    });
+    if (!resp.ok) {
+      const txt = await resp.text();
+      console.error("Resend error:", resp.status, txt);
+      return new Response(JSON.stringify({ error: "resend failed", status: resp.status }), { status: 502, headers: corsHeaders });
+    }
+    return new Response(JSON.stringify({ sent: true }), { headers: corsHeaders });
+  } catch (err) {
+    console.error("status-alert send failed:", err);
+    return new Response(JSON.stringify({ error: String(err) }), { status: 500, headers: corsHeaders });
+  }
+});

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -1295,6 +1295,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/testimonials.html
+++ b/testimonials.html
@@ -903,6 +903,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="/handouts">Handouts</a></li>
                     <li><a href="/bct-repository">NudgeKit</a></li>
                     <li><a href="/dataverse">Dataverse</a></li>

--- a/toc-builder.html
+++ b/toc-builder.html
@@ -1314,7 +1314,7 @@ document.addEventListener('keydown', function(e){
 </div>
 <div class="im-footer-section">
 <h4>Resources</h4>
-<ul>
+<ul><li><a href="/status.html">System Status</a></li>
 <li><a href="/handouts.html">Handouts</a></li>
 <li><a href="/blog.html">Blog</a></li>
 <li><a href="/faq.html">FAQ</a></li>

--- a/toc-workbench.html
+++ b/toc-workbench.html
@@ -1327,6 +1327,7 @@ window.addEventListener('scroll', function(){
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="/handouts">Handouts</a></li>
                     <li><a href="/bct-repository">NudgeKit</a></li>
                     <li><a href="/dataverse">Dataverse</a></li>

--- a/transparency.html
+++ b/transparency.html
@@ -967,6 +967,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="/handouts">Handouts</a></li>
                     <li><a href="/bct-repository">NudgeKit</a></li>
                     <li><a href="/dataverse">Dataverse</a></li>

--- a/updates.html
+++ b/updates.html
@@ -916,6 +916,7 @@ body { padding-top: 70px; }
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/verify-certificate.html
+++ b/verify-certificate.html
@@ -880,6 +880,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/workshops.html
+++ b/workshops.html
@@ -1579,6 +1579,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
             <div class="footer-section">
                 <h4>Resources</h4>
                 <ul>
+                    <li><a href="/status.html">System Status</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>


### PR DESCRIPTION
Builds on the status page with true cross-visitor uptime, automated incident alerting, and discoverability.

## Server-side monitoring
- **`netlify/functions/status-probe.mjs`** (scheduled every 15 min) probes all 11 components from the server (no CORS limits, real status codes), stores a 90-day history in **Netlify Blobs**, and is **flap-resistant** — an outage is only declared after 2 consecutive failed checks.
- **`netlify/functions/status-history.mjs`** serves that shared history at **`/api/status-history`**.
- **`status.html`** now renders **true cross-visitor 90-day uptime** from the endpoint, falling back to per-browser `localStorage` when it isn't live yet.

## Automated alerts + remediation
- On a confirmed outage the probe **auto-opens a GitHub issue** (auto-closed on recovery — GitHub emails watchers) and **sends an email** via a new, self-contained **`supabase/functions/status-alert`** (Resend), kept separate from `send-notification` so it can never affect onboarding mail.
- **Light auto-remediation**: a Supabase keepalive ping fires when the backend looks down (the common free-tier auto-pause).
- Every alert/remediation path **degrades gracefully** when its credentials are absent.

## Discoverability
- **"System Status" footer link** added across 33 top-level pages.

## Activation notes (post-merge)
- Netlify functions deploy automatically. For full alerting, two secrets are needed: `GITHUB_TOKEN` (Netlify env, for issue alerts) and the `status-alert` Supabase function deployed with `RESEND_API_KEY` + optional `STATUS_ALERT_EMAIL`. Until then, the probe + history + page + footer all work; alerts simply no-op.

Verified: inline JS + both `.mjs` pass `node --check`; `status-alert.ts` brace-balanced; mojibake guard passes; footer insert verified across all three footer style variants.

https://claude.ai/code/session_01D7jhwxK4U2r5AfuzCsEcXL

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7jhwxK4U2r5AfuzCsEcXL)_