### PR TITLE
Updates page: move shipped items out of the Roadmap, refresh with new ideas

### DIFF
--- a/updates.html
+++ b/updates.html
@@ -687,6 +687,22 @@ body { padding-top: 70px; }
     <div class="whats-new-grid">
         <div class="whats-new-card card-streak" onclick="toggleCard(this)">
             <span class="whats-new-toggle-icon"><svg viewBox="0 0 24 24"><polyline points="6 9 12 15 18 9"></polyline></svg></span>
+            <div class="whats-new-card-icon icon-reading"><svg width="16" height="16" viewBox="0 0 24 24" fill="none"><use href="#si_Trophy"/></svg></div>
+            <div class="whats-new-card-title">Verifiable Open Badges</div>
+            <div class="whats-new-card-desc">Finish a course or a track and earn a W3C Open Badges 3.0 credential you can verify and share on LinkedIn &mdash; 9 course badges and 5 track credentials, auto-issued on completion.</div>
+            <span class="whats-new-card-tag tag-new">New</span>
+            <div class="whats-new-card-expand"><div class="whats-new-card-expand-content">Each badge carries its own evidence and criteria, so anyone can check it independently &mdash; no central registry needed. Find yours on your Account page.</div><a href="/account.html" class="whats-new-card-action">See your badges &rarr;</a></div>
+        </div>
+        <div class="whats-new-card card-notes" onclick="toggleCard(this)">
+            <span class="whats-new-toggle-icon"><svg viewBox="0 0 24 24"><polyline points="6 9 12 15 18 9"></polyline></svg></span>
+            <div class="whats-new-card-icon icon-tour"><svg width="16" height="16" viewBox="0 0 24 24" fill="none"><use href="#si_Users"/></svg></div>
+            <div class="whats-new-card-title">Team pathways in the Organization Dashboard</div>
+            <div class="whats-new-card-desc">Build custom learning pathways for your team &mdash; combining courses, labs, templates, games and case challenges &mdash; or start from a pre-built path for MEL Officers, Programme Managers, Field Staff or Governance teams, with facilitator guides and rubrics.</div>
+            <span class="whats-new-card-tag tag-new">New</span>
+            <div class="whats-new-card-expand"><div class="whats-new-card-expand-content">Includes cohort management and assessment rubrics. Built for organisations and teams.</div><a href="/org-dashboard.html" class="whats-new-card-action">Open the Organization Dashboard &rarr;</a></div>
+        </div>
+        <div class="whats-new-card card-streak" onclick="toggleCard(this)">
+            <span class="whats-new-toggle-icon"><svg viewBox="0 0 24 24"><polyline points="6 9 12 15 18 9"></polyline></svg></span>
             <div class="whats-new-card-icon icon-streak"><svg width="16" height="16" viewBox="0 0 24 24" fill="none"><use href="#si_Fact_check"/></svg></div>
             <div class="whats-new-card-title">&ldquo;Assess Yourself&rdquo; on every flagship</div>
             <div class="whats-new-card-desc">All 15 flagship courses now end with a six-question auto-graded self-check &mdash; 90 questions in total, each grounded in that course&rsquo;s own material, with instant feedback and a short explanation.</div>
@@ -914,30 +930,32 @@ body { padding-top: 70px; }
     <h2 class="section-heading">Roadmap</h2>
     <p class="section-sub">Features and tools we're building to push development education forward</p>
 
+    <p class="section-sub" style="margin-top:-0.5rem;font-size:0.85rem;opacity:0.8;">Already shipped? Those now live in <a href="#whats-new" style="color:var(--accent-color);">What's New</a> above. Below is what we're building next.</p>
+
     <div class="roadmap-grid">
-        <div class="roadmap-item" style="border-color: #10B981;">
-            <h4><svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" x2="8" y1="13" y2="13"/><line x1="16" x2="8" y1="17" y2="17"/></svg>Learning Pathways <span style="font-size:0.65rem; background:rgba(16,185,129,0.15); color:#059669; padding:2px 8px; border-radius:4px; font-weight:600; margin-left:0.5rem; vertical-align:middle;">SHIPPED</span></h4>
-            <p>Custom learning path builder in the <a href="org-dashboard.html" style="color:var(--accent-color);">Organization Dashboard</a>. Combine courses, interactive labs, templates, games, and case challenges into structured professional development journeys for your team.</p>
+        <div class="roadmap-item" style="border-color: #F59E0B;">
+            <h4><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>Vernacular Courses <span style="font-size:0.65rem; background:rgba(245,158,11,0.16); color:#B45309; padding:2px 8px; border-radius:4px; font-weight:600; margin-left:0.5rem; vertical-align:middle;">PLANNED</span></h4>
+            <p>Full flagship courses in Hindi, Tamil, Telugu, Bengali, and Marathi — not just interface translation, but native, citizen-facing course content for frontline and community educators.</p>
         </div>
-        <div class="roadmap-item">
-            <h4><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>Vernacular Content</h4>
-            <p>Full courses in Hindi, Tamil, Telugu, Bengali, and Marathi for citizen-facing education</p>
+        <div class="roadmap-item" style="border-color: #F59E0B;">
+            <h4><svg viewBox="0 0 24 24"><path d="M12 2a3 3 0 00-3 3v1a3 3 0 006 0V5a3 3 0 00-3-3z"/><path d="M19 10v2a7 7 0 01-14 0v-2"/><line x1="12" x2="12" y1="19" y2="22"/></svg>AI Study Companion <span style="font-size:0.65rem; background:rgba(245,158,11,0.16); color:#B45309; padding:2px 8px; border-radius:4px; font-weight:600; margin-left:0.5rem; vertical-align:middle;">PLANNED</span></h4>
+            <p>Ask-anything Q&amp;A inside every course, grounded in that course's own deck and readings — so answers cite the material, not the open web. Builds on our existing AI study notebooks.</p>
         </div>
-        <div class="roadmap-item" style="border-color: #10B981;">
-            <h4><svg viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"/></svg>Team Training Packages <span style="font-size:0.65rem; background:rgba(16,185,129,0.15); color:#059669; padding:2px 8px; border-radius:4px; font-weight:600; margin-left:0.5rem; vertical-align:middle;">SHIPPED</span></h4>
-            <p>Pre-built training paths for MEL Officers, Program Managers, Field Staff, and Governance teams. Includes facilitator guides, assessment rubrics, and cohort management. Available in the <a href="org-dashboard.html" style="color:var(--accent-color);">Organization Dashboard</a>.</p>
+        <div class="roadmap-item" style="border-color: #F59E0B;">
+            <h4><svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/><path d="M12 8v5M9.5 10.5l2.5 2.5 2.5-2.5"/></svg>Offline Course Packs <span style="font-size:0.65rem; background:rgba(245,158,11,0.16); color:#B45309; padding:2px 8px; border-radius:4px; font-weight:600; margin-left:0.5rem; vertical-align:middle;">PLANNED</span></h4>
+            <p>Download a whole flagship course to your phone and study it offline — for field staff and low-connectivity settings. Extends the site's existing offline (PWA) foundation.</p>
         </div>
-        <div class="roadmap-item" style="border-color: #10B981;">
-            <h4><svg viewBox="0 0 24 24"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>Interactive Assessments <span style="font-size:0.65rem; background:rgba(16,185,129,0.15); color:#059669; padding:2px 8px; border-radius:4px; font-weight:600; margin-left:0.5rem; vertical-align:middle;">SHIPPED</span></h4>
-            <p>Every flagship course now ends with a six-question auto-graded self-assessment. Portfolio-grade work products live in the <a href="challenges.html" style="color:var(--accent-color);">Live Case Challenges</a>, and structured <a href="peer-review.html" style="color:var(--accent-color);">Peer Review</a> is available too.</p>
+        <div class="roadmap-item" style="border-color: #F59E0B;">
+            <h4><svg viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"/></svg>Facilitated Cohorts <span style="font-size:0.65rem; background:rgba(245,158,11,0.16); color:#B45309; padding:2px 8px; border-radius:4px; font-weight:600; margin-left:0.5rem; vertical-align:middle;">EXPLORING</span></h4>
+            <p>Time-boxed, mentor-led runs of a flagship course with a peer group and shared deadlines — a facilitated layer on top of the self-paced courses, growing out of Build Circles.</p>
         </div>
-        <div class="roadmap-item" style="border-color: #10B981;">
-            <h4><svg viewBox="0 0 24 24"><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>Open Badges & Micro-credentials <span style="font-size:0.65rem; background:rgba(16,185,129,0.15); color:#059669; padding:2px 8px; border-radius:4px; font-weight:600; margin-left:0.5rem; vertical-align:middle;">SHIPPED</span></h4>
-            <p>W3C Open Badges 3.0 verifiable digital credentials shareable on LinkedIn. 9 course-level badges and 5 track-level credentials, auto-issued on completion. Available in your <a href="account.html" style="color:var(--accent-color);">Account</a> page.</p>
+        <div class="roadmap-item" style="border-color: #F59E0B;">
+            <h4><svg viewBox="0 0 24 24"><path d="M3 3v18h18"/><path d="M18 17V9M13 17V5M8 17v-3"/></svg>MEL Data Sandbox <span style="font-size:0.65rem; background:rgba(245,158,11,0.16); color:#B45309; padding:2px 8px; border-radius:4px; font-weight:600; margin-left:0.5rem; vertical-align:middle;">EXPLORING</span></h4>
+            <p>In-browser R and Python notebooks with sample survey datasets, so you can practise the analysis a course teaches — cleaning, indicators, regression — without installing anything.</p>
         </div>
-        <div class="roadmap-item" style="border-color: #10B981;">
-            <h4><svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>Live Case Challenges <span style="font-size:0.65rem; background:rgba(16,185,129,0.15); color:#059669; padding:2px 8px; border-radius:4px; font-weight:600; margin-left:0.5rem; vertical-align:middle;">SHIPPED</span></h4>
-            <p>Real development problems from partner NGOs and organisations. 10+ challenges across all tracks with expert feedback. Browse them on the <a href="challenges.html" style="color:var(--accent-color);">Challenges</a> page.</p>
+        <div class="roadmap-item" style="border-color: #F59E0B;">
+            <h4><svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" x2="8" y1="13" y2="13"/><line x1="16" x2="8" y1="17" y2="17"/></svg>Grant &amp; Proposal Lab <span style="font-size:0.65rem; background:rgba(245,158,11,0.16); color:#B45309; padding:2px 8px; border-radius:4px; font-weight:600; margin-left:0.5rem; vertical-align:middle;">EXPLORING</span></h4>
+            <p>An interactive theory-of-change and logframe builder that turns your programme logic into a funder-ready proposal draft, with indicator suggestions drawn from our repositories.</p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## What does this PR do?

The Roadmap section on `/updates` had drifted — **5 of its 6 items were marked `SHIPPED`**, so it read as a changelog, not a roadmap. (Note: "Updates & Roadmap" and "What's New" are the same page — What's New is the `#whats-new` section, Roadmap is `#roadmap` below it.)

- **Removed the 5 shipped items** from the Roadmap. Two of them (Interactive Assessments → "Assess Yourself", Live Case Challenges) were already in What's New; for the other three I added What's New cards so nothing is lost:
  - **Verifiable Open Badges** (learner-facing)
  - **Team pathways in the Organization Dashboard** (combines the shipped Learning Pathways + Team Training Packages)
- **Rebuilt the Roadmap** with six genuinely not-yet-built ideas, each tagged **PLANNED** or **EXPLORING** (no SHIPPED badges): Vernacular Courses, AI Study Companion, Offline Course Packs, Facilitated Cohorts, MEL Data Sandbox, Grant & Proposal Lab.
- Added a one-line note that shipped features live in What's New.

The roadmap ideas are proposals — easy to trim or reword; tell me which to keep.

## Type of change

- [x] Documentation / content update

## Checklist

- [x] updates.html parses; mojibake PASS
- [x] Rendered and eyeballed (roadmap + new What's New cards) via headless Chromium
- [ ] Eyeball on the deployed site after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cKaedtLCrBq3y6WZtSmAn

---
_Generated by [Claude Code](https://claude.ai/code/session_018cKaedtLCrBq3y6WZtSmAn)_