### PR TITLE
Fix Long View topbar back-link wrap; finalize status alerts

### DIFF
--- a/css/longview.css
+++ b/css/longview.css
@@ -46,7 +46,15 @@ a { color: var(--color-primary); }
 .im-topbar { position: fixed; top: 0; left: 0; right: 0; z-index: 9999; background: rgba(16, 21, 34, 0.95); backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px); border-bottom: 1px solid rgba(255,255,255,0.08); padding: 0.5rem 1rem; display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; }
 .im-topbar-home { display: flex; align-items: center; gap: 0.5rem; color: #fff; text-decoration: none; font-family: var(--font-heading); font-weight: 700; }
 .im-topbar-right { display: flex; align-items: center; gap: 0.6rem; }
-.im-premium-btn { display: inline-flex; align-items: center; gap: 0.35rem; background: linear-gradient(135deg, #667eea, #764ba2); color: #ffffff; -webkit-text-fill-color: #ffffff; text-decoration: none; font-weight: 700; font-size: 0.85rem; padding: 0.4rem 0.8rem; border-radius: 8px; font-family: var(--font-heading); }
+.im-premium-btn { display: inline-flex; align-items: center; gap: 0.35rem; background: linear-gradient(135deg, #667eea, #764ba2); color: #ffffff; -webkit-text-fill-color: #ffffff; text-decoration: none; font-weight: 700; font-size: 0.85rem; padding: 0.4rem 0.8rem; border-radius: 8px; font-family: var(--font-heading); white-space: nowrap; }
+.im-topbar-right { flex-wrap: nowrap; }
+.im-topbar-home span { white-space: nowrap; }
+@media (max-width: 430px) {
+  .im-topbar { padding: 0.5rem 0.6rem; gap: 0.4rem; }
+  .im-topbar-right { gap: 0.35rem; }
+  .im-premium-btn { font-size: 0.76rem; padding: 0.35rem 0.55rem; }
+  .im-theme-btn { width: 28px; height: 28px; padding: 5px; }
+}
 .im-premium-btn svg { width: 15px; height: 15px; }
 .im-theme-selector { display: flex; gap: 2px; background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; padding: 2px; }
 .im-theme-btn { background: transparent; border: none; color: #9aa6c8; padding: 6px; border-radius: 5px; cursor: pointer; transition: all 0.2s; display: flex; align-items: center; justify-content: center; width: 30px; height: 30px; }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,16 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.66.1 — June 8, 2026
+
+### Fixed
+
+- The Long View companion pages (gallery, evidence map, numbers in the news): the "← The Long View" topbar back-link wrapped onto multiple lines and collided with the logo on narrow phones — it now stays on one line, with a tighter mobile topbar layout.
+
+### Changed
+
+- Status alert emails now send from the verified `notifications@impactmojo.in` address (status monitoring is now wired to GitHub-issue + email alerts).
+
 ## v10.66.0 — June 8, 2026 (New visualisation in the gallery)
 
 ### For Learners

--- a/supabase/functions/status-alert/index.ts
+++ b/supabase/functions/status-alert/index.ts
@@ -19,7 +19,7 @@
 
 import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 
-const FROM = Deno.env.get("STATUS_ALERT_FROM") || "ImpactMojo Status <status@impactmojo.in>";
+const FROM = Deno.env.get("STATUS_ALERT_FROM") || "ImpactMojo Status <notifications@impactmojo.in>";
 const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "";
 
 const corsHeaders = {


### PR DESCRIPTION
## Fix: Long View topbar back-link wrap (your screenshot)
On narrow phones the **"← The Long View"** back-link wrapped onto three lines and collided with the logo. Root cause: `.im-premium-btn` in the shared `css/longview.css` had no `white-space` rule. Added `white-space:nowrap`, kept the topbar right-group on one line, and tightened the topbar at ≤430px. Because the stylesheet is shared, this fixes **gallery**, **evidence-map**, and **numbers-in-the-news** at once.

## Status alerts enabled (infra)
`supabase/functions/status-alert` now sends from the verified `notifications@impactmojo.in`. The function is **deployed and ACTIVE**, `GITHUB_TOKEN` + `STATUS_ALERT_EMAIL` are set in Netlify, and a real end-to-end test email succeeded (`{"sent":true}`). So outage → GitHub issue + email, recovery → auto-close + all-clear is now operational.

changelog v10.66.1. Mojibake guard passes.

https://claude.ai/code/session_01D7jhwxK4U2r5AfuzCsEcXL

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7jhwxK4U2r5AfuzCsEcXL)_