### PR TITLE
Fix: flagship course content not loading on stale sessions (401 → anon retry)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.73.4 — June 9, 2026 (Fix: flagship course content not loading)
+
+### Fixed
+
+- **Flagship course modules now load again for returning users.** If your saved login session had gone stale, the course-content service rejected the whole request, so *no* modules appeared (just "Unable to load course content"). The loader now retries anonymously on that error, so the public module always loads — and signing in again restores the gated modules.
+
 ## v10.73.3 — June 9, 2026 (Homepage navigation translated)
 
 ### For Learners

--- a/js/course-loader.js
+++ b/js/course-loader.js
@@ -183,27 +183,46 @@
       'Authorization': 'Bearer ' + (token || cfg.SUPABASE_ANON_KEY),
     };
 
+    // Headers that drop the (possibly stale) user token and use the anon key.
+    // The edge function rejects an expired/invalid JWT with a 401 for the WHOLE
+    // request — it does NOT fall back to serving public content — so without
+    // this a returning user with a stale session would see no content at all.
+    var anonHeaders = {
+      'Content-Type': 'application/json',
+      'apikey': cfg.SUPABASE_ANON_KEY,
+      'Authorization': 'Bearer ' + cfg.SUPABASE_ANON_KEY,
+    };
+
     // Fetch with a per-attempt timeout and one automatic retry, so a hung
     // edge-function request can no longer leave the page spinning forever.
     var MAX_ATTEMPTS = 2;
     var TIMEOUT_MS = 12000;
 
-    function attempt(n) {
+    function attempt(n, anonOnly) {
       var controller = new AbortController();
       var timer = setTimeout(function () { controller.abort(); }, TIMEOUT_MS);
 
       fetch(EDGE_FN_URL, {
         method: 'POST',
-        headers: headers,
+        headers: anonOnly ? anonHeaders : headers,
         body: JSON.stringify({ course_id: courseId }),
         signal: controller.signal,
       })
         .then(function (res) {
           clearTimeout(timer);
+          // A stale/expired user token makes the function 401 the entire
+          // request. Retry once as anonymous so public modules still load
+          // (re-logging in restores access to the gated modules).
+          if (res.status === 401 && !anonOnly && token) {
+            console.warn('[CourseLoader] 401 with user token — retrying anonymously');
+            attempt(n, true);
+            return null;
+          }
           if (!res.ok) throw new Error('HTTP ' + res.status);
           return res.json();
         })
         .then(function (data) {
+          if (!data) return; // handed off to the anonymous retry above
           if (data.modules && data.modules.length > 0) {
             injectContent(data.modules);
           } else {
@@ -214,7 +233,7 @@
           clearTimeout(timer);
           if (n < MAX_ATTEMPTS) {
             console.warn('[CourseLoader] attempt ' + n + ' failed (' + err.message + '), retrying…');
-            setTimeout(function () { attempt(n + 1); }, 1500 * n);
+            setTimeout(function () { attempt(n + 1, anonOnly); }, 1500 * n);
           } else {
             console.error('[CourseLoader] Failed to load content:', err);
             showError();
@@ -222,7 +241,7 @@
         });
     }
 
-    attempt(1);
+    attempt(1, false);
   }
 
   // ── CSS for spinner animation ───────────────────────────────────


### PR DESCRIPTION
## Symptom
None of the course content on flagship pages loads for some users — placeholders fall through to "Unable to load course content."

## Root cause
The `serve-course-content` Supabase edge function rejects an **expired/invalid user JWT with a `401` for the entire request** — it does not degrade to serving the public Module 1. Verified directly:

```
POST serve-course-content  (anon key)          → 200, Module 1 content
POST serve-course-content  (invalid/expired JWT) → 401 UNAUTHORIZED_INVALID_JWT_FORMAT
```

`course-loader.js` treats any non-OK status as a hard failure (`throw` → one retry → `showError()`). So a **returning user whose Supabase session has gone stale** (refresh token also expired/invalid) sends a dead token and gets a 401 on the whole request → **no modules load at all**. Logged-out visitors are unaffected because they send the anon key. (Unrelated to the recent translation work — `course-loader.js` was last touched in #565.)

## Fix
On a `401` while a user token was used, retry the fetch once with the **anon key only**. Public modules load for everyone; signing in again restores the gated modules. CORS, timeouts, and the existing generic retry are unchanged.

## Verification
- `node --check js/course-loader.js` passes.
- Edge function confirmed: anon → Module 1; invalid JWT → 401 (the case now handled).

https://claude.ai/code/session_01WL6V7neAkA2V1vACS1gxtu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WL6V7neAkA2V1vACS1gxtu)_