### PR TITLE
Homepage: drop the bare "Pro" from Pro Studio tool cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -2985,7 +2985,7 @@ window.addEventListener('authStateChanged', function(e) {
                                 New
                             </span>
 </div>
-<h3 class="card-title">Advisory Board Pro</h3>
+<h3 class="card-title">Advisory Board</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -3012,7 +3012,7 @@ window.addEventListener('authStateChanged', function(e) {
                                 520 Users
                             </span>
 </div>
-<h3 class="card-title">Theory of Change Workbench Pro</h3>
+<h3 class="card-title">Theory of Change Workbench</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -3039,7 +3039,7 @@ window.addEventListener('authStateChanged', function(e) {
                                 70+ Notes
                             </span>
 </div>
-<h3 class="card-title">Field Notes Pro</h3>
+<h3 class="card-title">Field Notes</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -3175,7 +3175,7 @@ window.addEventListener('authStateChanged', function(e) {
                                 Workshop Tool
                             </span>
 </div>
-<h3 class="card-title">Theory of Change Workshop Pro</h3>
+<h3 class="card-title">Theory of Change Workshop</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -3202,7 +3202,7 @@ window.addEventListener('authStateChanged', function(e) {
                                 Workshop Tool
                             </span>
 </div>
-<h3 class="card-title">Logical Framework Builder Pro</h3>
+<h3 class="card-title">Logical Framework Builder</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -3229,7 +3229,7 @@ window.addEventListener('authStateChanged', function(e) {
                                 Workshop Tool
                             </span>
 </div>
-<h3 class="card-title">Data Visualization Chart Selector Pro</h3>
+<h3 class="card-title">Data Visualization Chart Selector</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -3256,7 +3256,7 @@ window.addEventListener('authStateChanged', function(e) {
                                 Workshop Tool
                             </span>
 </div>
-<h3 class="card-title">Stakeholder Mapping Workshop Pro</h3>
+<h3 class="card-title">Stakeholder Mapping Workshop</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -3283,7 +3283,7 @@ window.addEventListener('authStateChanged', function(e) {
                                 Workshop Tool
                             </span>
 </div>
-<h3 class="card-title">Empathy Mapping Workshop Pro</h3>
+<h3 class="card-title">Empathy Mapping Workshop</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -3310,7 +3310,7 @@ window.addEventListener('authStateChanged', function(e) {
                                 Workshop Tool
                             </span>
 </div>
-<h3 class="card-title">Policy Analysis Canvas Pro</h3>
+<h3 class="card-title">Policy Analysis Canvas</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -3337,7 +3337,7 @@ window.addEventListener('authStateChanged', function(e) {
                                 Workshop Tool
                             </span>
 </div>
-<h3 class="card-title">AI Strategy Canvas Pro</h3>
+<h3 class="card-title">AI Strategy Canvas</h3>
 <div class="star-rating">
 <div class="stars">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>


### PR DESCRIPTION
## What does this PR do?

Continues the **Pro Studio** rebrand: the ten tool cards in the Pro Studio section now show plain tool names instead of the redundant "… Pro" suffix (e.g. **"Theory of Change Workbench"** not "…Workbench Pro"). Under the "Pro Studio" umbrella the per-tool "Pro" is redundant, and in the coming freemium model "Pro" refers to the *Premium upgrade*, not the whole tool.

- **Display-only** rename of the card titles (10 cards).
- Each card **keeps its accurate Premium badge** — I did **not** add a "free to use" label, because the underlying apps are still paywalled; the section subtitle already signals the move to freemium. As each app is converted (in the workshop-pro / devdata-pro sessions), I'll flip that tool's badge to the freemium one.
- **No gating or functionality changed**, including the internal Advisory Board tool (only its card label lost the "Pro").

## Type of change

- [x] Content / branding update

## Checklist

- [x] index.html parses; mojibake PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cKaedtLCrBq3y6WZtSmAn

---
_Generated by [Claude Code](https://claude.ai/code/session_018cKaedtLCrBq3y6WZtSmAn)_