### PR TITLE
Fix giant black SVG icons on Data Visualization course page (restore dropped CSS)

### DIFF
--- a/courses/dataviz/index.html
+++ b/courses/dataviz/index.html
@@ -1489,7 +1489,117 @@ body.dark-mode, [data-theme="dark"] {
             font-size: 0.9rem;
             margin-bottom: 0;
         }
-        
+
+        /* --- Icon & card styles (restored: this block was dropped in an edit,
+           which left the inline SVG icons unsized and solid-black — they default
+           to filling their container with the default black fill) --- */
+        .gradient-bar {
+            position: fixed;
+            top: 0; left: 0; right: 0;
+            height: 4px;
+            background: var(--gradient-primary);
+            z-index: 1001;
+        }
+
+        .content-card {
+            background: var(--card-bg);
+            border: 1px solid var(--color-border);
+            border-radius: 12px;
+            padding: 1.75rem;
+            margin-bottom: 1.5rem;
+            box-shadow: var(--shadow-sm);
+        }
+
+        .content-card h3 {
+            font-family: 'Inter', sans-serif;
+            font-size: 1.2rem;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-bottom: 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .content-card h3 svg {
+            width: 20px; height: 20px;
+            stroke: var(--cyan);
+            fill: none;
+            flex-shrink: 0;
+        }
+
+        .content-card h4 {
+            font-family: 'Inter', sans-serif;
+            font-size: 1rem;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin: 1.25rem 0 0.75rem;
+        }
+
+        .content-card p {
+            color: var(--text-secondary);
+            margin-bottom: 1rem;
+            line-height: 1.8;
+        }
+
+        .feature-card-icon {
+            width: 40px; height: 40px;
+            background: var(--gradient-primary);
+            border-radius: 8px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .feature-card-icon svg {
+            width: 20px; height: 20px;
+            stroke: white;
+            fill: none;
+        }
+
+        .key-concept {
+            background: var(--card-bg);
+            border: 2px solid var(--indigo);
+            border-radius: 12px;
+            padding: 1.5rem;
+            margin: 1.5rem 0;
+        }
+
+        .key-concept-icon {
+            width: 36px; height: 36px;
+            background: var(--indigo);
+            border-radius: 8px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .key-concept-icon svg {
+            width: 18px; height: 18px;
+            stroke: white;
+            fill: none;
+        }
+
+        .callout-icon svg {
+            width: 16px; height: 16px;
+            stroke: white;
+            fill: none;
+        }
+
+        .sidebar-logo-icon svg {
+            width: 20px; height: 20px;
+            stroke: white;
+            fill: none;
+        }
+
+        .nav-link svg {
+            width: 14px; height: 14px;
+            opacity: 0.7;
+            stroke: currentColor;
+            fill: none;
+        }
+
         /* Concept Box */
         .concept-box {
             background: var(--color-bg-secondary);
@@ -3494,7 +3604,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                             </g>
                             <!-- Stats box -->
                             <g transform="translate(20, 140)">
-                                <rect x="0" y="0" width="460" height="90" fill="var(--bg-card)" stroke="var(--border-light)" rx="6"/>
+                                <rect x="0" y="0" width="460" height="90" fill="var(--card-bg)" stroke="var(--color-border)" rx="6"/>
                                 <text x="230" y="20" font-size="11" fill="var(--text-primary)" text-anchor="middle" font-weight="600">All Four Datasets Share Identical Statistics</text>
                                 <text x="80" y="45" font-size="10" fill="var(--text-muted)" text-anchor="middle">Mean X: 9.0</text>
                                 <text x="180" y="45" font-size="10" fill="var(--text-muted)" text-anchor="middle">Mean Y: 7.5</text>


### PR DESCRIPTION
## What you saw
The "gigantic black circle" above **The Case for Visualization** (and other oversized black shapes on the Data Visualization course page) was an **inline SVG icon with no size and no fill rule**.

## Root cause
An earlier edit to `courses/dataviz/index.html` **dropped a block of icon/card CSS**. That left 37 inline SVG icons (`<svg viewBox="0 0 24 24" stroke-width="2">…`) with:
- **no `width`/`height`** → an inline SVG with only a `viewBox` expands to fill its container, and
- **no `fill="none"` / `stroke`** → SVG's default fill is solid black.

So an "info circle" outline icon rendered as a **giant solid-black disc**. The block was confirmed present in `Backups/dataviz-backup-20260604-1442.html` and missing from the current file.

## Fix
Restored the dropped rules, with variable names remapped to the page's current scheme (`--bg-card`→`--card-bg`, `--border-light`→`--color-border`, `--shadow-soft`→`--shadow-sm`):
`.content-card` (+ `h3` / `h3 svg` / `h4` / `p`), `.feature-card-icon` (+ `svg`), `.key-concept` (+ icon/svg), `.callout-icon svg`, `.sidebar-logo-icon svg`, `.nav-link svg`, `.gradient-bar`, plus a stray inline-SVG `<rect>` using the old var names. Icons now render at 14–20px, stroked in the accent colour, inline with their headings.

**Scope:** dataviz-only — every other course page was checked and is intact (gandhi's one bare icon is the hamburger menu, which has its own CSS).

## Note on the second screenshot
The "All Courses (54)" modal with overlapping FLAGSHIP/NEW badges is a **separate** layout bug in a different (dynamically-rendered) component I couldn't pin down from the screenshot — not addressed here. I've asked which screen it's from so I fix the right file.

https://claude.ai/code/session_01Qbw3X4vqXkDH4wEhQyV7gK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qbw3X4vqXkDH4wEhQyV7gK)_