### PR TITLE
Homepage: rename the tools section to "Pro Studio"

### DIFF
--- a/BookCompanionTools/budget-template-generator.html
+++ b/BookCompanionTools/budget-template-generator.html
@@ -478,7 +478,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Games/bidding-wars-game.html
+++ b/Games/bidding-wars-game.html
@@ -547,7 +547,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Games/climate-action-game.html
+++ b/Games/climate-action-game.html
@@ -919,7 +919,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Games/commons-crisis-game.html
+++ b/Games/commons-crisis-game.html
@@ -449,7 +449,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Games/cooperation-paradox-game.html
+++ b/Games/cooperation-paradox-game.html
@@ -515,7 +515,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Games/counterfactual-game.html
+++ b/Games/counterfactual-game.html
@@ -363,7 +363,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Games/digital-ethics-game.html
+++ b/Games/digital-ethics-game.html
@@ -481,7 +481,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Games/econ-concepts-game.html
+++ b/Games/econ-concepts-game.html
@@ -402,7 +402,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Games/externality-game.html
+++ b/Games/externality-game.html
@@ -322,7 +322,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="/" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Games/gender-equity-game.html
+++ b/Games/gender-equity-game.html
@@ -456,7 +456,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Games/info-asymmetry-game.html
+++ b/Games/info-asymmetry-game.html
@@ -639,7 +639,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Games/network-effects-game.html
+++ b/Games/network-effects-game.html
@@ -1190,7 +1190,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Games/opportunity-cost-game.html
+++ b/Games/opportunity-cost-game.html
@@ -387,7 +387,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Games/prisoners-dilemma-game.html
+++ b/Games/prisoners-dilemma-game.html
@@ -437,7 +437,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Games/public-good-game.html
+++ b/Games/public-good-game.html
@@ -1260,7 +1260,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Games/public-health-game.html
+++ b/Games/public-health-game.html
@@ -920,7 +920,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Games/real-middle-india.html
+++ b/Games/real-middle-india.html
@@ -399,7 +399,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Games/risk-reward-game.html
+++ b/Games/risk-reward-game.html
@@ -426,7 +426,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Cross Cutting Resources/Case Studies/case_study_template.html
+++ b/Handouts/Cross Cutting Resources/Case Studies/case_study_template.html
@@ -377,7 +377,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Cross Cutting Resources/Case Studies/case_study_worksheets.html
+++ b/Handouts/Cross Cutting Resources/Case Studies/case_study_worksheets.html
@@ -408,7 +408,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Cross Cutting Resources/Communications/communication_guide.html
+++ b/Handouts/Cross Cutting Resources/Communications/communication_guide.html
@@ -423,7 +423,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Cross Cutting Resources/Local Application Worksheet/local_application_worksheet.html
+++ b/Handouts/Cross Cutting Resources/Local Application Worksheet/local_application_worksheet.html
@@ -378,7 +378,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Cross Cutting Resources/Software Tools Guide/software_tools_guide.html
+++ b/Handouts/Cross Cutting Resources/Software Tools Guide/software_tools_guide.html
@@ -415,7 +415,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_analysis_guide.html
+++ b/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_analysis_guide.html
@@ -392,7 +392,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_analysis_handout_1.html
+++ b/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_analysis_handout_1.html
@@ -433,7 +433,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_analysis_handout_2.html
+++ b/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_analysis_handout_2.html
@@ -435,7 +435,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_quick_reference.html
+++ b/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_quick_reference.html
@@ -403,7 +403,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_workshop_exercises.html
+++ b/Handouts/Data and Technology Track/Bivariate Analysis/bivariate_workshop_exercises.html
@@ -367,7 +367,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Data and Technology Track/Data Literacy/data_literacy_handout.html
+++ b/Handouts/Data and Technology Track/Data Literacy/data_literacy_handout.html
@@ -399,7 +399,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Data and Technology Track/Data Literacy/data_literacy_handout_1.html
+++ b/Handouts/Data and Technology Track/Data Literacy/data_literacy_handout_1.html
@@ -433,7 +433,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Data and Technology Track/Data Literacy/data_literacy_handout_2.html
+++ b/Handouts/Data and Technology Track/Data Literacy/data_literacy_handout_2.html
@@ -434,7 +434,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Data and Technology Track/EDA/eda_survey_handout_1.html
+++ b/Handouts/Data and Technology Track/EDA/eda_survey_handout_1.html
@@ -436,7 +436,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Data and Technology Track/EDA/eda_survey_handout_2.html
+++ b/Handouts/Data and Technology Track/EDA/eda_survey_handout_2.html
@@ -451,7 +451,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Data and Technology Track/Econometrics/common_mistakes_guide.html
+++ b/Handouts/Data and Technology Track/Econometrics/common_mistakes_guide.html
@@ -521,7 +521,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Data and Technology Track/Econometrics/econometrics_formula_sheet.html
+++ b/Handouts/Data and Technology Track/Econometrics/econometrics_formula_sheet.html
@@ -485,7 +485,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Data and Technology Track/Econometrics/econometrics_handout_1.html
+++ b/Handouts/Data and Technology Track/Econometrics/econometrics_handout_1.html
@@ -527,7 +527,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Data and Technology Track/Econometrics/econometrics_handout_2.html
+++ b/Handouts/Data and Technology Track/Econometrics/econometrics_handout_2.html
@@ -565,7 +565,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Data and Technology Track/Econometrics/econometrics_problem_sets.html
+++ b/Handouts/Data and Technology Track/Econometrics/econometrics_problem_sets.html
@@ -515,7 +515,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_analysis_handout_1.html
+++ b/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_analysis_handout_1.html
@@ -448,7 +448,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_analysis_handout_2.html
+++ b/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_analysis_handout_2.html
@@ -490,7 +490,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_analysis_template.html
+++ b/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_analysis_template.html
@@ -384,7 +384,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_problem_sets.html
+++ b/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_problem_sets.html
@@ -373,7 +373,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_quick_reference.html
+++ b/Handouts/Data and Technology Track/Multivariate Analysis/multivariate_quick_reference.html
@@ -369,7 +369,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Education and Pedagogy/education_pedagogy_handout.html
+++ b/Handouts/Education and Pedagogy/education_pedagogy_handout.html
@@ -422,7 +422,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Education and Pedagogy/education_pedagogy_handout_2.html
+++ b/Handouts/Education and Pedagogy/education_pedagogy_handout_2.html
@@ -525,7 +525,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Gender Equity and Inclusion Track/Data Feminism/data_feminism_handout_1.html
+++ b/Handouts/Gender Equity and Inclusion Track/Data Feminism/data_feminism_handout_1.html
@@ -411,7 +411,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Gender Equity and Inclusion Track/Data Feminism/data_feminism_handout_2.html
+++ b/Handouts/Gender Equity and Inclusion Track/Data Feminism/data_feminism_handout_2.html
@@ -419,7 +419,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Gender Equity and Inclusion Track/Data Feminism/data_feminism_south_asia.html
+++ b/Handouts/Gender Equity and Inclusion Track/Data Feminism/data_feminism_south_asia.html
@@ -341,7 +341,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Gender Equity and Inclusion Track/Gender Studies/gender_studies_handout.html
+++ b/Handouts/Gender Equity and Inclusion Track/Gender Studies/gender_studies_handout.html
@@ -415,7 +415,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Gender Equity and Inclusion Track/Gender Studies/gender_studies_quick_reference.html
+++ b/Handouts/Gender Equity and Inclusion Track/Gender Studies/gender_studies_quick_reference.html
@@ -462,7 +462,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Gender Equity and Inclusion Track/Marginalised Identities/marginalized_identities_handout_1.html
+++ b/Handouts/Gender Equity and Inclusion Track/Marginalised Identities/marginalized_identities_handout_1.html
@@ -441,7 +441,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Gender Equity and Inclusion Track/Marginalised Identities/marginalized_identities_handout_2.html
+++ b/Handouts/Gender Equity and Inclusion Track/Marginalised Identities/marginalized_identities_handout_2.html
@@ -475,7 +475,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Health Communication and Wellbeing Track/Care Economy/care_economy_handout_1.html
+++ b/Handouts/Health Communication and Wellbeing Track/Care Economy/care_economy_handout_1.html
@@ -473,7 +473,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Health Communication and Wellbeing Track/Care Economy/care_economy_handout_2.html
+++ b/Handouts/Health Communication and Wellbeing Track/Care Economy/care_economy_handout_2.html
@@ -484,7 +484,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Monitoring Evaluation and Learning Track/Assumptions Checklist/assumptions_checklist.html
+++ b/Handouts/Monitoring Evaluation and Learning Track/Assumptions Checklist/assumptions_checklist.html
@@ -415,7 +415,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Monitoring Evaluation and Learning Track/MLE/mel_handout_1.html
+++ b/Handouts/Monitoring Evaluation and Learning Track/MLE/mel_handout_1.html
@@ -574,7 +574,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Monitoring Evaluation and Learning Track/MLE/mel_handout_2.html
+++ b/Handouts/Monitoring Evaluation and Learning Track/MLE/mel_handout_2.html
@@ -610,7 +610,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Monitoring Evaluation and Learning Track/Qualitative Research/qualitative_research_handout.html
+++ b/Handouts/Monitoring Evaluation and Learning Track/Qualitative Research/qualitative_research_handout.html
@@ -456,7 +456,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Monitoring Evaluation and Learning Track/Research Design Worksheet/research_design_worksheet.html
+++ b/Handouts/Monitoring Evaluation and Learning Track/Research Design Worksheet/research_design_worksheet.html
@@ -509,7 +509,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Philosophy Law and Governance Track/Post Truth Politics/post_truth_politics_handout_1.html
+++ b/Handouts/Philosophy Law and Governance Track/Post Truth Politics/post_truth_politics_handout_1.html
@@ -458,7 +458,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Philosophy Law and Governance Track/Post Truth Politics/post_truth_politics_handout_2.html
+++ b/Handouts/Philosophy Law and Governance Track/Post Truth Politics/post_truth_politics_handout_2.html
@@ -477,7 +477,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Policy and Economics Track/Development Economics/development_economics_handout.html
+++ b/Handouts/Policy and Economics Track/Development Economics/development_economics_handout.html
@@ -442,7 +442,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Policy and Economics Track/Development Economics/development_economics_problem_sets.html
+++ b/Handouts/Policy and Economics Track/Development Economics/development_economics_problem_sets.html
@@ -430,7 +430,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Policy and Economics Track/Livelihoods/livelihood_assessment_toolkit.html
+++ b/Handouts/Policy and Economics Track/Livelihoods/livelihood_assessment_toolkit.html
@@ -434,7 +434,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Policy and Economics Track/Livelihoods/livelihoods_handout.html
+++ b/Handouts/Policy and Economics Track/Livelihoods/livelihoods_handout.html
@@ -457,7 +457,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Policy and Economics Track/Policy Tracking/policy_tracking_sheet.html
+++ b/Handouts/Policy and Economics Track/Policy Tracking/policy_tracking_sheet.html
@@ -357,7 +357,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Policy and Economics Track/Political Economy/political_economy_101_handout_1.html
+++ b/Handouts/Policy and Economics Track/Political Economy/political_economy_101_handout_1.html
@@ -539,7 +539,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Policy and Economics Track/Political Economy/political_economy_101_handout_2.html
+++ b/Handouts/Policy and Economics Track/Political Economy/political_economy_101_handout_2.html
@@ -533,7 +533,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Policy and Economics Track/Political Economy/political_economy_handout_1.html
+++ b/Handouts/Policy and Economics Track/Political Economy/political_economy_handout_1.html
@@ -480,7 +480,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Policy and Economics Track/Political Economy/political_economy_handout_2.html
+++ b/Handouts/Policy and Economics Track/Political Economy/political_economy_handout_2.html
@@ -543,7 +543,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Policy and Economics Track/Poverty and Inequality/poverty_inequality_handout_1.html
+++ b/Handouts/Policy and Economics Track/Poverty and Inequality/poverty_inequality_handout_1.html
@@ -427,7 +427,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Policy and Economics Track/Poverty and Inequality/poverty_inequality_handout_2.html
+++ b/Handouts/Policy and Economics Track/Poverty and Inequality/poverty_inequality_handout_2.html
@@ -435,7 +435,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Policy and Economics Track/Social Safety Nets/safety_nets_south_asia.html
+++ b/Handouts/Policy and Economics Track/Social Safety Nets/safety_nets_south_asia.html
@@ -372,7 +372,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Policy and Economics Track/Social Safety Nets/social_safety_nets_handout_1.html
+++ b/Handouts/Policy and Economics Track/Social Safety Nets/social_safety_nets_handout_1.html
@@ -414,7 +414,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Policy and Economics Track/Social Safety Nets/social_safety_nets_handout_2.html
+++ b/Handouts/Policy and Economics Track/Social Safety Nets/social_safety_nets_handout_2.html
@@ -426,7 +426,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Quick Reference Cards/quick_reference_cards.html
+++ b/Handouts/Quick Reference Cards/quick_reference_cards.html
@@ -371,7 +371,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_change_handout.html
+++ b/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_change_handout.html
@@ -444,7 +444,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_change_handout_1.html
+++ b/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_change_handout_1.html
@@ -412,7 +412,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_change_handout_2.html
+++ b/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_change_handout_2.html
@@ -442,7 +442,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_dashboard_south_asia.html
+++ b/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Climate Change/climate_dashboard_south_asia.html
@@ -471,7 +471,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Environmental Justice/environmental_justice_handout_1.html
+++ b/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Environmental Justice/environmental_justice_handout_1.html
@@ -484,7 +484,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Environmental Justice/environmental_justice_handout_2.html
+++ b/Handouts/Thematic Areas/Climate Change - Science, Mitigation, Adaptation, Resilience and Futures/Environmental Justice/environmental_justice_handout_2.html
@@ -517,7 +517,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_handout_1.html
+++ b/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_handout_1.html
@@ -445,7 +445,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_handout_2.html
+++ b/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_handout_2.html
@@ -452,7 +452,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_law_handout_1.html
+++ b/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_law_handout_1.html
@@ -465,7 +465,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_law_handout_2.html
+++ b/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_law_handout_2.html
@@ -485,7 +485,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_law_practical_skills.html
+++ b/Handouts/Thematic Areas/Constitution, Law, Justice and Jurisprudence/Constitution/constitution_law_practical_skills.html
@@ -508,7 +508,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Digital Development Ethics/AI Bias and Algorithmic Justice/handout_3_ai_bias.html
+++ b/Handouts/Thematic Areas/Digital Development Ethics/AI Bias and Algorithmic Justice/handout_3_ai_bias.html
@@ -342,7 +342,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Digital Development Ethics/Digital Justice and Data Consent/handout_4_consent.html
+++ b/Handouts/Thematic Areas/Digital Development Ethics/Digital Justice and Data Consent/handout_4_consent.html
@@ -349,7 +349,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Digital Development Ethics/Digital Surveillance and State Power/handout_1_surveillance.html
+++ b/Handouts/Thematic Areas/Digital Development Ethics/Digital Surveillance and State Power/handout_1_surveillance.html
@@ -318,7 +318,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Digital Development Ethics/Ethics in Digital Work for Development/digital_dev_ethics_handout_1.html
+++ b/Handouts/Thematic Areas/Digital Development Ethics/Ethics in Digital Work for Development/digital_dev_ethics_handout_1.html
@@ -405,7 +405,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Digital Development Ethics/Ethics in Digital Work for Development/digital_dev_ethics_handout_2.html
+++ b/Handouts/Thematic Areas/Digital Development Ethics/Ethics in Digital Work for Development/digital_dev_ethics_handout_2.html
@@ -464,7 +464,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Digital Development Ethics/Platform Labour and Digital Governance/handout_2_platforms.html
+++ b/Handouts/Thematic Areas/Digital Development Ethics/Platform Labour and Digital Governance/handout_2_platforms.html
@@ -333,7 +333,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Health and Wellbeing/Public Health/public_health_assessment_framework.html
+++ b/Handouts/Thematic Areas/Health and Wellbeing/Public Health/public_health_assessment_framework.html
@@ -435,7 +435,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Health and Wellbeing/Public Health/public_health_handout.html
+++ b/Handouts/Thematic Areas/Health and Wellbeing/Public Health/public_health_handout.html
@@ -457,7 +457,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Justice and Governance/Community Led Development/community_led_dev_handout_1.html
+++ b/Handouts/Thematic Areas/Justice and Governance/Community Led Development/community_led_dev_handout_1.html
@@ -462,7 +462,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Justice and Governance/Community Led Development/community_led_dev_handout_2.html
+++ b/Handouts/Thematic Areas/Justice and Governance/Community Led Development/community_led_dev_handout_2.html
@@ -507,7 +507,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Justice and Governance/Decent Work/decent_work_handout_1.html
+++ b/Handouts/Thematic Areas/Justice and Governance/Decent Work/decent_work_handout_1.html
@@ -426,7 +426,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Justice and Governance/Decent Work/decent_work_handout_2.html
+++ b/Handouts/Thematic Areas/Justice and Governance/Decent Work/decent_work_handout_2.html
@@ -434,7 +434,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/Justice and Governance/Decent Work/decent_work_south_asia.html
+++ b/Handouts/Thematic Areas/Justice and Governance/Decent Work/decent_work_south_asia.html
@@ -388,7 +388,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/South Asia Region/South Asia Historical - Modern Policy Timeline/historical_timeline.html
+++ b/Handouts/Thematic Areas/South Asia Region/South Asia Historical - Modern Policy Timeline/historical_timeline.html
@@ -380,7 +380,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/Thematic Areas/South Asia Region/South Asia Regional Dashboard/regional_dashboard.html
+++ b/Handouts/Thematic Areas/South Asia Region/South Asia Regional Dashboard/regional_dashboard.html
@@ -318,7 +318,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Handouts/index.html
+++ b/Handouts/index.html
@@ -464,7 +464,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/ImpactMojo_PressKit.html
+++ b/ImpactMojo_PressKit.html
@@ -445,7 +445,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="/index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/budget-fiscal-lab.html
+++ b/Labs/budget-fiscal-lab.html
@@ -266,7 +266,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/climate-adaptation-lab.html
+++ b/Labs/climate-adaptation-lab.html
@@ -342,7 +342,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/community-lab.html
+++ b/Labs/community-lab.html
@@ -548,7 +548,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/conflict-sensitive-lab.html
+++ b/Labs/conflict-sensitive-lab.html
@@ -311,7 +311,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/data-feminism-lab.html
+++ b/Labs/data-feminism-lab.html
@@ -301,7 +301,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/design-thinking-lab.html
+++ b/Labs/design-thinking-lab.html
@@ -565,7 +565,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/dpi-lab.html
+++ b/Labs/dpi-lab.html
@@ -290,7 +290,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/ethics-research-lab.html
+++ b/Labs/ethics-research-lab.html
@@ -329,7 +329,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/gender-studies-lab.html
+++ b/Labs/gender-studies-lab.html
@@ -359,7 +359,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/grant-writing-lab.html
+++ b/Labs/grant-writing-lab.html
@@ -313,7 +313,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/impact-partnerships-lab.html
+++ b/Labs/impact-partnerships-lab.html
@@ -543,7 +543,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/mel-design-lab.html
+++ b/Labs/mel-design-lab.html
@@ -347,7 +347,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/mel-plan-lab.html
+++ b/Labs/mel-plan-lab.html
@@ -351,7 +351,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/participatory-methods-lab.html
+++ b/Labs/participatory-methods-lab.html
@@ -275,7 +275,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/policy-advocacy-lab.html
+++ b/Labs/policy-advocacy-lab.html
@@ -351,7 +351,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/policy-analysis-lab.html
+++ b/Labs/policy-analysis-lab.html
@@ -195,7 +195,7 @@ textarea{min-height:80px}
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/policy-brief-lab.html
+++ b/Labs/policy-brief-lab.html
@@ -303,7 +303,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/r-python-dev.html
+++ b/Labs/r-python-dev.html
@@ -211,7 +211,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/resource-sustainability-lab.html
+++ b/Labs/resource-sustainability-lab.html
@@ -548,7 +548,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/risk-mitigation-lab.html
+++ b/Labs/risk-mitigation-lab.html
@@ -529,7 +529,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/sampling-basics-lab.html
+++ b/Labs/sampling-basics-lab.html
@@ -131,7 +131,7 @@ input[type=range]{width:100%;accent-color:var(--accent)}
 <div class="im-topbar" id="imTopbar">
   <div class="im-topbar-left">
     <a href="../index.html" class="im-topbar-home">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+      <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
       <span>ImpactMojo</span>
     </a>
   </div>

--- a/Labs/sampling-design-lab.html
+++ b/Labs/sampling-design-lab.html
@@ -224,7 +224,7 @@ body.facil-on .facil{display:block}
 <div class="im-topbar" id="imTopbar">
   <div class="im-topbar-left">
     <a href="../index.html" class="im-topbar-home">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+      <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
       <span>ImpactMojo</span>
     </a>
   </div>

--- a/Labs/sampling-toolkit.html
+++ b/Labs/sampling-toolkit.html
@@ -113,7 +113,7 @@ a{color:var(--accent)}
 <div class="im-topbar" id="imTopbar">
   <div class="im-topbar-left">
     <a href="../index.html" class="im-topbar-home">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+      <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
       <span>ImpactMojo</span>
     </a>
   </div>

--- a/Labs/stakeholder-mapping-lab.html
+++ b/Labs/stakeholder-mapping-lab.html
@@ -340,7 +340,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/storytelling-lab.html
+++ b/Labs/storytelling-lab.html
@@ -515,7 +515,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/survey-design-lab.html
+++ b/Labs/survey-design-lab.html
@@ -303,7 +303,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/Labs/systems-thinking-lab.html
+++ b/Labs/systems-thinking-lab.html
@@ -327,7 +327,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/SupportGifts/thankyou.html
+++ b/SupportGifts/thankyou.html
@@ -553,7 +553,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/admin/cms.html
+++ b/admin/cms.html
@@ -654,7 +654,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/admin/index.html
+++ b/admin/index.html
@@ -876,7 +876,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/admin/learner-analytics.html
+++ b/admin/learner-analytics.html
@@ -280,7 +280,7 @@ body {
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="/index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/ai-agents-for-evaluators.html
+++ b/ai-agents-for-evaluators.html
@@ -213,7 +213,7 @@ table.rubric td:first-child { color: var(--text); font-weight: 600; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="/index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/ai-for-me-certificate.html
+++ b/ai-for-me-certificate.html
@@ -238,7 +238,7 @@ a { color: var(--accent-blue); }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="/index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/api-docs.html
+++ b/api-docs.html
@@ -209,7 +209,7 @@ pre code { font-family: 'JetBrains Mono', monospace; font-size: 0.82rem; color: 
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="/index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/build-circles.html
+++ b/build-circles.html
@@ -203,7 +203,7 @@ details.faq .faq-body { padding: 0 1.1rem 1rem 2.3rem; color: var(--text-2); fon
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="/index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/climate-trace-india.html
+++ b/climate-trace-india.html
@@ -616,7 +616,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="/index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/content-marketing-kit.html
+++ b/content-marketing-kit.html
@@ -490,7 +490,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="/index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/contribute.html
+++ b/contribute.html
@@ -288,7 +288,7 @@ body {
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="/index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/causal/index.html
+++ b/courses/causal/index.html
@@ -1244,7 +1244,7 @@ body.dark-mode, [data-theme="dark"] {
         /* ==========================================
            TYPOGRAPHY STYLES
            ========================================== */
-        h1, h2, h3, h4, h5, h6 {
+        h1, h2, h3, h3, h5, h6 {
             font-family: var(--font-serif);
             font-weight: 400;
             color: var(--color-text);
@@ -1271,7 +1271,7 @@ body.dark-mode, [data-theme="dark"] {
             margin-bottom: var(--spacing-md);
         }
         
-        h4 {
+        h3 {
             font-family: var(--font-sans);
             font-weight: 600;
             font-size: 1.1rem;
@@ -1547,7 +1547,7 @@ body.dark-mode, [data-theme="dark"] {
             font-size: 1.25rem;
         }
         
-        .card h4 {
+        .card h3 {
             margin-top: 0;
             margin-bottom: var(--spacing-sm);
         }
@@ -2034,7 +2034,7 @@ body.dark-mode, [data-theme="dark"] {
             margin: var(--spacing-xl) 0;
         }
         
-        .reading-box h4 {
+        .reading-box h3 {
             display: flex;
             align-items: center;
             gap: var(--spacing-sm);
@@ -2098,7 +2098,7 @@ body.dark-mode, [data-theme="dark"] {
             box-shadow: var(--shadow-md);
         }
         
-        .resource-card h4 {
+        .resource-card h3 {
             font-size: 1.1rem;
             font-weight: 600;
             margin: 0 0 0.25rem 0;
@@ -2415,7 +2415,7 @@ body.dark-mode, [data-theme="dark"] {
             gap: var(--spacing-2xl);
         }
         
-        .footer-column h4 {
+        .footer-column h3 {
             color: var(--color-text-primary);
             font-family: var(--font-heading);
             font-size: 1rem;
@@ -2656,7 +2656,7 @@ body.dark-mode, [data-theme="dark"] {
             border: 3px solid var(--color-accent);
         }
         
-        .founder-card h4 {
+        .founder-card h3 {
             font-family: var(--font-heading);
             color: var(--color-text-primary);
             margin-bottom: var(--spacing-xs);
@@ -2718,7 +2718,7 @@ body.dark-mode, [data-theme="dark"] {
             margin: var(--spacing-xl) 0;
         }
         
-        .resources-cta h4 {
+        .resources-cta h3 {
             font-family: var(--font-heading);
             color: var(--color-text-primary);
             margin-bottom: var(--spacing-md);
@@ -2727,7 +2727,7 @@ body.dark-mode, [data-theme="dark"] {
             gap: var(--spacing-sm);
         }
         
-        .resources-cta h4 svg {
+        .resources-cta h3 svg {
             width: 24px;
             height: 24px;
             stroke: var(--color-accent);
@@ -2809,7 +2809,7 @@ body.dark-mode, [data-theme="dark"] {
         }
         .quiz-header { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1.5rem; }
         .quiz-header svg { width: 28px; height: 28px; color: var(--indigo); }
-        .quiz-header h4 { margin: 0; font-size: 1.25rem; color: var(--text-primary); }
+        .quiz-header h3 { margin: 0; font-size: 1.25rem; color: var(--text-primary); }
         .quiz-intro { font-size: 0.95rem; color: var(--text-muted); margin-bottom: 1.5rem; padding-bottom: 1rem; border-bottom: 1px solid var(--border-light); }
         .quiz-question { margin-bottom: 1.5rem; padding: 1.25rem; background: var(--bg-primary); border-radius: 12px; border: 1px solid var(--border-light); }
         .quiz-question:last-child { margin-bottom: 0; }
@@ -3079,7 +3079,7 @@ body.dark-mode, [data-theme="dark"] {
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     gap: 1.5rem; margin-bottom: 1.5rem;
 }
-.im-footer-section h4 {
+.im-footer-section h3 {
     font-family: 'Inter', sans-serif;
     color: var(--im-text-primary, #F1F5F9);
     font-size: 0.9rem; margin-bottom: 0.75rem;
@@ -3119,7 +3119,7 @@ body.dark-mode, [data-theme="dark"] {
 
 /* ImpactMojo Global Font Overrides */
 body { font-family: 'Amaranth', sans-serif !important; }
-h1, h2, h3, h4, h5, h6 { font-family: 'Inter', sans-serif !important; }
+h1, h2, h3, h3, h5, h6 { font-family: 'Inter', sans-serif !important; }
 code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !important; }
 
 
@@ -3549,17 +3549,17 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                     <div class="card-grid">
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Crosshair_detailed.svg" alt="" class="sargam-icon"></div>
-                            <h4>Identification before estimation</h4>
+                            <h3>Identification before estimation</h3>
                             <p>Every method is taught as an answer to one question: what has to be true for this comparison to recover a causal effect? The assumption comes first, the regression second.</p>
                         </div>
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Code.svg" alt="" class="sargam-icon"></div>
-                            <h4>Code you can run</h4>
+                            <h3>Code you can run</h3>
                             <p>R and Stata for each design, on data shapes you will actually meet: household surveys, programme rosters, district panels. Paired with the DevEconomics Toolkit's DiD, RDD, and synthetic control apps.</p>
                         </div>
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Article.svg" alt="" class="sargam-icon"></div>
-                            <h4>The buyer's seat</h4>
+                            <h3>The buyer's seat</h3>
                             <p>The final part is for the practitioner who commissions evidence rather than produces it: reading a results table, interrogating a design, and choosing what a claim can be made to bear.</p>
                         </div>
                     </div>
@@ -3640,7 +3640,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 <section id="course-assessment" class="quiz-section">
                     <div class="quiz-header">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
-                        <h4>Assess Yourself — Causal Inference</h4>
+                        <h3>Assess Yourself — Causal Inference</h3>
                     </div>
                     <p class="quiz-intro">Six auto-graded questions on the core ideas of the course. Pick an answer and check it; each explains the reasoning. Nothing is stored and there's no sign-in.</p>
 
@@ -3723,15 +3723,15 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                     </div>
                     <div class="card-grid">
                         <div class="card">
-                            <h4>Core textbooks</h4>
+                            <h3>Core textbooks</h3>
                             <p>Imbens &amp; Rubin, <em>Causal Inference for Statistics, Social, and Biomedical Sciences</em> (2015). Angrist &amp; Pischke, <em>Mostly Harmless Econometrics</em> (2009). Cunningham, <em>Causal Inference: The Mixtape</em> (2021, <a href="https://mixtape.scunning.com/" target="_blank" rel="noopener">free online</a>). Morgan &amp; Winship, <em>Counterfactuals and Causal Inference</em> (2nd ed., 2014).</p>
                         </div>
                         <div class="card">
-                            <h4>Sibling courses</h4>
+                            <h3>Sibling courses</h3>
                             <p>Pairs with <a href="../mel/index.html">The Evidence Question (MEL)</a> for the conceptual spine and <a href="../../101-courses/econometrics-101/index.html">Econometrics 101</a> for the entry-level treatment. The DevEconomics Toolkit ships interactive DiD, RDD, and synthetic control apps used in the worked examples.</p>
                         </div>
                         <div class="card">
-                            <h4>The credibility debate</h4>
+                            <h3>The credibility debate</h3>
                             <p>Banerjee &amp; Duflo, <em>Poor Economics</em> (2011), against Deaton, "Instruments, Randomization, and Learning about Development" (<em>JEL</em> 2010) and Pritchett &amp; Sandefur on external validity (2015). Read all three before Module 12.</p>
                         </div>
                     </div>
@@ -3746,21 +3746,21 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 </div>
                 <div class="footer-links">
                     <div class="footer-column">
-                        <h4>Learn</h4>
+                        <h3>Learn</h3>
                         <a href="/catalog">All Courses</a>
                         <a href="/workshops">Workshops</a>
                         <a href="/handouts">Handouts</a>
                         <a href="/podcast">Podcast</a>
                     </div>
                     <div class="footer-column">
-                        <h4>Connect</h4>
+                        <h3>Connect</h3>
                         <a href="/about">About Us</a>
                         <a href="/contact">Contact</a>
                         <a href="/faq">FAQ</a>
                         <a href="/blog">Blog</a>
                     </div>
                     <div class="footer-column">
-                        <h4>Support</h4>
+                        <h3>Support</h3>
                         <a href="/premium">Premium</a>
                         <a href="/premium">Support Us</a>
                         <a href="/coaching">Coaching</a>

--- a/courses/causal/index.html
+++ b/courses/causal/index.html
@@ -3236,7 +3236,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <div class="im-topbar" id="imTopbar" role="navigation" aria-label="Site navigation">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/causal/lexicon.html
+++ b/courses/causal/lexicon.html
@@ -3148,7 +3148,7 @@ html[data-theme="dark"]{--indigo:#6366F1}
 <div class="im-topbar" id="imTopbar" role="navigation" aria-label="Site navigation">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/dataviz/index.html
+++ b/courses/dataviz/index.html
@@ -3282,7 +3282,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <div class="im-topbar" id="imTopbar" role="navigation" aria-label="Site navigation">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/dataviz/index.html
+++ b/courses/dataviz/index.html
@@ -4514,21 +4514,21 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         </div>
         <div class="footer-links">
             <div class="footer-column">
-                <h4>Learn</h4>
+                <h3 style="font-size:1rem;font-weight:600">Learn</h3>
                 <a href="/catalog">All Courses</a>
                 <a href="/workshops">Workshops</a>
                 <a href="/handouts">Handouts</a>
                 <a href="/podcast">Podcast</a>
             </div>
             <div class="footer-column">
-                <h4>Connect</h4>
+                <h3 style="font-size:1rem;font-weight:600">Connect</h3>
                 <a href="/about">About Us</a>
                 <a href="/contact">Contact</a>
                 <a href="/faq">FAQ</a>
                 <a href="/blog">Blog</a>
             </div>
             <div class="footer-column">
-                <h4>Support</h4>
+                <h3 style="font-size:1rem;font-weight:600">Support</h3>
                 <a href="/premium">Premium</a>
                 <a href="/premium">Support Us</a>
                 <a href="/coaching">Coaching</a>
@@ -4684,7 +4684,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             
             if (rec) {
                 resultDiv.innerHTML = `
-                    <h4 style="color: var(--cyan); margin-bottom: 0.75rem;">Recommended Charts</h4>
+                    <h3 style="color: var(--cyan); margin-bottom: 0.75rem;">Recommended Charts</h3>
                     <div style="display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 1rem;">
                         ${rec.charts.map(c => `<span style="background: var(--cyan); color: white; padding: 0.35rem 0.75rem; border-radius: 20px; font-size: 0.85rem;">${c}</span>`).join('')}
                     </div>

--- a/courses/dataviz/lexicon.html
+++ b/courses/dataviz/lexicon.html
@@ -582,7 +582,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/devai/index.html
+++ b/courses/devai/index.html
@@ -1067,17 +1067,17 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                     <div class="card-grid">
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Search.svg" alt=""></div>
-                            <h4>Evidence-Based Assessment</h4>
+                            <h3 style="font-size:1.05rem;font-weight:600">Evidence-Based Assessment</h3>
                             <p>Move beyond vendor demos to rigorous evaluation. Learn to assess tools using development research standards, not Silicon Valley metrics.</p>
                         </div>
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Globe_detailed.svg" alt=""></div>
-                            <h4>Context-Specific Application</h4>
+                            <h3 style="font-size:1.05rem;font-weight:600">Context-Specific Application</h3>
                             <p>What works in Accra may fail in Upper East Region. Deep focus on infrastructure constraints, <a href="../dataviz/index.html">data quality</a> challenges, and organizational capacity.</p>
                         </div>
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Crosshair_detailed.svg" alt=""></div>
-                            <h4>Ethical Frameworks</h4>
+                            <h3 style="font-size:1.05rem;font-weight:600">Ethical Frameworks</h3>
                             <p>Algorithmic bias, data sovereignty, consent in low-literacy contexts. The ethical dimensions that vendor pitches never mention.</p>
                         </div>
                     </div>
@@ -1660,7 +1660,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 <section id="course-assessment" class="quiz-section">
                     <div class="quiz-header">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
-                        <h4>Assess Yourself — AI for M&amp;E</h4>
+                        <h3 style="font-size:1rem;font-weight:600">Assess Yourself — AI for M&amp;E</h3>
                     </div>
                     <p class="quiz-intro">Six auto-graded questions on where AI helps in M&amp;E, its limits, bias, accountability, and privacy. Pick an answer and check it; each explains the reasoning. Nothing is stored and there's no sign-in.</p>
 
@@ -1793,21 +1793,21 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         </div>
         <div class="footer-links">
             <div class="footer-column">
-                <h4>Learn</h4>
+                <h3 style="font-size:1rem;font-weight:700">Learn</h3>
                 <a href="/catalog">All Courses</a>
                 <a href="/workshops">Workshops</a>
                 <a href="/handouts">Handouts</a>
                 <a href="/podcast">Podcast</a>
             </div>
             <div class="footer-column">
-                <h4>Connect</h4>
+                <h3 style="font-size:1rem;font-weight:700">Connect</h3>
                 <a href="/about">About Us</a>
                 <a href="/contact">Contact</a>
                 <a href="/faq">FAQ</a>
                 <a href="/blog">Blog</a>
             </div>
             <div class="footer-column">
-                <h4>Support</h4>
+                <h3 style="font-size:1rem;font-weight:700">Support</h3>
                 <a href="/premium">Premium</a>
                 <a href="/premium">Support Us</a>
                 <a href="/coaching">Coaching</a>

--- a/courses/devai/index.html
+++ b/courses/devai/index.html
@@ -859,7 +859,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <div class="im-topbar" id="imTopbar" role="navigation" aria-label="Site navigation">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/devai/lexicon.html
+++ b/courses/devai/lexicon.html
@@ -351,7 +351,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/devecon/index.html
+++ b/courses/devecon/index.html
@@ -3465,17 +3465,17 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                     <div class="card-grid">
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Bar_chart.svg" alt="" class="sargam-icon"></div>
-                            <h4>Evidence-Based Practice</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">Evidence-Based Practice</h3>
                             <p>Move beyond intuition to rigorous evidence. Learn to evaluate what works, what doesn't, and why—using the same methods Nobel laureates use, from <a href="../../blog/quasi-experimental-designs.html">quasi-experimental designs</a> to RCTs.</p>
                         </div>
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Crosshair_detailed.svg" alt="" class="sargam-icon"></div>
-                            <h4>Theoretical Foundations</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">Theoretical Foundations</h3>
                             <p>Understand the models that explain poverty traps, coordination failures, and structural transformation—essential for designing effective interventions.</p>
                         </div>
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Globe_detailed.svg" alt="" class="sargam-icon"></div>
-                            <h4>South Asian Context</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">South Asian Context</h3>
                             <p>Deep focus on India, Bangladesh, Pakistan, and the <a href="../../blog/south-asia-development-landscape.html">region</a>—where half the world's poor live and where your work will have maximum impact.</p>
                         </div>
                     </div>
@@ -3596,7 +3596,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 <section id="course-assessment" class="quiz-section">
                     <div class="quiz-header">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
-                        <h4>Assess Yourself — Development Economics</h4>
+                        <h3 style="font-size:1.25rem;font-weight:600">Assess Yourself — Development Economics</h3>
                     </div>
                     <p class="quiz-intro">Six auto-graded questions on the core ideas of the course. Pick an answer and check it; each explains the reasoning. Nothing is stored and there's no sign-in.</p>
 
@@ -3731,21 +3731,21 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 </div>
                 <div class="footer-links">
                     <div class="footer-column">
-                        <h4>Learn</h4>
+                        <h3 style="font-size:1rem;font-weight:600">Learn</h3>
                         <a href="/catalog">All Courses</a>
                         <a href="/workshops">Workshops</a>
                         <a href="/handouts">Handouts</a>
                         <a href="/podcast">Podcast</a>
                     </div>
                     <div class="footer-column">
-                        <h4>Connect</h4>
+                        <h3 style="font-size:1rem;font-weight:600">Connect</h3>
                         <a href="/about">About Us</a>
                         <a href="/contact">Contact</a>
                         <a href="/faq">FAQ</a>
                         <a href="/blog">Blog</a>
                     </div>
                     <div class="footer-column">
-                        <h4>Support</h4>
+                        <h3 style="font-size:1rem;font-weight:600">Support</h3>
                         <a href="/premium">Premium</a>
                         <a href="/premium">Support Us</a>
                         <a href="/coaching">Coaching</a>

--- a/courses/devecon/index.html
+++ b/courses/devecon/index.html
@@ -3113,7 +3113,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <div class="im-topbar" id="imTopbar" role="navigation" aria-label="Site navigation">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/devecon/lexicon.html
+++ b/courses/devecon/lexicon.html
@@ -602,7 +602,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/gandhi/index.html
+++ b/courses/gandhi/index.html
@@ -2233,7 +2233,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <div class="im-topbar" id="imTopbar" role="navigation" aria-label="Site navigation">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/gandhi/index.html
+++ b/courses/gandhi/index.html
@@ -3591,21 +3591,21 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         </div>
         <div class="footer-links">
             <div class="footer-column">
-                <h4>Learn</h4>
+                <h3 style="font-size:1rem;font-weight:700">Learn</h3>
                 <a href="/catalog">All Courses</a>
                 <a href="/workshops">Workshops</a>
                 <a href="/handouts">Handouts</a>
                 <a href="/podcast">Podcast</a>
             </div>
             <div class="footer-column">
-                <h4>Connect</h4>
+                <h3 style="font-size:1rem;font-weight:700">Connect</h3>
                 <a href="/about">About Us</a>
                 <a href="/contact">Contact</a>
                 <a href="/faq">FAQ</a>
                 <a href="/blog">Blog</a>
             </div>
             <div class="footer-column">
-                <h4>Support</h4>
+                <h3 style="font-size:1rem;font-weight:700">Support</h3>
                 <a href="/premium">Premium</a>
                 <a href="/premium">Support Us</a>
                 <a href="/coaching">Coaching</a>

--- a/courses/gandhi/lexicon.html
+++ b/courses/gandhi/lexicon.html
@@ -895,7 +895,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/gender/index.html
+++ b/courses/gender/index.html
@@ -1739,7 +1739,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
 <div class="im-topbar" id="imTopbar" role="navigation" aria-label="Site navigation">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/gender/index.html
+++ b/courses/gender/index.html
@@ -1973,22 +1973,22 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
       <div class="why-grid">
         <div class="why-card">
           <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Bar_chart.svg" alt="" class="why-card-icon">
-          <h4>Theoretical Depth</h4>
+          <h3 style="font-size:0.9rem;font-weight:700">Theoretical Depth</h3>
           <p>Butler, Crenshaw, Connell, Agarwal, Kabeer, Menon, Chakravarti — primary texts and core arguments, not summaries.</p>
         </div>
         <div class="why-card">
           <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Crosshair_detailed.svg" alt="" class="why-card-icon">
-          <h4>South Asia Grounded</h4>
+          <h3 style="font-size:0.9rem;font-weight:700">South Asia Grounded</h3>
           <p>Caste-gender intersections, personal laws, the Indian women's movement, NFHS data — the scholarship that actually speaks to your context.</p>
         </div>
         <div class="why-card">
           <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Globe_detailed.svg" alt="" class="why-card-icon">
-          <h4><a href="../law/index.html">Law &amp; Policy</a> Fluency</h4>
+          <h3 style="font-size:0.9rem;font-weight:700"><a href="../law/index.html">Law &amp; Policy</a> Fluency</h3>
           <p>PWDVA, POSH, the 73rd Amendment, the Vishaka guidelines — understand what the law says, what it misses, and how courts have interpreted it.</p>
         </div>
         <div class="why-card">
           <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Article.svg" alt="" class="why-card-icon">
-          <h4>Practice-Ready</h4>
+          <h3 style="font-size:0.9rem;font-weight:700">Practice-Ready</h3>
           <p>Gender mainstreaming tools, care work measurement via <a href="../../Labs/survey-design-lab.html">survey instruments</a>, GBV programme design — theory connected to what you actually do in the field.</p>
         </div>
       </div>
@@ -2141,7 +2141,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                 <section id="course-assessment" class="quiz-section">
                     <div class="quiz-header">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
-                        <h4>Assess Yourself — Gender &amp; Development</h4>
+                        <h3 style="font-size:1.25rem;font-weight:700">Assess Yourself — Gender &amp; Development</h3>
                     </div>
                     <p class="quiz-intro">Six auto-graded questions spanning the course — the sex/gender distinction, practical versus strategic gender needs, unpaid care work, intersectionality, gender mainstreaming, and measures of gender inequality. Pick an answer and check it; each explains the reasoning. Nothing is stored and there's no sign-in.</p>
 
@@ -2307,21 +2307,21 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
         </div>
         <div class="footer-links">
             <div class="footer-column">
-                <h4>Learn</h4>
+                <h3 style="font-size:1rem;font-weight:700">Learn</h3>
                 <a href="/catalog">All Courses</a>
                 <a href="/workshops">Workshops</a>
                 <a href="/handouts">Handouts</a>
                 <a href="/podcast">Podcast</a>
             </div>
             <div class="footer-column">
-                <h4>Connect</h4>
+                <h3 style="font-size:1rem;font-weight:700">Connect</h3>
                 <a href="/about">About Us</a>
                 <a href="/contact">Contact</a>
                 <a href="/faq">FAQ</a>
                 <a href="/blog">Blog</a>
             </div>
             <div class="footer-column">
-                <h4>Support</h4>
+                <h3 style="font-size:1rem;font-weight:700">Support</h3>
                 <a href="/premium">Premium</a>
                 <a href="/premium">Support Us</a>
                 <a href="/coaching">Coaching</a>

--- a/courses/gender/lexicon.html
+++ b/courses/gender/lexicon.html
@@ -361,7 +361,7 @@ body {
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/law/index.html
+++ b/courses/law/index.html
@@ -3081,7 +3081,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <div class="im-topbar" id="imTopbar" role="navigation" aria-label="Site navigation">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/law/index.html
+++ b/courses/law/index.html
@@ -3411,17 +3411,17 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                     <div class="card-grid">
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Shield.svg" alt="" class="sargam-icon"></div>
-                            <h4>Rights-Based Programming</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">Rights-Based Programming</h3>
                             <p>Move beyond charity to entitlements. Understand how constitutional rights create legal obligations that governments must fulfill, and how to use this framework in program design. See also our <a href="../gender/index.html">Gender Studies</a> course for rights-based approaches to gender justice.</p>
                         </div>
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Article.svg" alt="" class="sargam-icon"></div>
-                            <h4>Legal Literacy for Practitioners</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">Legal Literacy for Practitioners</h3>
                             <p>Read judgments, understand PIL strategy, navigate regulatory frameworks. The practical legal knowledge every development professional needs but rarely gets in graduate training.</p>
                         </div>
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Globe_detailed.svg" alt="" class="sargam-icon"></div>
-                            <h4>Comparative South Asian Lens</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">Comparative South Asian Lens</h3>
                             <p>India, Bangladesh, Nepal, Sri Lanka, Pakistan. Each constitution reflects different histories and trade-offs. Comparative analysis reveals what works, what doesn't, and why institutional design matters—questions also explored in our <a href="../pubpol/index.html">Public Policy</a> course.</p>
                         </div>
                     </div>
@@ -3541,7 +3541,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 <section id="course-assessment" class="quiz-section">
                     <div class="quiz-header">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
-                        <h4>Assess Yourself — Constitution &amp; Law</h4>
+                        <h3 style="font-size:1.25rem;font-weight:600">Assess Yourself — Constitution &amp; Law</h3>
                     </div>
                     <p class="quiz-intro">Six auto-graded questions on the core ideas of the course. Pick an answer and check it; each explains the reasoning. Nothing is stored and there's no sign-in.</p>
 
@@ -3675,21 +3675,21 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         </div>
         <div class="footer-links">
             <div class="footer-column">
-                <h4>Learn</h4>
+                <h3 style="font-size:1rem;font-weight:600">Learn</h3>
                 <a href="/catalog">All Courses</a>
                 <a href="/workshops">Workshops</a>
                 <a href="/handouts">Handouts</a>
                 <a href="/podcast">Podcast</a>
             </div>
             <div class="footer-column">
-                <h4>Connect</h4>
+                <h3 style="font-size:1rem;font-weight:600">Connect</h3>
                 <a href="/about">About Us</a>
                 <a href="/contact">Contact</a>
                 <a href="/faq">FAQ</a>
                 <a href="/blog">Blog</a>
             </div>
             <div class="footer-column">
-                <h4>Support</h4>
+                <h3 style="font-size:1rem;font-weight:600">Support</h3>
                 <a href="/premium">Premium</a>
                 <a href="/premium">Support Us</a>
                 <a href="/coaching">Coaching</a>

--- a/courses/law/lexicon.html
+++ b/courses/law/lexicon.html
@@ -379,7 +379,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/livelihoods/index.html
+++ b/courses/livelihoods/index.html
@@ -3173,7 +3173,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <div class="im-topbar" id="imTopbar" role="navigation" aria-label="Site navigation">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/livelihoods/index.html
+++ b/courses/livelihoods/index.html
@@ -3326,7 +3326,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 <section id="course-assessment" class="quiz-section">
                     <div class="quiz-header">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
-                        <h4>Assess Yourself — Livelihoods &amp; Development</h4>
+                        <h2 style="font-size:1.25rem;font-weight:600">Assess Yourself — Livelihoods &amp; Development</h2>
                     </div>
                     <p class="quiz-intro">Six auto-graded questions on the core ideas of the course. Pick an answer and check it; each explains the reasoning. Nothing is stored and there's no sign-in.</p>
 
@@ -3517,21 +3517,21 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 </div>
                 <div class="footer-links">
                     <div class="footer-column">
-                        <h4>Learn</h4>
+                        <h3 style="font-size:1rem;font-weight:600">Learn</h3>
                         <a href="/catalog">All Courses</a>
                         <a href="/workshops">Workshops</a>
                         <a href="/handouts">Handouts</a>
                         <a href="/podcast">Podcast</a>
                     </div>
                     <div class="footer-column">
-                        <h4>Connect</h4>
+                        <h3 style="font-size:1rem;font-weight:600">Connect</h3>
                         <a href="/about">About Us</a>
                         <a href="/contact">Contact</a>
                         <a href="/faq">FAQ</a>
                         <a href="/blog">Blog</a>
                     </div>
                     <div class="footer-column">
-                        <h4>Support</h4>
+                        <h3 style="font-size:1rem;font-weight:600">Support</h3>
                         <a href="/premium">Premium</a>
                         <a href="/premium">Support Us</a>
                         <a href="/coaching">Coaching</a>

--- a/courses/media/index.html
+++ b/courses/media/index.html
@@ -3127,7 +3127,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <div class="im-topbar" id="imTopbar" role="navigation" aria-label="Site navigation">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/media/index.html
+++ b/courses/media/index.html
@@ -3440,17 +3440,17 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                     <div class="card-grid">
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Bar_chart.svg" alt="" class="sargam-icon"></div>
-                            <h4>Beyond the Cause</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">Beyond the Cause</h3>
                             <p>Move past the cause-impact gap. Learn why development communication overwhelmingly focuses on problems, what it costs, and how organizations like ASER and GiveDirectly have used <a href="../../blog/data-driven-decisions.html">data-driven approaches</a> to chart a different course.</p>
                         </div>
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Shield.svg" alt="" class="sargam-icon"></div>
-                            <h4>Ethics of Representation</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">Ethics of Representation</h3>
                             <p>From consent and dignity to the politics of who tells whose story. Rigorous frameworks—informed by <a href="../gender/index.html">gender</a> and power analysis—for navigating the ethical minefield of development imagery, storytelling, and failure reporting.</p>
                         </div>
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Globe_detailed.svg" alt="" class="sargam-icon"></div>
-                            <h4>Indian Models</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">Indian Models</h3>
                             <p>Deep dives into PARI, Khabar Lahariya, and Video Volunteers: three Indian organizations that have fundamentally reimagined who produces media, for whom, and to what end. See also our <a href="../dataviz/index.html">Data Visualization</a> course for how data journalism tools complement narrative approaches.</p>
                         </div>
                     </div>
@@ -3564,7 +3564,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 <section id="course-assessment" class="quiz-section">
                     <div class="quiz-header">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
-                        <h4>Assess Yourself — Media for Development</h4>
+                        <h3 style="font-size:1.25rem;font-weight:600">Assess Yourself — Media for Development</h3>
                     </div>
                     <p class="quiz-intro">Six auto-graded questions on the core ideas of the course. Pick an answer and check it; each explains the reasoning. Nothing is stored and there's no sign-in.</p>
 
@@ -3700,21 +3700,21 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         </div>
         <div class="footer-links">
             <div class="footer-column">
-                <h4>Learn</h4>
+                <h3 style="font-size:1rem;font-weight:600">Learn</h3>
                 <a href="/catalog">All Courses</a>
                 <a href="/workshops">Workshops</a>
                 <a href="/handouts">Handouts</a>
                 <a href="/podcast">Podcast</a>
             </div>
             <div class="footer-column">
-                <h4>Connect</h4>
+                <h3 style="font-size:1rem;font-weight:600">Connect</h3>
                 <a href="/about">About Us</a>
                 <a href="/contact">Contact</a>
                 <a href="/faq">FAQ</a>
                 <a href="/blog">Blog</a>
             </div>
             <div class="footer-column">
-                <h4>Support</h4>
+                <h3 style="font-size:1rem;font-weight:600">Support</h3>
                 <a href="/premium">Premium</a>
                 <a href="/premium">Support Us</a>
                 <a href="/coaching">Coaching</a>

--- a/courses/media/media-lexicon.html
+++ b/courses/media/media-lexicon.html
@@ -379,7 +379,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/mel/index.html
+++ b/courses/mel/index.html
@@ -3127,7 +3127,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <div class="im-topbar" id="imTopbar" role="navigation" aria-label="Site navigation">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/mel/index.html
+++ b/courses/mel/index.html
@@ -3488,17 +3488,17 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                     <div class="card-grid">
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Bar_chart.svg" alt="" class="sargam-icon"></div>
-                            <h4>Evidence-Based Practice</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">Evidence-Based Practice</h3>
                             <p>Move beyond anecdotes to systematic evidence. Learn to design <a href="../../blog/indicators-that-matter.html">indicator systems</a>, collect quality data, and analyze results that drive real decisions.</p>
                         </div>
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Crosshair_detailed.svg" alt="" class="sargam-icon"></div>
-                            <h4>Methodological Range</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">Methodological Range</h3>
                             <p>Master the full spectrum—from RCTs to contribution analysis, from <a href="../../Labs/survey-design-lab.html">household surveys</a> to Most Significant Change. Know when to use which approach.</p>
                         </div>
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Globe_detailed.svg" alt="" class="sargam-icon"></div>
-                            <h4>South Asian Context</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">South Asian Context</h3>
                             <p>Deep focus on India, Bangladesh, and the region—with case studies from MGNREGA, Pratham, BRAC, and J-PAL South Asia that show MEL in action.</p>
                         </div>
                     </div>
@@ -3629,7 +3629,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 <section id="course-assessment" class="quiz-section">
                     <div class="quiz-header">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
-                        <h4>Assess Yourself — MEL Fundamentals</h4>
+                        <h3 style="font-size:1.25rem;font-weight:600">Assess Yourself — MEL Fundamentals</h3>
                     </div>
                     <p class="quiz-intro">Six auto-graded questions spanning the course — theory of change, indicators, baselines, attribution, data quality, and evaluation criteria. Pick an answer and check it; each explains the reasoning. Nothing is stored and there's no sign-in.</p>
 
@@ -3765,21 +3765,21 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         </div>
         <div class="footer-links">
             <div class="footer-column">
-                <h4>Learn</h4>
+                <h3 style="font-size:1rem;font-weight:600">Learn</h3>
                 <a href="/catalog">All Courses</a>
                 <a href="/workshops">Workshops</a>
                 <a href="/handouts">Handouts</a>
                 <a href="/podcast">Podcast</a>
             </div>
             <div class="footer-column">
-                <h4>Connect</h4>
+                <h3 style="font-size:1rem;font-weight:600">Connect</h3>
                 <a href="/about">About Us</a>
                 <a href="/contact">Contact</a>
                 <a href="/faq">FAQ</a>
                 <a href="/blog">Blog</a>
             </div>
             <div class="footer-column">
-                <h4>Support</h4>
+                <h3 style="font-size:1rem;font-weight:600">Support</h3>
                 <a href="/premium">Premium</a>
                 <a href="/premium">Support Us</a>
                 <a href="/coaching">Coaching</a>

--- a/courses/mel/lexicon.html
+++ b/courses/mel/lexicon.html
@@ -379,7 +379,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/poa/index.html
+++ b/courses/poa/index.html
@@ -3187,7 +3187,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <div class="im-topbar" id="imTopbar" role="navigation" aria-label="Site navigation">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/poa/index.html
+++ b/courses/poa/index.html
@@ -3526,17 +3526,17 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                     <div class="card-grid">
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Bar_chart.svg" alt="" class="sargam-icon"></div>
-                            <h4>Evidence-Based Practice</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">Evidence-Based Practice</h3>
                             <p>Learn to evaluate NREGA, RTI, Food Security, and Forest Rights using rigorous evidence—including <a href="../../blog/indicators-that-matter.html">indicators that matter</a>—what works, what doesn't, and why implementation varies across states.</p>
                         </div>
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Crosshair_detailed.svg" alt="" class="sargam-icon"></div>
-                            <h4>Theoretical Foundations</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">Theoretical Foundations</h3>
                             <p>Understand how Appadurai's capacity to aspire, Sen's capability approach, and Ray's aspirations economics explain why rights-based policy enables mobility.</p>
                         </div>
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Globe_detailed.svg" alt="" class="sargam-icon"></div>
-                            <h4>South Asian Context</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">South Asian Context</h3>
                             <p>Deep comparative analysis of India, Bangladesh, Pakistan's social protection systems—where they converge, diverge, and what practitioners can learn. See also our <a href="../gender/index.html">Gender Studies</a> course for how gender shapes access to these rights.</p>
                         </div>
                     </div>
@@ -3657,7 +3657,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 <section id="course-assessment" class="quiz-section">
                     <div class="quiz-header">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
-                        <h4>Assess Yourself — Politics of Aspiration</h4>
+                        <h3 style="font-size:1.25rem;font-weight:600">Assess Yourself — Politics of Aspiration</h3>
                     </div>
                     <p class="quiz-intro">Six auto-graded questions on the core ideas of the course. Pick an answer and check it; each explains the reasoning. Nothing is stored and there's no sign-in.</p>
 
@@ -3793,21 +3793,21 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         </div>
         <div class="footer-links">
             <div class="footer-column">
-                <h4>Learn</h4>
+                <h3 style="font-size:1rem;font-weight:600">Learn</h3>
                 <a href="/catalog">All Courses</a>
                 <a href="/workshops">Workshops</a>
                 <a href="/handouts">Handouts</a>
                 <a href="/podcast">Podcast</a>
             </div>
             <div class="footer-column">
-                <h4>Connect</h4>
+                <h3 style="font-size:1rem;font-weight:600">Connect</h3>
                 <a href="/about">About Us</a>
                 <a href="/contact">Contact</a>
                 <a href="/faq">FAQ</a>
                 <a href="/blog">Blog</a>
             </div>
             <div class="footer-column">
-                <h4>Support</h4>
+                <h3 style="font-size:1rem;font-weight:600">Support</h3>
                 <a href="/premium">Premium</a>
                 <a href="/premium">Support Us</a>
                 <a href="/coaching">Coaching</a>

--- a/courses/poa/lexicon.html
+++ b/courses/poa/lexicon.html
@@ -647,7 +647,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/powerBI/powerbi.html
+++ b/courses/powerBI/powerbi.html
@@ -3342,7 +3342,7 @@ html[data-theme="dark"]{--s-card:#0F172A;--s-soft:#1E293B;--s-ink:#E2E8F0;--s-fa
 <div class="im-topbar" id="imTopbar" role="navigation" aria-label="Site navigation">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/powerBI/powerbilexicon.html
+++ b/courses/powerBI/powerbilexicon.html
@@ -3148,7 +3148,7 @@ html[data-theme="dark"]{--indigo:#6366F1}
 <div class="im-topbar" id="imTopbar" role="navigation" aria-label="Site navigation">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/pubchoice/index.html
+++ b/courses/pubchoice/index.html
@@ -3607,17 +3607,17 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                     <div class="card-grid" style="margin: 2rem 0;">
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Bar_chart.svg" alt="" class="sargam-icon"></div>
-                            <h4>Mechanism-Level Diagnosis</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">Mechanism-Level Diagnosis</h3>
                             <p>Move past "implementation gaps" to identify the specific incentive structures, decision rules, and principal-agent chains that produce predictable failure. The toolkit travels across sectors and countries.</p>
                         </div>
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Crosshair_detailed.svg" alt="" class="sargam-icon"></div>
-                            <h4>Two Schools, One Synthesis</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">Two Schools, One Synthesis</h3>
                             <p>Virginia school tools for diagnosing capture and rent-seeking. Bloomington school tools for designing commons and polycentric governance. New Institutional Economics for understanding why rules persist or change.</p>
                         </div>
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Globe_detailed.svg" alt="" class="sargam-icon"></div>
-                            <h4>South Asian Cases at the Centre</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">South Asian Cases at the Centre</h3>
                             <p>Forest commons in Nepal, irrigation tank cascades in Sri Lanka, panchayati raj in India, BISP in Pakistan, BRAC programme structure in Bangladesh. Theory tested against the region where most of you work.</p>
                         </div>
                     </div>
@@ -3782,7 +3782,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 <section id="course-assessment" class="quiz-section">
                     <div class="quiz-header">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
-                        <h4>Assess Yourself — Public Choice</h4>
+                        <h3 style="font-size:1.25rem;font-weight:600">Assess Yourself — Public Choice</h3>
                     </div>
                     <p class="quiz-intro">Six auto-graded questions on the core ideas of the course. Pick an answer and check it; each explains the reasoning. Nothing is stored and there's no sign-in.</p>
 
@@ -3888,22 +3888,22 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                     <div class="card-grid">
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Activity.svg" alt="" class="sargam-icon"></div>
-                            <h4>Algorithmic Governance</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">Algorithmic Governance</h3>
                             <p>When decisions are delegated to opaque algorithms (Aadhaar authentication failures denying rations, predictive policing in urban India, automated welfare eligibility), the principal-agent chain extends into code. Existing Public Choice tools assume a human bureaucrat with discoverable preferences. Algorithmic systems require new accountability mechanisms.</p>
                         </div>
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Globe_detailed.svg" alt="" class="sargam-icon"></div>
-                            <h4>Climate Commons at Scale</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">Climate Commons at Scale</h3>
                             <p>Ostrom&rsquo;s design principles work for commons with bounded user groups and observable resource conditions. The atmosphere is neither. Transboundary water systems (Indus, Brahmaputra, Teesta) sit between the local commons that Ostrom studied and the truly global ones that her framework struggles with. The South Asian region will be a major test bed for the next decade.</p>
                         </div>
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Article.svg" alt="" class="sargam-icon"></div>
-                            <h4>Digital Public Infrastructure</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">Digital Public Infrastructure</h3>
                             <p>India Stack, Aadhaar, UPI, and the broader DPI movement create new public-good provision mechanisms with novel governance questions. Who decides interoperability standards? Who has standing to challenge design choices? The Public Choice analysis of DPI is in its infancy.</p>
                         </div>
                         <div class="card">
                             <div class="card-icon"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Chat.svg" alt="" class="sargam-icon"></div>
-                            <h4>Polarisation and Legislative Decay</h4>
+                            <h3 style="font-size:1.1rem;font-weight:600">Polarisation and Legislative Decay</h3>
                             <p>Several South Asian legislatures now pass major legislation with minimal debate or committee scrutiny. The Public Choice literature on agenda control, log-rolling, and bargaining assumes legislatures function as deliberative bodies. When they do not, the analytical tools need updating.</p>
                         </div>
                     </div>
@@ -5217,7 +5217,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                     <div class="founders-grid">
                         <div class="founder-card">
                             <img src="https://www.impactmojo.in/assets/images/varna-photo.jpg" alt="Varna Sri Raman" class="founder-photo">
-                            <h4>Varna</h4>
+                            <h3 style="font-size:1.25rem;font-weight:600">Varna</h3>
                             <p class="founder-title">Co-founder, ImpactMojo</p>
                             <p>Development economist (PhD) and qualified lawyer specialising in Law and Economics. Sixteen years of work across MEL, gender, and policy in South Asia, with a particular focus on translating institutional analysis into programme design.</p>
                             <div class="founder-cta">
@@ -5229,7 +5229,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                         </div>
                         <div class="founder-card">
                             <img src="https://www.impactmojo.in/assets/images/vandana-photo.jpg" alt="Vandana Soni" class="founder-photo">
-                            <h4>Vandana Soni</h4>
+                            <h3 style="font-size:1.25rem;font-weight:600">Vandana Soni</h3>
                             <p class="founder-title">Co-founder, ImpactMojo</p>
                             <p>Development practitioner and educator with deep experience in MEL system design, organisational learning, and capability-building across INGOs and government programmes in South Asia.</p>
                             <div class="founder-cta">
@@ -5255,21 +5255,21 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         </div>
         <div class="footer-links">
             <div class="footer-column">
-                <h4>Learn</h4>
+                <h3 style="font-size:1rem;font-weight:600">Learn</h3>
                 <a href="/catalog">All Courses</a>
                 <a href="/workshops">Workshops</a>
                 <a href="/handouts">Handouts</a>
                 <a href="/podcast">Podcast</a>
             </div>
             <div class="footer-column">
-                <h4>Connect</h4>
+                <h3 style="font-size:1rem;font-weight:600">Connect</h3>
                 <a href="/about">About Us</a>
                 <a href="/contact">Contact</a>
                 <a href="/faq">FAQ</a>
                 <a href="/blog">Blog</a>
             </div>
             <div class="footer-column">
-                <h4>Support</h4>
+                <h3 style="font-size:1rem;font-weight:600">Support</h3>
                 <a href="/premium">Premium</a>
                 <a href="/premium">Support Us</a>
                 <a href="/coaching">Coaching</a>

--- a/courses/pubchoice/index.html
+++ b/courses/pubchoice/index.html
@@ -3343,7 +3343,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <div class="im-topbar" id="imTopbar" role="navigation" aria-label="Site navigation">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/pubpol/index.html
+++ b/courses/pubpol/index.html
@@ -798,7 +798,7 @@ body.dark-mode, [data-theme="dark"] {
 <div class="im-topbar" id="imTopbar" role="navigation" aria-label="Site navigation">
     <div class="im-topbar-left">
         <a href="https://www.impactmojo.in" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/pubpol/index.html
+++ b/courses/pubpol/index.html
@@ -505,7 +505,7 @@ body.dark-mode, [data-theme="dark"] {
         .footer-logo img{height:32px;margin-bottom:0.75rem;}
         .footer-logo p{font-size:0.85rem;color:var(--text-muted);}
         .footer-links{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;}
-        .footer-column h4{font-size:0.78rem;font-weight:700;text-transform:uppercase;letter-spacing:0.06em;color:var(--text-secondary);margin-bottom:0.75rem;font-family:var(--font-heading);}
+        .footer-column h4, .footer-column h3, .footer-column h2{font-size:0.78rem;font-weight:700;text-transform:uppercase;letter-spacing:0.06em;color:var(--text-secondary);margin-bottom:0.75rem;font-family:var(--font-heading);}
         .footer-column a{display:block;color:var(--text-muted);font-size:0.85rem;padding:2px 0;text-decoration:none;transition:color 0.2s;}
         .footer-column a:hover{color:var(--accent-color);text-decoration:none;}
         .footer-bottom{max-width:var(--content-max-width);margin:0 auto;padding-top:1.25rem;border-top:1px solid var(--color-border);display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:0.5rem;}
@@ -1183,7 +1183,7 @@ body.dark-mode, [data-theme="dark"] {
                 <section id="course-assessment" class="quiz-section">
                     <div class="quiz-header">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
-                        <h4>Assess Yourself — Public Policy</h4>
+                        <h3 style="font-size:1.25rem;font-weight:600">Assess Yourself — Public Policy</h3>
                     </div>
                     <p class="quiz-intro">Six auto-graded questions on the core ideas of the course. Pick an answer and check it; each explains the reasoning. Nothing is stored and there's no sign-in.</p>
 
@@ -1329,21 +1329,21 @@ body.dark-mode, [data-theme="dark"] {
         </div>
         <div class="footer-links">
             <div class="footer-column">
-                <h4>Learn</h4>
+                <h3 style="font-size:0.78rem;font-weight:700">Learn</h3>
                 <a href="/catalog">All Courses</a>
                 <a href="/workshops">Workshops</a>
                 <a href="/handouts">Handouts</a>
                 <a href="/podcast">Podcast</a>
             </div>
             <div class="footer-column">
-                <h4>Connect</h4>
+                <h3 style="font-size:0.78rem;font-weight:700">Connect</h3>
                 <a href="/about">About Us</a>
                 <a href="/contact">Contact</a>
                 <a href="/faq">FAQ</a>
                 <a href="/blog">Blog</a>
             </div>
             <div class="footer-column">
-                <h4>Support</h4>
+                <h3 style="font-size:0.78rem;font-weight:700">Support</h3>
                 <a href="/premium">Premium</a>
                 <a href="/premium">Support Us</a>
                 <a href="/coaching">Coaching</a>

--- a/courses/pubpol/lexicon.html
+++ b/courses/pubpol/lexicon.html
@@ -176,7 +176,7 @@
 <div class="im-topbar">
     <div class="im-topbar-left">
         <a href="https://www.impactmojo.in" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
         <a href="index.html" class="back-btn">

--- a/courses/sel/index.html
+++ b/courses/sel/index.html
@@ -3049,7 +3049,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <div class="im-topbar" id="imTopbar" role="navigation" aria-label="Site navigation">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/courses/sel/index.html
+++ b/courses/sel/index.html
@@ -3176,7 +3176,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <section class="section reveal" id="frameworks" style="max-width:900px;margin:0 auto;padding:2.5rem 1.5rem;">
   <div style="background:var(--secondary-bg);border:1px solid var(--border-color);border-left:4px solid var(--accent-color);border-radius:12px;padding:1.75rem 1.75rem 1.25rem;">
     <div style="font-family:'Inter',sans-serif;font-size:0.78rem;text-transform:uppercase;letter-spacing:0.7px;color:var(--accent-color);font-weight:700;margin-bottom:0.5rem;">A Note on Frameworks</div>
-    <h3 style="font-family:'Inter',sans-serif;font-size:1.35rem;font-weight:700;margin:0 0 0.85rem;color:var(--text-primary);">SEL is not one framework. We draw on several.</h3>
+    <h2 style="font-family:'Inter',sans-serif;font-size:1.35rem;font-weight:700;margin:0 0 0.85rem;color:var(--text-primary);font-size:1.35rem;font-weight:700">SEL is not one framework. We draw on several.</h2>
     <p style="color:var(--text-secondary);line-height:1.75;margin-bottom:0.9rem;">Most Indian SEL training collapses the field into <strong>CASEL's five competencies</strong>. That framing is well-validated globally, but it is one framework among several — and the others matter especially in Indian contexts.</p>
     <ul style="color:var(--text-secondary);line-height:1.75;padding-left:1.25rem;margin-bottom:0.9rem;">
       <li><strong>CASEL</strong> — Collaborative for Academic, Social &amp; Emotional Learning. Five competencies: self-awareness, self-management, social awareness, relationship skills, responsible decision-making. The dominant US framework; most cited in global research.</li>
@@ -3299,7 +3299,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 <section id="course-assessment" class="quiz-section">
                     <div class="quiz-header">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
-                        <h4>Assess Yourself — Social-Emotional Learning</h4>
+                        <h3 style="font-size:1.25rem;font-weight:600">Assess Yourself — Social-Emotional Learning</h3>
                     </div>
                     <p class="quiz-intro">Six auto-graded questions on the core ideas of the course. Pick an answer and check it; each explains the reasoning. Nothing is stored and there's no sign-in.</p>
 
@@ -3808,21 +3808,21 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         </div>
         <div class="footer-links">
             <div class="footer-column">
-                <h4>Learn</h4>
+                <h3 style="font-size:1rem;font-weight:600">Learn</h3>
                 <a href="/catalog">All Courses</a>
                 <a href="/workshops">Workshops</a>
                 <a href="/handouts">Handouts</a>
                 <a href="/podcast">Podcast</a>
             </div>
             <div class="footer-column">
-                <h4>Connect</h4>
+                <h3 style="font-size:1rem;font-weight:600">Connect</h3>
                 <a href="/about">About Us</a>
                 <a href="/contact">Contact</a>
                 <a href="/faq">FAQ</a>
                 <a href="/blog">Blog</a>
             </div>
             <div class="footer-column">
-                <h4>Support</h4>
+                <h3 style="font-size:1rem;font-weight:600">Support</h3>
                 <a href="/premium">Premium</a>
                 <a href="/premium">Support Us</a>
                 <a href="/coaching">Coaching</a>

--- a/courses/sel/lexicon.html
+++ b/courses/sel/lexicon.html
@@ -379,7 +379,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/css/imx-main.css
+++ b/css/imx-main.css
@@ -2511,7 +2511,7 @@
             margin-bottom: 2rem;
         }
 
-        .footer-section h4 {
+        .footer-section h4, .footer-section h3, .footer-section h2 {
             /* WCAG AA: sky-800 #075985 = 7.56:1 on the footer bg.
                Was sky-500 #0EA5E9 which is 2.65:1 — fails. */
             color: #075985;
@@ -2520,7 +2520,7 @@
             text-transform: uppercase;
             letter-spacing: 0.5px;
         }
-        body.dark-mode .footer-section h4, [data-theme="dark"] .footer-section h4 { color: #7DD3FC; }
+        body.dark-mode .footer-section h4, body.dark-mode .footer-section h3, body.dark-mode .footer-section h2, [data-theme="dark"] .footer-section h4, [data-theme="dark"] .footer-section h3, [data-theme="dark"] .footer-section h2 { color: #7DD3FC; }
 
         .footer-section ul {
             list-style: none;

--- a/events.html
+++ b/events.html
@@ -285,7 +285,7 @@ body {
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="/index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/impact-dashboard.html
+++ b/impact-dashboard.html
@@ -322,7 +322,7 @@ body {
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="/index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/index.html
+++ b/index.html
@@ -2960,8 +2960,8 @@ window.addEventListener('authStateChanged', function(e) {
 </section>
 
 <section class="section" id="premium">
-<h2 class="section-title">Premium Offerings</h2>
-<p class="section-subtitle">Advanced tools and in-depth content for serious practitioners</p>
+<h2 class="section-title">Pro Studio</h2>
+<p class="section-subtitle">Professional-grade tools for serious practitioners &mdash; moving to a free-to-use model, with export and advanced modes on Premium</p>
 <div class="imx-premium-tiers">
     <div style="padding: 1.25rem 1.5rem; border-radius: 12px; background: rgba(99, 102, 241, 0.08); border: 1px solid rgba(99, 102, 241, 0.15);">
         <div style="font-weight: 700; font-size: 0.88rem; color: #4338CA; margin-bottom: 0.4rem;">Practitioner Tier</div>
@@ -3355,7 +3355,7 @@ window.addEventListener('authStateChanged', function(e) {
 <div class="action-buttons">
 <button class="btn btn-premium" onclick="openModal('premiumModal')">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Direction_alt"/></svg>
-                    View All Premium Tools
+                    Explore the Pro Studio
                 </button>
 </div>
 </section>

--- a/offline.html
+++ b/offline.html
@@ -420,7 +420,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="/index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/org-dashboard.html
+++ b/org-dashboard.html
@@ -718,7 +718,7 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="/index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/peer-review.html
+++ b/peer-review.html
@@ -292,7 +292,7 @@ body {
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="/index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/premium-tools/code-converter-pro.html
+++ b/premium-tools/code-converter-pro.html
@@ -434,7 +434,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/premium-tools/qual-insights-lab.html
+++ b/premium-tools/qual-insights-lab.html
@@ -409,7 +409,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="../index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/premium-tools/tor-builder.html
+++ b/premium-tools/tor-builder.html
@@ -208,7 +208,7 @@ table.cost .num{text-align:right;font-family:'JetBrains Mono',monospace;}
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="/index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/sitemap.html
+++ b/sitemap.html
@@ -743,7 +743,7 @@ body { padding-top: 56px; }
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="/index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>

--- a/verify.html
+++ b/verify.html
@@ -336,7 +336,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]) {
 <div class="im-topbar" id="imTopbar">
     <div class="im-topbar-left">
         <a href="/index.html" class="im-topbar-home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
             <span>ImpactMojo</span>
         </a>
     </div>


### PR DESCRIPTION
## What does this PR do?

First step of the **Pro Studio** rebrand: renames the homepage professional-tools section from **"Premium Offerings" → "Pro Studio"**, with a subtitle signalling the move to a free-to-use (freemium) model — *free to use, export/advanced modes on Premium*. Also updates the section CTA "View All Premium Tools → Explore the Pro Studio".

**Deliberately limited scope** (see the note below): individual card names still say "… Pro" because 9 of them are **external apps** whose titles and gating live in separate repos not reachable from this session — renaming only the homepage cards would mismatch the live apps. Advisory Board Pro (internal) is untouched (token cost).

## Follow-up needed (blocked on repo access)

To actually modernize + convert the 9 external tools to the freemium model, these repos must be added to a session — they're under the **`Varnasr`** account, and this session is locked to the `impactmojo` org (no cross-owner adds):
- `Varnasr/impactmojo-workshop-pro` · `Varnasr/impactmojo-field-notes-pro` · `Varnasr/impactmojo-devdata-pro`

Either start a new session seeded with those repos, or move them into the `impactmojo` org.

## Type of change

- [x] Content / branding update

## Checklist

- [x] index.html parses; mojibake PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cKaedtLCrBq3y6WZtSmAn

---
_Generated by [Claude Code](https://claude.ai/code/session_018cKaedtLCrBq3y6WZtSmAn)_