### PR TITLE
Wire Products &amp; Kits into nav + footer; broaden System Status footer

### DIFF
--- a/404.html
+++ b/404.html
@@ -1744,6 +1744,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                 <h4>Resources</h4>
                 <ul class="footer-links">
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="catalog.html">Course Catalog</a></li>
                     <li><a href="handouts.html">Resource Library</a></li>
                     <li><a href="blog.html">Blog</a></li>

--- a/PAGE-TEMPLATE.html
+++ b/PAGE-TEMPLATE.html
@@ -1342,6 +1342,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                 </a>
                 <ul class="dropdown-menu">
                     <li><a href="catalog.html">Catalog</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="handouts.html">Resources</a></li>
                     <li class="dropdown-divider"></li>
                     <li><a href="premium.html">Premium</a></li>
@@ -1448,6 +1449,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/about.html
+++ b/about.html
@@ -2003,6 +2003,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                 </a>
                 <ul class="dropdown-menu">
                     <li><a href="catalog.html">Catalog</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="handouts.html">Resources</a></li>
                     <li class="dropdown-divider"></li>
                     <li><a href="premium.html">Premium</a></li>
@@ -2377,6 +2378,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/accessibility.html
+++ b/accessibility.html
@@ -1317,6 +1317,7 @@ body { padding-top: 70px; } /* clear fixed header */
                 </a>
                 <ul class="dropdown-menu">
                     <li><a href="catalog.html">Catalog</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="handouts.html">Resources</a></li>
                     <li class="dropdown-divider"></li>
                     <li><a href="premium.html">Premium</a></li>
@@ -1499,6 +1500,7 @@ body { padding-top: 70px; } /* clear fixed header */
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/account.html
+++ b/account.html
@@ -2111,6 +2111,7 @@ h1, h2, h3, h4, h5, h6 {
                 </a>
                 <ul class="dropdown-menu">
                     <li><a href="catalog.html">Catalog</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="handouts.html">Resources</a></li>
                     <li class="dropdown-divider"></li>
                     <li><a href="premium.html">Premium</a></li>
@@ -2851,6 +2852,7 @@ h1, h2, h3, h4, h5, h6 {
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/bct-repository.html
+++ b/bct-repository.html
@@ -1568,6 +1568,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="/handouts">Handouts</a></li>
                     <li><a href="/bct-repository">NudgeKit</a></li>
                     <li><a href="/dataverse">Dataverse</a></li>

--- a/blog.html
+++ b/blog.html
@@ -2697,6 +2697,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 <h4>Resources</h4>
                 <ul class="footer-links">
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="catalog.html">Course Catalog</a></li>
                     <li><a href="handouts.html">Resource Library</a></li>
                     <li><a href="blog.html">Blog</a></li>

--- a/catalog.html
+++ b/catalog.html
@@ -1999,6 +1999,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 </a>
                 <ul class="dropdown-menu">
                     <li><a href='/catalog'>Catalog</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href='/handouts'>Resources</a></li>
                     <li class="dropdown-divider"></li>
                     <li><a href='/premium'>Premium</a></li>
@@ -2186,6 +2187,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href='/blog'>Blog</a></li>
                     <li><a href='/podcast'>Podcast</a></li>
                     <li><a href='/handouts'>Handouts</a></li>

--- a/challenges.html
+++ b/challenges.html
@@ -878,6 +878,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="/handouts">Handouts</a></li>
                     <li><a href="/bct-repository">NudgeKit</a></li>
                     <li><a href="/dataverse">Dataverse</a></li>

--- a/climate-trace-india.html
+++ b/climate-trace-india.html
@@ -676,6 +676,7 @@ body { padding-top: 56px; }
                 </a>
                 <ul class="dropdown-menu">
                     <li><a href="catalog.html">Catalog</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="handouts.html">Resources</a></li>
                     <li class="dropdown-divider"></li>
                     <li><a href="premium.html">Premium</a></li>

--- a/data-protection.html
+++ b/data-protection.html
@@ -1805,6 +1805,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/dataverse.html
+++ b/dataverse.html
@@ -1821,6 +1821,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="/handouts">Handouts</a></li>
                     <li><a href="/bct-repository">NudgeKit</a></li>
                     <li><a href="/dataverse">Dataverse</a></li>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -1260,6 +1260,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.66.2 — June 8, 2026
+
+### Changed
+
+- Discoverability: **Products & Kits** added to the Learn nav dropdown (all 14 nav pages incl. the homepage) and to the site footer; **System Status** + **Products & Kits** now both sit in the footer across the top-level pages. The ToR Builder remains discoverable via the catalog (Labs) and the ToR Practice Pack / blog cross-links.
+
 ## v10.66.1 — June 8, 2026
 
 ### Fixed

--- a/faq.html
+++ b/faq.html
@@ -1660,6 +1660,7 @@ body.dark-mode .badge-free, body.dark-mode .badge-status-live, body.dark-mode .s
                 </a>
                 <ul class="dropdown-menu">
                     <li><a href="catalog.html">Catalog</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="handouts.html">Resources</a></li>
                     <li class="dropdown-divider"></li>
                     <li><a href="premium.html">Premium</a></li>
@@ -1876,6 +1877,7 @@ body.dark-mode .badge-free, body.dark-mode .badge-status-live, body.dark-mode .s
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/forgot-password.html
+++ b/forgot-password.html
@@ -1794,6 +1794,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 </a>
                 <ul class="dropdown-menu">
                     <li><a href="catalog.html">Catalog</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="handouts.html">Resources</a></li>
                     <li class="dropdown-divider"></li>
                     <li><a href="premium.html">Premium</a></li>
@@ -1957,6 +1958,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/grievance.html
+++ b/grievance.html
@@ -1686,6 +1686,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/handouts.html
+++ b/handouts.html
@@ -1432,6 +1432,7 @@ body.dark-mode .badge-free, body.dark-mode .badge-status-live, body.dark-mode .s
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="/handouts">Educational Handouts</a></li>
                     <li><a href="/blog">Learning Loops Blog</a></li>
                     <li><a href="/podcast">Between the Logframes</a></li>

--- a/index.html
+++ b/index.html
@@ -494,6 +494,7 @@ window.addEventListener('click', function(e) {
 <li class="dropdown-divider"></li>
 <li id="nav-resources"><a href='/handouts'><span data-i18n="nav.handouts">Handouts</span></a></li>
 <li id="nav-catalog"><a href='/catalog'><span data-i18n="nav.catalog">Catalog</span></a></li>
+<li id="nav-products"><a href='/products'>Products &amp; Kits</a></li>
 </ul>
 </li>
 
@@ -6360,6 +6361,7 @@ window.addEventListener('authStateChanged', function(e) {
 <div class="footer-section">
 <h4>Resources</h4>
 <ul><li><a href="/status.html">System Status</a></li>
+<li><a href="/products.html">Products &amp; Kits</a></li>
 <li><a href='/handouts'>Educational Handouts</a></li>
 <li><a href='/blog'>Learning Loops Blog</a></li>
 <li><a href='/podcast'>Between the Logframes</a></li>

--- a/live-projects.html
+++ b/live-projects.html
@@ -941,6 +941,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 </a>
                 <ul class="dropdown-menu">
                     <li><a href="catalog.html" onclick="closeMobileMenu()">Catalog</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="handouts.html" onclick="closeMobileMenu()">Resources</a></li>
                     <li class="dropdown-divider"></li>
                     <li><a href="premium.html" onclick="closeMobileMenu()">Premium</a></li>

--- a/login.html
+++ b/login.html
@@ -1624,6 +1624,7 @@ body.dark-mode .badge-free, body.dark-mode .badge-status-live, body.dark-mode .s
                 </a>
                 <ul class="dropdown-menu">
                     <li><a href="catalog.html">Catalog</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="handouts.html">Resources</a></li>
                     <li class="dropdown-divider"></li>
                     <li><a href="premium.html">Premium</a></li>
@@ -1812,6 +1813,7 @@ body.dark-mode .badge-free, body.dark-mode .badge-status-live, body.dark-mode .s
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/org-dashboard.html
+++ b/org-dashboard.html
@@ -2369,6 +2369,7 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/podcast.html
+++ b/podcast.html
@@ -1843,6 +1843,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/portfolio.html
+++ b/portfolio.html
@@ -696,6 +696,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                 <a href="javascript:void(0)" onclick="toggleMobileDropdown(event, this)">Learn <svg class="dropdown-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"></polyline></svg></a>
                 <ul class="dropdown-menu">
                     <li><a href="catalog.html">Catalog</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="handouts.html">Handouts</a></li>
                     <li class="dropdown-divider"></li>
                     <li><a href="premium.html">Premium</a></li>
@@ -892,7 +893,8 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
             <div class="footer-section"><h4>Quick Links</h4><ul><li><a href="catalog.html">Course Catalog</a></li><li><a href="premium.html">Premium Access</a></li><li><a href="faq.html">FAQ</a></li>
 <li><a href="/docs/" rel="noopener noreferrer" target="_blank">Documentation</a></li>
 </ul></div>
-            <div class="footer-section"><h4>Resources</h4><ul><li><a href="/status.html">System Status</a></li><li><a href="blog.html">Blog</a></li><li><a href="podcast.html">Podcast</a></li><li><a href="handouts.html">Handouts</a></li></ul></div>
+            <div class="footer-section"><h4>Resources</h4><ul><li><a href="/status.html">System Status</a></li>
+<li><a href="/products.html">Products &amp; Kits</a></li><li><a href="blog.html">Blog</a></li><li><a href="podcast.html">Podcast</a></li><li><a href="handouts.html">Handouts</a></li></ul></div>
         </div>
         <div class="footer-bottom">
             <p class="footer-copyright">&copy; 2024-2026 ImpactMojo. All rights reserved. Made with &lt;3 in India.</p>

--- a/premium.html
+++ b/premium.html
@@ -2197,6 +2197,7 @@ body{padding-top:74px}
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1196,6 +1196,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/refund-policy.html
+++ b/refund-policy.html
@@ -1347,6 +1347,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/signup.html
+++ b/signup.html
@@ -1772,6 +1772,7 @@ body.dark-mode .badge-free, body.dark-mode .badge-status-live, body.dark-mode .s
                 </a>
                 <ul class="dropdown-menu">
                     <li><a href="catalog.html">Catalog</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="handouts.html">Resources</a></li>
                     <li class="dropdown-divider"></li>
                     <li><a href="premium.html">Premium</a></li>
@@ -2067,6 +2068,7 @@ body.dark-mode .badge-free, body.dark-mode .badge-status-live, body.dark-mode .s
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/status.html
+++ b/status.html
@@ -488,6 +488,7 @@ main .nav-links a, main .footer a, main a.refresh-btn { text-decoration: none; }
                 <ul>
                     <li><a href="/blog.html">Blog</a></li>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="https://github.com/ImpactMojo/ImpactMojo">GitHub</a></li>
                 </ul>
             </div>

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -1296,6 +1296,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/testimonials.html
+++ b/testimonials.html
@@ -904,6 +904,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="/handouts">Handouts</a></li>
                     <li><a href="/bct-repository">NudgeKit</a></li>
                     <li><a href="/dataverse">Dataverse</a></li>

--- a/toc-builder.html
+++ b/toc-builder.html
@@ -1315,6 +1315,7 @@ document.addEventListener('keydown', function(e){
 <div class="im-footer-section">
 <h4>Resources</h4>
 <ul><li><a href="/status.html">System Status</a></li>
+<li><a href="/products.html">Products &amp; Kits</a></li>
 <li><a href="/handouts.html">Handouts</a></li>
 <li><a href="/blog.html">Blog</a></li>
 <li><a href="/faq.html">FAQ</a></li>

--- a/toc-workbench.html
+++ b/toc-workbench.html
@@ -1328,6 +1328,7 @@ window.addEventListener('scroll', function(){
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="/handouts">Handouts</a></li>
                     <li><a href="/bct-repository">NudgeKit</a></li>
                     <li><a href="/dataverse">Dataverse</a></li>

--- a/transparency.html
+++ b/transparency.html
@@ -968,6 +968,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="/handouts">Handouts</a></li>
                     <li><a href="/bct-repository">NudgeKit</a></li>
                     <li><a href="/dataverse">Dataverse</a></li>

--- a/updates.html
+++ b/updates.html
@@ -917,6 +917,7 @@ body { padding-top: 70px; }
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/verify-certificate.html
+++ b/verify-certificate.html
@@ -671,6 +671,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                 </a>
                 <ul class="dropdown-menu">
                     <li><a href="catalog.html">Catalog</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="handouts.html">Resources</a></li>
                     <li class="dropdown-divider"></li>
                     <li><a href="premium.html">Premium</a></li>
@@ -881,6 +882,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>

--- a/workshops.html
+++ b/workshops.html
@@ -1580,6 +1580,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                 <h4>Resources</h4>
                 <ul>
                     <li><a href="/status.html">System Status</a></li>
+                    <li><a href="/products.html">Products &amp; Kits</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="podcast.html">Podcast</a></li>
                     <li><a href="handouts.html">Handouts</a></li>


### PR DESCRIPTION
Closes the discoverability gap on the new pages.

## What was missing
- **Products & Kits** was reachable only from its own URL (linked from 0 other pages).
- **System Status** was in the footer on 35 top-level pages.

## What this does
- **Nav:** adds **Products & Kits** to the *Learn* dropdown across all 14 nav-bearing top-level pages, including the homepage (`index.html`).
- **Footer:** adds **Products & Kits** alongside **System Status** in the footer Resources list across the top-level pages — so both new pages are now in the site footer.
- Anchored, idempotent insertions (after the Catalog item in the dropdown; after the System Status `<li>` in the footer); no page gets more than two product links (one nav + one footer). Quote-style variants handled.

**ToR Builder** stays discoverable through the catalog (Labs) and the ToR Practice Pack / blog cross-links — appropriate for a single tool rather than the global nav.

changelog v10.66.2. Mojibake guard passes; edits spot-checked on index/about/catalog.

https://claude.ai/code/session_01D7jhwxK4U2r5AfuzCsEcXL

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7jhwxK4U2r5AfuzCsEcXL)_