### PR TITLE
Live Projects: modernize the hub page (refresh + light redesign)

### DIFF
--- a/live-projects.html
+++ b/live-projects.html
@@ -384,6 +384,59 @@ html[data-theme="dark"] .theme-btn:hover { background: rgba(0,0,0,0.1); color: #
     50% { transform: translateY(-15px) rotate(5deg); }
 }
 
+/* ── HERO refresh ─────────────────────────────────────────── */
+.hero {
+    background:
+        radial-gradient(60% 120% at 15% 0%, rgba(99,102,241,0.10) 0%, transparent 60%),
+        radial-gradient(50% 120% at 90% 10%, rgba(14,165,233,0.10) 0%, transparent 55%),
+        var(--secondary-bg);
+    padding: 3rem 1.5rem 2.75rem;
+}
+.hero-eyebrow {
+    display: inline-block;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.7rem;
+    font-weight: 500;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--accent-color);
+    background: color-mix(in srgb, var(--accent-color) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent-color) 28%, transparent);
+    padding: 0.32rem 0.85rem;
+    border-radius: 999px;
+    margin-bottom: 1.1rem;
+    position: relative;
+}
+.hero-stat .number { font-size: 1.9rem; letter-spacing: -0.01em; }
+
+/* ── card polish: hover accent + live pulse ───────────────── */
+.project-card { position: relative; }
+.project-card::after {
+    content: '';
+    position: absolute; left: 0; right: 0; top: 0; height: 3px;
+    background: var(--gradient-primary);
+    opacity: 0; transition: opacity 0.3s ease;
+    border-radius: 16px 16px 0 0;
+}
+.project-card:hover::after { opacity: 1; }
+.card-banner .banner-label.live::before {
+    content: '';
+    display: inline-block;
+    width: 6px; height: 6px; border-radius: 50%;
+    background: #22c55e;
+    margin-right: 6px; vertical-align: middle;
+    box-shadow: 0 0 0 0 rgba(34,197,94,0.7);
+    animation: livepulse 2s infinite;
+}
+@keyframes livepulse {
+    0%   { box-shadow: 0 0 0 0 rgba(34,197,94,0.6); }
+    70%  { box-shadow: 0 0 0 7px rgba(34,197,94,0); }
+    100% { box-shadow: 0 0 0 0 rgba(34,197,94,0); }
+}
+@media (prefers-reduced-motion: reduce) {
+    .card-banner .banner-label.live::before { animation: none; }
+}
+
 /* ── CONTEXT SECTION ──────────────────────────────────────── */
 .context-section {
     max-width: 1280px;
@@ -991,13 +1044,14 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <div class="mobile-menu-overlay" id="mobileMenuOverlay" onclick="closeMobileMenu()"></div>
 
 <!-- ── HERO ────────────────────────────────────────────────── -->
-<section class="hero ib-hero">
+<section class="hero">
+    <span class="hero-eyebrow">An ImpactMojo Studio · Live data</span>
     <h1>Live <span>Projects</span></h1>
-    <p>Interactive dashboards and data explorations built from real-world development and climate data. Open-source, no login required.</p>
+    <p>Interactive dashboards built from real-world development and climate data — pulling live from open APIs. Free, open-source, no login.</p>
     <div class="hero-stats">
         <div class="hero-stat">
-            <div class="number" id="projectCount">6</div>
-            <div class="label">Projects</div>
+            <div class="number" id="projectCount">7</div>
+            <div class="label">Dashboards</div>
         </div>
         <div class="hero-stat">
             <div class="number">Live</div>
@@ -1084,7 +1138,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         <a href="https://climatetrace.impactmojo.in" target="_blank" rel="noopener" class="project-card">
             <div class="card-banner" style="background: linear-gradient(135deg, #1e3a5f 0%, #0f172a 50%, #1a4731 100%);">
                 <svg class="banner-icon-img" width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-                <span class="banner-label">Live Data</span>
+                <span class="banner-label live">Live Data</span>
                 <span class="banner-source">Climate TRACE API v6</span>
             </div>
             <div class="card-body">
@@ -1111,7 +1165,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         <a href="https://devindicators.impactmojo.in" target="_blank" rel="noopener" class="project-card">
             <div class="card-banner" style="background: linear-gradient(135deg, #4338ca 0%, #6366f1 100%);">
                 <svg class="banner-icon-img" width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
-                <span class="banner-label">Live Dashboard</span>
+                <span class="banner-label live">Live Dashboard</span>
             </div>
             <div class="card-body">
                 <h3>India Development Indicators</h3>
@@ -1136,7 +1190,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         <a href="https://janvayu.impactmojo.in" target="_blank" rel="noopener" class="project-card">
             <div class="card-banner" style="background: linear-gradient(135deg, #dc2626 0%, #f59e0b 100%);">
                 <svg class="banner-icon-img" width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9.59 4.59A2 2 0 1 1 11 8H2m10.59 11.41A2 2 0 1 0 14 16H2m15.73-8.27A2.5 2.5 0 1 1 19.5 12H2"/></svg>
-                <span class="banner-label">Live Platform</span>
+                <span class="banner-label live">Live Platform</span>
             </div>
             <div class="card-body">
                 <h3>JanVayu — Air Quality Accountability</h3>
@@ -1184,7 +1238,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         <a href="https://industrygroups.impactmojo.in" target="_blank" rel="noopener" class="project-card">
             <div class="card-banner" style="background: linear-gradient(135deg, #b45309 0%, #d97706 100%);">
                 <svg class="banner-icon-img" width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="6" width="22" height="12" rx="2"/><path d="M1 10h22"/><path d="M6 6v-2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v2"/></svg>
-                <span class="banner-label">Live Database</span>
+                <span class="banner-label live">Live Database</span>
             </div>
             <div class="card-body">
                 <h3>India Conglomerate Infrastructure Tracker</h3>
@@ -1208,7 +1262,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         <a href="https://sdgtracker.impactmojo.in" target="_blank" rel="noopener" class="project-card">
             <div class="card-banner" style="background: linear-gradient(135deg, #059669 0%, #10b981 100%);">
                 <svg class="banner-icon-img" width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/></svg>
-                <span class="banner-label">Live Dashboard</span>
+                <span class="banner-label live">Live Dashboard</span>
             </div>
             <div class="card-body">
                 <h3>SDG Progress Tracker — India</h3>


### PR DESCRIPTION
## What does this PR do?

Refreshes and lightly redesigns the **Live Projects** hub page. (The 7 underlying dashboards live on separate subdomains — all verified live — and are not touched here; only the hub listing is in this repo.)

- **Fixed the stale count** — the hero said "6 Projects" but there are 7; now "7 Dashboards".
- **Cleaner hero** — dropped the heavy full-bleed purple gradient (shared `.ib-hero`) for a subtle dual-radial wash, a monospace eyebrow pill ("An ImpactMojo Studio · Live data"), and a tighter subtitle. Reads current instead of dated.
- **Card polish** — a gradient top-accent on hover, and a pulsing green **live** indicator on the five genuinely live-API cards (Climate TRACE, Development Indicators, JanVayu, SDG Tracker, Industry Groups). The map atlas and research-platform cards stay unpulsed so the signal stays honest. Pulse respects `prefers-reduced-motion`.

Verified rendering in **light and dark** via headless Chromium.

## Type of change

- [x] Accessibility improvement / UI refresh
- [x] Bug fix (stale count)

## Checklist

- [x] HTML parses; mojibake guard PASS
- [x] Verified in light & dark (headless Chromium)
- [ ] Eyeball on the deployed site after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cKaedtLCrBq3y6WZtSmAn

---
_Generated by [Claude Code](https://claude.ai/code/session_018cKaedtLCrBq3y6WZtSmAn)_