### PR TITLE
Products: drop confusing "artefact" wording

### DIFF
--- a/products.html
+++ b/products.html
@@ -248,7 +248,7 @@ main .nav-links a, main .footer a, main a.go, main a.pl, main .free-banner a{tex
 
         <div class="subhead">Templates</div>
         <div class="dl-grid">
-            <div class="dl"><span class="ext docx">DOCX</span><h3>Terms of Reference</h3><p>A complete ToR skeleton with guidance prompts for every section — the artefact behind the ToR Builder.</p><div class="dlmeta">Word · ₹199</div><a class="dlbtn" href="/products/tor-template/"><svg viewBox="0 0 24 24"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg>View product</a></div>
+            <div class="dl"><span class="ext docx">DOCX</span><h3>Terms of Reference</h3><p>A complete ToR skeleton with guidance prompts for every section — the document behind the ToR Builder.</p><div class="dlmeta">Word · ₹199</div><a class="dlbtn" href="/products/tor-template/"><svg viewBox="0 0 24 24"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg>View product</a></div>
             <div class="dl"><span class="ext xlsx">XLSX</span><h3>Logframe</h3><p>Logical framework matrix — results levels, indicators, baselines, targets, MoV and assumptions, ready to fill.</p><div class="dlmeta">Excel · 8 KB</div><a class="dlbtn" href="/downloads/ImpactMojo-Logframe-Template.xlsx" download><svg viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>Download</a></div>
             <div class="dl"><span class="ext xlsx">XLSX</span><h3>Activity Budget &amp; Costing</h3><p>Activity-based budget with live formulas — days × rate, subtotal, contingency and total computed for you.</p><div class="dlmeta">Excel · 8 KB</div><a class="dlbtn" href="/downloads/ImpactMojo-Budget-Template.xlsx" download><svg viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>Download</a></div>
             <div class="dl"><span class="ext docx">DOCX</span><h3>MEL Plan</h3><p>Monitoring, evaluation &amp; learning plan with an indicator matrix, methods, roles, ethics and reporting schedule.</p><div class="dlmeta">Word · 40 KB</div><a class="dlbtn" href="/downloads/ImpactMojo-MEL-Plan-Template.docx" download><svg viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>Download</a></div>
@@ -269,7 +269,7 @@ main .nav-links a, main .footer a, main a.go, main a.pl, main .free-banner a{tex
         <!-- PRACTICE PACKS -->
         <div class="section-head" id="packs">
             <h2 class="anchor">Practice Packs</h2>
-            <p>Focused 3-hour interactive sprints, each producing a real work artefact. <strong>₹299 each</strong> (first two modules free) — or all included with Practitioner.</p>
+            <p>Focused 3-hour interactive sprints — each one walks you through making a real, finished document you can use at work. <strong>₹299 each</strong> (first two modules free) — or all included with Practitioner.</p>
         </div>
         <div class="subhead">Method Packs — cross-cutting skills</div>
         <div class="pack-grid" id="methodPacks"></div>
@@ -368,7 +368,7 @@ function renderPacks(id, arr){
     document.getElementById(id).innerHTML = arr.map(([slug,title,art])=>`
         <a class="pack" href="/practice-packs/${slug}/">
             <span class="pt">${title}</span>
-            <span class="pa">Artefact: ${art}</span>
+            <span class="pa">You'll make: ${art}</span>
             <span class="pf"><span class="pp">₹299</span><span class="pl">Open →</span></span>
         </a>`).join('');
 }


### PR DESCRIPTION
Per feedback that "artefact" is confusing: the Practice Packs section now says **"You'll make: \<document\>"** and describes each pack as walking you through "making a real, finished document you can use at work." The ToR card reads "the document behind the ToR Builder." No other changes.

https://claude.ai/code/session_01D7jhwxK4U2r5AfuzCsEcXL

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7jhwxK4U2r5AfuzCsEcXL)_