### PR TITLE
ToR Builder Pro (premium tool) + strip services from Products page

### DIFF
--- a/blog/writing-a-tor-for-research.html
+++ b/blog/writing-a-tor-for-research.html
@@ -521,6 +521,7 @@ body {
             <div class="callout">
                 <h4>Before you finalise the methods section</h4>
                 <p>State your answer on each of the three dimensions explicitly in the ToR. "This is an <em>outcome evaluation</em> (Dimension 1), <em>mixed-methods with quant primary</em> (Dimension 2), <em>quasi-experimental pre-post with matched comparison schools</em> (Dimension 3)." If you cannot fill in those three slots, you do not yet know what research you are commissioning — and the agency cannot help you until you do.</p>
+                <p>If you would rather build this interactively, our <a href="/premium-tools/tor-builder.html"><strong>ToR Builder Pro</strong></a> walks you through these three dimensions, suggests methods to match, and exports a finished ToR plus a costing sheet — the working version of everything in this guide.</p>
             </div>
 
             <h2>What ₹2L, ₹10L, ₹40L Actually Buy You (India, 2026)</h2>
@@ -629,7 +630,7 @@ body {
             <div class="related-section">
                 <h3>Continue on ImpactMojo</h3>
                 <ul>
-                    <li><a href="/tools/tor-builder.html">ToR Builder</a> — Free interactive tool that turns this guide into a finished ToR plus a costing sheet you can export.</li>
+                    <li><a href="/premium-tools/tor-builder.html">ToR Builder Pro</a> — The interactive Pro tool that turns this guide into a finished ToR plus a costing sheet you can export.</li>
                     <li><a href="/practice-packs/tor-writing/">ToR Practice Pack</a> — A guided sprint through commissioning research end-to-end (first two modules free).</li>
                     <li><a href="/blog/knowing-what-you-want.html">Knowing What You Want</a> — The reflection beneath every ToR is knowing what you actually want.</li>
                     <li><a href="/Labs/mel-design-lab.html">MEL Design Lab</a> — Interactive tool for designing the research / evaluation that sits behind your ToR.</li>

--- a/catalog.html
+++ b/catalog.html
@@ -2114,7 +2114,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             <button class="filter-tab active" data-filter="all">All</button>
             <button class="filter-tab" data-filter="flagship"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Star.svg" alt="" style="width:1em;height:1em;vertical-align:-0.15em;display:inline-block;" aria-hidden="true"> Flagship (15)</button>
             <button class="filter-tab" data-filter="course">Courses (40)</button>
-            <button class="filter-tab" data-filter="lab">Labs (12)</button>
+            <button class="filter-tab" data-filter="lab">Labs (11)</button>
             <button class="filter-tab" data-filter="game">Games (16)</button>
             <button class="filter-tab" data-filter="deep-dive"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Library_books.svg" alt="" style="width:1em;height:1em;vertical-align:-0.15em;display:inline-block;" aria-hidden="true"> Deep Dives (16)</button>
             <button class="filter-tab" data-filter="book-summary"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Book.svg" alt="" style="width:1em;height:1em;vertical-align:-0.15em;display:inline-block;" aria-hidden="true"> Book Companions (46)</button>
@@ -2370,7 +2370,7 @@ const allContent = [
     { id: 'l10', type: 'lab', title: 'Impact and Partnerships Lab', description: 'Map partnership ecosystems and design collaboration frameworks.', track: 'mel', rating: 4.8, users: '450', url: '/Labs/impact-partnerships-lab.html' },
     { id: 'l11', type: 'lab', title: 'Gender Analysis Lab', description: 'Apply gender frameworks, assess intersectionality, design gender-responsive programmes, and plan inclusive interventions.', track: 'gender', rating: 4.8, users: '420', url: '/Labs/gender-studies-lab.html' },
     { id: 'l12', type: 'lab', title: 'Teacher Evidence Explorer', description: 'Filter 30+ teacher-effectiveness interventions by evidence quality, cost, type, outcome, and India relevance. Built from rigorous evaluations 2000–2024 — TaRL, contract teachers, mentoring, Mindspark, pay-for-performance, and more.', track: 'health', rating: 4.9, users: 'New', url: '/Labs/teacher-evidence-lab.html' },
-    { id: 'l13', type: 'lab', title: 'ToR Builder', description: 'Write a Terms of Reference that gets you useful research. Structured prompts build a complete ToR plus a costing sheet — export as Markdown or PDF. Pairs with the ToR Practice Pack.', track: 'mel', rating: 4.9, users: 'New', url: '/tools/tor-builder.html' },
+    { id: 'p10', type: 'premium', title: 'ToR Builder Pro', description: 'Turn structured prompts into a complete Terms of Reference plus a costing sheet, in your browser — export as Markdown or PDF. The interactive companion to the ToR Template and Practice Pack.', track: 'mel', rating: 4.9, users: 'New', url: '/premium-tools/tor-builder.html' },
     
     // GAMES (16)
     { id: 'g1', type: 'game', title: 'The Real Middle', description: 'Understand who the middle-class really is in India through wealth inequality dynamics.', track: 'policy', rating: 4.0, users: '850', url: '/Games/real-middle-india.html' },

--- a/catalog_data.json
+++ b/catalog_data.json
@@ -630,11 +630,11 @@
       "link": "/specials/the-fine-print/"
     },
     {
-      "title": "ToR Builder",
-      "type": "Lab",
+      "title": "ToR Builder Pro",
+      "type": "Premium",
       "track": "MEL & Research",
       "level": "All levels",
-      "link": "/tools/tor-builder.html"
+      "link": "/premium-tools/tor-builder.html"
     }
   ],
   "META": {

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -6048,11 +6048,11 @@
   },
   {
     "id": "TOOL-TOR",
-    "title": "ToR Builder",
+    "title": "ToR Builder Pro",
     "description": "Write a Terms of Reference that gets you useful research. Structured prompts build a complete ToR plus a costing sheet, exportable as Markdown or PDF. Pairs with the ToR Practice Pack.",
     "type": "tool",
     "category": "Book Companion Tools",
-    "url": "/tools/tor-builder.html",
+    "url": "/premium-tools/tor-builder.html",
     "tags": [
       "ToR",
       "Terms of Reference",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,13 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.72.0 — June 8, 2026
+
+### Changed
+
+- **ToR Builder is now ToR Builder Pro**, a standalone premium tool alongside the other Pro tools: moved to **`/premium-tools/tor-builder.html`** (old paths 301-redirect), listed in the Premium Tools lineup on the Products page and catalog, and now **mentioned in the body of the "How to Write a ToR" blog post** (in the three-dimensions section) as well as the further-reading list.
+- **Products page trimmed of services** — Coaching and Workshops removed; only a single tiny "Subscribe by UPI" line remains. It's a products page now, not a services page.
+
 ## v10.71.0 — June 8, 2026
 
 ### Changed

--- a/netlify.toml
+++ b/netlify.toml
@@ -77,6 +77,13 @@
 # ToR Builder moved out of BookCompanionTools to /tools/
 [[redirects]]
   from = "/BookCompanionTools/tor-generator.html"
-  to = "/tools/tor-builder.html"
+  to = "/premium-tools/tor-builder.html"
+  status = 301
+  force = true
+
+# /tools/ interim path -> final premium-tools home
+[[redirects]]
+  from = "/tools/tor-builder.html"
+  to = "/premium-tools/tor-builder.html"
   status = 301
   force = true

--- a/practice-packs/tor-writing/index.html
+++ b/practice-packs/tor-writing/index.html
@@ -583,7 +583,7 @@ It pulls from your answers in Modules 1-4. Empty fields show as placeholders.</d
         <li><a href="/practice-packs/survey-instrument/">Practice Pack: Designing a Survey Instrument</a> -- the next step after commissioning</li>
         <li><a href="/practice-packs/programme-costing/">Practice Pack: Costing a Programme from Activities Up</a></li>
         <li><a href="/practice-packs/logframe-building/">Practice Pack: Building a Logframe That Actually Tracks</a></li>
-        <li><a href="/tools/tor-builder.html">ToR Builder</a> -- the free interactive tool that drafts your ToR + costing sheet</li>
+        <li><a href="/premium-tools/tor-builder.html">ToR Builder</a> -- the free interactive tool that drafts your ToR + costing sheet</li>
         <li><a href="/Labs/mel-design-lab.html">MEL Design Lab</a> -- generic evaluation planner</li>
         <li><a href="/blog/writing-a-tor-for-research.html">Blog: How to Write a ToR</a></li>
         <li><a href="/catalog.html">Full Catalog</a></li>

--- a/premium-tools/tor-builder.html
+++ b/premium-tools/tor-builder.html
@@ -3,13 +3,13 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>ToR Builder — Terms of Reference Generator | ImpactMojo</title>
+<title>ToR Builder Pro — Terms of Reference Generator | ImpactMojo</title>
 <meta name="description" content="Free interactive Terms of Reference (ToR) generator for commissioning development research and evaluations. Build a complete ToR plus a costing sheet and export as Markdown or PDF.">
 <meta name="robots" content="index, follow">
-<meta property="og:title" content="ToR Builder — Terms of Reference Generator | ImpactMojo">
+<meta property="og:title" content="ToR Builder Pro — Terms of Reference Generator | ImpactMojo">
 <meta property="og:description" content="Build a complete, well-structured Terms of Reference (plus a costing sheet) for commissioning research or evaluation — and export it in one click.">
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://www.impactmojo.in/tools/tor-builder.html">
+<meta property="og:url" content="https://www.impactmojo.in/premium-tools/tor-builder.html">
 <meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="ToR Builder — Terms of Reference Generator | ImpactMojo">
@@ -212,8 +212,8 @@ table.cost .num{text-align:right;font-family:'JetBrains Mono',monospace;}
 
 <main class="wrap" id="main">
     <div class="hero">
-        <span class="badge"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"/></svg> Free Interactive Tool</span>
-        <h1>ToR Builder</h1>
+        <span class="badge"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"/></svg> Premium Tool</span>
+        <h1>ToR Builder Pro</h1>
         <p>Write a <strong>Terms of Reference</strong> that gets you useful research. Fill in the structured prompts on the left, watch a complete, professional ToR — plus a costing sheet — assemble on the right, then export it.</p>
         <p class="links">Pairs with the <a href="/practice-packs/tor-writing/">ToR Practice Pack</a> &middot; and the guide <a href="/blog/writing-a-tor-for-research.html">How to Write a ToR</a></p>
     </div>

--- a/products.html
+++ b/products.html
@@ -303,6 +303,13 @@ main .nav-links a, main .footer a, main a.go, main a.pl, main .free-banner a{tex
             </div>
             <div class="card">
                 <div class="eyebrow">Premium tool</div>
+                <h3>ToR Builder Pro</h3>
+                <p>Turn structured prompts into a complete Terms of Reference plus a costing sheet, in your browser — export as Markdown or PDF. The interactive companion to the ToR Template.</p>
+                <div class="price">Practitioner</div>
+                <a class="go ghost" href="/premium-tools/tor-builder.html">Open tool</a>
+            </div>
+            <div class="card">
+                <div class="eyebrow">Premium tool</div>
                 <h3>Statistical Code Converter Pro</h3>
                 <p>Translate code between R, Stata, SPSS and Python with regression diagnostics, effect-size calculators, and power analysis.</p>
                 <div class="price">Practitioner</div>
@@ -310,12 +317,10 @@ main .nav-links a, main .footer a, main a.go, main a.pl, main .free-banner a{tex
             </div>
         </div>
 
-        <!-- Plans & services — compact strip only (this is a products page) -->
-        <div style="margin-top:2.5rem;padding:1rem 1.25rem;background:var(--card-bg);border:1px solid var(--border-color);border-radius:12px;font-size:.9rem;color:var(--text-secondary);display:flex;flex-wrap:wrap;gap:.4rem .9rem;align-items:center;justify-content:center;text-align:center;">
-            <span>Want everything unlocked? <a href="/subscribe/"><strong>Subscribe by UPI</strong></a> — Practitioner includes all products.</span>
-            <span style="color:var(--text-muted)">·</span>
-            <span><a href="/premium.html#organisation">Org plans</a> · <a href="/coaching.html">Coaching</a> · <a href="/workshops.html">Workshops</a></span>
-        </div>
+        <!-- tiny membership strip (this is a products page — no services) -->
+        <p style="margin-top:2.5rem;text-align:center;font-size:.85rem;color:var(--text-muted)">
+            Want everything unlocked? <a href="/subscribe/">Subscribe by UPI</a> — Practitioner includes all products.
+        </p>
 
         <div class="note">
             <p>Templates, workbooks and decks are free to download and adapt under <strong>CC BY-NC-ND 4.0</strong>. Practice Packs are a one-time purchase; memberships renew until cancelled. See our <a href="/refund-policy.html">refund policy</a>, <a href="/terms-of-service.html">terms</a> and <a href="/privacy-policy.html">privacy policy</a>. Questions about bulk or institutional access? <a href="/contact.html">Get in touch</a>.</p>

--- a/products/tor-template/index.html
+++ b/products/tor-template/index.html
@@ -120,14 +120,14 @@ section.blk h2{font-size:1.5rem;margin-bottom:.8rem;}
     <a class="btn buy" href="#buy">Buy now →</a>
     <a class="btn ghost" href="#sample">See sample pages</a>
   </div>
-  <p class="note">Editable Word file · used with the free <a href="/tools/tor-builder.html">ToR Builder</a> · delivered to your inbox within 24 hours of payment.</p>
+  <p class="note">Editable Word file · used with the free <a href="/premium-tools/tor-builder.html">ToR Builder</a> · delivered to your inbox within 24 hours of payment.</p>
 
   <!-- LONG LETTER -->
   <section class="blk letter">
     <h2>Why a ToR is the cheapest place to fix an evaluation</h2>
     <p>Here is a pattern anyone who has commissioned research knows. A study is needed. Someone writes a page or two — background, "objectives", a budget line — and sends it out. Proposals come back wildly different, because the question was never really defined. Months later a report arrives that answers a question nobody asked, and the money is gone.</p>
     <p>The expensive mistakes in research are almost never made during the fieldwork. <strong>They are made in the Terms of Reference</strong> — the moment the question, the scope, and the expectations are set. Get the ToR right and an average consultant will do useful work. Get it wrong and the best consultant in the country cannot save it.</p>
-    <p>This template is the ToR we wished every commissioner used. Every section carries a short prompt telling you what good looks like — so you are not staring at a blank page wondering what a "scope" or a "methodology expectation" should actually say. It is built on the same framework as our <a href="/practice-packs/tor-writing/">ToR Practice Pack</a> and the free <a href="/tools/tor-builder.html">ToR Builder</a>.</p>
+    <p>This template is the ToR we wished every commissioner used. Every section carries a short prompt telling you what good looks like — so you are not staring at a blank page wondering what a "scope" or a "methodology expectation" should actually say. It is built on the same framework as our <a href="/practice-packs/tor-writing/">ToR Practice Pack</a> and the free <a href="/premium-tools/tor-builder.html">ToR Builder</a>.</p>
   </section>
 
   <!-- DIAGRAM (excalidraw-style) -->
@@ -260,7 +260,7 @@ section.blk h2{font-size:1.5rem;margin-bottom:.8rem;}
     <details><summary>What format is it?</summary><p>An editable Microsoft Word (.docx) file that also opens in Google Docs, LibreOffice and Pages.</p></details>
     <details><summary>Can I reuse it for multiple studies?</summary><p>Yes — buy once, use it for every ToR you write. It's licensed for your own and your organisation's work.</p></details>
     <details><summary>How fast is delivery?</summary><p>Within 24 hours of confirming payment, usually much sooner. We verify the UPI reference, then email the file.</p></details>
-    <details><summary>Isn't there a free ToR tool?</summary><p>Yes — the <a href="/tools/tor-builder.html">ToR Builder</a> drafts a ToR in your browser. This template is the editable document version you keep, share and standardise across your team.</p></details>
+    <details><summary>Isn't there a free ToR tool?</summary><p>Yes — the <a href="/premium-tools/tor-builder.html">ToR Builder</a> drafts a ToR in your browser. This template is the editable document version you keep, share and standardise across your team.</p></details>
   </section>
 </main>
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1653,7 +1653,7 @@
         <priority>0.5</priority>
     </url>
     <url>
-        <loc>https://www.impactmojo.in/tools/tor-builder.html</loc>
+        <loc>https://www.impactmojo.in/premium-tools/tor-builder.html</loc>
         <lastmod>2026-06-08</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>


### PR DESCRIPTION
Two corrections you flagged.

## ToR Builder → ToR Builder Pro (a standalone premium tool)
- Moved to **`/premium-tools/tor-builder.html`** to sit with the other Pro tools (old `/tools/` and `/BookCompanionTools/` paths 301-redirect).
- Branded **"ToR Builder Pro"** on the page (title, eyebrow, H1) and reclassified **type `premium`** in the catalog + search index.
- Added to the **Premium Tools** lineup on the Products page (now 4 Pro tools).
- **Mentioned in the body of the "How to Write a ToR" blog post** — a contextual callout in the three-dimensions section, plus the further-reading link, both rebranded Pro.

## Products page = products, not services
- Removed **Coaching** and **Workshops** from the page entirely.
- The plans strip is now a single tiny line: "Want everything unlocked? Subscribe by UPI." Nothing else.

JS `node --check`, JSON, sitemap XML, mojibake all pass. changelog v10.72.0.

https://claude.ai/code/session_01D7jhwxK4U2r5AfuzCsEcXL

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7jhwxK4U2r5AfuzCsEcXL)_