### PR TITLE
Products: explain why these are paid (value/effort)

### DIFF
--- a/products.html
+++ b/products.html
@@ -221,7 +221,7 @@ main .nav-links a, main .footer a, main a.go, main a.pl, main .free-banner a{tex
     <section class="page-hero">
         <h1>Products &amp; Kits</h1>
         <p>Practitioner tools you can <strong>download and own</strong> — ready-to-use templates, fill-in workbooks, editable slide decks, formulae posters, concept refresher sheets and checklists — plus interactive Practice Packs.</p>
-        <div class="free-banner">💡 <strong>Most of ImpactMojo is free.</strong> 60+ courses, 400+ handouts, games and labs cost nothing — <a href="/catalog.html">browse the free catalog</a>. Below are the practitioner products that go deeper.</div>
+        <div class="free-banner">💡 <strong>Most of ImpactMojo is free — and stays that way.</strong> 60+ courses, 400+ handouts, games and labs cost nothing, because learning should be open — <a href="/catalog.html">browse the free catalog</a>.<br><br><strong>So why are these paid?</strong> Because they're a different thing: not lessons, but <em>finished, ready-to-use work tools</em> — templates, workbooks, decks and references that each took real hours to design, pressure-test against actual evaluations, and refine down to something you can use today. You're not paying for information; you're paying for the days of blank-page work they save you. The modest price reflects that effort — and it's what keeps the rest of the library free.</div>
     </section>
 
     <div class="container">


### PR DESCRIPTION
Adds, per request, a clear explanation on the products page of **why most of ImpactMojo is free but these items are paid** — framed around value, effort and hours:

> Most of ImpactMojo is free and stays that way, because learning should be open. These are paid because they're a different thing — finished, ready-to-use work tools that each took real hours to design, pressure-test against actual evaluations, and refine. You're paying for the days of blank-page work they save you; the price reflects that effort and keeps the rest of the library free.

Mojibake passes.

https://claude.ai/code/session_01D7jhwxK4U2r5AfuzCsEcXL

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7jhwxK4U2r5AfuzCsEcXL)_