### PR TITLE
Fix ToC Builder canvas being squeezed by the footer

### DIFF
--- a/toc-builder.html
+++ b/toc-builder.html
@@ -85,7 +85,7 @@ body.dark-mode, [data-theme="dark"] {
     --bg:#f8fafc;--card-bg-tool:#fff;--border:#e2e8f0;--text:#1e293b;--text-muted-tool:#94a3b8;--accent:#0EA5E9;--hover:#f1f5f9
 }
 *{box-sizing:border-box;margin:0;padding:0}
-body{font-family:'Amaranth', sans-serif;background:var(--bg);color:var(--text);display:flex;flex-direction:column;height:100vh;overflow:hidden}
+body{font-family:'Amaranth', sans-serif;background:var(--bg);color:var(--text);display:flex;flex-direction:column;min-height:100vh;overflow-x:hidden}
 a{color:var(--accent-color);text-decoration:none;transition:color 0.25s}
 a:hover{color:var(--accent-hover)}
 
@@ -118,7 +118,7 @@ a:hover{color:var(--accent-hover)}
 .toc-btn-primary{background:var(--accent);color:white;border-color:var(--accent)}
 select.toc-btn{appearance:auto}
 /* Layout */
-.toc-layout{display:flex;flex:1;overflow:hidden}
+.toc-layout{display:flex;flex:none;height:calc(100vh - 110px);overflow:hidden}
 /* Sidebar — BCT Techniques */
 .toc-sidebar{width:280px;background:var(--card-bg);border-right:1px solid var(--border);display:flex;flex-direction:column;flex-shrink:0}
 .toc-sidebar-header{padding:0.75rem;border-bottom:1px solid var(--border)}


### PR DESCRIPTION
## Problem
On the ToC Builder (`/toc-builder.html`), the drag-and-drop canvas is clipped — the second row of INPUT/ACTIVITY/OUTPUT nodes is cut off and the footer butts right up against it, leaving no room to add or see more nodes.

## Cause
`body` was locked to `height:100vh` with `overflow:hidden` as a flex column, and the full site footer (`im-footer`, ~340px) sits inside that column as a sibling of `.toc-layout`. Because `.toc-layout` was `flex:1` (flex-basis 0), the footer kept its full natural height and the canvas got only the leftover ~260px — permanently squeezed, with no page scroll to escape it.

## Fix (2 lines of CSS)
- `body`: `height:100vh; overflow:hidden` → `min-height:100vh; overflow-x:hidden` — the page can now scroll to reach the footer.
- `.toc-layout`: `flex:1` → `flex:none; height:calc(100vh - 110px)` — the builder workspace now fills the viewport (minus the nav + toolbar), and the footer sits just below the fold instead of stealing canvas height.

Net effect: the canvas grows from ~260px to a near-full-viewport workspace, both node rows are visible, and there's room to keep adding nodes. The inner canvas still scrolls (it's 3000×2000). No JS changed.

https://claude.ai/code/session_01137sPToiGb9ypcDMEEFasw

---
_Generated by [Claude Code](https://claude.ai/code/session_01137sPToiGb9ypcDMEEFasw)_