### PR TITLE
Products: reduce Plans &amp; Services to a compact strip

### DIFF
--- a/products.html
+++ b/products.html
@@ -305,40 +305,11 @@ main .nav-links a, main .footer a, main a.go, main a.pl, main .free-banner a{tex
             </div>
         </div>
 
-        <!-- PLANS & SERVICES (de-emphasised) -->
-        <div class="section-head" id="plans">
-            <h2 class="anchor">Plans &amp; Services</h2>
-            <p>Unlock everything with a membership, or work with us directly.</p>
-        </div>
-        <div class="cards">
-            <div class="card featured">
-                <div class="eyebrow">Membership · best value</div>
-                <h3>Practitioner</h3>
-                <p>Unlocks all 18 Practice Packs and the premium tools.</p>
-                <div class="price">₹399 <small>/ mo · ₹3,990 / yr</small></div>
-                <a class="go primary" href="/premium.html#practitioner">See plan</a>
-            </div>
-            <div class="card">
-                <div class="eyebrow">Membership · teams</div>
-                <h3>Organisation</h3>
-                <p>Team seats, shared resources and onboarding for NGOs and impact teams.</p>
-                <div class="price">₹999 <small>/ mo · ₹9,990 / yr</small></div>
-                <a class="go ghost" href="/premium.html#organisation">See plan</a>
-            </div>
-            <div class="card">
-                <div class="eyebrow">Service · 1:1</div>
-                <h3>Coaching</h3>
-                <p>Personalised sessions on MEL, research design, theory of change and careers.</p>
-                <div class="price">from ₹400 <small>/ session</small></div>
-                <a class="go ghost" href="/coaching.html">Book coaching</a>
-            </div>
-            <div class="card">
-                <div class="eyebrow">Service · teams</div>
-                <h3>Workshops</h3>
-                <p>Customised, hands-on workshops for NGOs and impact teams, remote or in person.</p>
-                <div class="price">from ₹12,000 <small>/ cohort</small></div>
-                <a class="go ghost" href="/workshops.html">Explore workshops</a>
-            </div>
+        <!-- Plans & services — compact strip only (this is a products page) -->
+        <div style="margin-top:2.5rem;padding:1rem 1.25rem;background:var(--card-bg);border:1px solid var(--border-color);border-radius:12px;font-size:.9rem;color:var(--text-secondary);display:flex;flex-wrap:wrap;gap:.4rem .9rem;align-items:center;justify-content:center;text-align:center;">
+            <span>Want everything unlocked? <a href="/premium.html#practitioner"><strong>Practitioner membership</strong></a> includes all products.</span>
+            <span style="color:var(--text-muted)">·</span>
+            <span><a href="/premium.html#organisation">Org plans</a> · <a href="/coaching.html">Coaching</a> · <a href="/workshops.html">Workshops</a></span>
         </div>
 
         <div class="note">


### PR DESCRIPTION
Per feedback that it's a *products* page: the Plans & Services section (Practitioner, Organisation, Coaching, Workshops) is cut from a 4-card block down to a single quiet one-line strip at the bottom linking to membership/coaching/workshops. Products (templates, workbooks, decks, packs, tools) now own the page.

Mojibake guard passes.

https://claude.ai/code/session_01D7jhwxK4U2r5AfuzCsEcXL

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7jhwxK4U2r5AfuzCsEcXL)_