### PR TITLE
Add Budget & Fiscal Analysis Lab (standardized pilot)

### DIFF
--- a/Labs/budget-fiscal-lab.html
+++ b/Labs/budget-fiscal-lab.html
@@ -1,0 +1,857 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
+    <meta name="theme-color" content="#0F172A">
+    <title>Budget &amp; Fiscal Analysis Lab | ImpactMojo</title>
+    <meta name="description" content="Interactive Budget &amp; Fiscal Analysis Lab — learn to read Union and State budgets, trace fund flows, calculate per-capita spending, and understand fiscal federalism in India and South Asia.">
+    <meta name="keywords" content="budget analysis, fiscal federalism, public finance, Union Budget, fund flow, per-capita spending, DBT, Finance Commission, South Asia, ImpactMojo">
+    <link rel="canonical" href="https://www.impactmojo.in/Labs/budget-fiscal-lab.html">
+
+<!-- Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-JRCMEB9TBW');
+</script>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+    <style>
+        :root {
+            --primary-bg: #FFFFFF; --secondary-bg: #F8FAFC; --accent-color: #0EA5E9; --accent-hover: #0284C7;
+            --secondary-accent: #6366F1; --success-color: #10B981; --warning-color: #F59E0B; --danger-color: #EF4444;
+            --text-primary: #0F172A; --text-secondary: #475569; --text-muted: #52627A;
+            --card-bg: #FFFFFF; --hover-bg: #F1F5F9; --border-color: #E2E8F0;
+            --gradient-primary: linear-gradient(135deg, #0EA5E9 0%, #6366F1 100%);
+            --font-sans: 'Amaranth', sans-serif; --font-heading: 'Inter', sans-serif; --font-mono: 'JetBrains Mono', monospace;
+        }
+@media (prefers-color-scheme: dark) { :root {
+            --primary-bg: #0F172A; --secondary-bg: #1E293B; --accent-color: #0EA5E9; --accent-hover: #0284C7;
+            --secondary-accent: #6366F1; --success-color: #10B981; --warning-color: #F59E0B; --danger-color: #EF4444;
+            --text-primary: #F1F5F9; --text-secondary: #CBD5E1; --text-muted: #94A3B8;
+            --card-bg: #1E293B; --hover-bg: #334155; --border-color: #334155;
+            --gradient-primary: linear-gradient(135deg, #0EA5E9 0%, #6366F1 100%);
+            --font-sans: 'Amaranth', sans-serif; --font-heading: 'Inter', sans-serif; --font-mono: 'JetBrains Mono', monospace;
+        } }
+body.light-mode, [data-theme="light"] {
+            --primary-bg: #FFFFFF; --secondary-bg: #F8FAFC; --accent-color: #0EA5E9; --accent-hover: #0284C7;
+            --secondary-accent: #6366F1; --success-color: #10B981; --warning-color: #F59E0B; --danger-color: #EF4444;
+            --text-primary: #0F172A; --text-secondary: #475569; --text-muted: #52627A;
+            --card-bg: #FFFFFF; --hover-bg: #F1F5F9; --border-color: #E2E8F0;
+            --gradient-primary: linear-gradient(135deg, #0EA5E9 0%, #6366F1 100%);
+            --font-sans: 'Amaranth', sans-serif; --font-heading: 'Inter', sans-serif; --font-mono: 'JetBrains Mono', monospace;
+        }
+body.dark-mode, [data-theme="dark"] {
+            --primary-bg: #0F172A; --secondary-bg: #1E293B; --accent-color: #0EA5E9; --accent-hover: #0284C7;
+            --secondary-accent: #6366F1; --success-color: #10B981; --warning-color: #F59E0B; --danger-color: #EF4444;
+            --text-primary: #F1F5F9; --text-secondary: #CBD5E1; --text-muted: #94A3B8;
+            --card-bg: #1E293B; --hover-bg: #334155; --border-color: #334155;
+            --gradient-primary: linear-gradient(135deg, #0EA5E9 0%, #6366F1 100%);
+            --font-sans: 'Amaranth', sans-serif; --font-heading: 'Inter', sans-serif; --font-mono: 'JetBrains Mono', monospace;
+        }
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        html { scroll-behavior: smooth; }
+        body { font-family: var(--font-sans); background: var(--primary-bg); color: var(--text-primary); line-height: 1.6; min-height: 100vh; }
+        .container { max-width: 1100px; margin: 0 auto; padding: 2rem; position: relative; z-index: 1; }
+        .back-link { display: inline-flex; align-items: center; gap: 0.5rem; color: var(--accent-color); text-decoration: none; font-size: 0.9rem; margin-bottom: 2rem; }
+        .back-link:hover { color: var(--accent-hover); }
+        .back-link svg { width: 18px; height: 18px; }
+        .header { text-align: center; margin-bottom: 2rem; padding-bottom: 2rem; border-bottom: 1px solid var(--border-color); }
+        .header-badge { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.35rem 1rem; background: rgba(14, 165, 233, 0.15); color: var(--accent-color); border-radius: 20px; font-size: 0.8rem; font-weight: 600; margin-bottom: 1rem; font-family: var(--font-heading); }
+        .header h1 { font-family: var(--font-heading); font-size: clamp(1.8rem, 4vw, 2.5rem); margin-bottom: 0.5rem; background: var(--gradient-primary); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+        .header p { color: var(--text-secondary); font-size: 1.05rem; max-width: 720px; margin: 0 auto; }
+        .top-controls { display: flex; justify-content: flex-end; gap: 0.5rem; margin-bottom: 1rem; flex-wrap: wrap; }
+        .ctrl-btn { padding: 0.6rem 0.9rem; background: var(--secondary-bg); border: 1px solid var(--border-color); border-radius: 8px; color: var(--text-primary); font-size: 0.85rem; cursor: pointer; display: flex; align-items: center; gap: 0.5rem; font-family: var(--font-sans); transition: all 0.2s; }
+        .ctrl-btn:hover { border-color: var(--accent-color); background: var(--hover-bg); }
+        .theme-selector { display: flex; gap: 4px; background: var(--card-bg); border: 1px solid var(--border-color); border-radius: 10px; padding: 4px; }
+        .theme-btn { background: transparent; border: none; color: var(--text-secondary); padding: 8px; border-radius: 6px; cursor: pointer; transition: all 0.2s ease; display: flex; align-items: center; justify-content: center; width: 36px; height: 36px; }
+        .theme-btn:hover { background: var(--hover-bg); color: var(--text-primary); }
+        .theme-btn.active { background: var(--accent-color); color: white; }
+        .theme-btn svg { width: 18px; height: 18px; }
+        .progress-bar { width: 100%; height: 6px; background: var(--border-color); border-radius: 3px; margin-bottom: 2rem; overflow: hidden; }
+        .progress-bar-fill { height: 100%; background: var(--gradient-primary); border-radius: 3px; transition: width 0.4s; width: 14%; }
+        .tabs { display: flex; gap: 0; margin-bottom: 2rem; border-bottom: 2px solid var(--border-color); overflow-x: auto; }
+        .tab-btn { padding: 0.85rem 1.1rem; background: none; border: none; border-bottom: 2px solid transparent; margin-bottom: -2px; color: var(--text-muted); font-size: 0.9rem; font-family: var(--font-sans); cursor: pointer; white-space: nowrap; display: flex; align-items: center; gap: 0.4rem; transition: all 0.2s; }
+        .tab-btn:hover { color: var(--text-secondary); }
+        .tab-btn.active { color: var(--accent-color); border-bottom-color: var(--accent-color); }
+        .tab-btn .tab-num { display: inline-flex; align-items: center; justify-content: center; width: 20px; height: 20px; border-radius: 50%; background: var(--border-color); font-size: 0.7rem; font-weight: 700; font-family: var(--font-heading); }
+        .tab-btn.active .tab-num { background: var(--accent-color); color: #fff; }
+        .tab-btn.completed .tab-num { background: var(--success-color); color: #fff; }
+        .tab-panel { display: none; animation: fadeIn 0.3s ease; }
+        .tab-panel.active { display: block; }
+        @keyframes fadeIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+        .section-title { font-family: var(--font-heading); font-size: 1.4rem; font-weight: 700; margin-bottom: 0.5rem; color: var(--text-primary); }
+        .section-desc { color: var(--text-secondary); font-size: 0.95rem; margin-bottom: 1.5rem; }
+        h3.block-title { font-family: var(--font-heading); font-size: 1.1rem; margin: 1.75rem 0 0.75rem; color: var(--text-primary); }
+        p.body-text { color: var(--text-secondary); font-size: 0.95rem; margin-bottom: 0.75rem; }
+
+        /* Info boxes */
+        .info-box { background: rgba(14,165,233,0.08); border-left: 4px solid var(--accent-color); padding: 1rem 1.25rem; border-radius: 0 8px 8px 0; margin: 1rem 0; font-size: 0.92rem; color: var(--text-secondary); }
+        .info-box strong { color: var(--text-primary); }
+        .info-box.warning { background: rgba(245,158,11,0.10); border-left-color: var(--warning-color); }
+        .info-box.success { background: rgba(16,185,129,0.10); border-left-color: var(--success-color); }
+        .illustrative-tag { display: inline-block; font-family: var(--font-mono); font-size: 0.68rem; letter-spacing: 0.5px; text-transform: uppercase; font-weight: 600; padding: 2px 8px; border-radius: 5px; background: rgba(245,158,11,0.15); color: var(--warning-color); border: 1px solid rgba(245,158,11,0.35); margin-left: 6px; vertical-align: middle; }
+
+        /* Tables */
+        .budget-table { width: 100%; border-collapse: collapse; margin: 1.25rem 0; font-size: 0.92rem; }
+        .budget-table th, .budget-table td { padding: 0.7rem 0.85rem; text-align: left; border-bottom: 1px solid var(--border-color); color: var(--text-secondary); }
+        .budget-table th { background: var(--secondary-bg); font-family: var(--font-heading); font-weight: 600; color: var(--accent-color); }
+        .budget-table td strong { color: var(--text-primary); }
+        .budget-table tr:hover td { background: var(--hover-bg); }
+        .budget-table .total-row td { font-weight: 700; background: var(--secondary-bg); color: var(--text-primary); }
+        .budget-table .highlight { color: var(--danger-color); font-weight: 700; }
+        .budget-table .up { color: var(--success-color); font-weight: 700; }
+        .table-scroll { overflow-x: auto; }
+
+        /* Sliders */
+        .slider-container { margin: 1.25rem 0; }
+        .slider-container label { display: block; font-family: var(--font-heading); font-size: 0.88rem; font-weight: 600; margin-bottom: 0.5rem; color: var(--text-secondary); }
+        input[type="range"] { width: 100%; height: 8px; border-radius: 4px; background: var(--border-color); outline: none; -webkit-appearance: none; appearance: none; }
+        input[type="range"]::-webkit-slider-thumb { -webkit-appearance: none; appearance: none; width: 22px; height: 22px; border-radius: 50%; background: var(--accent-color); cursor: pointer; border: 3px solid var(--card-bg); box-shadow: 0 2px 6px rgba(0,0,0,0.25); }
+        input[type="range"]::-moz-range-thumb { width: 20px; height: 20px; border-radius: 50%; background: var(--accent-color); cursor: pointer; border: 3px solid var(--card-bg); }
+        .slider-value { font-family: var(--font-mono); font-size: 1.1rem; color: var(--accent-color); font-weight: 700; margin-top: 0.5rem; }
+
+        /* Result / chart box */
+        .result-box { background: var(--secondary-bg); border: 1px solid var(--border-color); border-radius: 12px; padding: 1.25rem 1.5rem; margin: 1.25rem 0; }
+        .result-box h4 { font-family: var(--font-heading); font-size: 1rem; margin-bottom: 0.75rem; color: var(--text-primary); }
+        .result-box p { color: var(--text-secondary); font-size: 0.92rem; margin-bottom: 0.35rem; }
+        .result-box strong { color: var(--text-primary); }
+        .big-figure { font-size: 2rem; font-weight: 700; font-family: var(--font-heading); color: var(--accent-color); }
+
+        /* Exercise / quiz */
+        .exercise { background: var(--secondary-bg); border: 1px solid var(--border-color); border-radius: 12px; padding: 1.5rem; margin: 1.5rem 0; }
+        .exercise-question { font-family: var(--font-heading); font-size: 1rem; font-weight: 600; margin-bottom: 1rem; color: var(--text-primary); }
+        .option { display: block; padding: 0.8rem 1rem; margin: 0.5rem 0; background: var(--card-bg); border: 2px solid var(--border-color); border-radius: 8px; cursor: pointer; transition: all 0.2s; color: var(--text-secondary); font-size: 0.92rem; }
+        .option:hover { border-color: var(--accent-color); }
+        .option.correct { border-color: var(--success-color); background: rgba(16,185,129,0.12); color: var(--text-primary); }
+        .option.incorrect { border-color: var(--danger-color); background: rgba(239,68,68,0.10); color: var(--text-primary); }
+        .feedback { margin-top: 0.75rem; padding: 0.85rem 1rem; border-radius: 8px; display: none; font-size: 0.9rem; }
+        .feedback.show { display: block; }
+        .feedback.correct { background: rgba(16,185,129,0.12); color: var(--text-primary); border-left: 3px solid var(--success-color); }
+        .feedback.incorrect { background: rgba(239,68,68,0.10); color: var(--text-primary); border-left: 3px solid var(--danger-color); }
+
+        /* Reveal cards */
+        .scheme-card { border: 1px solid var(--border-color); border-radius: 12px; padding: 1.25rem; margin: 0.75rem 0; background: var(--card-bg); cursor: pointer; transition: all 0.2s; }
+        .scheme-card:hover { border-color: var(--accent-color); box-shadow: 0 4px 14px rgba(15,23,42,0.08); }
+        .scheme-card.selected { border-color: var(--accent-color); background: rgba(14,165,233,0.06); }
+        .scheme-card h4 { font-family: var(--font-heading); color: var(--accent-color); margin-bottom: 0.4rem; font-size: 1rem; }
+        .scheme-card p { color: var(--text-secondary); font-size: 0.9rem; margin-bottom: 0.35rem; }
+        .scheme-card .meta { font-size: 0.82rem; color: var(--text-muted); }
+        .scheme-card .reveal-hint { font-family: var(--font-mono); font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-muted); }
+
+        /* Fund flow */
+        .fund-flow { display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center; justify-content: center; margin: 1.5rem 0; padding: 1.25rem; background: var(--secondary-bg); border-radius: 12px; }
+        .flow-box { padding: 0.85rem 1rem; background: var(--card-bg); border: 2px solid var(--accent-color); border-radius: 10px; text-align: center; min-width: 140px; font-family: var(--font-heading); font-size: 0.82rem; color: var(--text-primary); }
+        .flow-box small { color: var(--text-muted); font-weight: 400; }
+        .flow-box.highlight { background: var(--accent-color); color: #fff; }
+        .flow-box.highlight small { color: rgba(255,255,255,0.85); }
+        .flow-arrow { font-size: 1.4rem; color: var(--accent-color); }
+
+        /* Tags */
+        .tag { display: inline-block; padding: 4px 12px; background: rgba(14,165,233,0.12); color: var(--accent-color); border-radius: 12px; font-size: 0.78rem; font-family: var(--font-heading); font-weight: 600; margin: 4px 4px 4px 0; }
+
+        /* Completion */
+        .completion-badge { text-align: center; padding: 2.5rem 1.5rem; background: var(--secondary-bg); border: 1px solid var(--border-color); border-radius: 16px; margin: 1rem 0; }
+        .completion-badge .tick { width: 72px; height: 72px; border-radius: 50%; background: var(--gradient-primary); display: flex; align-items: center; justify-content: center; margin: 0 auto 1rem; }
+        .completion-badge .tick svg { width: 38px; height: 38px; stroke: #fff; }
+        .completion-badge h2 { font-family: var(--font-heading); color: var(--text-primary); font-size: 1.6rem; margin-bottom: 0.75rem; }
+        .completion-badge p { color: var(--text-secondary); max-width: 560px; margin: 0 auto; }
+        .takeaway-list { text-align: left; max-width: 560px; margin: 1.25rem auto; color: var(--text-secondary); font-size: 0.95rem; line-height: 1.9; padding-left: 1.25rem; }
+        .next-steps { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; margin-top: 1.5rem; }
+
+        /* Buttons + nav */
+        .btn { padding: 0.7rem 1.5rem; border-radius: 8px; border: 1px solid var(--border-color); background: var(--secondary-bg); color: var(--text-primary); font-size: 0.9rem; font-family: var(--font-sans); cursor: pointer; transition: all 0.2s; display: inline-flex; align-items: center; gap: 0.4rem; text-decoration: none; }
+        .btn:hover { border-color: var(--accent-color); background: var(--hover-bg); }
+        .btn-primary { background: var(--accent-color); border-color: var(--accent-color); color: #fff; font-weight: 600; }
+        .btn-primary:hover { background: var(--accent-hover); color: #fff; }
+        .nav-row { display: flex; justify-content: space-between; margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid var(--border-color); gap: 1rem; }
+        ul.body-list { margin: 0.5rem 0 0.75rem 1.5rem; color: var(--text-secondary); font-size: 0.92rem; line-height: 1.8; }
+
+        .v3-inline-icon { width: 16px; height: 16px; vertical-align: middle; display: inline-block; }
+        .v3-paper-plane { position: fixed; top: 15%; right: 6%; width: 130px; height: 130px; opacity: 0.18; z-index: 0; pointer-events: none; animation: v3-float-plane 25s ease-in-out infinite; }
+        @keyframes v3-float-plane { 0% { transform: translate(0,0) rotate(0deg);} 20% { transform: translate(-50px,40px) rotate(10deg);} 40% { transform: translate(100px,30px) rotate(-8deg);} 60% { transform: translate(40px,60px) rotate(15deg);} 80% { transform: translate(-30px,-40px) rotate(-12deg);} 100% { transform: translate(0,0) rotate(0deg);} }
+        @media (prefers-reduced-motion: reduce) { .v3-paper-plane { animation: none !important; } .tab-panel { animation: none; } }
+
+        @media (max-width: 768px) {
+            .container { padding: 1rem; }
+            .v3-paper-plane { width: 90px; height: 90px; opacity: 0.12; }
+            .budget-table { font-size: 0.82rem; }
+            .budget-table th, .budget-table td { padding: 0.5rem 0.55rem; }
+        }
+        @media print {
+            body { background: #fff; color: #000; }
+            .top-controls, .back-link, .tabs, .nav-row, .btn, .im-topbar, .v3-paper-plane { display: none !important; }
+            .tab-panel { display: block !important; page-break-inside: avoid; margin-bottom: 2rem; }
+        }
+    </style>
+<style>
+/* ===== ImpactMojo Design System (topbar / footer) ===== */
+:root {
+    --im-primary-bg: #0F172A; --im-secondary-bg: #1E293B; --im-accent: #0EA5E9; --im-accent-hover: #0284C7;
+    --im-secondary-accent: #6366F1; --im-success: #10B981; --im-text-primary: #F1F5F9; --im-text-secondary: #94A3B8;
+    --im-text-muted: #64748B; --im-card-bg: #1E293B; --im-hover-bg: #334155; --im-border: #334155;
+    --im-nav-bg: rgba(15, 23, 42, 0.95); --im-gradient: linear-gradient(135deg, #0EA5E9 0%, #6366F1 100%);
+}
+[data-theme="light"] {
+    --im-primary-bg: #F8FAFC; --im-secondary-bg: #FFFFFF; --im-accent: #0284C7; --im-accent-hover: #0369A1;
+    --im-text-primary: #0F172A; --im-text-secondary: #475569; --im-text-muted: #64748B; --im-card-bg: #FFFFFF;
+    --im-hover-bg: #F1F5F9; --im-border: #E2E8F0; --im-nav-bg: rgba(248, 250, 252, 0.95);
+}
+.im-topbar { position: fixed; top: 0; left: 0; right: 0; z-index: 9999; background: var(--im-nav-bg); backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px); border-bottom: 1px solid var(--im-border); padding: 0.5rem 1rem; display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; flex-wrap: wrap; font-family: 'Inter', sans-serif; }
+.im-topbar a { text-decoration: none; }
+.im-topbar-left { display: flex; align-items: center; gap: 0.75rem; }
+.im-topbar-home { display: flex; align-items: center; gap: 0.5rem; color: var(--im-text-primary); font-weight: 700; font-size: 1rem; background: var(--im-gradient); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+.im-topbar-home svg { width: 24px; height: 24px; flex-shrink: 0; }
+.im-topbar-right { display: flex; align-items: center; gap: 0.5rem; }
+.im-premium-btn { background: var(--im-gradient); color: #fff !important; padding: 0.35rem 0.85rem; border-radius: 6px; font-size: 0.8rem; font-weight: 600; display: flex; align-items: center; gap: 0.35rem; transition: opacity 0.2s; -webkit-text-fill-color: #fff; }
+.im-premium-btn:hover { opacity: 0.9; }
+.im-premium-btn svg { width: 14px; height: 14px; }
+.im-browse-btn { display: inline-flex; align-items: center; gap: 0.4rem; font-family: 'Inter', sans-serif; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: var(--im-text-primary); background: var(--im-card-bg); border: 1.5px solid var(--im-border); padding: 0.5rem 1rem; border-radius: 0.5rem; text-decoration: none; transition: all 0.18s ease; }
+.im-browse-btn:hover { background: var(--im-accent); color: #FFFFFF; border-color: var(--im-accent); transform: translateY(-1px); }
+.im-browse-btn svg { width: 14px; height: 14px; }
+.im-theme-selector { display: flex; gap: 2px; background: var(--im-card-bg); border: 1px solid var(--im-border); border-radius: 8px; padding: 2px; }
+.im-theme-btn { background: transparent; border: none; color: var(--im-text-secondary); padding: 6px; border-radius: 5px; cursor: pointer; transition: all 0.2s; display: flex; align-items: center; justify-content: center; width: 30px; height: 30px; }
+.im-theme-btn:hover { background: var(--im-hover-bg); color: var(--im-text-primary); }
+.im-theme-btn.active { background: var(--im-accent); color: #fff; }
+.im-theme-btn svg { width: 16px; height: 16px; }
+.im-footer { background: var(--im-secondary-bg); border-top: 1px solid var(--im-border); padding: 2rem 1rem; margin-top: 3rem; font-family: 'Inter', sans-serif; color: var(--im-text-secondary); }
+.im-footer-content { max-width: 1100px; margin: 0 auto; }
+.im-footer-made { text-align: center; margin-bottom: 1.5rem; font-size: 0.9rem; color: var(--im-text-muted); }
+.im-footer-made a { color: var(--im-accent); }
+.im-footer-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1.5rem; margin-bottom: 1.5rem; }
+.im-footer-section h4 { color: var(--im-text-primary); font-size: 0.9rem; margin-bottom: 0.75rem; font-weight: 600; }
+.im-footer-section ul { list-style: none; padding: 0; margin: 0; }
+.im-footer-section li { margin-bottom: 0.4rem; }
+.im-footer-section a { color: var(--im-text-secondary); text-decoration: none; font-size: 0.85rem; transition: color 0.2s; }
+.im-footer-section a:hover { color: var(--im-accent); }
+.im-footer-bottom { text-align: center; padding-top: 1rem; border-top: 1px solid var(--im-border); font-size: 0.8rem; color: var(--im-text-muted); }
+.im-footer-bottom p { margin: 0.25rem 0; }
+.im-footer-bottom a { color: var(--im-accent); text-decoration: none; }
+@media (max-width: 768px) {
+    .im-topbar { padding: 0.4rem 0.75rem; gap: 0.5rem; }
+    .im-topbar-home span { display: inline; font-size: 0.85rem; }
+    .im-footer-grid { grid-template-columns: repeat(2, 1fr); gap: 1rem; }
+}
+@media (max-width: 480px) { .im-footer-grid { grid-template-columns: 1fr; } .im-topbar-home span { display: none; } }
+body { font-family: 'Amaranth', sans-serif; }
+h1, h2, h3, h4, h5, h6 { font-family: 'Inter', sans-serif; }
+code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace; }
+/* Body clears fixed im-topbar */
+body { padding-top: 56px; }
+@media (max-width: 768px) { body { padding-top: 52px; } }
+</style>
+<!-- SEO / social -->
+<meta name="robots" content="index, follow">
+<meta property="og:title" content="Budget & Fiscal Analysis Lab">
+<meta property="og:description" content="Read Union and State budgets, trace fund flows, calculate per-capita spending, and understand fiscal federalism — a hands-on ImpactMojo lab for South Asian development practitioners.">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<meta property="og:url" content="https://www.impactmojo.in/Labs/budget-fiscal-lab.html">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="ImpactMojo">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Budget & Fiscal Analysis Lab">
+<meta name="twitter:description" content="Hands-on ImpactMojo lab: read government budgets, trace fund flows, calculate per-capita spends, and grasp fiscal federalism in India and South Asia.">
+<meta name="twitter:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<link rel="icon" type="image/png" href="/assets/images/favicon.png">
+<link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">
+</head>
+<body>
+<!-- ImpactMojo Top Bar -->
+<div class="im-topbar" id="imTopbar">
+    <div class="im-topbar-left">
+        <a href="../index.html" class="im-topbar-home">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <span>ImpactMojo</span>
+        </a>
+    </div>
+    <div class="im-topbar-right">
+        <a href="/catalog.html" class="im-browse-btn" title="Browse all content"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>Browse</a>
+        <a href="../premium.html" class="im-premium-btn">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+            Premium
+        </a>
+        <div class="im-theme-selector" aria-label="Theme selection">
+            <button class="im-theme-btn" data-theme="system" title="System theme" aria-label="Use system theme">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+            </button>
+            <button class="im-theme-btn" data-theme="light" title="Light theme" aria-label="Use light theme">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+            </button>
+            <button class="im-theme-btn" data-theme="dark" title="Dark theme" aria-label="Use dark theme">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
+        </div>
+    </div>
+</div>
+
+<a href="#main" class="back-link" style="position:absolute;left:-9999px;top:0;">Skip to content</a>
+<div class="container" id="main">
+    <svg class="v3-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M80,130 L150,50" stroke="#10B981" stroke-width="2" stroke-dasharray="4,4"/>
+        <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+    </svg>
+
+    <a href="../index.html" class="back-link">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="M12 19l-7-7 7-7"/></svg>
+        Back to ImpactMojo
+    </a>
+
+    <div class="header">
+        <div class="header-badge"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Bar_chart.svg" alt="" class="v3-inline-icon" loading="lazy" style="filter:brightness(0) saturate(100%) invert(56%) sepia(72%) saturate(2840%) hue-rotate(177deg) brightness(97%) contrast(93%)"> Interactive Lab</div>
+        <h1>Budget &amp; Fiscal Analysis Lab</h1>
+        <p>Learn to read, dissect, and analyse government budgets like a practitioner — from Union Budget speeches to state-level scheme allocations. Built for development work across South Asia.</p>
+    </div>
+
+    <div class="top-controls">
+        <button class="ctrl-btn" onclick="exportNotes()">Export notes</button>
+        <button class="ctrl-btn" onclick="window.print()">Print</button>
+    </div>
+
+    <div class="progress-bar"><div class="progress-bar-fill" id="progressFill"></div></div>
+
+    <div class="tabs" id="tabs">
+        <button class="tab-btn active" onclick="switchTab(0)"><span class="tab-num">1</span> Budget Anatomy</button>
+        <button class="tab-btn" onclick="switchTab(1)"><span class="tab-num">2</span> Fund Flows</button>
+        <button class="tab-btn" onclick="switchTab(2)"><span class="tab-num">3</span> Scheme Analysis</button>
+        <button class="tab-btn" onclick="switchTab(3)"><span class="tab-num">4</span> Per-Capita Math</button>
+        <button class="tab-btn" onclick="switchTab(4)"><span class="tab-num">5</span> Fiscal Federalism</button>
+        <button class="tab-btn" onclick="switchTab(5)"><span class="tab-num">6</span> Practice</button>
+        <button class="tab-btn" onclick="switchTab(6)"><span class="tab-num">7</span> Done</button>
+    </div>
+
+    <!-- ===== TAB 1: Budget Anatomy ===== -->
+    <div class="tab-panel active" data-panel="0">
+        <h2 class="section-title">Anatomy of an Indian Budget</h2>
+        <p class="section-desc">Understanding how a budget is structured is the first skill for any practitioner working with government schemes.</p>
+
+        <div class="info-box">
+            <strong>Context:</strong> India's Union Budget (presented every February) planned total expenditure of about <strong>₹50.65 lakh crore</strong> in 2025-26. Knowing how that money is organised is essential before you can analyse any single scheme.
+        </div>
+
+        <h3 class="block-title">The three documents practitioners must know</h3>
+
+        <div class="scheme-card" onclick="toggleCard(this)">
+            <h4>1. Budget Speech</h4>
+            <p>The Finance Minister's speech announcing new schemes, tax changes, and policy priorities. <strong>What to look for:</strong> new scheme announcements, allocation changes, sectoral priorities.</p>
+            <div class="meta">Example (Union Budget 2025-26): nil income tax on annual income up to ₹12 lakh under the new regime; the new <em>PM Dhan-Dhaanya Krishi Yojana</em> covering 100 low-productivity districts; Kisan Credit Card limit raised from ₹3 lakh to ₹5 lakh.</div>
+        </div>
+
+        <div class="scheme-card" onclick="toggleCard(this)">
+            <h4>2. Expenditure Budget (Demand for Grants)</h4>
+            <p>Ministry-wise detailed breakdown of planned spending. <strong>What to look for:</strong> scheme-level allocations, revenue vs capital expenditure.</p>
+            <div class="meta">Key ministries for development work: Rural Development, Education, Health &amp; Family Welfare, Women &amp; Child Development, Agriculture.</div>
+        </div>
+
+        <div class="scheme-card" onclick="toggleCard(this)">
+            <h4>3. Receipts Budget</h4>
+            <p>Where the money comes from — taxes, borrowings, non-tax revenue. <strong>What to look for:</strong> fiscal deficit target, tax-to-GDP ratio, dependence on borrowings.</p>
+            <div class="meta">India's fiscal deficit target for 2025-26: 4.4% of GDP (down from a revised 4.8% in 2024-25).</div>
+        </div>
+
+        <h3 class="block-title">Key budget terms</h3>
+        <div class="table-scroll">
+        <table class="budget-table">
+            <tr><th>Term</th><th>Meaning</th><th>Why it matters</th></tr>
+            <tr><td><strong>BE (Budget Estimate)</strong></td><td>What the government plans to spend</td><td>Often aspirational — compare with RE and actuals</td></tr>
+            <tr><td><strong>RE (Revised Estimate)</strong></td><td>Mid-year correction to the BE</td><td>Shows where the government is cutting or adding</td></tr>
+            <tr><td><strong>Actuals</strong></td><td>What was really spent</td><td>Compare with BE to see utilisation rates</td></tr>
+            <tr><td><strong>Revenue Expenditure</strong></td><td>Salaries, subsidies, interest payments (consumption)</td><td>Recurring — does not create physical assets</td></tr>
+            <tr><td><strong>Capital Expenditure</strong></td><td>Infrastructure, equipment, buildings (investment)</td><td>Creates long-term assets; watched as a growth signal</td></tr>
+            <tr><td><strong>Fiscal Deficit</strong></td><td>Total borrowing needed = total expenditure − total receipts (excluding borrowings)</td><td>Higher = more debt servicing burden in future years</td></tr>
+        </table>
+        </div>
+
+        <div class="exercise">
+            <div class="exercise-question">Quick check: a ministry's BE is ₹500 crore, RE is ₹400 crore, and actual spending is ₹350 crore. What does this tell you?</div>
+            <div class="option" onclick="selectOption(this, false, 'q1')">The ministry is efficient and saved money</div>
+            <div class="option" onclick="selectOption(this, true, 'q1')">The ministry overestimated needs and under-utilised funds — a possible implementation bottleneck</div>
+            <div class="option" onclick="selectOption(this, false, 'q1')">The ministry needs a budget increase next year</div>
+            <div class="option" onclick="selectOption(this, false, 'q1')">This is normal and not worth investigating</div>
+            <div class="feedback" id="fb-q1"></div>
+        </div>
+
+        <div class="nav-row">
+            <span></span>
+            <button class="btn btn-primary" onclick="switchTab(1)">Next: Fund Flows &rarr;</button>
+        </div>
+    </div>
+
+    <!-- ===== TAB 2: Fund Flows ===== -->
+    <div class="tab-panel" data-panel="1">
+        <h2 class="section-title">Tracing Fund Flows in India</h2>
+        <p class="section-desc">Money allocated in Delhi does not always reach the field. Tracing fund flows helps you spot delays and bottlenecks in implementation.</p>
+
+        <div class="info-box"><strong>Why this matters:</strong> Understanding the path a rupee takes — Centre to State to district to beneficiary — tells you where funds get stuck.</div>
+
+        <h3 class="block-title">The journey of a rupee: PMGSY (rural roads) example</h3>
+        <div class="fund-flow">
+            <div class="flow-box highlight">Union Budget<br><small>~₹19,000 cr BE</small></div>
+            <div class="flow-arrow">&rarr;</div>
+            <div class="flow-box">Ministry of Rural Development<br><small>Central allocation</small></div>
+            <div class="flow-arrow">&rarr;</div>
+            <div class="flow-box">State Rural Dev. Dept<br><small>Cost-share 60:40*</small></div>
+            <div class="flow-arrow">&rarr;</div>
+            <div class="flow-box">District Panchayat<br><small>Implementation</small></div>
+            <div class="flow-arrow">&rarr;</div>
+            <div class="flow-box">Gram Panchayat / Contractor<br><small>Road built</small></div>
+        </div>
+        <p class="body-text" style="font-size:0.82rem;color:var(--text-muted);">*Centre:State share is 60:40 for most states and 90:10 for North-Eastern and Himalayan states.</p>
+
+        <div class="info-box warning">
+            <strong>Leakage — a contested but important idea:</strong> At each hand-off, funds can be delayed or diverted. The long-quoted claim that "only 15 paise of every rupee reaches the poor" (attributed to Rajiv Gandhi in 1985) is debated and dated — modern Direct Benefit Transfer (DBT) has cut leakage sharply for cash schemes. Use the slider below to build intuition, not to quote a fixed number.
+        </div>
+
+        <h3 class="block-title">Interactive: fund-flow simulator <span class="illustrative-tag">Illustrative model</span></h3>
+        <p class="body-text">Adjust the sliders to see how central share and administrative losses change what actually reaches the ground.</p>
+
+        <div class="slider-container">
+            <label>Central Allocation (₹ crore)</label>
+            <input type="range" id="centralAlloc" min="100" max="5000" value="1000" oninput="updateFundFlow()">
+            <div class="slider-value" id="centralVal">₹1,000 cr</div>
+        </div>
+        <div class="slider-container">
+            <label>Central Share (%)</label>
+            <input type="range" id="centralShare" min="50" max="100" value="60" oninput="updateFundFlow()">
+            <div class="slider-value" id="shareVal">60%</div>
+        </div>
+        <div class="slider-container">
+            <label>Administrative &amp; leakage loss (%)</label>
+            <input type="range" id="leakage" min="0" max="50" value="25" oninput="updateFundFlow()">
+            <div class="slider-value" id="leakageVal">25%</div>
+        </div>
+
+        <div class="result-box" id="fundFlowResult">
+            <h4>Result</h4>
+            <p>Central releases: <strong id="centralRelease">₹600 cr</strong></p>
+            <p>State matching share: <strong id="stateMatch">₹400 cr</strong></p>
+            <p>Total pool: <strong id="totalPool">₹1,000 cr</strong></p>
+            <p>After 25% loss: <span class="big-figure" id="finalAmount">₹750 cr</span> reaches implementation</p>
+            <p style="margin-top:0.5rem;color:var(--text-muted);"><strong id="lossAmount">₹250 cr</strong> is lost before a single road is built.</p>
+        </div>
+
+        <h3 class="block-title">Key schemes &amp; their flow patterns</h3>
+        <div class="table-scroll">
+        <table class="budget-table">
+            <tr><th>Scheme</th><th>Fund flow pattern</th><th>Common bottleneck</th></tr>
+            <tr><td>MGNREGA</td><td>Centre &rarr; State &rarr; District &rarr; GP &rarr; Worker (DBT)</td><td>Wage payment delays, job-card issues</td></tr>
+            <tr><td>PM-KISAN</td><td>Centre &rarr; Farmer's bank account (DBT)</td><td>Land-record mismatches, exclusion errors</td></tr>
+            <tr><td>Ayushman Bharat (PM-JAY)</td><td>Centre &rarr; State Health Agency &rarr; Empanelled hospital</td><td>Empanelment delays, claim rejections</td></tr>
+            <tr><td>PM Awas Yojana</td><td>Centre &rarr; State &rarr; District &rarr; Beneficiary (instalments)</td><td>Beneficiary identification, construction quality</td></tr>
+            <tr><td>PM POSHAN (Mid-Day Meal)</td><td>Centre &rarr; State &rarr; School (cost-sharing 60:40)</td><td>Food-grain supply, cooking-cost releases</td></tr>
+        </table>
+        </div>
+
+        <div class="nav-row">
+            <button class="btn" onclick="switchTab(0)">&larr; Back</button>
+            <button class="btn btn-primary" onclick="switchTab(2)">Next: Scheme Analysis &rarr;</button>
+        </div>
+    </div>
+
+    <!-- ===== TAB 3: Scheme Analysis ===== -->
+    <div class="tab-panel" data-panel="2">
+        <h2 class="section-title">Reading a Scheme Budget</h2>
+        <p class="section-desc">When someone says "₹50,000 crore for education," what does that actually buy? This is how you read beyond the headline number.</p>
+
+        <div class="info-box">
+            <strong>Practitioner skill:</strong> Always break a headline allocation into components, and always compare BE with RE to see what changed mid-year.
+        </div>
+
+        <h3 class="block-title">Case study: Samagra Shiksha (school education) <span class="illustrative-tag">Illustrative breakdown</span></h3>
+        <p class="body-text">Samagra Shiksha is India's flagship school-education scheme. Its 2025-26 allocation was about <strong>₹41,250 crore (BE)</strong>, later revised to roughly <strong>₹38,000 crore (RE)</strong>. The component split below is a <em>teaching example</em> to practise reading a scheme — the totals are realistic, but the sub-line numbers are illustrative, not official.</p>
+
+        <div class="table-scroll">
+        <table class="budget-table">
+            <tr><th>Component</th><th>BE (₹ cr)</th><th>RE (₹ cr)</th><th>Change</th></tr>
+            <tr><td>Samagra Shiksha (total)</td><td>41,250</td><td>38,000</td><td class="highlight">−7.9%</td></tr>
+            <tr><td>&nbsp;&nbsp;&rarr; RTE / general education</td><td>20,000</td><td>18,500</td><td>−7.5%</td></tr>
+            <tr><td>&nbsp;&nbsp;&rarr; Teacher training</td><td>1,300</td><td>950</td><td class="highlight">−27%</td></tr>
+            <tr><td>&nbsp;&nbsp;&rarr; Digital / ICT education</td><td>2,600</td><td>2,900</td><td class="up">+12%</td></tr>
+            <tr><td>&nbsp;&nbsp;&rarr; School infrastructure</td><td>8,300</td><td>6,600</td><td class="highlight">−20%</td></tr>
+            <tr><td>&nbsp;&nbsp;&rarr; Inclusive education</td><td>1,050</td><td>800</td><td class="highlight">−24%</td></tr>
+        </table>
+        </div>
+
+        <div class="info-box warning">
+            <strong>Red flags to spot:</strong><br>
+            • <strong>Teacher training cut ~27%</strong> — quality investment shrinks even as enrolment grows.<br>
+            • <strong>Infrastructure cut ~20%</strong> — schools continue to lack basic facilities.<br>
+            • A rise in one glossy line (digital) can distract from cuts to core lines.
+        </div>
+
+        <div class="exercise">
+            <div class="exercise-question">You are reviewing a state's Women &amp; Child Development budget. BE was ₹2,000 cr, RE is ₹1,400 cr. The ICDS/Anganwadi component was cut from ₹1,200 cr to ₹800 cr, while "administrative overheads" stayed flat at ₹200 cr. What should you flag? <span class="illustrative-tag">Illustrative figures</span></div>
+            <div class="option" onclick="selectOption(this, false, 'q2')">The overall 30% cut is concerning but normal</div>
+            <div class="option" onclick="selectOption(this, true, 'q2')">Frontline ICDS services for children are being cut while administrative costs are protected — a prioritisation problem</div>
+            <div class="option" onclick="selectOption(this, false, 'q2')">Administrative costs should also be cut proportionally</div>
+            <div class="option" onclick="selectOption(this, false, 'q2')">This is a state matter, not worth flagging</div>
+            <div class="feedback" id="fb-q2"></div>
+        </div>
+
+        <div class="nav-row">
+            <button class="btn" onclick="switchTab(1)">&larr; Back</button>
+            <button class="btn btn-primary" onclick="switchTab(3)">Next: Per-Capita Math &rarr;</button>
+        </div>
+    </div>
+
+    <!-- ===== TAB 4: Per-Capita Math ===== -->
+    <div class="tab-panel" data-panel="3">
+        <h2 class="section-title">Per-Capita &amp; Per-Beneficiary Math</h2>
+        <p class="section-desc">Never trust a budget number without dividing it by the people it serves. ₹10,000 crore sounds huge; ₹200 per person tells a different story.</p>
+
+        <h3 class="block-title">Interactive calculator <span class="illustrative-tag">Illustrative model</span></h3>
+        <div class="slider-container">
+            <label>Total budget allocation (₹ crore)</label>
+            <input type="range" id="totalBudget" min="100" max="10000" value="1000" oninput="updatePerCapita()">
+            <div class="slider-value" id="budgetVal">₹1,000 cr</div>
+        </div>
+        <div class="slider-container">
+            <label>Target population / beneficiaries (in lakh)</label>
+            <input type="range" id="population" min="1" max="500" value="50" oninput="updatePerCapita()">
+            <div class="slider-value" id="popVal">50 lakh</div>
+        </div>
+        <div class="slider-container">
+            <label>Actual utilisation (%)</label>
+            <input type="range" id="utilization" min="10" max="100" value="70" oninput="updatePerCapita()">
+            <div class="slider-value" id="utilVal">70%</div>
+        </div>
+
+        <div class="result-box">
+            <h4>Per-beneficiary spending</h4>
+            <p><span class="big-figure">₹<span id="perPerson">1,400</span></span> per person per year</p>
+            <p>That is <strong>₹<span id="perMonth">117</span></strong> per person per month</p>
+            <p style="color:var(--text-muted);">Or <strong>₹<span id="perDay">3.84</span></strong> per person per day</p>
+        </div>
+
+        <h3 class="block-title">Real examples from India <span class="illustrative-tag">Approx. 2024-26 figures</span></h3>
+        <div class="table-scroll">
+        <table class="budget-table">
+            <tr><th>Scheme</th><th>Annual budget</th><th>Beneficiaries</th><th>Per person / year</th><th>Per person / day</th></tr>
+            <tr><td>MGNREGA</td><td>~₹86,000 cr</td><td>~7.5 cr households</td><td>~₹11,500</td><td>~₹31</td></tr>
+            <tr><td>PM-KISAN</td><td>~₹60,000 cr</td><td>~9.7 cr farmers</td><td>~₹6,000 (₹6k/yr entitlement)</td><td>~₹16</td></tr>
+            <tr><td>Ayushman Bharat (PM-JAY)</td><td>~₹9,400 cr</td><td>~55 cr eligible</td><td>~₹170</td><td>~₹0.47</td></tr>
+            <tr><td>PM POSHAN (Mid-Day Meal)</td><td>~₹12,500 cr</td><td>~11.8 cr children</td><td>~₹1,060</td><td>~₹2.90</td></tr>
+            <tr><td>Saksham Anganwadi / POSHAN 2.0</td><td>~₹21,000 cr</td><td>~8 cr children</td><td>~₹2,600</td><td>~₹7.10</td></tr>
+        </table>
+        </div>
+
+        <div class="info-box warning">
+            <strong>Reality check:</strong> Ayushman Bharat's ~₹170 per eligible person per year sounds tiny until you realise it is <em>insurance</em> (risk-pooling for a ₹5 lakh cover), not a cash transfer. A single hospitalisation can cost far more than the per-capita figure — per-capita framing is a starting question, not the final verdict.
+        </div>
+
+        <div class="nav-row">
+            <button class="btn" onclick="switchTab(2)">&larr; Back</button>
+            <button class="btn btn-primary" onclick="switchTab(4)">Next: Fiscal Federalism &rarr;</button>
+        </div>
+    </div>
+
+    <!-- ===== TAB 5: Fiscal Federalism ===== -->
+    <div class="tab-panel" data-panel="4">
+        <h2 class="section-title">Fiscal Federalism in Practice</h2>
+        <p class="section-desc">India is a federal system where both Centre and States raise and spend money. The Finance Commission decides how central tax revenue is shared.</p>
+
+        <div class="info-box"><strong>Why state practitioners care:</strong> How much fiscal room a state has determines whether it can set its own development priorities or must follow central scheme designs.</div>
+
+        <h3 class="block-title">Who taxes what?</h3>
+        <div class="table-scroll">
+        <table class="budget-table">
+            <tr><th>Tax type</th><th>Who levies</th><th>Goes to</th></tr>
+            <tr><td>Income &amp; corporate tax</td><td>Centre</td><td>Divisible pool (shared with states)</td></tr>
+            <tr><td>GST</td><td>Centre + States jointly</td><td>CGST to Centre, SGST to State; IGST apportioned</td></tr>
+            <tr><td>Customs duty</td><td>Centre only</td><td>Centre keeps 100%</td></tr>
+            <tr><td>Excise / cess on petrol, diesel</td><td>Centre only</td><td>Centre keeps 100% (cesses stay outside the divisible pool)</td></tr>
+            <tr><td>Stamp duty, State excise (liquor)</td><td>States</td><td>State keeps 100%</td></tr>
+            <tr><td>Property tax</td><td>Local bodies</td><td>Municipality / Panchayat</td></tr>
+        </table>
+        </div>
+
+        <h3 class="block-title">Finance Commission &amp; devolution</h3>
+        <p class="body-text">The 15th Finance Commission (award period 2021–26) recommended that <strong>41% of the divisible pool</strong> go to states (vertical devolution). Its criteria for sharing among states (horizontal devolution) were:</p>
+        <div class="result-box">
+            <p><strong>Horizontal devolution weights (15th FC):</strong></p>
+            <ul class="body-list">
+                <li>Income distance: 45% (poorer states get more)</li>
+                <li>Population (2011 Census): 15%</li>
+                <li>Area: 15%</li>
+                <li>Forest &amp; ecology: 10%</li>
+                <li>Demographic performance: 12.5%</li>
+                <li>Tax &amp; fiscal effort: 2.5%</li>
+            </ul>
+        </div>
+
+        <div class="exercise">
+            <div class="exercise-question">A low-income state raises only a small share of its own revenue and depends heavily on central transfers, while a richer state raises most of its own. What does this mean for development planning? <span class="illustrative-tag">Illustrative</span></div>
+            <div class="option" onclick="selectOption(this, false, 'q3')">The poorer state is simply badly governed and should raise more taxes</div>
+            <div class="option" onclick="selectOption(this, true, 'q3')">The poorer state has limited fiscal autonomy — its plans depend on central priorities and the timing of transfers, making long-term planning harder</div>
+            <div class="option" onclick="selectOption(this, false, 'q3')">The richer state is over-taxing its citizens</div>
+            <div class="option" onclick="selectOption(this, false, 'q3')">Both states have equal development capacity</div>
+            <div class="feedback" id="fb-q3"></div>
+        </div>
+
+        <div class="nav-row">
+            <button class="btn" onclick="switchTab(3)">&larr; Back</button>
+            <button class="btn btn-primary" onclick="switchTab(5)">Next: Practice &rarr;</button>
+        </div>
+    </div>
+
+    <!-- ===== TAB 6: Practice ===== -->
+    <div class="tab-panel" data-panel="5">
+        <h2 class="section-title">Build Your Own Budget Analysis</h2>
+        <p class="section-desc">Apply everything to a simplified state education budget — the kind of review a programme manager or policy researcher does in practice.</p>
+
+        <div class="info-box"><strong>Scenario:</strong> You are a development consultant reviewing the education budget of a hypothetical Indian state (population 5 crore, ~80 lakh school-age children). <span class="illustrative-tag">Illustrative scenario</span></div>
+
+        <div class="table-scroll">
+        <table class="budget-table">
+            <tr><th>Head</th><th>BE this year (₹ cr)</th><th>BE last year (₹ cr)</th><th>Change</th></tr>
+            <tr><td>Teacher salaries</td><td>8,500</td><td>8,000</td><td class="up">+6.3%</td></tr>
+            <tr><td>School infrastructure</td><td>1,200</td><td>1,500</td><td class="highlight">−20%</td></tr>
+            <tr><td>Mid-day meal</td><td>800</td><td>750</td><td class="up">+6.7%</td></tr>
+            <tr><td>Digital education</td><td>600</td><td>200</td><td class="up">+200%</td></tr>
+            <tr><td>Scholarships (SC/ST/OBC)</td><td>400</td><td>450</td><td class="highlight">−11.1%</td></tr>
+            <tr><td>Teacher training</td><td>150</td><td>180</td><td class="highlight">−16.7%</td></tr>
+            <tr><td>Administrative costs</td><td>350</td><td>320</td><td class="up">+9.4%</td></tr>
+            <tr class="total-row"><td>Total</td><td>12,000</td><td>11,400</td><td>+5.3%</td></tr>
+        </table>
+        </div>
+
+        <h3 class="block-title">Your analysis tasks — click each to reveal guidance</h3>
+
+        <div class="scheme-card" onclick="toggleCard(this)">
+            <h4>1. What is the per-student spending? <span class="reveal-hint">tap to reveal</span></h4>
+            <p>₹12,000 cr ÷ 80 lakh students = <strong>₹15,000 per student per year</strong> — about ₹1,250 a month or ₹42 a day. Compare that with local private-school fees to gauge adequacy.</p>
+        </div>
+        <div class="scheme-card" onclick="toggleCard(this)">
+            <h4>2. Revenue vs capital split? <span class="reveal-hint">tap to reveal</span></h4>
+            <p>Revenue (salaries + meals + admin): ₹9,650 cr (~80%). Capital (infrastructure + digital): ₹1,800 cr (~15%). Roughly <strong>80% consumption, 15% investment</strong> — typical for Indian states.</p>
+        </div>
+        <div class="scheme-card" onclick="toggleCard(this)">
+            <h4>3. What are the red flags? <span class="reveal-hint">tap to reveal</span></h4>
+            <p>Infrastructure −20% while digital +200% (are schools ready for digital?); scholarships −11% (marginalised students lose support); teacher training −17% but salaries +6% (paying more for the same quality?); admin +9% while frontline services shrink.</p>
+        </div>
+        <div class="scheme-card" onclick="toggleCard(this)">
+            <h4>4. What would you ask the Education Department? <span class="reveal-hint">tap to reveal</span></h4>
+            <p>What was last year's infrastructure utilisation rate? How many schools lack electricity/internet for digital learning? What is the teacher-vacancy rate? Why were scholarships cut when SC/ST dropout is rising?</p>
+        </div>
+
+        <div class="nav-row">
+            <button class="btn" onclick="switchTab(4)">&larr; Back</button>
+            <button class="btn btn-primary" onclick="switchTab(6)">Finish Lab &rarr;</button>
+        </div>
+    </div>
+
+    <!-- ===== TAB 7: Done ===== -->
+    <div class="tab-panel" data-panel="6">
+        <div class="completion-badge">
+            <div class="tick"><svg viewBox="0 0 24 24" fill="none" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></div>
+            <h2>Lab complete</h2>
+            <p>You can now read budget documents, trace fund flows, calculate per-capita spending, and spot red flags in fiscal data.</p>
+            <ul class="takeaway-list">
+                <li>Read and interpret Union and State budget documents (BE / RE / actuals)</li>
+                <li>Trace fund flows from Centre to beneficiary and locate bottlenecks</li>
+                <li>Calculate per-capita and per-beneficiary spending</li>
+                <li>Identify fiscal-federalism constraints on state planning</li>
+                <li>Write a budget-analysis brief grounded in evidence</li>
+            </ul>
+            <div>
+                <span class="tag">Budget Analysis</span>
+                <span class="tag">Fiscal Federalism</span>
+                <span class="tag">Public Finance</span>
+                <span class="tag">South Asia</span>
+            </div>
+        </div>
+
+        <h3 class="block-title" style="text-align:center;">Recommended next steps</h3>
+        <div class="next-steps">
+            <a href="policy-analysis-lab.html" class="btn btn-primary">Try the Policy Analysis Lab &rarr;</a>
+            <a href="../index.html" class="btn">Explore more on ImpactMojo</a>
+        </div>
+
+        <div class="nav-row">
+            <button class="btn" onclick="switchTab(5)">&larr; Review</button>
+            <button class="btn" onclick="window.print()">Print / save as PDF</button>
+        </div>
+    </div>
+
+</div>
+
+<!-- ImpactMojo Footer -->
+<footer class="im-footer" role="contentinfo">
+<div class="im-footer-content">
+<p class="im-footer-made">Made with &#10084; by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+<div class="im-footer-grid">
+<div class="im-footer-section">
+<h4>Learn</h4>
+<ul>
+<li><a href="../courses.html">Courses</a></li>
+<li><a href="index.html">Interactive Labs</a></li>
+<li><a href="../Games/">Games</a></li>
+<li><a href="../catalog.html">Full Catalog</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Explore</h4>
+<ul>
+<li><a href="../index.html">Home</a></li>
+<li><a href="../blog.html">Blog</a></li>
+<li><a href="../BookSummaries/">Book Summaries</a></li>
+<li><a href="../premium.html">Premium</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>About</h4>
+<ul>
+<li><a href="../about.html">About ImpactMojo</a></li>
+<li><a href="../contact.html">Contact</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Connect</h4>
+<ul>
+<li><a href="https://www.impactmojo.in">impactmojo.in</a></li>
+</ul>
+</div>
+</div>
+<div class="im-footer-bottom">
+<p>&copy; 2026 ImpactMojo. Free development education for South Asia.</p>
+<p><a href="../index.html">Home</a> &middot; <a href="index.html">Labs</a> &middot; <a href="../catalog.html">Catalog</a></p>
+</div>
+</div>
+</footer>
+
+<script>
+/* THEME (3-button: system / light / dark) */
+(function initTheme() {
+    var saved = localStorage.getItem('impactmojo-theme') || 'system';
+    applyTheme(saved);
+    document.querySelectorAll('.im-theme-btn').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+            var theme = btn.dataset.theme;
+            localStorage.setItem('impactmojo-theme', theme);
+            applyTheme(theme);
+        });
+    });
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function() {
+        if ((localStorage.getItem('impactmojo-theme') || 'system') === 'system') applyTheme('system');
+    });
+})();
+function applyTheme(theme) {
+    var root = document.documentElement;
+    if (theme === 'light') { root.setAttribute('data-theme', 'light'); }
+    else if (theme === 'dark') { root.removeAttribute('data-theme'); }
+    else { if (window.matchMedia('(prefers-color-scheme: light)').matches) root.setAttribute('data-theme', 'light'); else root.removeAttribute('data-theme'); }
+    document.querySelectorAll('.im-theme-btn').forEach(function(b) { b.classList.toggle('active', b.dataset.theme === theme); });
+}
+
+/* TABS */
+var TOTAL_TABS = 7;
+var visited = { 0: true };
+function switchTab(idx) {
+    visited[idx] = true;
+    document.querySelectorAll('.tab-btn').forEach(function(b, i) {
+        b.classList.toggle('active', i === idx);
+        b.classList.toggle('completed', i < idx || (visited[i] && i !== idx));
+    });
+    document.querySelectorAll('.tab-panel').forEach(function(p, i) { p.classList.toggle('active', i === idx); });
+    document.getElementById('progressFill').style.width = ((idx + 1) / TOTAL_TABS * 100) + '%';
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+}
+
+/* QUIZ */
+function selectOption(el, isCorrect, group) {
+    var parent = el.closest('.exercise');
+    parent.querySelectorAll('.option').forEach(function(o) {
+        o.classList.remove('correct', 'incorrect');
+        o.style.pointerEvents = 'none';
+    });
+    el.classList.add(isCorrect ? 'correct' : 'incorrect');
+    var fb = parent.querySelector('.feedback');
+    fb.classList.add('show');
+    fb.classList.remove('correct', 'incorrect');
+    fb.classList.add(isCorrect ? 'correct' : 'incorrect');
+    fb.innerHTML = (isCorrect ? '✅ Correct. ' : '❌ Not quite. ') + explain(group);
+}
+function explain(group) {
+    if (group === 'q1') return 'A large gap between BE, RE and actuals usually signals poor planning or an implementation bottleneck — the ministry either overestimated needs or could not execute. Always check utilisation before assuming "savings".';
+    if (group === 'q2') return 'When frontline services (ICDS/Anganwadi) are cut but administrative costs are protected, it points to a prioritisation failure — the bureaucracy is shielded while children lose nutrition and early-education support.';
+    if (group === 'q3') return 'States with low own-revenue depend heavily on the Finance Commission and centrally sponsored schemes. They have less room to set their own priorities and must wait on central fund releases, which makes multi-year planning harder.';
+    return '';
+}
+
+/* REVEAL CARDS */
+function toggleCard(el) { el.classList.toggle('selected'); }
+
+/* FUND FLOW SIMULATOR */
+function updateFundFlow() {
+    var central = parseInt(document.getElementById('centralAlloc').value, 10);
+    var share = parseInt(document.getElementById('centralShare').value, 10);
+    var leakage = parseInt(document.getElementById('leakage').value, 10);
+    document.getElementById('centralVal').textContent = '₹' + central.toLocaleString('en-IN') + ' cr';
+    document.getElementById('shareVal').textContent = share + '%';
+    document.getElementById('leakageVal').textContent = leakage + '%';
+    var centralRelease = Math.round(central * share / 100);
+    var stateMatch = Math.round(central * (100 - share) / 100);
+    var totalPool = centralRelease + stateMatch;
+    var finalAmount = Math.round(totalPool * (100 - leakage) / 100);
+    var loss = totalPool - finalAmount;
+    document.getElementById('centralRelease').textContent = '₹' + centralRelease.toLocaleString('en-IN') + ' cr';
+    document.getElementById('stateMatch').textContent = '₹' + stateMatch.toLocaleString('en-IN') + ' cr';
+    document.getElementById('totalPool').textContent = '₹' + totalPool.toLocaleString('en-IN') + ' cr';
+    document.getElementById('finalAmount').textContent = '₹' + finalAmount.toLocaleString('en-IN') + ' cr';
+    document.getElementById('lossAmount').textContent = '₹' + loss.toLocaleString('en-IN') + ' cr';
+}
+
+/* PER-CAPITA CALCULATOR */
+function updatePerCapita() {
+    var budget = parseInt(document.getElementById('totalBudget').value, 10);
+    var pop = parseInt(document.getElementById('population').value, 10);
+    var util = parseInt(document.getElementById('utilization').value, 10);
+    document.getElementById('budgetVal').textContent = '₹' + budget.toLocaleString('en-IN') + ' cr';
+    document.getElementById('popVal').textContent = pop + ' lakh';
+    document.getElementById('utilVal').textContent = util + '%';
+    var actualBudget = budget * util / 100;
+    var totalPop = pop * 100000;
+    var perPerson = Math.round(actualBudget * 10000000 / totalPop);
+    var perMonth = Math.round(perPerson / 12);
+    var perDay = (perPerson / 365).toFixed(2);
+    document.getElementById('perPerson').textContent = perPerson.toLocaleString('en-IN');
+    document.getElementById('perMonth').textContent = perMonth.toLocaleString('en-IN');
+    document.getElementById('perDay').textContent = perDay;
+}
+
+/* EXPORT NOTES */
+function exportNotes() {
+    var lines = [
+        'ImpactMojo — Budget & Fiscal Analysis Lab',
+        '=========================================',
+        '',
+        'Key skills practised:',
+        '- Reading BE / RE / Actuals and spotting under-utilisation',
+        '- Tracing fund flows (Centre -> State -> district -> beneficiary)',
+        '- Reading a scheme budget by component, not headline',
+        '- Per-capita and per-beneficiary math',
+        '- Fiscal federalism: divisible pool, 15th FC devolution (41% vertical)',
+        '',
+        'Reminder: figures marked "Illustrative" are teaching examples, not official data.',
+        'Verify current allocations against the Union/State Budget and PRS Legislative Research.'
+    ].join('\n');
+    var blob = new Blob([lines], { type: 'text/plain' });
+    var a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'budget-fiscal-lab-notes.txt';
+    a.click();
+    URL.revokeObjectURL(a.href);
+}
+
+/* INIT */
+updateFundFlow();
+updatePerCapita();
+</script>
+</body>
+</html>

--- a/Labs/index.html
+++ b/Labs/index.html
@@ -3,19 +3,19 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>15 Interactive Labs — Hands-On Tools for Development Practice | ImpactMojo</title>
-<meta name="description" content="The ImpactMojo Interactive Labs — 15 free, browser-based workspaces for development practitioners. Build theories of change, MEL systems, gender analyses, policy briefs, advocacy campaigns, partnership maps and more. Free forever, your work saves to your browser.">
+<title>16 Interactive Labs — Hands-On Tools for Development Practice | ImpactMojo</title>
+<meta name="description" content="The ImpactMojo Interactive Labs — 16 free, browser-based workspaces for development practitioners. Build theories of change, MEL systems, gender analyses, policy briefs, advocacy campaigns, partnership maps and more. Free forever, your work saves to your browser.">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://www.impactmojo.in/labs/">
 <meta property="og:type" content="website">
-<meta property="og:title" content="15 Interactive Labs — Hands-On Tools for Development Practice">
-<meta property="og:description" content="15 free, browser-based ImpactMojo Labs — theory of change, MEL systems, gender analysis, policy briefs, advocacy, partnerships and more. Free forever, work saves to your browser.">
+<meta property="og:title" content="16 Interactive Labs — Hands-On Tools for Development Practice">
+<meta property="og:description" content="16 free, browser-based ImpactMojo Labs — theory of change, MEL systems, gender analysis, policy briefs, advocacy, partnerships and more. Free forever, work saves to your browser.">
 <meta property="og:url" content="https://www.impactmojo.in/labs/">
 <meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
 <meta property="og:site_name" content="ImpactMojo">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="15 ImpactMojo Interactive Labs">
-<meta name="twitter:description" content="15 free, browser-based hands-on labs for development practice. Free forever, work saves to your browser.">
+<meta name="twitter:title" content="16 ImpactMojo Interactive Labs">
+<meta name="twitter:description" content="16 free, browser-based hands-on labs for development practice. Free forever, work saves to your browser.">
 <meta name="twitter:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
 
 <!-- Google Analytics -->
@@ -155,11 +155,11 @@ html[data-theme="dark"] .card-badge{color:#6EE7B7}
 <section class="hero">
   <div class="hero-inner">
     <div class="hero-eyebrow">Interactive Labs &middot; Free &amp; Open</div>
-    <h1 class="hero-title">15 Interactive Labs</h1>
+    <h1 class="hero-title">16 Interactive Labs</h1>
     <p class="hero-sub">Hands-on, browser-based workspaces for South Asian development practitioners &mdash; build theories of change, design MEL systems, run gender analyses, draft policy briefs, plan advocacy campaigns, map partnerships, model risk and more. No installs, no sign-up. Free forever, and your work saves to your own browser.</p>
     <div class="hero-stats">
       <div class="hero-stat">
-        <div class="hero-stat-num">13</div>
+        <div class="hero-stat-num">16</div>
         <div class="hero-stat-lbl">Interactive Labs</div>
       </div>
       <div class="hero-stat">
@@ -180,17 +180,17 @@ html[data-theme="dark"] .card-badge{color:#6EE7B7}
 
 <div class="filter-bar">
   <span class="filter-label">Filter:</span>
-  <button class="filter-chip active" data-filter="all">All (13)</button>
-  <button class="filter-chip" data-filter="mel">MEL &amp; Evidence (4)</button>
+  <button class="filter-chip active" data-filter="all">All (16)</button>
+  <button class="filter-chip" data-filter="mel">MEL &amp; Evidence (6)</button>
   <button class="filter-chip" data-filter="strategy">Strategy &amp; Design (4)</button>
-  <button class="filter-chip" data-filter="policy">Policy &amp; Advocacy (2)</button>
+  <button class="filter-chip" data-filter="policy">Policy &amp; Advocacy (3)</button>
   <button class="filter-chip" data-filter="gender">Gender &amp; Social (2)</button>
   <button class="filter-chip" data-filter="communication">Communication (1)</button>
   <input type="search" class="filter-search" placeholder="Search labs by title or description..." aria-label="Search labs">
 </div>
 
 <main class="labs-section">
-  <div class="section-title">All 15 Interactive Labs</div>
+  <div class="section-title">All 16 Interactive Labs</div>
   <div class="lab-grid" id="labGrid">
 
 <!-- toc -->
@@ -334,6 +334,18 @@ html[data-theme="dark"] .card-badge{color:#6EE7B7}
   <div class="card-meta"><span>Policy &amp; Advocacy</span> &middot; <span>Browser-based</span> &middot; <span>Free</span></div>
   <div class="card-actions">
     <a class="card-cta" href="/labs/policy-analysis-lab.html">Open lab &rarr;</a>
+  </div>
+</div>
+
+<!-- budget-fiscal -->
+<div class="lab-card" data-track="policy">
+  <span class="card-badge">Free Lab</span>
+  <div class="card-track">Policy &amp; Advocacy</div>
+  <div class="card-title">Budget &amp; Fiscal Analysis Lab</div>
+  <div class="card-desc">Read Union and State budgets like a practitioner &mdash; decode BE/RE/actuals, trace fund flows from Centre to beneficiary, calculate per-capita spends, and understand fiscal federalism. Includes a fund-flow simulator and per-capita calculator.</div>
+  <div class="card-meta"><span>Policy &amp; Advocacy</span> &middot; <span>Browser-based</span> &middot; <span>Free</span></div>
+  <div class="card-actions">
+    <a class="card-cta" href="/labs/budget-fiscal-lab.html">Open lab &rarr;</a>
   </div>
 </div>
 

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -5818,7 +5818,12 @@
     "url": "/labs/sampling-toolkit.html",
     "type": "lab",
     "category": "Interactive Labs",
-    "tags": ["sampling", "sample size", "MEL", "toolkit"]
+    "tags": [
+      "sampling",
+      "sample size",
+      "MEL",
+      "toolkit"
+    ]
   },
   {
     "id": "sampling-basics-lab",
@@ -10135,6 +10140,23 @@
       "author",
       "community",
       "course"
+    ]
+  },
+  {
+    "id": "budget-fiscal-lab",
+    "title": "Budget & Fiscal Analysis Lab",
+    "description": "Read Union and State budgets, trace fund flows from Centre to beneficiary, calculate per-capita spending, and understand fiscal federalism through an interactive fund-flow simulator and per-capita calculator.",
+    "url": "/labs/budget-fiscal-lab.html",
+    "type": "lab",
+    "category": "Interactive Labs",
+    "tags": [
+      "interactive",
+      "practice",
+      "tools",
+      "budget",
+      "fiscal",
+      "public finance",
+      "policy"
     ]
   }
 ]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.79.31 — July 1, 2026 (New Budget & Fiscal Analysis Lab)
+
+### For Learners
+
+- **[Budget & Fiscal Analysis Lab](https://www.impactmojo.in/labs/budget-fiscal-lab.html)** — a new hands-on lab that teaches you to read Union and State budgets like a practitioner: decode BE/RE/actuals, trace fund flows from Centre to beneficiary, calculate per-capita spends with an interactive calculator, and understand fiscal federalism and Finance Commission devolution. The first of several new labs being added to the collection.
+
 ## v10.79.30 — July 1, 2026 (Free Tools section on the homepage)
 
 ### For Learners

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -967,6 +967,12 @@
         <priority>0.8</priority>
     </url>
     <url>
+        <loc>https://www.impactmojo.in/labs/budget-fiscal-lab.html</loc>
+        <lastmod>2026-07-01</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
         <loc>https://www.impactmojo.in/ImpactMojo_PressKit.html</loc>
         <lastmod>2026-03-22</lastmod>
         <changefreq>monthly</changefreq>


### PR DESCRIPTION
## What does this PR do?

Adds a new **Budget & Fiscal Analysis Lab** (`Labs/budget-fiscal-lab.html`), re-skinned from a draft into the ImpactMojo standard lab template. This is the **pilot** for a batch of 12 new labs — shipping one first to lock the pattern before doing the rest.

Standardization: cyan/indigo brand palette, 3-mode dark/light/system theme toggle, site topbar + back-link + footer, full SEO/OG/Twitter meta, Google Analytics, print styles, and a tabbed 7-step flow. Preserves the fund-flow simulator and per-capita calculator.

Fact-checked against Union Budget 2025-26 (PRS/PIB): corrected total expenditure (~₹50.65 lakh crore), scheme allocations (PM-JAY, PM POSHAN, Samagra Shiksha, Saksham Anganwadi), removed a fabricated "PM-SVANidhi 2.0" claim, and labelled all synthetic teaching tables as *Illustrative*.

Wiring: Labs/index.html card + corrected filter/hero/title counts (15→16, also fixed pre-existing count drift), search-index.json entry, sitemap.xml URL, changelog entry.

## Type of change

- [ ] Bug fix (broken link, layout, JS error)
- [x] New content (course, case study, translation)
- [ ] New feature or tool
- [ ] Accessibility improvement
- [ ] Performance improvement
- [ ] Documentation update

## Checklist

- [x] Tested on desktop browser
- [ ] Tested on mobile browser
- [x] No console errors
- [x] Links are working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtxPBaMqQTtWSCiYLWzMgQ)_