### PR TITLE
Add ToR Builder tool and Products &amp; Kits hub page

### DIFF
--- a/BookCompanionTools/tor-generator.html
+++ b/BookCompanionTools/tor-generator.html
@@ -1,0 +1,709 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ToR Builder — Terms of Reference Generator | ImpactMojo</title>
+<meta name="description" content="Free interactive Terms of Reference (ToR) generator for commissioning development research and evaluations. Build a complete ToR plus a costing sheet and export as Markdown or PDF.">
+<meta name="robots" content="index, follow">
+<meta property="og:title" content="ToR Builder — Terms of Reference Generator | ImpactMojo">
+<meta property="og:description" content="Build a complete, well-structured Terms of Reference (plus a costing sheet) for commissioning research or evaluation — and export it in one click.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://www.impactmojo.in/BookCompanionTools/tor-generator.html">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="ToR Builder — Terms of Reference Generator | ImpactMojo">
+<meta name="twitter:description" content="Build a complete Terms of Reference plus a costing sheet and export in one click.">
+
+<!-- Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-JRCMEB9TBW');
+</script>
+
+<link href="https://fonts.googleapis.com" rel="preconnect">
+<link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&amp;family=Inter:wght@400;500;600;700;800&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
+
+<link rel="icon" type="image/png" href="/assets/images/favicon.png">
+<link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">
+<link rel="manifest" href="/manifest.json">
+<meta name="theme-color" content="#0EA5E9">
+
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+:root {
+    --primary-bg:#F8FAFC; --secondary-bg:#FFFFFF; --accent-color:#0284C7; --accent-hover:#0369A1;
+    --secondary-accent:#6366F1; --success-color:#16A34A; --warning-color:#D97706; --danger-color:#DC2626;
+    --text-primary:#0F172A; --text-secondary:#475569; --text-muted:#64748B;
+    --card-bg:#FFFFFF; --hover-bg:#F1F5F9; --border-color:#E2E8F0; --nav-bg:rgba(248,250,252,0.95);
+    --shadow-sm:0 1px 2px rgba(0,0,0,.04); --shadow-md:0 4px 6px rgba(0,0,0,.06); --shadow-lg:0 10px 25px rgba(0,0,0,.08);
+    --gradient-primary:linear-gradient(135deg,#0369A1 0%,#4338CA 100%);
+}
+@media (prefers-color-scheme: dark){:root{
+    --primary-bg:#0F172A; --secondary-bg:#1E293B; --accent-color:#0EA5E9; --accent-hover:#0284C7;
+    --success-color:#10B981; --warning-color:#F59E0B; --danger-color:#EF4444;
+    --text-primary:#F1F5F9; --text-secondary:#CBD5E1; --text-muted:#94A3B8;
+    --card-bg:#1E293B; --hover-bg:#334155; --border-color:#334155; --nav-bg:rgba(15,23,42,0.95);
+    --shadow-sm:0 1px 2px rgba(0,0,0,.1); --shadow-md:0 4px 6px rgba(0,0,0,.2); --shadow-lg:0 10px 25px rgba(0,0,0,.3);
+}}
+body.light-mode{
+    --primary-bg:#F8FAFC; --secondary-bg:#FFFFFF; --accent-color:#0284C7; --accent-hover:#0369A1;
+    --success-color:#16A34A; --warning-color:#D97706; --danger-color:#DC2626;
+    --text-primary:#0F172A; --text-secondary:#475569; --text-muted:#64748B;
+    --card-bg:#FFFFFF; --hover-bg:#F1F5F9; --border-color:#E2E8F0; --nav-bg:rgba(248,250,252,0.95);
+}
+body.dark-mode{
+    --primary-bg:#0F172A; --secondary-bg:#1E293B; --accent-color:#0EA5E9; --accent-hover:#0284C7;
+    --success-color:#10B981; --warning-color:#F59E0B; --danger-color:#EF4444;
+    --text-primary:#F1F5F9; --text-secondary:#CBD5E1; --text-muted:#94A3B8;
+    --card-bg:#1E293B; --hover-bg:#334155; --border-color:#334155; --nav-bg:rgba(15,23,42,0.95);
+}
+html{scroll-behavior:smooth;}
+body{font-family:'Amaranth',Arial,sans-serif; background:var(--primary-bg); color:var(--text-primary); line-height:1.6; padding-top:56px; min-height:100vh;}
+h1,h2,h3,h4{font-family:'Inter',Helvetica,sans-serif; line-height:1.3;}
+a{color:var(--accent-color); text-decoration:none;}
+a:hover{color:var(--accent-hover);}
+code,.mono{font-family:'JetBrains Mono',monospace;}
+
+.skip-link{position:absolute;left:-999px;top:0;z-index:10000;background:var(--accent-color);color:#fff;padding:.6rem 1rem;border-radius:0 0 8px 0;}
+.skip-link:focus{left:0;}
+
+/* Topbar */
+.im-topbar{position:fixed;top:0;left:0;right:0;z-index:9999;background:var(--nav-bg);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);border-bottom:1px solid var(--border-color);padding:.5rem 1rem;display:flex;align-items:center;justify-content:space-between;gap:.75rem;}
+.im-topbar a{text-decoration:none;}
+.im-topbar-home{display:flex;align-items:center;gap:.5rem;color:var(--text-primary);font-family:'Inter',sans-serif;font-weight:700;}
+.im-topbar-home svg{width:22px;height:22px;stroke:var(--accent-color);fill:none;stroke-width:2;}
+.im-topbar-right{display:flex;align-items:center;gap:.5rem;}
+.im-browse-btn,.im-premium-btn{display:inline-flex;align-items:center;gap:.4rem;padding:.4rem .8rem;border-radius:8px;font-family:'Inter',sans-serif;font-weight:600;font-size:.82rem;border:1px solid var(--border-color);color:var(--text-primary);}
+.im-premium-btn{background:var(--gradient-primary);color:#fff;-webkit-text-fill-color:#fff;border:none;}
+.im-browse-btn svg,.im-premium-btn svg{width:15px;height:15px;stroke:currentColor;fill:none;stroke-width:2;}
+.im-browse-btn:hover{border-color:var(--accent-color);color:var(--accent-color);}
+.im-theme-selector{display:flex;gap:2px;background:var(--card-bg);border:1px solid var(--border-color);border-radius:8px;padding:2px;}
+.im-theme-btn{background:transparent;border:none;color:var(--text-muted);padding:6px;border-radius:5px;cursor:pointer;display:flex;align-items:center;justify-content:center;width:30px;height:30px;}
+.im-theme-btn:hover{background:var(--hover-bg);color:var(--text-primary);}
+.im-theme-btn.active{background:var(--accent-color);color:#fff;}
+.im-theme-btn svg{width:16px;height:16px;stroke:currentColor;fill:none;stroke-width:2;}
+@media(max-width:768px){body{padding-top:52px;} .im-topbar-home span{display:none;} .im-browse-btn span,.im-premium-btn{display:none;}}
+
+/* Paper plane */
+.paper-plane{position:fixed;bottom:2rem;right:2rem;width:110px;height:110px;opacity:.12;pointer-events:none;z-index:0;animation:float 7s ease-in-out infinite;}
+@keyframes float{0%,100%{transform:translateY(0) rotate(0)}50%{transform:translateY(-14px) rotate(4deg)}}
+@media(prefers-reduced-motion:reduce){.paper-plane{animation:none;}}
+
+/* Layout */
+.wrap{max-width:1280px;margin:0 auto;padding:1.5rem 1.25rem 2rem;position:relative;z-index:1;}
+.hero{text-align:center;padding:1rem 0 1.75rem;}
+.hero .badge{display:inline-flex;align-items:center;gap:.45rem;background:var(--hover-bg);color:var(--accent-color);border:1px solid var(--border-color);padding:.3rem .8rem;border-radius:999px;font-family:'Inter',sans-serif;font-weight:600;font-size:.78rem;margin-bottom:.85rem;}
+.hero h1{font-size:2.1rem;background:var(--gradient-primary);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;margin-bottom:.5rem;}
+.hero p{color:var(--text-secondary);max-width:680px;margin:0 auto;}
+.hero .links{margin-top:.9rem;font-size:.9rem;color:var(--text-muted);}
+
+.grid{display:grid;grid-template-columns:1fr 1fr;gap:1.5rem;align-items:start;}
+@media(max-width:920px){.grid{grid-template-columns:1fr;}}
+
+.section{background:var(--card-bg);border:1px solid var(--border-color);border-radius:14px;padding:1.1rem 1.2rem;margin-bottom:1.1rem;box-shadow:var(--shadow-sm);}
+.section h2{font-size:1.02rem;display:flex;align-items:center;gap:.5rem;margin-bottom:.85rem;}
+.section h2 .n{width:24px;height:24px;flex-shrink:0;border-radius:7px;background:var(--gradient-primary);color:#fff;display:inline-flex;align-items:center;justify-content:center;font-size:.78rem;font-weight:700;font-family:'Inter',sans-serif;}
+.fg{margin-bottom:.85rem;}
+.fg:last-child{margin-bottom:0;}
+.fg label{display:block;font-family:'Inter',sans-serif;font-weight:600;font-size:.85rem;margin-bottom:.3rem;}
+.fg .hint{font-size:.78rem;color:var(--text-muted);margin-bottom:.4rem;}
+input[type=text],input[type=number],input[type=date],textarea,select{
+    width:100%;padding:.6rem .7rem;background:var(--primary-bg);border:1px solid var(--border-color);border-radius:9px;
+    color:var(--text-primary);font-family:'Amaranth',sans-serif;font-size:.92rem;outline:none;transition:border-color .15s;}
+input:focus,textarea:focus,select:focus{border-color:var(--accent-color);}
+textarea{resize:vertical;min-height:70px;line-height:1.5;}
+.row2{display:grid;grid-template-columns:1fr 1fr;gap:.7rem;}
+@media(max-width:480px){.row2{grid-template-columns:1fr;}}
+
+.chips{display:flex;flex-wrap:wrap;gap:.45rem;}
+.chip{display:inline-flex;align-items:center;gap:.35rem;padding:.35rem .7rem;border:1px solid var(--border-color);border-radius:999px;font-size:.82rem;cursor:pointer;user-select:none;transition:all .15s;}
+.chip input{display:none;}
+.chip.on{background:var(--accent-color);color:#fff;border-color:var(--accent-color);}
+
+.dynlist .item{display:flex;gap:.5rem;margin-bottom:.5rem;align-items:flex-start;}
+.dynlist .item input,.dynlist .item textarea{flex:1;}
+.icon-btn{flex-shrink:0;width:38px;height:38px;border:1px solid var(--border-color);background:var(--card-bg);border-radius:9px;color:var(--text-muted);cursor:pointer;font-size:1.1rem;line-height:1;display:flex;align-items:center;justify-content:center;}
+.icon-btn:hover{border-color:var(--danger-color);color:var(--danger-color);}
+.add-btn{margin-top:.2rem;display:inline-flex;align-items:center;gap:.4rem;background:none;border:1px dashed var(--border-color);color:var(--accent-color);padding:.45rem .8rem;border-radius:9px;font-family:'Inter',sans-serif;font-weight:600;font-size:.82rem;cursor:pointer;}
+.add-btn:hover{border-color:var(--accent-color);background:var(--hover-bg);}
+
+/* costing table */
+table.cost{width:100%;border-collapse:collapse;font-size:.85rem;}
+table.cost th,table.cost td{padding:.4rem .45rem;border-bottom:1px solid var(--border-color);text-align:left;}
+table.cost th{font-family:'Inter',sans-serif;font-size:.74rem;text-transform:uppercase;letter-spacing:.4px;color:var(--text-muted);}
+table.cost td input{padding:.4rem .45rem;font-size:.85rem;}
+table.cost .num{text-align:right;font-family:'JetBrains Mono',monospace;}
+.cost-total{display:flex;justify-content:space-between;align-items:center;margin-top:.7rem;font-family:'Inter',sans-serif;font-weight:700;}
+.cost-total .amt{font-family:'JetBrains Mono',monospace;color:var(--accent-color);font-size:1.05rem;}
+
+/* preview */
+.preview-wrap{position:sticky;top:72px;}
+.preview-actions{display:flex;flex-wrap:wrap;gap:.5rem;margin-bottom:.8rem;}
+.btn{display:inline-flex;align-items:center;gap:.4rem;padding:.55rem .95rem;border-radius:9px;font-family:'Inter',sans-serif;font-weight:600;font-size:.84rem;cursor:pointer;border:1px solid var(--border-color);background:var(--card-bg);color:var(--text-primary);transition:all .15s;}
+.btn:hover{border-color:var(--accent-color);color:var(--accent-color);}
+.btn.primary{background:var(--gradient-primary);color:#fff;-webkit-text-fill-color:#fff;border:none;}
+.btn.primary:hover{transform:translateY(-1px);box-shadow:0 6px 16px rgba(14,165,233,.3);color:#fff;}
+.btn svg{width:15px;height:15px;stroke:currentColor;fill:none;stroke-width:2;}
+.preview{background:var(--card-bg);border:1px solid var(--border-color);border-radius:14px;padding:1.5rem;box-shadow:var(--shadow-md);max-height:calc(100vh - 180px);overflow:auto;}
+.preview h1{font-size:1.3rem;-webkit-text-fill-color:initial;background:none;color:var(--text-primary);margin-bottom:.2rem;}
+.preview h2{font-size:.95rem;color:var(--accent-color);margin:1.1rem 0 .3rem;border-bottom:1px solid var(--border-color);padding-bottom:.2rem;}
+.preview p,.preview li{font-size:.9rem;color:var(--text-secondary);}
+.preview ul,.preview ol{margin:.2rem 0 .2rem 1.1rem;}
+.preview .meta{color:var(--text-muted);font-size:.82rem;}
+.preview table{width:100%;border-collapse:collapse;font-size:.82rem;margin:.4rem 0;}
+.preview table th,.preview table td{border:1px solid var(--border-color);padding:.3rem .45rem;text-align:left;}
+.preview .empty{color:var(--text-muted);font-style:italic;}
+.toast{position:fixed;bottom:1.5rem;left:50%;transform:translateX(-50%) translateY(20px);background:var(--text-primary);color:var(--primary-bg);padding:.7rem 1.2rem;border-radius:10px;font-family:'Inter',sans-serif;font-weight:600;font-size:.85rem;opacity:0;pointer-events:none;transition:all .25s;z-index:10000;}
+.toast.show{opacity:1;transform:translateX(-50%) translateY(0);}
+
+.cta{background:linear-gradient(135deg,rgba(99,102,241,.1),rgba(14,165,233,.08));border:1px solid var(--border-color);border-radius:14px;padding:1.1rem 1.2rem;margin-top:1.1rem;}
+.cta h3{font-size:.98rem;margin-bottom:.35rem;}
+.cta p{font-size:.86rem;color:var(--text-secondary);margin-bottom:.6rem;}
+
+/* footer */
+.im-footer{background:var(--secondary-bg);border-top:1px solid var(--border-color);padding:2.5rem 1.25rem 1.5rem;margin-top:2rem;position:relative;z-index:1;}
+.im-footer-content{max-width:1200px;margin:0 auto;}
+.im-footer-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(170px,1fr));gap:1.5rem;margin:1rem 0;}
+.im-footer-section h4{font-size:.85rem;text-transform:uppercase;letter-spacing:.5px;margin-bottom:.7rem;}
+.im-footer-section ul{list-style:none;}
+.im-footer-section li{margin-bottom:.4rem;}
+.im-footer-section a{color:var(--text-secondary);font-size:.88rem;}
+.im-footer-section a:hover{color:var(--accent-color);}
+.im-footer-bottom{border-top:1px solid var(--border-color);padding-top:1rem;text-align:center;color:var(--text-muted);font-size:.82rem;}
+.im-footer-made{text-align:center;color:var(--text-muted);font-size:.85rem;margin-bottom:.5rem;}
+
+@media print{.im-topbar,.paper-plane,.im-footer,.preview-actions,.grid > div:first-child,.hero .links,.cta,.skip-link{display:none !important;}
+.preview{border:none;box-shadow:none;max-height:none;overflow:visible;padding:0;}
+.grid{grid-template-columns:1fr;} body{padding-top:0;}}
+</style>
+</head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+
+<svg class="paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M80,130 L150,50" stroke="#10B981" stroke-width="2" stroke-dasharray="4,4"/>
+    <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+</svg>
+
+<!-- Topbar -->
+<div class="im-topbar" id="imTopbar">
+    <div class="im-topbar-left">
+        <a href="/index.html" class="im-topbar-home">
+            <svg viewBox="0 0 24 24"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <span>ImpactMojo</span>
+        </a>
+    </div>
+    <div class="im-topbar-right">
+        <a href="/catalog.html" class="im-browse-btn" title="Browse all content"><svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg><span>Browse</span></a>
+        <a href="/premium.html" class="im-premium-btn"><svg viewBox="0 0 24 24"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>Premium</a>
+        <div class="im-theme-selector" aria-label="Theme selection">
+            <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="Use system theme"><svg viewBox="0 0 24 24"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
+            <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Use light theme"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg></button>
+            <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Use dark theme"><svg viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+        </div>
+    </div>
+</div>
+
+<main class="wrap" id="main">
+    <div class="hero">
+        <span class="badge"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"/></svg> Free Interactive Tool</span>
+        <h1>ToR Builder</h1>
+        <p>Write a <strong>Terms of Reference</strong> that gets you useful research. Fill in the structured prompts on the left, watch a complete, professional ToR — plus a costing sheet — assemble on the right, then export it.</p>
+        <p class="links">Pairs with the <a href="/practice-packs/tor-writing/">ToR Practice Pack</a> &middot; and the guide <a href="/blog/writing-a-tor-for-research.html">How to Write a ToR</a></p>
+    </div>
+
+    <div class="grid">
+        <!-- ============ FORM ============ -->
+        <div>
+            <div class="section">
+                <h2><span class="n">1</span> The Basics</h2>
+                <div class="fg"><label for="title">Assignment title</label><input type="text" id="title" placeholder="e.g., Midline Evaluation of the Rural Livelihoods Programme"></div>
+                <div class="row2">
+                    <div class="fg"><label for="org">Commissioning organisation</label><input type="text" id="org" placeholder="e.g., ImpactMojo Foundation"></div>
+                    <div class="fg"><label for="date">Date</label><input type="date" id="date"></div>
+                </div>
+                <div class="fg"><label for="engagement">Type of engagement</label>
+                    <select id="engagement">
+                        <option>Evaluation (midline/endline)</option>
+                        <option>Baseline study</option>
+                        <option>Research study</option>
+                        <option>Needs / situation assessment</option>
+                        <option>Feasibility / scoping study</option>
+                        <option>Process / implementation review</option>
+                        <option>Impact evaluation</option>
+                        <option>Consultancy / technical assistance</option>
+                    </select>
+                </div>
+            </div>
+
+            <div class="section">
+                <h2><span class="n">2</span> Background &amp; Rationale</h2>
+                <div class="fg"><div class="hint">What is the programme/problem, who funds it, and why are you commissioning this work now? 2–4 sentences.</div>
+                    <textarea id="background" placeholder="The Rural Livelihoods Programme has worked with 12,000 households since 2022… We are commissioning a midline evaluation to…"></textarea></div>
+            </div>
+
+            <div class="section">
+                <h2><span class="n">3</span> Purpose &amp; Objectives</h2>
+                <div class="fg"><label for="purpose">Overall purpose</label><div class="hint">One sentence: what decision will this evidence inform?</div>
+                    <textarea id="purpose" placeholder="To assess progress against intended outcomes and inform mid-course adjustments for the second phase."></textarea></div>
+                <div class="fg"><label>Specific objectives</label><div class="hint">The 3–5 things this assignment must achieve.</div>
+                    <div class="dynlist" id="objectives"></div>
+                    <button class="add-btn" onclick="addItem('objectives','objective')" type="button">+ Add objective</button>
+                </div>
+            </div>
+
+            <div class="section">
+                <h2><span class="n">4</span> Type of Enquiry</h2>
+                <div class="hint" style="margin-bottom:.7rem">Three choices that shape your whole design — and auto-suggest methods below. (From the ImpactMojo ToR framework.)</div>
+                <div class="fg"><label>What kind of question is it?</label>
+                    <div class="chips" id="dim-purpose">
+                        <label class="chip"><input type="radio" name="qpurpose" value="outcome"> Outcome — did it work?</label>
+                        <label class="chip"><input type="radio" name="qpurpose" value="process"> Process — how/why?</label>
+                        <label class="chip"><input type="radio" name="qpurpose" value="theory"> Theory-based — for whom &amp; under what conditions?</label>
+                    </div>
+                </div>
+                <div class="fg"><label>What kind of data?</label>
+                    <div class="chips" id="dim-data">
+                        <label class="chip"><input type="radio" name="qdata" value="quant"> Quantitative</label>
+                        <label class="chip"><input type="radio" name="qdata" value="qual"> Qualitative</label>
+                        <label class="chip"><input type="radio" name="qdata" value="mixed"> Mixed methods</label>
+                    </div>
+                </div>
+                <div class="fg"><label>What time structure?</label>
+                    <div class="chips" id="dim-time">
+                        <label class="chip"><input type="radio" name="qtime" value="cross"> Cross-sectional (snapshot)</label>
+                        <label class="chip"><input type="radio" name="qtime" value="long"> Longitudinal (over time)</label>
+                    </div>
+                </div>
+            </div>
+
+            <div class="section">
+                <h2><span class="n">5</span> Key Questions</h2>
+                <div class="fg"><div class="hint">The specific questions the work must answer. Keep them few and answerable.</div>
+                    <div class="dynlist" id="questions"></div>
+                    <button class="add-btn" onclick="addItem('questions','question')" type="button">+ Add question</button>
+                </div>
+            </div>
+
+            <div class="section">
+                <h2><span class="n">6</span> Scope</h2>
+                <div class="row2">
+                    <div class="fg"><label for="geography">Geography / sites</label><input type="text" id="geography" placeholder="e.g., 4 districts in Bihar"></div>
+                    <div class="fg"><label for="population">Population / participants</label><input type="text" id="population" placeholder="e.g., SHG members, programme staff, non-participants"></div>
+                </div>
+                <div class="fg"><label for="period">Period under review</label><input type="text" id="period" placeholder="e.g., Jan 2022 – Dec 2025"></div>
+            </div>
+
+            <div class="section">
+                <h2><span class="n">7</span> Methodology</h2>
+                <div class="fg"><label>Suggested methods <span id="methodHint" class="hint" style="display:inline"></span></label>
+                    <div class="chips" id="methods"></div>
+                </div>
+                <div class="fg"><label for="methodNotes">Notes / constraints on methodology</label>
+                    <textarea id="methodNotes" placeholder="e.g., must include disaggregation by gender and caste; ethics approval required; data must be anonymised."></textarea></div>
+            </div>
+
+            <div class="section">
+                <h2><span class="n">8</span> Deliverables &amp; Timeline</h2>
+                <div class="fg"><label>Deliverables</label>
+                    <div class="dynlist" id="deliverables"></div>
+                    <button class="add-btn" onclick="addItem('deliverables','deliverable')" type="button">+ Add deliverable</button>
+                </div>
+                <div class="row2">
+                    <div class="fg"><label for="start">Start</label><input type="text" id="start" placeholder="e.g., 1 Aug 2026"></div>
+                    <div class="fg"><label for="end">Final report due</label><input type="text" id="end" placeholder="e.g., 30 Oct 2026"></div>
+                </div>
+            </div>
+
+            <div class="section">
+                <h2><span class="n">9</span> Team &amp; Qualifications</h2>
+                <div class="fg"><div class="hint">Skills, experience, and any sectoral/linguistic requirements.</div>
+                    <textarea id="team" placeholder="Lead with 7+ yrs in livelihoods evaluation; mixed-methods expertise; Hindi fluency; experience with SHG programmes; female enumerators for women respondents."></textarea></div>
+            </div>
+
+            <div class="section">
+                <h2><span class="n">10</span> Costing Sheet</h2>
+                <div class="hint" style="margin-bottom:.6rem">Build an indicative budget by phase or role. Currency: <input type="text" id="currency" value="₹" style="width:60px;display:inline-block;padding:.2rem .4rem"></div>
+                <table class="cost"><thead><tr><th>Item / phase</th><th style="width:70px">Days</th><th style="width:110px">Day rate</th><th style="width:90px" class="num">Cost</th><th style="width:34px"></th></tr></thead>
+                    <tbody id="costRows"></tbody></table>
+                <button class="add-btn" onclick="addCostRow()" type="button">+ Add line</button>
+                <div class="fg" style="margin-top:.7rem"><label for="contingency">Contingency %</label><input type="number" id="contingency" value="10" min="0" max="50" style="width:90px"></div>
+                <div class="cost-total"><span>Estimated total</span><span class="amt" id="costTotal">—</span></div>
+            </div>
+
+            <div class="section">
+                <h2><span class="n">11</span> How to Apply</h2>
+                <div class="row2">
+                    <div class="fg"><label for="deadline">Submission deadline</label><input type="text" id="deadline" placeholder="e.g., 15 Jul 2026, 17:00 IST"></div>
+                    <div class="fg"><label for="contact">Contact</label><input type="text" id="contact" placeholder="e.g., research@yourorg.org"></div>
+                </div>
+                <div class="fg"><label for="apply">What to submit</label>
+                    <textarea id="apply" placeholder="A technical proposal (max 8 pages), CVs of the core team, a financial proposal, and two references for similar work."></textarea></div>
+            </div>
+        </div>
+
+        <!-- ============ PREVIEW ============ -->
+        <div>
+            <div class="preview-wrap">
+                <div class="preview-actions">
+                    <button class="btn primary" onclick="copyMarkdown()"><svg viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>Copy Markdown</button>
+                    <button class="btn" onclick="downloadMarkdown()"><svg viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>Download .md</button>
+                    <button class="btn" onclick="window.print()"><svg viewBox="0 0 24 24"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg>Print / PDF</button>
+                    <button class="btn" onclick="loadExample()"><svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>Load example</button>
+                    <button class="btn" onclick="resetAll()"><svg viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>Reset</button>
+                </div>
+                <div class="preview" id="preview"></div>
+                <div class="cta">
+                    <h3>Want to go deeper?</h3>
+                    <p>The <strong>ToR Practice Pack</strong> walks you through commissioning research end-to-end — research types, scoping, costing, and reviewing proposals — and produces a polished ToR + costing sheet. First two modules free.</p>
+                    <a class="btn primary" href="/practice-packs/tor-writing/">Open the ToR Practice Pack →</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+
+<footer class="im-footer" role="contentinfo">
+<div class="im-footer-content">
+<p class="im-footer-made">Free, open educational tooling from ImpactMojo</p>
+<div class="im-footer-grid">
+<div class="im-footer-section"><h4>About</h4><ul>
+<li><a href="/about.html">About Us</a></li><li><a href="/contact.html">Contact</a></li><li><a href="/transparency.html">Transparency</a></li><li><a href="/status.html">System Status</a></li></ul></div>
+<div class="im-footer-section"><h4>Legal</h4><ul>
+<li><a href="/privacy-policy.html">Privacy Policy</a></li><li><a href="/terms-of-service.html">Terms of Service</a></li><li><a href="/disclaimer.html">Disclaimer</a></li></ul></div>
+<div class="im-footer-section"><h4>Quick Links</h4><ul>
+<li><a href="/catalog.html">Catalog</a></li><li><a href="/premium.html">Premium</a></li><li><a href="/practice-packs/tor-writing/">ToR Practice Pack</a></li></ul></div>
+<div class="im-footer-section"><h4>Resources</h4><ul>
+<li><a href="/handouts.html">Handouts</a></li><li><a href="/blog.html">Blog</a></li><li><a href="/faq.html">FAQ</a></li><li><a href="/sitemap.html">Sitemap</a></li></ul></div>
+</div>
+<div class="im-footer-bottom"><p>&copy; 2026 ImpactMojo. Code under MIT; content under CC BY-NC-ND 4.0.</p></div>
+</div>
+</footer>
+
+<div class="toast" id="toast"></div>
+
+<!-- Theme toggle -->
+<script>
+(function(){
+    function sys(){return window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark';}
+    function apply(t){var r=t==='system'?sys():t;document.documentElement.setAttribute('data-theme',r);document.body.classList.remove('dark-mode','light-mode');document.body.classList.add(r==='light'?'light-mode':'dark-mode');}
+    function upd(p){document.querySelectorAll('.im-theme-btn').forEach(function(b){b.classList.toggle('active',b.getAttribute('data-imtheme')===p);});}
+    var saved=localStorage.getItem('im-theme')||'system';apply(saved);
+    document.addEventListener('DOMContentLoaded',function(){upd(saved);document.querySelectorAll('.im-theme-btn').forEach(function(b){b.addEventListener('click',function(){var t=this.getAttribute('data-imtheme');localStorage.setItem('im-theme',t);apply(t);upd(t);});});});
+    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change',function(){if((localStorage.getItem('im-theme')||'system')==='system')apply('system');});
+})();
+</script>
+
+<!-- ToR Builder logic -->
+<script>
+const SKEY = 'imx-tor-builder-v1';
+const $ = id => document.getElementById(id);
+const esc = s => (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+
+const METHOD_LIBRARY = {
+    quant: ['Household survey','Structured questionnaire','Quasi-experimental comparison','Administrative / MIS data analysis','Difference-in-differences'],
+    qual: ['Key informant interviews','Focus group discussions','Case studies','Most Significant Change','Observation'],
+    mixed: ['Household survey','Key informant interviews','Focus group discussions','Document review','Case studies'],
+    outcome: ['Comparison against baseline','Contribution analysis'],
+    process: ['Process tracing','Implementation fidelity review'],
+    theory: ['Theory-based / contribution analysis','Realist evaluation (what works for whom)'],
+    long: ['Panel / repeat measurement','Cohort tracking'],
+    cross: ['One-time data collection']
+};
+
+/* dynamic lists */
+function addItem(listId, kind, value){
+    const list = $(listId);
+    const div = document.createElement('div');
+    div.className = 'item';
+    const multiline = kind === 'objective' || kind === 'deliverable';
+    div.innerHTML = (multiline
+        ? `<input type="text" placeholder="Add a ${kind}…">`
+        : `<input type="text" placeholder="Add a ${kind}…">`) +
+        `<button class="icon-btn" title="Remove" type="button" onclick="this.parentElement.remove();render();save();">&times;</button>`;
+    if(value) div.querySelector('input').value = value;
+    div.querySelector('input').addEventListener('input', ()=>{render();save();});
+    list.appendChild(div);
+}
+function listValues(listId){return [...$(listId).querySelectorAll('input')].map(i=>i.value.trim()).filter(Boolean);}
+
+/* costing */
+function addCostRow(item,days,rate){
+    const tb = $('costRows');
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td><input type="text" class="ci-item" placeholder="e.g., Inception & design"></td>
+        <td><input type="number" class="ci-days" min="0" value="0"></td>
+        <td><input type="number" class="ci-rate" min="0" value="0"></td>
+        <td class="num ci-cost">0</td>
+        <td><button class="icon-btn" type="button" title="Remove" onclick="this.closest('tr').remove();calcCost();render();save();">&times;</button></td>`;
+    if(item) tr.querySelector('.ci-item').value = item;
+    if(days!=null) tr.querySelector('.ci-days').value = days;
+    if(rate!=null) tr.querySelector('.ci-rate').value = rate;
+    tr.querySelectorAll('input').forEach(i=>i.addEventListener('input',()=>{calcCost();render();save();}));
+    tb.appendChild(tr);
+}
+function fmt(n){return (Math.round(n)).toLocaleString('en-IN');}
+function calcCost(){
+    const cur = $('currency').value || '';
+    let sub = 0;
+    [...$('costRows').querySelectorAll('tr')].forEach(tr=>{
+        const d = parseFloat(tr.querySelector('.ci-days').value)||0;
+        const r = parseFloat(tr.querySelector('.ci-rate').value)||0;
+        const c = d*r; tr.querySelector('.ci-cost').textContent = fmt(c);
+        sub += c;
+    });
+    const cont = (parseFloat($('contingency').value)||0)/100;
+    const total = sub*(1+cont);
+    $('costTotal').textContent = total>0 ? cur+fmt(total) : '—';
+    return {cur, sub, cont, total, rows:[...$('costRows').querySelectorAll('tr')].map(tr=>({
+        item:tr.querySelector('.ci-item').value.trim(),
+        days:parseFloat(tr.querySelector('.ci-days').value)||0,
+        rate:parseFloat(tr.querySelector('.ci-rate').value)||0,
+        cost:(parseFloat(tr.querySelector('.ci-days').value)||0)*(parseFloat(tr.querySelector('.ci-rate').value)||0)
+    }))};
+}
+
+/* methods auto-suggest from the three dimensions */
+function refreshMethods(){
+    const get = n => (document.querySelector(`input[name="${n}"]:checked`)||{}).value;
+    const sel = new Set([...$('methods').querySelectorAll('input:checked')].map(i=>i.value));
+    const suggested = new Set();
+    [get('qdata'),get('qpurpose'),get('qtime')].forEach(k=>{(METHOD_LIBRARY[k]||[]).forEach(m=>suggested.add(m));});
+    const all = [...suggested];
+    $('methodHint').textContent = all.length ? '· suggested from your choices above' : '';
+    $('methods').innerHTML = all.map(m=>{
+        const on = sel.has(m);
+        return `<label class="chip${on?' on':''}"><input type="checkbox" value="${esc(m)}" ${on?'checked':''}>${esc(m)}</label>`;
+    }).join('') || '<span class="hint">Pick the enquiry type above to see suggested methods.</span>';
+    $('methods').querySelectorAll('.chip').forEach(c=>{
+        const cb=c.querySelector('input');
+        cb.addEventListener('change',()=>{c.classList.toggle('on',cb.checked);render();save();});
+    });
+}
+
+/* chip visual state for radios */
+function wireChips(){
+    document.querySelectorAll('#dim-purpose .chip, #dim-data .chip, #dim-time .chip').forEach(c=>{
+        const r=c.querySelector('input');
+        r.addEventListener('change',()=>{
+            c.parentElement.querySelectorAll('.chip').forEach(x=>x.classList.remove('on'));
+            c.classList.add('on'); refreshMethods(); render(); save();
+        });
+    });
+}
+
+/* build the document model */
+function model(){
+    const get = n => (document.querySelector(`input[name="${n}"]:checked`)||{}).value;
+    const enquiry = [];
+    const P={outcome:'Outcome (did it work?)',process:'Process (how & why?)',theory:'Theory-based (for whom & under what conditions?)'};
+    const D={quant:'Quantitative',qual:'Qualitative',mixed:'Mixed methods'};
+    const T={cross:'Cross-sectional (snapshot)',long:'Longitudinal (over time)'};
+    if(get('qpurpose')) enquiry.push(P[get('qpurpose')]);
+    if(get('qdata')) enquiry.push(D[get('qdata')]);
+    if(get('qtime')) enquiry.push(T[get('qtime')]);
+    return {
+        title:$('title').value.trim(), org:$('org').value.trim(), date:$('date').value,
+        engagement:$('engagement').value, background:$('background').value.trim(),
+        purpose:$('purpose').value.trim(), objectives:listValues('objectives'),
+        enquiry, questions:listValues('questions'),
+        geography:$('geography').value.trim(), population:$('population').value.trim(), period:$('period').value.trim(),
+        methods:[...$('methods').querySelectorAll('input:checked')].map(i=>i.value),
+        methodNotes:$('methodNotes').value.trim(), deliverables:listValues('deliverables'),
+        start:$('start').value.trim(), end:$('end').value.trim(), team:$('team').value.trim(),
+        cost:calcCost(), deadline:$('deadline').value.trim(), contact:$('contact').value.trim(), apply:$('apply').value.trim()
+    };
+}
+
+/* ---- render preview ---- */
+function render(){
+    const m = model();
+    const ol = a => a.length ? '<ol>'+a.map(x=>`<li>${esc(x)}</li>`).join('')+'</ol>' : '<p class="empty">—</p>';
+    const ul = a => a.length ? '<ul>'+a.map(x=>`<li>${esc(x)}</li>`).join('')+'</ul>' : '<p class="empty">—</p>';
+    let costTable = '<p class="empty">—</p>';
+    const rows = m.cost.rows.filter(r=>r.item||r.cost);
+    if(rows.length){
+        costTable = '<table><tr><th>Item</th><th>Days</th><th>Rate</th><th>Cost</th></tr>'+
+            rows.map(r=>`<tr><td>${esc(r.item)}</td><td>${r.days}</td><td>${m.cost.cur}${fmt(r.rate)}</td><td>${m.cost.cur}${fmt(r.cost)}</td></tr>`).join('')+
+            `<tr><td colspan="3"><strong>Subtotal</strong></td><td><strong>${m.cost.cur}${fmt(m.cost.sub)}</strong></td></tr>`+
+            (m.cost.cont? `<tr><td colspan="3">Contingency (${Math.round(m.cost.cont*100)}%)</td><td>${m.cost.cur}${fmt(m.cost.sub*m.cost.cont)}</td></tr>`:'')+
+            `<tr><td colspan="3"><strong>Total</strong></td><td><strong>${m.cost.cur}${fmt(m.cost.total)}</strong></td></tr></table>`;
+    }
+    $('preview').innerHTML = `
+        <h1>${esc(m.title)||'Terms of Reference'}</h1>
+        <p class="meta">${esc(m.engagement)}${m.org?' &middot; '+esc(m.org):''}${m.date?' &middot; '+esc(m.date):''}</p>
+        <h2>1. Background &amp; Rationale</h2>${m.background?`<p>${esc(m.background)}</p>`:'<p class="empty">—</p>'}
+        <h2>2. Purpose</h2>${m.purpose?`<p>${esc(m.purpose)}</p>`:'<p class="empty">—</p>'}
+        <h2>3. Objectives</h2>${ol(m.objectives)}
+        ${m.enquiry.length?`<h2>4. Type of Enquiry</h2>${ul(m.enquiry)}`:''}
+        <h2>5. Key Questions</h2>${ol(m.questions)}
+        <h2>6. Scope</h2><ul>
+            ${m.geography?`<li><strong>Geography:</strong> ${esc(m.geography)}</li>`:''}
+            ${m.population?`<li><strong>Participants:</strong> ${esc(m.population)}</li>`:''}
+            ${m.period?`<li><strong>Period under review:</strong> ${esc(m.period)}</li>`:''}
+            ${!(m.geography||m.population||m.period)?'<li class="empty">—</li>':''}</ul>
+        <h2>7. Methodology</h2>${ul(m.methods)}${m.methodNotes?`<p>${esc(m.methodNotes)}</p>`:''}
+        <h2>8. Deliverables &amp; Timeline</h2>${ul(m.deliverables)}
+            ${(m.start||m.end)?`<p class="meta">${m.start?'Start: '+esc(m.start):''}${m.start&&m.end?' &middot; ':''}${m.end?'Final report: '+esc(m.end):''}</p>`:''}
+        <h2>9. Team &amp; Qualifications</h2>${m.team?`<p>${esc(m.team)}</p>`:'<p class="empty">—</p>'}
+        <h2>10. Indicative Budget</h2>${costTable}
+        <h2>11. How to Apply</h2>
+            ${m.apply?`<p>${esc(m.apply)}</p>`:''}
+            <ul>${m.deadline?`<li><strong>Deadline:</strong> ${esc(m.deadline)}</li>`:''}${m.contact?`<li><strong>Contact:</strong> ${esc(m.contact)}</li>`:''}${!(m.deadline||m.contact||m.apply)?'<li class="empty">—</li>':''}</ul>
+    `;
+}
+
+/* ---- markdown export ---- */
+function toMarkdown(){
+    const m = model();
+    const L=[];
+    L.push(`# Terms of Reference — ${m.title||'[Title]'}`,'');
+    const meta=[m.engagement,m.org,m.date].filter(Boolean).join(' · ');
+    if(meta) L.push(`*${meta}*`,'');
+    const sec=(h,b)=>{L.push(`## ${h}`); L.push(b&&b.length?b:'_To be completed._',''); };
+    const num=a=>a.length?a.map((x,i)=>`${i+1}. ${x}`).join('\n'):'';
+    const bul=a=>a.length?a.map(x=>`- ${x}`).join('\n'):'';
+    sec('1. Background & Rationale', m.background);
+    sec('2. Purpose', m.purpose);
+    sec('3. Objectives', num(m.objectives));
+    if(m.enquiry.length) sec('4. Type of Enquiry', bul(m.enquiry));
+    sec('5. Key Questions', num(m.questions));
+    sec('6. Scope', bul([m.geography&&`**Geography:** ${m.geography}`, m.population&&`**Participants:** ${m.population}`, m.period&&`**Period under review:** ${m.period}`].filter(Boolean)));
+    sec('7. Methodology', [bul(m.methods), m.methodNotes].filter(Boolean).join('\n\n'));
+    sec('8. Deliverables & Timeline', [bul(m.deliverables), [m.start&&`Start: ${m.start}`, m.end&&`Final report: ${m.end}`].filter(Boolean).join(' · ')].filter(Boolean).join('\n\n'));
+    sec('9. Team & Qualifications', m.team);
+    // budget table
+    const rows=m.cost.rows.filter(r=>r.item||r.cost);
+    let bud='';
+    if(rows.length){
+        bud='| Item | Days | Rate | Cost |\n|---|---:|---:|---:|\n'+
+            rows.map(r=>`| ${r.item} | ${r.days} | ${m.cost.cur}${fmt(r.rate)} | ${m.cost.cur}${fmt(r.cost)} |`).join('\n')+
+            `\n| **Subtotal** | | | **${m.cost.cur}${fmt(m.cost.sub)}** |`+
+            (m.cost.cont?`\n| Contingency (${Math.round(m.cost.cont*100)}%) | | | ${m.cost.cur}${fmt(m.cost.sub*m.cost.cont)} |`:'')+
+            `\n| **Total** | | | **${m.cost.cur}${fmt(m.cost.total)}** |`;
+    }
+    sec('10. Indicative Budget', bud);
+    sec('11. How to Apply', [m.apply, m.deadline&&`**Deadline:** ${m.deadline}`, m.contact&&`**Contact:** ${m.contact}`].filter(Boolean).join('\n\n'));
+    L.push('---','_Drafted with the ImpactMojo ToR Builder · impactmojo.in_');
+    return L.join('\n');
+}
+function copyMarkdown(){navigator.clipboard.writeText(toMarkdown()).then(()=>toast('ToR copied as Markdown')).catch(()=>toast('Copy failed — select & copy manually'));}
+function downloadMarkdown(){
+    const m=model();
+    const name=(m.title||'Terms-of-Reference').replace(/[^a-z0-9]+/gi,'_').replace(/^_+|_+$/g,'').slice(0,60)||'ToR';
+    const blob=new Blob([toMarkdown()],{type:'text/markdown'});
+    const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=name+'.md';a.click();
+    setTimeout(()=>URL.revokeObjectURL(a.href),1000); toast('Downloaded '+name+'.md');
+}
+
+function toast(msg){const t=$('toast');t.textContent=msg;t.classList.add('show');setTimeout(()=>t.classList.remove('show'),2200);}
+
+/* ---- persistence ---- */
+function save(){
+    try{localStorage.setItem(SKEY, JSON.stringify(serialize()));}catch(e){}
+}
+function serialize(){
+    const get=n=>(document.querySelector(`input[name="${n}"]:checked`)||{}).value||'';
+    return {
+        f:{title:$('title').value,org:$('org').value,date:$('date').value,engagement:$('engagement').value,
+            background:$('background').value,purpose:$('purpose').value,geography:$('geography').value,
+            population:$('population').value,period:$('period').value,methodNotes:$('methodNotes').value,
+            start:$('start').value,end:$('end').value,team:$('team').value,currency:$('currency').value,
+            contingency:$('contingency').value,deadline:$('deadline').value,contact:$('contact').value,apply:$('apply').value},
+        dims:{qpurpose:get('qpurpose'),qdata:get('qdata'),qtime:get('qtime')},
+        objectives:listValues('objectives'), questions:listValues('questions'), deliverables:listValues('deliverables'),
+        methods:[...$('methods').querySelectorAll('input:checked')].map(i=>i.value),
+        cost:[...$('costRows').querySelectorAll('tr')].map(tr=>({item:tr.querySelector('.ci-item').value,days:tr.querySelector('.ci-days').value,rate:tr.querySelector('.ci-rate').value}))
+    };
+}
+function restore(d){
+    if(!d) return false;
+    Object.entries(d.f||{}).forEach(([k,v])=>{if($(k)!=null)$(k).value=v;});
+    ['objectives','questions','deliverables'].forEach(id=>$(id).innerHTML='');
+    (d.objectives||[]).forEach(v=>addItem('objectives','objective',v));
+    (d.questions||[]).forEach(v=>addItem('questions','question',v));
+    (d.deliverables||[]).forEach(v=>addItem('deliverables','deliverable',v));
+    Object.entries(d.dims||{}).forEach(([k,v])=>{if(v){const el=document.querySelector(`input[name="${k}"][value="${v}"]`);if(el){el.checked=true;el.closest('.chip').classList.add('on');}}});
+    refreshMethods();
+    (d.methods||[]).forEach(v=>{const cb=document.querySelector(`#methods input[value="${CSS.escape(v)}"]`);if(cb){cb.checked=true;cb.closest('.chip').classList.add('on');}});
+    $('costRows').innerHTML='';
+    (d.cost||[]).forEach(r=>addCostRow(r.item,r.days,r.rate));
+    return true;
+}
+
+/* ---- example ---- */
+function loadExample(){
+    resetAll(true);
+    $('title').value='Midline Evaluation of the Rural Livelihoods Programme';
+    $('org').value='ImpactMojo Foundation'; $('date').value=new Date().toISOString().slice(0,10);
+    $('engagement').value='Evaluation (midline/endline)';
+    $('background').value='Since 2022 the Rural Livelihoods Programme has supported 12,000 women in self-help groups across four districts of Bihar with savings, credit, and enterprise training. With the programme at its midpoint, we are commissioning a midline evaluation to test progress and inform the design of Phase II.';
+    $('purpose').value='To assess progress against intended outcomes and surface the changes most worth making before Phase II.';
+    ['Assess changes in household income and women’s economic agency since baseline','Identify which programme components are working, for whom, and why','Recommend concrete adjustments for Phase II'].forEach(v=>addItem('objectives','objective',v));
+    document.querySelector('input[name="qpurpose"][value="theory"]').checked=true;document.querySelector('#dim-purpose .chip input[value="theory"]').closest('.chip').classList.add('on');
+    document.querySelector('input[name="qdata"][value="mixed"]').checked=true;document.querySelector('#dim-data .chip input[value="mixed"]').closest('.chip').classList.add('on');
+    document.querySelector('input[name="qtime"][value="long"]').checked=true;document.querySelector('#dim-time .chip input[value="long"]').closest('.chip').classList.add('on');
+    refreshMethods();
+    ['Has household income changed since baseline, and for which groups?','What explains differences between high- and low-performing SHGs?','Which components should Phase II keep, drop, or redesign?'].forEach(v=>addItem('questions','question',v));
+    $('geography').value='4 districts in Bihar'; $('population').value='SHG members, programme staff, and a comparison group of non-members';
+    $('period').value='Jan 2022 – Jun 2026';
+    setTimeout(()=>{ // methods exist after refresh
+        ['Household survey','Key informant interviews','Focus group discussions'].forEach(v=>{const cb=document.querySelector(`#methods input[value="${CSS.escape(v)}"]`);if(cb){cb.checked=true;cb.closest('.chip').classList.add('on');}});
+        render();save();
+    },0);
+    $('methodNotes').value='Disaggregate all findings by caste and age. Ethics approval and informed consent required. Female enumerators for women respondents.';
+    ['Inception report with evaluation matrix','Cleaned, anonymised datasets','Draft report','Final report (max 30 pp) + 2-page brief','Validation workshop'].forEach(v=>addItem('deliverables','deliverable',v));
+    $('start').value='1 Aug 2026'; $('end').value='30 Oct 2026';
+    $('team').value='Team lead with 7+ years in livelihoods evaluation and mixed-methods design; Hindi fluency; prior SHG experience; female field researchers.';
+    $('costRows').innerHTML='';
+    addCostRow('Inception & design',6,12000);addCostRow('Tool development & training',5,12000);addCostRow('Fieldwork & data collection',20,9000);addCostRow('Analysis & reporting',12,12000);
+    $('contingency').value='10';
+    $('deadline').value='15 Jul 2026, 17:00 IST'; $('contact').value='research@impactmojo.in';
+    $('apply').value='A technical proposal (max 8 pages), CVs of the core team, a financial proposal in the currency above, and two references for comparable assignments.';
+    calcCost();render();save();toast('Loaded a worked example');
+}
+
+function resetAll(silent){
+    if(!silent && !confirm('Clear the whole form?')) return;
+    ['title','org','date','background','purpose','geography','population','period','methodNotes','start','end','team','deadline','contact','apply'].forEach(id=>$(id).value='');
+    $('engagement').selectedIndex=0; $('currency').value='₹'; $('contingency').value='10';
+    ['objectives','questions','deliverables','costRows','methods'].forEach(id=>$(id).innerHTML='');
+    document.querySelectorAll('#dim-purpose .chip,#dim-data .chip,#dim-time .chip').forEach(c=>{c.classList.remove('on');const r=c.querySelector('input');if(r)r.checked=false;});
+    if(!silent){
+        addItem('objectives','objective');addItem('questions','question');
+        ['Inception report','Draft report','Final report'].forEach(v=>addItem('deliverables','deliverable',v));
+        addCostRow();refreshMethods();calcCost();render();save();toast('Form cleared');
+    }
+}
+
+/* ---- init ---- */
+(function init(){
+    // live updates on all native inputs
+    document.addEventListener('input', e=>{
+        if(e.target.closest('.section')){calcCost();render();save();}
+    });
+    let loaded=false;
+    try{loaded=restore(JSON.parse(localStorage.getItem(SKEY)));}catch(e){}
+    if(!loaded){
+        addItem('objectives','objective');addItem('questions','question');
+        ['Inception report','Draft report','Final report (max 30 pp)'].forEach(v=>addItem('deliverables','deliverable',v));
+        addCostRow('Inception & design');addCostRow('Fieldwork');addCostRow('Analysis & reporting');
+    }
+    wireChips();refreshMethods();calcCost();render();
+})();
+</script>
+
+<!-- Supabase Auth + i18n -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
+<script src="/js/translate-sarvam.js" defer></script>
+</body>
+</html>

--- a/blog/writing-a-tor-for-research.html
+++ b/blog/writing-a-tor-for-research.html
@@ -629,6 +629,8 @@ body {
             <div class="related-section">
                 <h3>Continue on ImpactMojo</h3>
                 <ul>
+                    <li><a href="/BookCompanionTools/tor-generator.html">ToR Builder</a> — Free interactive tool that turns this guide into a finished ToR plus a costing sheet you can export.</li>
+                    <li><a href="/practice-packs/tor-writing/">ToR Practice Pack</a> — A guided sprint through commissioning research end-to-end (first two modules free).</li>
                     <li><a href="/blog/knowing-what-you-want.html">Knowing What You Want</a> — The reflection beneath every ToR is knowing what you actually want.</li>
                     <li><a href="/Labs/mel-design-lab.html">MEL Design Lab</a> — Interactive tool for designing the research / evaluation that sits behind your ToR.</li>
                     <li><a href="/courses/mel/">MEL Flagship Course</a> — Foundations of Monitoring, Evaluation &amp; Learning for practitioners on either side of the commissioning table.</li>

--- a/catalog.html
+++ b/catalog.html
@@ -2113,7 +2113,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             <button class="filter-tab active" data-filter="all">All</button>
             <button class="filter-tab" data-filter="flagship"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Star.svg" alt="" style="width:1em;height:1em;vertical-align:-0.15em;display:inline-block;" aria-hidden="true"> Flagship (15)</button>
             <button class="filter-tab" data-filter="course">Courses (40)</button>
-            <button class="filter-tab" data-filter="lab">Labs (11)</button>
+            <button class="filter-tab" data-filter="lab">Labs (12)</button>
             <button class="filter-tab" data-filter="game">Games (16)</button>
             <button class="filter-tab" data-filter="deep-dive"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Library_books.svg" alt="" style="width:1em;height:1em;vertical-align:-0.15em;display:inline-block;" aria-hidden="true"> Deep Dives (16)</button>
             <button class="filter-tab" data-filter="book-summary"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Book.svg" alt="" style="width:1em;height:1em;vertical-align:-0.15em;display:inline-block;" aria-hidden="true"> Book Companions (46)</button>
@@ -2368,6 +2368,7 @@ const allContent = [
     { id: 'l10', type: 'lab', title: 'Impact and Partnerships Lab', description: 'Map partnership ecosystems and design collaboration frameworks.', track: 'mel', rating: 4.8, users: '450', url: '/Labs/impact-partnerships-lab.html' },
     { id: 'l11', type: 'lab', title: 'Gender Analysis Lab', description: 'Apply gender frameworks, assess intersectionality, design gender-responsive programmes, and plan inclusive interventions.', track: 'gender', rating: 4.8, users: '420', url: '/Labs/gender-studies-lab.html' },
     { id: 'l12', type: 'lab', title: 'Teacher Evidence Explorer', description: 'Filter 30+ teacher-effectiveness interventions by evidence quality, cost, type, outcome, and India relevance. Built from rigorous evaluations 2000–2024 — TaRL, contract teachers, mentoring, Mindspark, pay-for-performance, and more.', track: 'health', rating: 4.9, users: 'New', url: '/Labs/teacher-evidence-lab.html' },
+    { id: 'l13', type: 'lab', title: 'ToR Builder', description: 'Write a Terms of Reference that gets you useful research. Structured prompts build a complete ToR plus a costing sheet — export as Markdown or PDF. Pairs with the ToR Practice Pack.', track: 'mel', rating: 4.9, users: 'New', url: '/BookCompanionTools/tor-generator.html' },
     
     // GAMES (16)
     { id: 'g1', type: 'game', title: 'The Real Middle', description: 'Understand who the middle-class really is in India through wealth inequality dynamics.', track: 'policy', rating: 4.0, users: '850', url: '/Games/real-middle-india.html' },

--- a/catalog_data.json
+++ b/catalog_data.json
@@ -628,6 +628,13 @@
       "track": "Monitoring, Evaluation & Learning",
       "level": "Core",
       "link": "/specials/the-fine-print/"
+    },
+    {
+      "title": "ToR Builder",
+      "type": "Lab",
+      "track": "MEL & Research",
+      "level": "All levels",
+      "link": "/BookCompanionTools/tor-generator.html"
     }
   ],
   "META": {

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -6047,6 +6047,22 @@
     ]
   },
   {
+    "id": "TOOL-TOR",
+    "title": "ToR Builder",
+    "description": "Write a Terms of Reference that gets you useful research. Structured prompts build a complete ToR plus a costing sheet, exportable as Markdown or PDF. Pairs with the ToR Practice Pack.",
+    "type": "tool",
+    "category": "Book Companion Tools",
+    "url": "/BookCompanionTools/tor-generator.html",
+    "tags": [
+      "ToR",
+      "Terms of Reference",
+      "MEL",
+      "Evaluation",
+      "Research",
+      "Commissioning"
+    ]
+  },
+  {
     "id": "LAB-IP",
     "title": "Impact Partnerships Lab",
     "description": "Interactive partnership mapping, due diligence, partnership design, and monitoring & learning for development partnerships",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,18 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.65.0 — June 8, 2026 (ToR Builder + Products & Kits hub)
+
+### For Learners
+
+- **ToR Builder** — a free interactive tool that turns structured prompts into a complete, professional Terms of Reference plus a costing sheet, exportable as Markdown or PDF. It encodes the ImpactMojo ToR framework (the three dimensions of enquiry, with method suggestions), autosaves as you type, and ships with a worked example. Find it in the catalog under Labs, or alongside the ToR Practice Pack and the "How to Write a ToR" guide.
+- **Products & Kits** — a single page that gathers everything you can buy on ImpactMojo (memberships, all 18 Practice Packs, premium tools, coaching and workshops) and links straight to each, while making clear that the bulk of the platform stays free.
+
+### Added
+
+- `/BookCompanionTools/tor-generator.html` (ToR Builder) wired into the catalog (Labs), `search-index.json`, `sitemap.xml`, and cross-linked from the ToR Practice Pack and ToR blog post.
+- `/products.html` curation hub linking existing paid resources (no duplicated content); added to `sitemap.xml` and footer links.
+
 ## v10.64.0 — June 8, 2026 (Status monitoring: real uptime + auto-alerts)
 
 ### For Learners

--- a/practice-packs/tor-writing/index.html
+++ b/practice-packs/tor-writing/index.html
@@ -583,6 +583,7 @@ It pulls from your answers in Modules 1-4. Empty fields show as placeholders.</d
         <li><a href="/practice-packs/survey-instrument/">Practice Pack: Designing a Survey Instrument</a> -- the next step after commissioning</li>
         <li><a href="/practice-packs/programme-costing/">Practice Pack: Costing a Programme from Activities Up</a></li>
         <li><a href="/practice-packs/logframe-building/">Practice Pack: Building a Logframe That Actually Tracks</a></li>
+        <li><a href="/BookCompanionTools/tor-generator.html">ToR Builder</a> -- the free interactive tool that drafts your ToR + costing sheet</li>
         <li><a href="/Labs/mel-design-lab.html">MEL Design Lab</a> -- generic evaluation planner</li>
         <li><a href="/blog/writing-a-tor-for-research.html">Blog: How to Write a ToR</a></li>
         <li><a href="/catalog.html">Full Catalog</a></li>

--- a/products.html
+++ b/products.html
@@ -1,0 +1,379 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+<!-- Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-JRCMEB9TBW');
+</script>
+
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="ImpactMojo Products & Kits — one place to find everything you can buy: practitioner Practice Packs, premium tools, memberships, coaching, and team workshops. All core learning stays free.">
+<meta name="robots" content="index, follow">
+<meta property="og:title" content="Products & Kits | ImpactMojo">
+<meta property="og:description" content="Practice Packs, premium tools, memberships, coaching and workshops — everything you can buy on ImpactMojo, in one place.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://www.impactmojo.in/products.html">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Products & Kits | ImpactMojo">
+<meta name="twitter:description" content="Everything you can buy on ImpactMojo, in one place.">
+
+<title>Products &amp; Kits | ImpactMojo</title>
+
+<link href="/assets/images/favicon.png" rel="icon" type="image/png">
+<link href="/assets/images/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png">
+<link href="/assets/images/apple-touch-icon.png" rel="apple-touch-icon">
+<link href="/manifest.json" rel="manifest">
+<meta name="theme-color" content="#0EA5E9">
+
+<link href="https://fonts.googleapis.com" rel="preconnect">
+<link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&amp;family=Inter:wght@400;500;600;700;800&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
+
+<style>
+* { margin:0; padding:0; box-sizing:border-box; }
+:root{
+    --primary-bg:#F8FAFC; --secondary-bg:#FFFFFF; --accent-color:#0284C7; --accent-hover:#0369A1;
+    --secondary-accent:#6366F1; --success-color:#16A34A; --warning-color:#D97706;
+    --text-primary:#0F172A; --text-secondary:#475569; --text-muted:#64748B;
+    --card-bg:#FFFFFF; --hover-bg:#F1F5F9; --border-color:#E2E8F0; --nav-bg:rgba(248,250,252,0.95);
+    --gradient-primary:linear-gradient(135deg,#0369A1 0%,#4338CA 100%);
+    --gradient-hero:linear-gradient(180deg,rgba(14,165,233,0.1) 0%,transparent 50%);
+    --shadow-sm:0 1px 2px rgba(0,0,0,.03); --shadow-md:0 4px 6px rgba(0,0,0,.05); --shadow-lg:0 10px 25px rgba(0,0,0,.08);
+}
+@media (prefers-color-scheme: dark){:root{
+    --primary-bg:#0F172A; --secondary-bg:#1E293B; --accent-color:#0EA5E9; --accent-hover:#0284C7;
+    --success-color:#10B981; --warning-color:#F59E0B;
+    --text-primary:#F1F5F9; --text-secondary:#CBD5E1; --text-muted:#94A3B8;
+    --card-bg:#1E293B; --hover-bg:#334155; --border-color:#334155; --nav-bg:rgba(15,23,42,0.95);
+    --shadow-sm:0 1px 2px rgba(0,0,0,.05); --shadow-md:0 4px 6px rgba(0,0,0,.1); --shadow-lg:0 10px 25px rgba(0,0,0,.2);
+}}
+body.light-mode{--primary-bg:#F8FAFC;--secondary-bg:#FFFFFF;--accent-color:#0284C7;--accent-hover:#0369A1;--success-color:#16A34A;--warning-color:#D97706;--text-primary:#0F172A;--text-secondary:#475569;--text-muted:#64748B;--card-bg:#FFFFFF;--hover-bg:#F1F5F9;--border-color:#E2E8F0;--nav-bg:rgba(248,250,252,0.95);}
+body.dark-mode{--primary-bg:#0F172A;--secondary-bg:#1E293B;--accent-color:#0EA5E9;--accent-hover:#0284C7;--success-color:#10B981;--warning-color:#F59E0B;--text-primary:#F1F5F9;--text-secondary:#CBD5E1;--text-muted:#94A3B8;--card-bg:#1E293B;--hover-bg:#334155;--border-color:#334155;--nav-bg:rgba(15,23,42,0.95);}
+
+html{scroll-behavior:smooth;}
+body{font-family:'Amaranth',Arial,sans-serif;background:var(--primary-bg);color:var(--text-primary);line-height:1.6;min-height:100vh;display:flex;flex-direction:column;overflow-x:hidden;}
+a{color:var(--accent-color);text-decoration:none;transition:color .2s;}
+a:hover{color:var(--accent-hover);}
+h1,h2,h3,h4{font-family:'Inter',Helvetica,sans-serif;font-weight:700;line-height:1.3;}
+.mono{font-family:'JetBrains Mono',monospace;}
+.skip-link{position:absolute;left:-999px;top:0;z-index:10000;background:var(--accent-color);color:#fff;padding:.6rem 1rem;border-radius:0 0 8px 0;}
+.skip-link:focus{left:0;color:#fff;}
+
+.paper-plane{position:fixed;top:14%;right:7%;width:120px;height:120px;opacity:.16;pointer-events:none;z-index:0;animation:float 7s ease-in-out infinite;}
+@keyframes float{0%,100%{transform:translateY(0) rotate(0)}50%{transform:translateY(-16px) rotate(4deg)}}
+@media(prefers-reduced-motion:reduce){.paper-plane{animation:none;}}
+@media(max-width:768px){.paper-plane{width:90px;height:90px;opacity:.1;}}
+
+/* header */
+.header{position:fixed;left:0;right:0;top:0;z-index:1000;background:var(--nav-bg);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);border-bottom:1px solid var(--border-color);}
+.nav-container{max-width:1400px;margin:0 auto;padding:.75rem 2rem;display:flex;align-items:center;justify-content:space-between;gap:1.5rem;}
+.logo-container{display:flex;align-items:center;gap:.75rem;}
+.logo-svg img{width:44px;height:44px;border-radius:10px;object-fit:contain;}
+.logo-main{font-family:'Inter',sans-serif;font-size:1.3rem;font-weight:700;color:var(--text-primary);line-height:1.2;}
+.logo-tagline{font-size:.7rem;color:var(--accent-color);font-weight:500;letter-spacing:.5px;}
+.nav-links{display:flex;align-items:center;gap:.25rem;list-style:none;}
+.nav-links>li>a{padding:.6rem .9rem;color:var(--text-primary);font-weight:500;font-size:.95rem;border-radius:8px;}
+.nav-links>li>a:hover{background:var(--hover-bg);color:var(--accent-color);}
+.theme-toggle{width:44px;height:44px;border-radius:10px;background:var(--card-bg);border:1px solid var(--border-color);cursor:pointer;display:flex;align-items:center;justify-content:center;}
+.theme-toggle:hover{background:var(--hover-bg);border-color:var(--accent-color);}
+.theme-toggle svg{width:20px;height:20px;stroke:var(--text-primary);fill:none;stroke-width:2;}
+.theme-toggle .icon-moon{display:none;}
+.light-mode .theme-toggle .icon-sun{display:none;}
+.light-mode .theme-toggle .icon-moon{display:block;}
+.mobile-menu-toggle{display:none;background:var(--card-bg);border:1px solid var(--border-color);border-radius:10px;cursor:pointer;width:44px;height:44px;align-items:center;justify-content:center;flex-direction:column;gap:5px;padding:10px;}
+.mobile-menu-toggle .hamburger-line{width:22px;height:2px;background:var(--text-primary);border-radius:2px;display:block;}
+
+.page-content{flex:1;position:relative;z-index:1;padding-top:64px;}
+.page-hero{padding:3.5rem 2rem 1rem;text-align:center;background:var(--gradient-hero);}
+.page-hero h1{font-size:2.5rem;margin-bottom:.75rem;background:var(--gradient-primary);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;}
+.page-hero p{font-size:1.1rem;color:var(--text-secondary);max-width:680px;margin:0 auto;}
+.free-banner{max-width:760px;margin:1rem auto 0;background:var(--hover-bg);border:1px solid var(--border-color);border-radius:12px;padding:.7rem 1rem;font-size:.92rem;color:var(--text-secondary);}
+.container{max-width:1200px;margin:0 auto;padding:2rem 1.25rem 1rem;width:100%;}
+
+.section-head{margin:2.2rem 0 .3rem;}
+.section-head h2{font-size:1.5rem;}
+.section-head p{color:var(--text-muted);font-size:.95rem;}
+.section-head .anchor{scroll-margin-top:80px;}
+
+.cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:1.1rem;margin-top:1.1rem;}
+.card{background:var(--card-bg);border:1px solid var(--border-color);border-radius:16px;padding:1.25rem;display:flex;flex-direction:column;transition:transform .2s,box-shadow .2s,border-color .2s;}
+.card:hover{transform:translateY(-3px);box-shadow:var(--shadow-lg);border-color:var(--accent-color);}
+.card .eyebrow{font-family:'Inter',sans-serif;font-weight:600;font-size:.72rem;text-transform:uppercase;letter-spacing:.6px;color:var(--accent-color);margin-bottom:.4rem;}
+.card h3{font-size:1.08rem;margin-bottom:.35rem;}
+.card p{font-size:.9rem;color:var(--text-secondary);flex:1;}
+.card .price{font-family:'Inter',sans-serif;font-weight:700;color:var(--text-primary);margin:.7rem 0 .2rem;font-size:1.05rem;}
+.card .price small{font-weight:500;color:var(--text-muted);font-size:.78rem;}
+.card .go{margin-top:.85rem;display:inline-flex;align-items:center;gap:.4rem;align-self:flex-start;padding:.55rem 1rem;border-radius:9px;font-family:'Inter',sans-serif;font-weight:600;font-size:.84rem;}
+.go.primary{background:var(--gradient-primary);color:#fff;-webkit-text-fill-color:#fff;}
+.go.primary:hover{transform:translateY(-1px);box-shadow:0 6px 16px rgba(14,165,233,.3);color:#fff;}
+.go.ghost{border:1px solid var(--border-color);color:var(--text-primary);}
+.go.ghost:hover{border-color:var(--accent-color);color:var(--accent-color);}
+.card.featured{border-color:var(--accent-color);box-shadow:var(--shadow-md);}
+.card .tag{display:inline-block;background:var(--accent-color);color:#fff;font-family:'Inter',sans-serif;font-weight:600;font-size:.68rem;padding:.15rem .5rem;border-radius:999px;margin-left:.4rem;vertical-align:middle;}
+.card ul.feat{list-style:none;margin:.5rem 0 0;}
+.card ul.feat li{font-size:.85rem;color:var(--text-secondary);padding-left:1.1rem;position:relative;margin-bottom:.25rem;}
+.card ul.feat li::before{content:'';position:absolute;left:0;top:.55em;width:6px;height:6px;border-radius:50%;background:var(--success-color);}
+
+/* compact pack grid */
+.pack-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(250px,1fr));gap:.75rem;margin-top:1rem;}
+.pack{display:flex;flex-direction:column;background:var(--card-bg);border:1px solid var(--border-color);border-radius:12px;padding:.85rem .95rem;transition:border-color .2s,transform .2s;}
+.pack:hover{border-color:var(--accent-color);transform:translateY(-2px);}
+.pack .pt{font-family:'Inter',sans-serif;font-weight:600;font-size:.92rem;color:var(--text-primary);margin-bottom:.2rem;}
+.pack .pa{font-size:.8rem;color:var(--text-muted);flex:1;}
+.pack .pf{display:flex;justify-content:space-between;align-items:center;margin-top:.55rem;}
+.pack .pf .pp{font-family:'JetBrains Mono',monospace;font-size:.82rem;color:var(--accent-color);font-weight:600;}
+.pack .pf .pl{font-family:'Inter',sans-serif;font-weight:600;font-size:.8rem;}
+.subhead{font-family:'Inter',sans-serif;font-weight:700;font-size:.8rem;text-transform:uppercase;letter-spacing:.7px;color:var(--text-muted);margin:1.2rem 0 .2rem;}
+
+.note{background:var(--card-bg);border:1px solid var(--border-color);border-radius:14px;padding:1.1rem 1.3rem;margin-top:2rem;font-size:.9rem;color:var(--text-secondary);}
+.note a{font-weight:600;}
+
+/* footer */
+.footer{background:var(--secondary-bg);border-top:1px solid var(--border-color);padding:3rem 2rem 1.5rem;position:relative;z-index:1;margin-top:2rem;}
+.footer-content{max-width:1200px;margin:0 auto;}
+.footer-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:2rem;margin-bottom:2rem;}
+.footer-section h4{color:var(--text-primary);font-size:.9rem;font-weight:600;margin-bottom:1rem;text-transform:uppercase;letter-spacing:.5px;}
+.footer-section ul{list-style:none;}
+.footer-section li{margin-bottom:.5rem;}
+.footer-section a{color:var(--text-secondary);font-size:.9rem;}
+.footer-section a:hover{color:var(--accent-color);}
+.footer-bottom{padding-top:1.5rem;border-top:1px solid var(--border-color);display:flex;flex-wrap:wrap;justify-content:space-between;align-items:center;gap:1rem;}
+.footer-copyright{color:var(--text-muted);font-size:.85rem;}
+
+@media(max-width:768px){
+    .nav-container{padding:.75rem 1rem;}
+    .mobile-menu-toggle{display:flex;}
+    .logo-tagline{display:none;}
+    .nav-links{display:none;position:fixed;top:64px;left:0;right:0;width:100%;background:var(--card-bg);flex-direction:column;padding:1rem;border-top:1px solid var(--border-color);box-shadow:var(--shadow-lg);z-index:9998;}
+    .nav-links.active{display:flex;}
+    .nav-links>li{width:100%;border-bottom:1px solid var(--border-color);}
+    .nav-links>li>a{display:block;padding:1rem;}
+    .page-hero h1{font-size:1.85rem;}
+    .footer-grid{grid-template-columns:1fr 1fr;}
+    .footer-bottom{flex-direction:column;text-align:center;}
+}
+@media(max-width:480px){.footer-grid{grid-template-columns:1fr;}.page-hero h1{font-size:1.55rem;}}
+main p a[href], main li a[href]{text-decoration:underline;text-underline-offset:.15em;}
+main .nav-links a, main .footer a, main a.go, main a.pl, main .free-banner a{text-decoration:none;}
+</style>
+</head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+
+<svg class="paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M80,130 L150,50" stroke="#10B981" stroke-width="2" stroke-dasharray="4,4"/>
+    <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+</svg>
+
+<header class="header" role="banner">
+    <nav class="nav-container" role="navigation" aria-label="Main navigation">
+        <a class="logo-container" href="/index.html">
+            <div class="logo-svg"><img alt="ImpactMojo logo" src="/assets/images/ImpactMojo%20Logo.png" width="44" height="44"></div>
+            <div class="logo-text"><div class="logo-main">ImpactMojo</div><div class="logo-tagline">Products &amp; Kits</div></div>
+        </a>
+        <button class="mobile-menu-toggle" aria-label="Toggle menu" type="button" onclick="document.getElementById('navLinks').classList.toggle('active')">
+            <span class="hamburger-line"></span><span class="hamburger-line"></span><span class="hamburger-line"></span>
+        </button>
+        <ul class="nav-links" id="navLinks">
+            <li><a href="/index.html">Home</a></li>
+            <li><a href="/catalog.html">Catalog</a></li>
+            <li><a href="/practice-packs/">Practice Packs</a></li>
+            <li><a href="/premium.html">Premium</a></li>
+            <li><a href="/contact.html">Contact</a></li>
+        </ul>
+        <div class="nav-buttons">
+            <button class="theme-toggle" onclick="toggleTheme()" title="Toggle Dark/Light Mode" aria-label="Toggle dark or light mode">
+                <svg class="icon-sun" viewBox="0 0 24 24"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+            </button>
+        </div>
+    </nav>
+</header>
+
+<main class="page-content" id="main">
+    <section class="page-hero">
+        <h1>Products &amp; Kits</h1>
+        <p>Everything you can buy on ImpactMojo, in one place — practitioner Practice Packs, premium tools, memberships, and hands-on services.</p>
+        <div class="free-banner">💡 <strong>Most of ImpactMojo is free.</strong> 60+ courses, 400+ handouts, games, labs and deep dives cost nothing — <a href="/catalog.html">browse the free catalog</a>. The items below are the optional, paid extras that go deeper.</div>
+    </section>
+
+    <div class="container">
+
+        <!-- MEMBERSHIP -->
+        <div class="section-head" id="membership">
+            <h2 class="anchor">Membership</h2>
+            <p>One subscription unlocks every Practice Pack and premium tool below.</p>
+        </div>
+        <div class="cards">
+            <div class="card">
+                <div class="eyebrow">Free forever</div>
+                <h3>Free</h3>
+                <p>Full access to all courses, handouts, games, labs, deep dives and book companions. No card required.</p>
+                <div class="price">₹0</div>
+                <a class="go ghost" href="/signup.html">Create a free account</a>
+            </div>
+            <div class="card featured">
+                <div class="eyebrow">Most popular</div>
+                <h3>Practitioner <span class="tag">Best value</span></h3>
+                <p>Everything in Free, plus all 18 Practice Packs and the premium tools, unlocked.</p>
+                <ul class="feat"><li>All Practice Packs included</li><li>All premium tools</li><li>Priority new releases</li></ul>
+                <div class="price">₹399 <small>/ month · or ₹3,990 / year</small></div>
+                <a class="go primary" href="/premium.html#practitioner">See Practitioner plan</a>
+            </div>
+            <div class="card">
+                <div class="eyebrow">For teams</div>
+                <h3>Organisation</h3>
+                <p>Team access for NGOs and impact teams — seats, shared resources, and onboarding support.</p>
+                <div class="price">₹999 <small>/ month · or ₹9,990 / year</small></div>
+                <a class="go ghost" href="/premium.html#organisation">See Organisation plan</a>
+            </div>
+        </div>
+
+        <!-- PRACTICE PACKS -->
+        <div class="section-head" id="packs">
+            <h2 class="anchor">Practice Packs</h2>
+            <p>Focused 3-hour interactive sprints, each producing a real work artefact. <strong>₹299 each</strong> (first two modules free) — or all included with Practitioner.</p>
+        </div>
+        <div class="subhead">Method Packs — cross-cutting skills</div>
+        <div class="pack-grid" id="methodPacks"></div>
+        <div class="subhead">Subject Packs — evaluation by sector</div>
+        <div class="pack-grid" id="subjectPacks"></div>
+
+        <!-- PREMIUM TOOLS -->
+        <div class="section-head" id="tools">
+            <h2 class="anchor">Premium Tools</h2>
+            <p>Professional-grade tools for researchers and evaluators — included with Practitioner.</p>
+        </div>
+        <div class="cards">
+            <div class="card">
+                <div class="eyebrow">Premium tool</div>
+                <h3>Research Question Builder Pro</h3>
+                <p>Guided research-question builder with PICO/SPIDER framing, method suggestions, and worked examples.</p>
+                <div class="price">Practitioner <small>· or ₹500/mo</small></div>
+                <a class="go ghost" href="/premium-tools/rq-builder.html">Open tool</a>
+            </div>
+            <div class="card">
+                <div class="eyebrow">Premium tool</div>
+                <h3>Qualitative Insights Lab Pro</h3>
+                <p>AI-assisted thematic coding, memo generation, and pattern identification for interview and FGD transcripts — built for researchers without NVivo licensing.</p>
+                <div class="price">Practitioner</div>
+                <a class="go ghost" href="/premium-tools/qual-insights-lab.html">Open tool</a>
+            </div>
+            <div class="card">
+                <div class="eyebrow">Premium tool</div>
+                <h3>Statistical Code Converter Pro</h3>
+                <p>Translate code between R, Stata, SPSS and Python with regression diagnostics, effect-size calculators, and power analysis.</p>
+                <div class="price">Practitioner</div>
+                <a class="go ghost" href="/premium-tools/code-converter-pro.html">Open tool</a>
+            </div>
+        </div>
+
+        <!-- SERVICES -->
+        <div class="section-head" id="services">
+            <h2 class="anchor">Coaching &amp; Workshops</h2>
+            <p>Work directly with the ImpactMojo team.</p>
+        </div>
+        <div class="cards">
+            <div class="card">
+                <div class="eyebrow">1:1 service</div>
+                <h3>Coaching</h3>
+                <p>Personalised sessions on MEL, research design, theory of change, careers and more — book a single session or a series.</p>
+                <div class="price">from ₹400 <small>/ session</small></div>
+                <a class="go primary" href="/coaching.html">Browse &amp; book coaching</a>
+            </div>
+            <div class="card">
+                <div class="eyebrow">Team service</div>
+                <h3>Workshops</h3>
+                <p>Customised, hands-on workshops for NGOs and impact teams — delivered remotely or in person.</p>
+                <div class="price">from ₹12,000 <small>/ cohort · custom quotes</small></div>
+                <a class="go ghost" href="/workshops.html">Explore workshops</a>
+            </div>
+            <div class="card">
+                <div class="eyebrow">Free taster</div>
+                <h3>Starter Kit</h3>
+                <p>Ten hand-picked handouts for development practitioners — a free download to see the quality before you buy anything.</p>
+                <div class="price">Free</div>
+                <a class="go ghost" href="/starter-kit.html">Get the free kit</a>
+            </div>
+        </div>
+
+        <div class="note">
+            <p>All payments are processed securely. Practice Packs are a one-time purchase; memberships renew until cancelled. See our <a href="/refund-policy.html">refund policy</a>, <a href="/terms-of-service.html">terms</a>, and <a href="/privacy-policy.html">privacy policy</a>. Questions about bulk or institutional access? <a href="/contact.html">Get in touch</a>.</p>
+        </div>
+
+    </div>
+</main>
+
+<footer class="footer">
+    <div class="footer-content">
+        <div class="footer-grid">
+            <div class="footer-section"><h4>About</h4><ul>
+                <li><a href="/about.html">About ImpactMojo</a></li><li><a href="/contact.html">Contact Us</a></li><li><a href="/transparency.html">Transparency</a></li></ul></div>
+            <div class="footer-section"><h4>Legal &amp; IT Act</h4><ul>
+                <li><a href="/terms-of-service">Terms of Service</a></li><li><a href="/privacy-policy">Privacy Policy</a></li><li><a href="/refund-policy">Refund Policy</a></li></ul></div>
+            <div class="footer-section"><h4>Quick Links</h4><ul>
+                <li><a href="/catalog.html">Course Catalog</a></li><li><a href="/premium.html">Premium Access</a></li><li><a href="/faq.html">FAQ</a></li></ul></div>
+            <div class="footer-section"><h4>Resources</h4><ul>
+                <li><a href="/products.html">Products &amp; Kits</a></li><li><a href="/blog.html">Blog</a></li><li><a href="/status.html">System Status</a></li></ul></div>
+        </div>
+        <div class="footer-bottom">
+            <p class="footer-copyright">© 2026 ImpactMojo. All rights reserved. Made with &lt;3 in India.</p>
+        </div>
+    </div>
+</footer>
+
+<script>
+function toggleTheme(){document.body.classList.toggle('light-mode');localStorage.setItem('theme',document.body.classList.contains('light-mode')?'light':'dark');}
+(function(){const s=localStorage.getItem('theme');const pd=window.matchMedia('(prefers-color-scheme: dark)').matches;if(s==='light'||(!s&&!pd))document.body.classList.add('light-mode');})();
+
+/* Practice Packs — collected from the live pack pages (links only, no duplicated content) */
+const METHOD = [
+    ['tor-writing','Writing a ToR','ToR + costing sheet'],
+    ['survey-instrument','Designing a Survey Instrument','survey instrument'],
+    ['logframe-building','Building a Logframe That Tracks','DAC-compatible logframe'],
+    ['programme-costing','Costing a Programme from Activities Up','activity-based budget'],
+    ['focus-group-discussion','Running a Real Focus Group','FGD facilitator’s guide'],
+    ['critiquing-evidence','Reading & Critiquing Evidence','1-page critique'],
+    ['stakeholder-mapping','Stakeholder Mapping for Influence','power–interest map'],
+    ['donor-reporting','Donor Reporting Funders Read','report skeleton'],
+    ['mel-from-scratch','Building an MEL System from Scratch','90-day MEL plan'],
+];
+const SUBJECT = [
+    ['sel-evaluation','SEL Evaluation','evaluation design'],
+    ['livelihoods-evaluation','Livelihoods Evaluation','evaluation design'],
+    ['gender-impact','Gender Impact Assessment','GIA design'],
+    ['education-evaluation','Education Programme Evaluation','evaluation design'],
+    ['health-evaluation','Health Intervention Evaluation','evaluation design'],
+    ['climate-evaluation','Climate Adaptation Evaluation','evaluation design'],
+    ['policy-evaluation','Public Policy Evaluation','evaluation design'],
+    ['media-evaluation','Media Campaign Evaluation','evaluation design'],
+    ['governance-evaluation','Governance Reform Evaluation','evaluation design'],
+];
+function renderPacks(id, arr){
+    document.getElementById(id).innerHTML = arr.map(([slug,title,art])=>`
+        <a class="pack" href="/practice-packs/${slug}/">
+            <span class="pt">${title}</span>
+            <span class="pa">Artefact: ${art}</span>
+            <span class="pf"><span class="pp">₹299</span><span class="pl">Open →</span></span>
+        </a>`).join('');
+}
+renderPacks('methodPacks', METHOD);
+renderPacks('subjectPacks', SUBJECT);
+</script>
+
+<script defer src="/js/translate.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1652,5 +1652,17 @@
         <changefreq>always</changefreq>
         <priority>0.5</priority>
     </url>
+    <url>
+        <loc>https://www.impactmojo.in/BookCompanionTools/tor-generator.html</loc>
+        <lastmod>2026-06-08</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.7</priority>
+    </url>
+    <url>
+        <loc>https://www.impactmojo.in/products.html</loc>
+        <lastmod>2026-06-08</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
 
 </urlset>


### PR DESCRIPTION
## ToR Builder
A free interactive **Terms of Reference generator** at `/BookCompanionTools/tor-generator.html`. Structured prompts assemble a complete, professional ToR **plus a costing sheet**, with live preview, Markdown/PDF export, autosave, and a worked example. It encodes the ImpactMojo ToR framework (the three dimensions of enquiry → auto-suggested methods).

Wired in: catalog (Labs, count 11→12), `data/search-index.json`, `sitemap.xml`, and cross-linked from the **ToR Practice Pack** and the **"How to Write a ToR" blog** (and the tool links back to both — a clean free-tool → paid-pack funnel).

## Products & Kits hub
`/products.html` — a single page that **collects and links** everything purchasable on ImpactMojo (memberships, all 18 Practice Packs, 3 premium tools, coaching, workshops) **without duplicating** their content. It also surfaces the free catalog and a free taster, so the "most of it is free" framing stays front-and-centre. Added to `sitemap.xml` and footer links.

changelog: v10.65.0. JSON/XML valid; all inline JS passes `node --check`; mojibake guard passes.

https://claude.ai/code/session_01D7jhwxK4U2r5AfuzCsEcXL

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7jhwxK4U2r5AfuzCsEcXL)_