### PR TITLE
Fix overlapping content in homepage Courses modal (malformed HTML in causal card)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5304,7 +5304,6 @@ window.addEventListener('authStateChanged', function(e) {
 <span class="imx-star-text">New</span>
 </div>
 </div>
-</div>
 <p class="modal-item-description">Design-based causal inference for practitioners who read and commission impact evidence — potential outcomes, RCTs, IV, regression discontinuity, difference-in-differences, synthetic control and causal ML, with R and Stata and Indian programme cases. 13 modules with a 65-term interactive lexicon.</p>
 <div class="modal-item-meta">
 <span class="modal-item-link">Open -></span>


### PR DESCRIPTION
## What you saw (second screenshot)
The "All Courses (54)" modal (opened from the main nav **Courses**) showed the **Causal Inference for Development** card with its FLAGSHIP/NEW badges, description, title, and "Open →" all **overlapping**.

## Root cause — malformed HTML (not CSS)
That one card in `#coursesModal` had an **extra `</div>`** that closed `.modal-item-content` while its `<a>` was still open:

```
content > a > title > /content(!)  …description, meta…  /a
```

`.modal-item` is a flrow (`display:flex`). The premature close ejected the **description and "Open →" out as extra flex children of `.modal-item`**, so they were laid out in the same row as the icon and title → the overlap. Every other card nests correctly (`content > a > title + description + meta > /a > /content`).

## Fix
Removed the single stray `</div>`. Verified: **only this one card was malformed** (the other 102 cards are well-formed), and the card now matches the standard structure.

---
This is the second of the two screenshots. The first (the "gigantic black symbols" on the Data Visualization course page) was fixed separately in #635.

https://claude.ai/code/session_01Qbw3X4vqXkDH4wEhQyV7gK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qbw3X4vqXkDH4wEhQyV7gK)_