### PR TITLE
Pro Studio: host the 7 workshop tools same-origin under premium-tools/

### DIFF
--- a/index.html
+++ b/index.html
@@ -3001,7 +3001,7 @@ window.addEventListener('authStateChanged', function(e) {
 </a>
 </div>
 <div class="card" data-required-tier="practitioner" data-tier-benefits="Upgrade to Practitioner (₹399/mo): Unlock advanced Theory of Change building with assumption mapping, evidence linkage, and PDF/PNG export!">
-<a href="https://impactmojo-workshop-pro.netlify.app/toc-pro.html" data-resource-id="toc-workshop-pro" rel="noopener noreferrer" target="_blank">
+<a href="/premium-tools/toc-pro.html" data-resource-id="toc-workshop-pro" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Crosshair_detailed"/></svg>
@@ -3164,7 +3164,7 @@ window.addEventListener('authStateChanged', function(e) {
 </div>
 <!-- Interactive Workshop Templates (Professional Tier) -->
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock interactive Theory of Change builder with drag-and-drop causal pathways and assumption mapping!">
-<a href="https://impactmojo-workshop-pro.netlify.app/toc-pro.html" data-resource-id="toc-workshop-pro" target="_blank" rel="noopener noreferrer">
+<a href="/premium-tools/toc-pro.html" data-resource-id="toc-workshop-pro" target="_blank" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Crosshair_detailed"/></svg>
@@ -3191,7 +3191,7 @@ window.addEventListener('authStateChanged', function(e) {
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock interactive Logframe builder with linked indicators and exportable results frameworks!">
-<a href="https://impactmojo-workshop-pro.netlify.app/logframe-pro.html" data-resource-id="logframe-pro" target="_blank" rel="noopener noreferrer">
+<a href="/premium-tools/logframe-pro.html" data-resource-id="logframe-pro" target="_blank" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Library_books"/></svg>
@@ -3218,7 +3218,7 @@ window.addEventListener('authStateChanged', function(e) {
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock the interactive Chart Selection Guide with decision tree and best-practice examples!">
-<a href="https://impactmojo-workshop-pro.netlify.app/chart-selector-pro.html" data-resource-id="chart-selector-pro" target="_blank" rel="noopener noreferrer">
+<a href="/premium-tools/chart-selector-pro.html" data-resource-id="chart-selector-pro" target="_blank" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Activity"/></svg>
@@ -3245,7 +3245,7 @@ window.addEventListener('authStateChanged', function(e) {
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock the Stakeholder Power Map for collaborative stakeholder analysis workshops!">
-<a href="https://impactmojo-workshop-pro.netlify.app/stakeholder-pro.html" data-resource-id="stakeholder-pro" target="_blank" rel="noopener noreferrer">
+<a href="/premium-tools/stakeholder-pro.html" data-resource-id="stakeholder-pro" target="_blank" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_User_alt_4"/></svg>
@@ -3272,7 +3272,7 @@ window.addEventListener('authStateChanged', function(e) {
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock the Empathy Map Builder for user-centered design workshops!">
-<a href="https://impactmojo-workshop-pro.netlify.app/empathy-pro.html" data-resource-id="empathy-pro" target="_blank" rel="noopener noreferrer">
+<a href="/premium-tools/empathy-pro.html" data-resource-id="empathy-pro" target="_blank" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Chat"/></svg>
@@ -3299,7 +3299,7 @@ window.addEventListener('authStateChanged', function(e) {
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock the Policy Analysis Canvas for structured policy evaluation workshops!">
-<a href="https://impactmojo-workshop-pro.netlify.app/policy-canvas-pro.html" data-resource-id="policy-canvas-pro" target="_blank" rel="noopener noreferrer">
+<a href="/premium-tools/policy-canvas-pro.html" data-resource-id="policy-canvas-pro" target="_blank" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Bar_chart"/></svg>
@@ -3326,7 +3326,7 @@ window.addEventListener('authStateChanged', function(e) {
 </a>
 </div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock the AI Opportunity Canvas for mapping responsible AI use cases!">
-<a href="https://impactmojo-workshop-pro.netlify.app/ai-canvas-pro.html" data-resource-id="ai-canvas-pro" target="_blank" rel="noopener noreferrer">
+<a href="/premium-tools/ai-canvas-pro.html" data-resource-id="ai-canvas-pro" target="_blank" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Lightning"/></svg>
@@ -3928,7 +3928,7 @@ window.addEventListener('authStateChanged', function(e) {
 <div class="modal-item" data-required-tier="practitioner" data-tier-benefits="Practitioner (₹399/mo): Unlock advanced ToC building with assumption mapping, evidence linkage & export!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><use href="#si_Crosshair_detailed"/></svg></div>
 <div class="modal-item-content">
-<a href="https://impactmojo-workshop-pro.netlify.app/toc-pro.html" data-resource-id="toc-workshop-pro" target="_blank" rel="noopener noreferrer">
+<a href="/premium-tools/toc-pro.html" data-resource-id="toc-workshop-pro" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">
                         Theory of Change Workbench Pro
                         <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
@@ -4028,7 +4028,7 @@ window.addEventListener('authStateChanged', function(e) {
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock interactive workshop templates for team facilitation!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><use href="#si_Crosshair_detailed"/></svg></div>
 <div class="modal-item-content">
-<a href="https://impactmojo-workshop-pro.netlify.app/toc-pro.html" data-resource-id="toc-workshop-pro" target="_blank" rel="noopener noreferrer">
+<a href="/premium-tools/toc-pro.html" data-resource-id="toc-workshop-pro" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">Theory of Change Workshop Pro
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -4044,7 +4044,7 @@ window.addEventListener('authStateChanged', function(e) {
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock interactive workshop templates for team facilitation!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg></div>
 <div class="modal-item-content">
-<a href="https://impactmojo-workshop-pro.netlify.app/logframe-pro.html" data-resource-id="logframe-pro" target="_blank" rel="noopener noreferrer">
+<a href="/premium-tools/logframe-pro.html" data-resource-id="logframe-pro" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">Logical Framework Builder Pro
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -4060,7 +4060,7 @@ window.addEventListener('authStateChanged', function(e) {
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock interactive workshop templates for team facilitation!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><path d="M21.21 15.89A10 10 0 1 1 8 2.83"/><path d="M22 12A10 10 0 0 0 12 2v10z"/></svg></div>
 <div class="modal-item-content">
-<a href="https://impactmojo-workshop-pro.netlify.app/chart-selector-pro.html" data-resource-id="chart-selector-pro" target="_blank" rel="noopener noreferrer">
+<a href="/premium-tools/chart-selector-pro.html" data-resource-id="chart-selector-pro" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">Data Visualization Chart Selector Pro
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -4076,7 +4076,7 @@ window.addEventListener('authStateChanged', function(e) {
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock interactive workshop templates for team facilitation!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"/></svg></div>
 <div class="modal-item-content">
-<a href="https://impactmojo-workshop-pro.netlify.app/stakeholder-pro.html" data-resource-id="stakeholder-pro" target="_blank" rel="noopener noreferrer">
+<a href="/premium-tools/stakeholder-pro.html" data-resource-id="stakeholder-pro" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">Stakeholder Mapping Workshop Pro
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -4092,7 +4092,7 @@ window.addEventListener('authStateChanged', function(e) {
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock interactive workshop templates for team facilitation!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><use href="#spr-10"/></svg></div>
 <div class="modal-item-content">
-<a href="https://impactmojo-workshop-pro.netlify.app/empathy-pro.html" data-resource-id="empathy-pro" target="_blank" rel="noopener noreferrer">
+<a href="/premium-tools/empathy-pro.html" data-resource-id="empathy-pro" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">Empathy Mapping Workshop Pro
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -4108,7 +4108,7 @@ window.addEventListener('authStateChanged', function(e) {
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock interactive workshop templates for team facilitation!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><use href="#spr-7"/></svg></div>
 <div class="modal-item-content">
-<a href="https://impactmojo-workshop-pro.netlify.app/policy-canvas-pro.html" data-resource-id="policy-canvas-pro" target="_blank" rel="noopener noreferrer">
+<a href="/premium-tools/policy-canvas-pro.html" data-resource-id="policy-canvas-pro" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">Policy Analysis Canvas Pro
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -4124,7 +4124,7 @@ window.addEventListener('authStateChanged', function(e) {
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock interactive workshop templates for team facilitation!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg></div>
 <div class="modal-item-content">
-<a href="https://impactmojo-workshop-pro.netlify.app/ai-canvas-pro.html" data-resource-id="ai-canvas-pro" target="_blank" rel="noopener noreferrer">
+<a href="/premium-tools/ai-canvas-pro.html" data-resource-id="ai-canvas-pro" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">AI Strategy Canvas Pro
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>

--- a/premium-tools/ai-canvas-pro.html
+++ b/premium-tools/ai-canvas-pro.html
@@ -116,6 +116,195 @@ body.dark-mode .header { background: rgba(15,23,42,0.95); }
 .freemium-note a:hover { text-decoration: underline; }
 @media (max-width: 640px) { .tool-name { font-size: 0.9rem; padding-left: 0.5rem; } .header-brand .brand-name { display: none; } }
 @media print { .freemium-note { display: none !important; } }
+
+/* ===== ImpactMojo Design System ===== */
+:root {
+    --im-primary-bg: #0F172A;
+    --im-secondary-bg: #1E293B;
+    --im-accent: #0EA5E9;
+    --im-accent-hover: #0284C7;
+    --im-secondary-accent: #6366F1;
+    --im-success: #10B981;
+    --im-text-primary: #F1F5F9;
+    --im-text-secondary: #94A3B8;
+    --im-text-muted: #64748B;
+    --im-card-bg: #1E293B;
+    --im-hover-bg: #334155;
+    --im-border: #334155;
+    --im-nav-bg: rgba(15, 23, 42, 0.95);
+    --im-gradient: linear-gradient(135deg, #0EA5E9 0%, #6366F1 100%);
+}
+[data-theme="light"] {
+    --im-primary-bg: #F8FAFC;
+    --im-secondary-bg: #FFFFFF;
+    --im-accent: #0369A1;
+    --im-accent-hover: #0369A1;
+    --im-text-primary: #0F172A;
+    --im-text-secondary: #475569;
+    --im-text-muted: #64748B;
+    --im-card-bg: #FFFFFF;
+    --im-hover-bg: #F1F5F9;
+    --im-border: #E2E8F0;
+    --im-nav-bg: rgba(248, 250, 252, 0.95);
+}
+
+/* ImpactMojo Top Bar */
+.im-topbar {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 9999;
+    background: var(--im-nav-bg, rgba(15, 23, 42, 0.95));
+    backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px);
+    border-bottom: 1px solid var(--im-border, #334155);
+    padding: 0.5rem 1rem;
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 0.75rem; flex-wrap: wrap;
+    font-family: 'Inter', sans-serif;
+}
+.im-topbar a { text-decoration: none; }
+.im-topbar-left {
+    display: flex; align-items: center; gap: 0.75rem;
+}
+.im-topbar-home {
+    display: flex; align-items: center; gap: 0.5rem;
+    color: var(--im-text-primary, #F1F5F9);
+    font-weight: 700; font-size: 1rem;
+    background: var(--im-gradient);
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+.im-topbar-home svg { width: 24px; height: 24px; flex-shrink: 0; }
+.im-topbar-right {
+    display: flex; align-items: center; gap: 0.5rem;
+}
+.im-premium-btn {
+    background: var(--im-gradient);
+    color: #fff !important;
+    padding: 0.35rem 0.85rem;
+    border-radius: 6px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    display: flex; align-items: center; gap: 0.35rem;
+    transition: opacity 0.2s;
+    -webkit-text-fill-color: #fff;
+}
+.im-browse-btn { display: inline-flex; align-items: center; gap: 0.4rem; font-family: 'Inter', sans-serif; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: var(--im-text, #1C1917); background: var(--im-surface, #FFFFFF); border: 1.5px solid var(--im-border, #E2E8F0); padding: 0.5rem 1rem; border-radius: 0.5rem; text-decoration: none; transition: background 0.18s ease, border-color 0.18s ease, transform 0.15s ease, box-shadow 0.18s ease; }
+.im-browse-btn:hover { background: var(--im-accent, #0EA5E9); color: #FFFFFF; border-color: var(--im-accent, #0EA5E9); transform: translateY(-1px); box-shadow: 0 4px 12px rgba(14, 165, 233, 0.25); }
+.im-browse-btn svg { width: 14px; height: 14px; }
+@media (prefers-color-scheme: dark) { .im-browse-btn { color: rgba(255,255,255,0.9); background: rgba(255,255,255,0.05); border-color: rgba(255,255,255,0.18); } .im-browse-btn:hover { background: var(--im-accent, #0EA5E9); border-color: var(--im-accent, #0EA5E9); color: #FFFFFF; } }
+.im-premium-btn:hover { opacity: 0.9; }
+.im-premium-btn svg { width: 14px; height: 14px; }
+
+/* Theme Selector - 3 mode */
+.im-theme-selector {
+    display: flex; gap: 2px;
+    background: var(--im-card-bg, #1E293B);
+    border: 1px solid var(--im-border, #334155);
+    border-radius: 8px; padding: 2px;
+}
+.im-theme-btn {
+    background: transparent; border: none;
+    color: var(--im-text-secondary, #94A3B8);
+    padding: 6px; border-radius: 5px; cursor: pointer;
+    transition: all 0.2s; display: flex; align-items: center;
+    justify-content: center; width: 30px; height: 30px;
+}
+.im-theme-btn:hover {
+    background: var(--im-hover-bg, #334155);
+    color: var(--im-text-primary, #F1F5F9);
+}
+.im-theme-btn.active {
+    background: var(--im-accent, #0EA5E9);
+    color: #fff;
+}
+.im-theme-btn svg { width: 16px; height: 16px; }
+
+/* Paper Plane */
+.im-paper-plane {
+    position: fixed; top: 15%; right: 8%;
+    width: 120px; height: 120px;
+    opacity: 0.15; z-index: 0;
+    pointer-events: none;
+    animation: im-fly 25s ease-in-out infinite;
+}
+[data-theme="light"] .im-paper-plane { opacity: 0.2; }
+@keyframes im-fly {
+    0%, 100% { transform: translate(0, 0) rotate(0deg); }
+    20% { transform: translate(60px, -40px) rotate(12deg); }
+    40% { transform: translate(120px, 30px) rotate(-8deg); }
+    60% { transform: translate(40px, 60px) rotate(15deg); }
+    80% { transform: translate(-30px, 20px) rotate(-5deg); }
+}
+
+/* ImpactMojo Footer */
+.im-footer {
+    background: var(--im-secondary-bg, #1E293B);
+    border-top: 1px solid var(--im-border, #334155);
+    padding: 2rem 1rem; margin-top: auto;
+    font-family: 'Inter', sans-serif;
+    color: var(--im-text-secondary, #94A3B8);
+}
+.im-footer-content {
+    max-width: 1100px; margin: 0 auto;
+}
+.im-footer-made {
+    text-align: center; margin-bottom: 1.5rem;
+    font-size: 0.9rem; color: var(--im-text-muted, #64748B);
+}
+.im-footer-made a { color: var(--im-accent, #0EA5E9); }
+.im-footer-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.5rem; margin-bottom: 1.5rem;
+}
+.im-footer-section h4 {
+    font-family: 'Inter', sans-serif;
+    color: var(--im-text-primary, #F1F5F9);
+    font-size: 0.9rem; margin-bottom: 0.75rem;
+    font-weight: 600;
+}
+.im-footer-section ul { list-style: none; padding: 0; margin: 0; }
+.im-footer-section li { margin-bottom: 0.4rem; }
+.im-footer-section a {
+    color: var(--im-text-secondary, #94A3B8);
+    text-decoration: none; font-size: 0.85rem;
+    transition: color 0.2s;
+}
+.im-footer-section a:hover { color: var(--im-accent, #0EA5E9); }
+.im-footer-bottom {
+    text-align: center; padding-top: 1rem;
+    border-top: 1px solid var(--im-border, #334155);
+    font-size: 0.8rem; color: var(--im-text-muted, #64748B);
+}
+.im-footer-bottom p { margin: 0.25rem 0; }
+.im-footer-bottom a { color: var(--im-accent, #0EA5E9); text-decoration: none; }
+
+/* Mobile Responsive */
+@media (max-width: 768px) {
+    .im-topbar { padding: 0.4rem 0.75rem; gap: 0.5rem; }
+    .im-topbar-home { font-size: 0.85rem; }
+    .im-topbar-home svg { width: 20px; height: 20px; }
+    .im-premium-btn { padding: 0.3rem 0.6rem; font-size: 0.75rem; }
+    .im-theme-btn { width: 26px; height: 26px; padding: 4px; }
+    .im-theme-btn svg { width: 14px; height: 14px; }
+    .im-paper-plane { width: 80px; height: 80px; top: 10%; right: 5%; }
+    .im-footer-grid { grid-template-columns: repeat(2, 1fr); gap: 1rem; }
+}
+@media (max-width: 480px) {
+    .im-footer-grid { grid-template-columns: 1fr; }
+    .im-topbar-home span { display: none; }
+}
+
+/* ImpactMojo Global Font Overrides */
+body { font-family: 'Amaranth', sans-serif !important; }
+h1, h2, h3, h4, h5, h6 { font-family: 'Inter', sans-serif !important; }
+code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !important; }
+
+/* WCAG 2.1 AA (1.4.1 Use of Color): inline anchors in content paragraphs must be distinguishable without relying on color alone. Scoped to <main> so nav/footer button-links are unaffected. */
+main p a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]),
+main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) {
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+}
+
 </style>
 </head>
 <body>
@@ -129,7 +318,15 @@ body.dark-mode .header { background: rgba(15,23,42,0.95); }
         <h1 class="tool-name">AI Strategy Canvas</h1>
     </div>
     <div class="header-actions">
-        <button class="btn" onclick="toggleDarkMode()" title="Toggle dark mode" aria-label="Toggle dark mode">&#9790;</button>
+        <a class="im-premium-btn" href="../premium.html" title="Go Premium">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+            Premium
+        </a>
+        <div class="im-theme-selector" aria-label="Theme selection">
+            <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="Use system theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
+            <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Use light theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg></button>
+            <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Use dark theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+        </div>
         <button class="btn" onclick="clearAll()">Clear All</button>
         <button class="btn" onclick="loadExample()">Load Example</button>
         <button class="btn btn-primary" onclick="exportToJSON()">Export <span class="pro-pill">&#9733; Premium</span></button>
@@ -300,7 +497,7 @@ function toggleDarkMode() {
     document.body.classList.toggle('dark-mode');
     localStorage.setItem('impactmojo_dark', document.body.classList.contains('dark-mode'));
 }
-if (localStorage.getItem('impactmojo_dark') === 'true') document.body.classList.add('dark-mode');
+/* theming handled by /js/theme.js (canonical im-theme controller) */
 init();
 </script>
 
@@ -330,5 +527,66 @@ function requirePremium() {
 if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initGate);
 else initGate();
 </script>
+
+<!-- ImpactMojo Paper Plane -->
+<svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M80,130 L150,50" stroke="#10B981" stroke-width="2" stroke-dasharray="4,4"/>
+    <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+    <circle cx="40" cy="155" r="2" fill="#0EA5E9" opacity="0.6"/>
+    <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
+    <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
+</svg>
+<!-- ImpactMojo Footer -->
+<footer class="im-footer" role="contentinfo">
+<div class="im-footer-content">
+<p class="im-footer-made">Made with &#10084; by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+<div class="im-footer-grid">
+<div class="im-footer-section">
+<h4>About ImpactMojo</h4>
+<ul>
+<li><a href="../about.html">About Us</a></li>
+<li><a href="../contact.html">Contact</a></li>
+<li><a href="https://github.com/ImpactMojo/ImpactMojo" rel="noopener noreferrer" target="_blank">GitHub</a></li>
+<li><a href="../transparency.html">Transparency</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Legal</h4>
+<ul>
+<li><a href="../privacy-policy.html">Privacy Policy</a></li>
+<li><a href="../terms-of-service.html">Terms of Service</a></li>
+<li><a href="../disclaimer.html">Disclaimer</a></li>
+<li><a href="../data-protection.html">Data Protection</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Quick Links</h4>
+<ul>
+<li><a href="../catalog.html">All Courses</a></li>
+<li><a href="../premium.html">Premium Content</a></li>
+<li><a href="../coaching.html">Coaching</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Resources</h4>
+<ul>
+<li><a href="../handouts.html">Handouts</a></li>
+<li><a href="../blog.html">Blog</a></li>
+<li><a href="../faq.html">FAQ</a></li>
+<li><a href="../sitemap.html">Sitemap</a></li>
+<li><a href="/docs/" rel="noopener noreferrer" target="_blank">Documentation</a></li>
+</ul>
+</div>
+</div>
+<div class="im-footer-bottom">
+<p>&copy; 2026 ImpactMojo. All content for educational purposes only.</p>
+<p>Released under <strong>MIT License</strong> | Supported by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+</div>
+</div>
+</footer>
+<!-- ImpactMojo canonical theme controller + translation -->
+<script src="/js/theme.js"></script>
+<script src="/js/translate-sarvam.js" defer></script>
 </body>
 </html>

--- a/premium-tools/ai-canvas-pro.html
+++ b/premium-tools/ai-canvas-pro.html
@@ -1,0 +1,334 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AI Strategy Canvas — free AI opportunity tool | ImpactMojo</title>
+<meta name="description" content="Interactive canvas to evaluate AI opportunities for development and social impact programs. Free to build — exporting is a Premium feature.">
+<link href="/assets/images/favicon.png" rel="icon" type="image/png">
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+:root {
+    --primary-bg: #FFFFFF; --secondary-bg: #F8FAFC; --accent-color: #0EA5E9;
+    --accent-hover: #0284C7; --text-primary: #0F172A; --text-secondary: #475569;
+    --card-bg: #FFFFFF; --border-color: #E2E8F0; --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+}
+body.dark-mode {
+    --primary-bg: #0F172A; --secondary-bg: #1E293B; --text-primary: #F1F5F9;
+    --text-secondary: #94A3B8; --card-bg: #1E293B; --border-color: #334155;
+}
+body { font-family: 'Amaranth', sans-serif; background: var(--primary-bg); color: var(--text-primary); }
+
+.header {
+    background: rgba(255,255,255,0.95); backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--border-color); padding: 1rem 2rem;
+    position: sticky; top: 0; z-index: 100; display: flex; align-items: center; justify-content: space-between;
+}
+body.dark-mode .header { background: rgba(15,23,42,0.95); }
+.header h1 { font-family: 'Inter', sans-serif; font-size: 1.25rem; }
+.btn { padding: 0.5rem 1rem; border-radius: 8px; border: 1px solid var(--border-color); background: var(--card-bg); color: var(--text-primary); cursor: pointer; font-size: 0.85rem; font-family: inherit; transition: all 0.2s; }
+.btn:hover { border-color: var(--accent-color); }
+.btn-primary { background: var(--accent-color); color: white; border-color: var(--accent-color); }
+
+.container { padding: 2rem; max-width: 1100px; margin: 0 auto; }
+
+.instructions {
+    background: var(--secondary-bg); border: 1px solid var(--border-color); border-radius: 10px;
+    padding: 1.25rem; margin-bottom: 1.5rem; font-size: 0.85rem; color: var(--text-secondary);
+}
+.instructions strong { color: var(--text-primary); }
+
+.project-bar {
+    background: var(--card-bg); border: 1px solid var(--border-color); border-radius: 10px;
+    padding: 1rem; margin-bottom: 1.5rem; display: flex; gap: 1rem; flex-wrap: wrap;
+}
+.project-bar input {
+    flex: 1; min-width: 200px; padding: 0.6rem; border: 1px solid var(--border-color); border-radius: 6px;
+    background: var(--primary-bg); color: var(--text-primary); font-family: inherit; font-size: 0.9rem;
+}
+
+.canvas-grid {
+    display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 0;
+    border: 2px solid var(--border-color); border-radius: 12px; overflow: hidden;
+}
+.canvas-section {
+    padding: 1rem; border: 1px solid var(--border-color); min-height: 180px;
+}
+.canvas-section.full-width { grid-column: 1 / -1; }
+.canvas-section.half-width { grid-column: span 1; }
+.canvas-section.two-thirds { grid-column: span 2; }
+
+.section-header {
+    display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.25rem;
+}
+.section-num {
+    width: 22px; height: 22px; border-radius: 50%; background: var(--accent-color);
+    color: white; font-size: 0.7rem; font-weight: 700; display: flex; align-items: center;
+    justify-content: center; flex-shrink: 0;
+}
+.section-title { font-family: 'Inter', sans-serif; font-size: 0.85rem; font-weight: 700; }
+.section-prompt { font-size: 0.75rem; color: var(--text-secondary); margin-bottom: 0.5rem; }
+
+.note-area {
+    width: 100%; min-height: 80px; border: 1px solid var(--border-color); border-radius: 6px;
+    padding: 0.5rem; background: var(--secondary-bg); color: var(--text-primary);
+    font-family: inherit; font-size: 0.82rem; resize: vertical; outline: none; line-height: 1.5;
+}
+.note-area:focus { border-color: var(--accent-color); }
+
+.score-section {
+    background: var(--secondary-bg); border: 2px solid var(--border-color);
+    border-radius: 12px; margin-top: 1.5rem; padding: 1.5rem;
+}
+.score-section h3 { font-family: 'Inter', sans-serif; font-size: 1rem; margin-bottom: 1rem; }
+.score-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; }
+.score-item { display: flex; flex-direction: column; gap: 0.25rem; }
+.score-item label { font-size: 0.82rem; font-weight: 500; }
+.score-item input[type="range"] { width: 100%; accent-color: var(--accent-color); }
+.score-item .score-val { font-size: 0.75rem; color: var(--text-secondary); text-align: right; }
+.total-score {
+    margin-top: 1rem; padding: 1rem; background: var(--card-bg); border-radius: 8px;
+    text-align: center; border: 1px solid var(--border-color);
+}
+.total-score .score-num { font-family: 'Inter', sans-serif; font-size: 2rem; font-weight: 700; color: var(--accent-color); }
+.total-score .score-label { font-size: 0.85rem; color: var(--text-secondary); }
+.verdict { font-size: 0.9rem; font-weight: 600; margin-top: 0.5rem; }
+
+@media (max-width: 768px) {
+    .canvas-grid { grid-template-columns: 1fr; }
+    .canvas-section.full-width, .canvas-section.half-width, .canvas-section.two-thirds { grid-column: 1; }
+}
+@media print {
+    .header, .instructions { display: none !important; }
+}
+
+/* ── Pro Studio branding + freemium ─────────────────────────── */
+.header { flex-wrap: wrap; gap: 0.75rem; }
+.header-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+.header-brand { display: flex; align-items: center; gap: 0.5rem; text-decoration: none; color: var(--text-primary); }
+.header-brand img { width: 30px; height: 30px; border-radius: 6px; }
+.header-brand .brand-name { font-family: 'Inter', sans-serif; font-weight: 700; font-size: 1rem; }
+.tool-name { font-family: 'Inter', sans-serif; font-size: 1.05rem; font-weight: 600; padding-left: 0.75rem; border-left: 2px solid var(--border-color); }
+.pro-pill { display: inline-flex; align-items: center; gap: 0.2rem; background: linear-gradient(135deg,#F59E0B,#EF4444); color: #fff; font-weight: 700; font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.4px; padding: 0.15rem 0.45rem; border-radius: 5px; white-space: nowrap; }
+.freemium-note { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 1.5rem; padding: 0.6rem 0.9rem; background: rgba(245,158,11,0.08); border: 1px solid rgba(245,158,11,0.3); border-radius: 8px; font-size: 0.82rem; color: var(--text-secondary); }
+.freemium-note a { color: #F59E0B; font-weight: 700; text-decoration: none; }
+.freemium-note a:hover { text-decoration: underline; }
+@media (max-width: 640px) { .tool-name { font-size: 0.9rem; padding-left: 0.5rem; } .header-brand .brand-name { display: none; } }
+@media print { .freemium-note { display: none !important; } }
+</style>
+</head>
+<body>
+
+<div class="header">
+    <div style="display:flex; align-items:center; gap:0.75rem; flex-wrap:wrap;">
+        <a class="header-brand" href="/" title="ImpactMojo home">
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="30" height="30">
+            <span class="brand-name">ImpactMojo</span>
+        </a>
+        <h1 class="tool-name">AI Strategy Canvas</h1>
+    </div>
+    <div class="header-actions">
+        <button class="btn" onclick="toggleDarkMode()" title="Toggle dark mode" aria-label="Toggle dark mode">&#9790;</button>
+        <button class="btn" onclick="clearAll()">Clear All</button>
+        <button class="btn" onclick="loadExample()">Load Example</button>
+        <button class="btn btn-primary" onclick="exportToJSON()">Export <span class="pro-pill">&#9733; Premium</span></button>
+        <button class="btn btn-primary" onclick="printTemplate()">Print <span class="pro-pill">&#9733; Premium</span></button>
+    </div>
+</div>
+
+<div class="container">
+    <div class="instructions">
+        <strong>AI Strategy Canvas:</strong> Use this canvas to evaluate whether an AI solution is appropriate for a development challenge. Work through each section to build a complete picture of the opportunity, risks, and feasibility.
+    </div>
+
+    <div class="freemium-note">
+        <span class="pro-pill">&#9733; Premium</span>
+        <span>Building is free. Exporting is a Premium feature. <a href="/premium.html#detail-professional">Upgrade to Professional &rarr;</a></span>
+    </div>
+
+    <div class="project-bar">
+        <input type="text" id="projectName" placeholder="Project / Initiative name" data-field="projectName">
+        <input type="text" id="orgName" placeholder="Organization" data-field="orgName">
+        <input type="text" id="dateFilled" placeholder="Date" data-field="dateFilled">
+    </div>
+
+    <div class="canvas-grid" id="canvasGrid"></div>
+
+    <div class="score-section">
+        <h3>Feasibility Score</h3>
+        <p style="font-size:0.82rem; color:var(--text-secondary); margin-bottom:1rem;">Rate each dimension 1-5 to get a quick feasibility assessment.</p>
+        <div class="score-grid" id="scoreGrid"></div>
+        <div class="total-score">
+            <div class="score-num" id="totalScore">0</div>
+            <div class="score-label">out of 30</div>
+            <div class="verdict" id="verdict"></div>
+        </div>
+    </div>
+</div>
+
+<script>
+var SECTIONS = [
+    { id: 'problem', num: 1, title: 'Problem Statement', prompt: 'What specific problem are you trying to solve? Who experiences it? What is the current workaround?', width: 'full-width' },
+    { id: 'ai_solution', num: 2, title: 'Proposed AI Solution', prompt: 'How could AI help? What type of AI (NLP, computer vision, prediction, automation)?', width: 'two-thirds' },
+    { id: 'non_ai', num: 3, title: 'Non-AI Alternative', prompt: 'What is the best non-AI solution? Why is AI better?', width: 'half-width' },
+    { id: 'data', num: 4, title: 'Data Availability', prompt: 'What data exists? Quality? Volume? Who owns it? Privacy concerns?', width: 'half-width' },
+    { id: 'users', num: 5, title: 'End Users & Context', prompt: 'Who will use the AI tool? Tech literacy? Connectivity? Language needs?', width: 'half-width' },
+    { id: 'impact', num: 6, title: 'Expected Impact', prompt: 'What measurable outcomes will improve? By how much? For whom?', width: 'half-width' },
+    { id: 'risks', num: 7, title: 'Risks & Ethics', prompt: 'Bias risks? Privacy concerns? Potential harms? Who could be excluded?', width: 'half-width' },
+    { id: 'resources', num: 8, title: 'Resources Needed', prompt: 'Team skills, budget, timeline, infrastructure, partnerships required?', width: 'half-width' },
+    { id: 'sustainability', num: 9, title: 'Sustainability', prompt: 'How will it be maintained? Who pays after the pilot? What if the AI vendor disappears?', width: 'half-width' },
+    { id: 'next_steps', num: 10, title: 'Next Steps', prompt: 'What is the minimum viable pilot? First 3 actions to take?', width: 'full-width' }
+];
+
+var SCORES = [
+    { id: 'data_ready', label: 'Data Readiness' },
+    { id: 'tech_feasible', label: 'Technical Feasibility' },
+    { id: 'user_ready', label: 'User Readiness' },
+    { id: 'ethical_ok', label: 'Ethical Soundness' },
+    { id: 'impact_potential', label: 'Impact Potential' },
+    { id: 'sustain', label: 'Sustainability' }
+];
+
+var STORAGE_KEY = 'impactmojo_ai_canvas';
+var data = {};
+
+function init() {
+    var saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) { try { data = JSON.parse(saved); } catch(e) { data = {}; } }
+
+    // Render canvas
+    var grid = document.getElementById('canvasGrid');
+    SECTIONS.forEach(function(s) {
+        var section = document.createElement('div');
+        section.className = 'canvas-section ' + s.width;
+        section.innerHTML = '<div class="section-header"><span class="section-num">' + s.num + '</span><span class="section-title">' + s.title + '</span></div>' +
+            '<div class="section-prompt">' + s.prompt + '</div>';
+        var ta = document.createElement('textarea');
+        ta.className = 'note-area';
+        ta.value = data[s.id] || '';
+        ta.dataset.field = s.id;
+        ta.addEventListener('input', function() { data[this.dataset.field] = this.value; save(); });
+        section.appendChild(ta);
+        grid.appendChild(section);
+    });
+
+    // Project bar
+    ['projectName', 'orgName', 'dateFilled'].forEach(function(f) {
+        var el = document.getElementById(f);
+        el.value = data[f] || '';
+        el.addEventListener('input', function() { data[f] = this.value; save(); });
+    });
+
+    // Score sliders
+    var scoreGrid = document.getElementById('scoreGrid');
+    SCORES.forEach(function(sc) {
+        var item = document.createElement('div');
+        item.className = 'score-item';
+        item.innerHTML = '<label>' + sc.label + '</label><input type="range" min="1" max="5" value="' + (data['score_' + sc.id] || 3) + '" data-score="' + sc.id + '"><div class="score-val">' + (data['score_' + sc.id] || 3) + '/5</div>';
+        var slider = item.querySelector('input[type="range"]');
+        var val = item.querySelector('.score-val');
+        slider.addEventListener('input', function() {
+            data['score_' + this.dataset.score] = parseInt(this.value);
+            val.textContent = this.value + '/5';
+            save(); updateTotal();
+        });
+        scoreGrid.appendChild(item);
+    });
+    updateTotal();
+}
+
+function save() { localStorage.setItem(STORAGE_KEY, JSON.stringify(data)); }
+
+function updateTotal() {
+    var total = 0;
+    SCORES.forEach(function(sc) { total += (data['score_' + sc.id] || 3); });
+    document.getElementById('totalScore').textContent = total;
+    var verdict = document.getElementById('verdict');
+    if (total >= 25) { verdict.textContent = 'Strong candidate for AI'; verdict.style.color = '#10B981'; }
+    else if (total >= 18) { verdict.textContent = 'Promising — address gaps before proceeding'; verdict.style.color = '#F59E0B'; }
+    else { verdict.textContent = 'Reconsider — significant barriers exist'; verdict.style.color = '#EF4444'; }
+}
+
+function clearAll() {
+    if (!confirm('Clear everything?')) return;
+    data = {}; localStorage.removeItem(STORAGE_KEY);
+    document.querySelectorAll('.note-area').forEach(function(ta) { ta.value = ''; });
+    document.querySelectorAll('.project-bar input').forEach(function(i) { i.value = ''; });
+    document.querySelectorAll('input[type="range"]').forEach(function(r) { r.value = 3; r.nextElementSibling.textContent = '3/5'; });
+    updateTotal();
+}
+
+function loadExample() {
+    data = {
+        projectName: 'AI-Assisted Crop Disease Detection', orgName: 'AgriTech4Good', dateFilled: '2026-03-16',
+        problem: 'Smallholder farmers in East Africa lose 20-30% of crops to disease annually. Most cannot identify diseases early enough to treat. Extension officers are scarce (1 per 3,000 farmers) and can\'t provide timely diagnosis.',
+        ai_solution: 'A mobile app using computer vision (image classification) to identify crop diseases from phone photos. Farmers photograph affected leaves, the AI identifies the disease and recommends treatment. Works offline with on-device inference.',
+        non_ai: 'Printed disease identification guides + SMS hotline to extension officers. AI is better because: visual diagnosis is faster and more accurate than text descriptions, available 24/7, scalable without hiring more officers.',
+        data: 'PlantVillage dataset (50,000+ labeled images). Need to supplement with local varieties. Data is open-access. Will need to collect ~5,000 local images for fine-tuning. No personal data collected from farmers.',
+        users: 'Smallholder farmers, 60% smartphone ownership, basic digital literacy. Connectivity varies (offline capability essential). Languages: Swahili, English, local languages. Extension officers as power users.',
+        impact: 'Target: 15% reduction in crop losses within 2 seasons. 50,000 farmers reached in pilot. Faster diagnosis (minutes vs. days). Secondary: build disease surveillance data for early warning system.',
+        risks: 'Misdiagnosis risk (confidence thresholds needed). Overreliance on AI vs. local knowledge. Phone quality affects accuracy. Could exclude non-smartphone users (30-40% of target).',
+        resources: 'Team: 2 ML engineers, 1 agronomist, 1 UX designer. Budget: $150K for 12-month pilot. Need: cloud GPU for training, local data collection team, partnerships with agri-dealers for treatment recommendations.',
+        sustainability: 'Freemium model: free basic ID, premium for treatment plans and weather alerts. Partnership with seed companies for sponsorship. Government extension service adoption as official tool. Open-source model weights for community.',
+        next_steps: '1. Collect 2,000 local crop disease images with agronomist labels\n2. Fine-tune PlantVillage model on local data\n3. Build offline-capable prototype and test with 50 farmers\n4. Partner with 3 agri-dealers for treatment recommendation validation',
+        score_data_ready: 4, score_tech_feasible: 4, score_user_ready: 3, score_ethical_ok: 4, score_impact_potential: 5, score_sustain: 3
+    };
+    // Update UI
+    document.querySelectorAll('.note-area').forEach(function(ta) { ta.value = data[ta.dataset.field] || ''; });
+    ['projectName', 'orgName', 'dateFilled'].forEach(function(f) { document.getElementById(f).value = data[f] || ''; });
+    document.querySelectorAll('input[type="range"]').forEach(function(r) {
+        var key = 'score_' + r.dataset.score;
+        if (data[key]) { r.value = data[key]; r.nextElementSibling.textContent = data[key] + '/5'; }
+    });
+    save(); updateTotal();
+}
+
+function exportToJSON() {
+    if (!requirePremium()) return; // building is free, exporting is Premium
+    var blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+    var a = document.createElement('a'); a.href = URL.createObjectURL(blob);
+    a.download = 'ai-opportunity-canvas.json'; a.click();
+}
+
+function printTemplate() {
+    if (!requirePremium()) return; // building is free, exporting is Premium
+    window.print();
+}
+
+function toggleDarkMode() {
+    document.body.classList.toggle('dark-mode');
+    localStorage.setItem('impactmojo_dark', document.body.classList.contains('dark-mode'));
+}
+if (localStorage.getItem('impactmojo_dark') === 'true') document.body.classList.add('dark-mode');
+init();
+</script>
+
+<!-- ImpactMojo auth + premium (Pro Studio freemium gate) -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
+<script src="/js/premium.js"></script>
+<script>
+// Pro Studio freemium: building is free for everyone; exporting is Premium.
+// The whole builder above is always visible — no sign-in wall to use it.
+window.TOOL_PREMIUM = false;
+var TOOL_TIER = 'professional';
+async function initGate() {
+  try { if (window.ImpactMojoAuth) await window.ImpactMojoAuth.waitForAuthReady(); } catch (e) {}
+  var auth = window.ImpactMojoAuth;
+  window.TOOL_PREMIUM = !!(auth && typeof auth.hasTierAccess === 'function' && auth.hasTierAccess(TOOL_TIER));
+}
+// Gate a Premium action (export/print). Free users get the upgrade path.
+function requirePremium() {
+  if (window.TOOL_PREMIUM) return true;
+  if (window.IMXPremium && typeof window.IMXPremium.showUpgradeModal === 'function') window.IMXPremium.showUpgradeModal(TOOL_TIER);
+  else window.location.href = '/premium.html#detail-' + TOOL_TIER;
+  return false;
+}
+if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initGate);
+else initGate();
+</script>
+</body>
+</html>

--- a/premium-tools/chart-selector-pro.html
+++ b/premium-tools/chart-selector-pro.html
@@ -106,6 +106,195 @@ body.dark-mode .header { background: rgba(15,23,42,0.95); }
 .tool-name { font-family: 'Inter', sans-serif; font-size: 1.05rem; font-weight: 600; padding-left: 0.75rem; border-left: 2px solid var(--border-color); }
 .free-pill { display: inline-flex; align-items: center; gap: 0.2rem; background: rgba(16,185,129,0.12); color: #10B981; font-weight: 700; font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.4px; padding: 0.15rem 0.5rem; border-radius: 5px; white-space: nowrap; }
 @media (max-width: 640px) { .tool-name { font-size: 0.9rem; padding-left: 0.5rem; } .header-brand .brand-name { display: none; } }
+
+/* ===== ImpactMojo Design System ===== */
+:root {
+    --im-primary-bg: #0F172A;
+    --im-secondary-bg: #1E293B;
+    --im-accent: #0EA5E9;
+    --im-accent-hover: #0284C7;
+    --im-secondary-accent: #6366F1;
+    --im-success: #10B981;
+    --im-text-primary: #F1F5F9;
+    --im-text-secondary: #94A3B8;
+    --im-text-muted: #64748B;
+    --im-card-bg: #1E293B;
+    --im-hover-bg: #334155;
+    --im-border: #334155;
+    --im-nav-bg: rgba(15, 23, 42, 0.95);
+    --im-gradient: linear-gradient(135deg, #0EA5E9 0%, #6366F1 100%);
+}
+[data-theme="light"] {
+    --im-primary-bg: #F8FAFC;
+    --im-secondary-bg: #FFFFFF;
+    --im-accent: #0369A1;
+    --im-accent-hover: #0369A1;
+    --im-text-primary: #0F172A;
+    --im-text-secondary: #475569;
+    --im-text-muted: #64748B;
+    --im-card-bg: #FFFFFF;
+    --im-hover-bg: #F1F5F9;
+    --im-border: #E2E8F0;
+    --im-nav-bg: rgba(248, 250, 252, 0.95);
+}
+
+/* ImpactMojo Top Bar */
+.im-topbar {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 9999;
+    background: var(--im-nav-bg, rgba(15, 23, 42, 0.95));
+    backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px);
+    border-bottom: 1px solid var(--im-border, #334155);
+    padding: 0.5rem 1rem;
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 0.75rem; flex-wrap: wrap;
+    font-family: 'Inter', sans-serif;
+}
+.im-topbar a { text-decoration: none; }
+.im-topbar-left {
+    display: flex; align-items: center; gap: 0.75rem;
+}
+.im-topbar-home {
+    display: flex; align-items: center; gap: 0.5rem;
+    color: var(--im-text-primary, #F1F5F9);
+    font-weight: 700; font-size: 1rem;
+    background: var(--im-gradient);
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+.im-topbar-home svg { width: 24px; height: 24px; flex-shrink: 0; }
+.im-topbar-right {
+    display: flex; align-items: center; gap: 0.5rem;
+}
+.im-premium-btn {
+    background: var(--im-gradient);
+    color: #fff !important;
+    padding: 0.35rem 0.85rem;
+    border-radius: 6px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    display: flex; align-items: center; gap: 0.35rem;
+    transition: opacity 0.2s;
+    -webkit-text-fill-color: #fff;
+}
+.im-browse-btn { display: inline-flex; align-items: center; gap: 0.4rem; font-family: 'Inter', sans-serif; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: var(--im-text, #1C1917); background: var(--im-surface, #FFFFFF); border: 1.5px solid var(--im-border, #E2E8F0); padding: 0.5rem 1rem; border-radius: 0.5rem; text-decoration: none; transition: background 0.18s ease, border-color 0.18s ease, transform 0.15s ease, box-shadow 0.18s ease; }
+.im-browse-btn:hover { background: var(--im-accent, #0EA5E9); color: #FFFFFF; border-color: var(--im-accent, #0EA5E9); transform: translateY(-1px); box-shadow: 0 4px 12px rgba(14, 165, 233, 0.25); }
+.im-browse-btn svg { width: 14px; height: 14px; }
+@media (prefers-color-scheme: dark) { .im-browse-btn { color: rgba(255,255,255,0.9); background: rgba(255,255,255,0.05); border-color: rgba(255,255,255,0.18); } .im-browse-btn:hover { background: var(--im-accent, #0EA5E9); border-color: var(--im-accent, #0EA5E9); color: #FFFFFF; } }
+.im-premium-btn:hover { opacity: 0.9; }
+.im-premium-btn svg { width: 14px; height: 14px; }
+
+/* Theme Selector - 3 mode */
+.im-theme-selector {
+    display: flex; gap: 2px;
+    background: var(--im-card-bg, #1E293B);
+    border: 1px solid var(--im-border, #334155);
+    border-radius: 8px; padding: 2px;
+}
+.im-theme-btn {
+    background: transparent; border: none;
+    color: var(--im-text-secondary, #94A3B8);
+    padding: 6px; border-radius: 5px; cursor: pointer;
+    transition: all 0.2s; display: flex; align-items: center;
+    justify-content: center; width: 30px; height: 30px;
+}
+.im-theme-btn:hover {
+    background: var(--im-hover-bg, #334155);
+    color: var(--im-text-primary, #F1F5F9);
+}
+.im-theme-btn.active {
+    background: var(--im-accent, #0EA5E9);
+    color: #fff;
+}
+.im-theme-btn svg { width: 16px; height: 16px; }
+
+/* Paper Plane */
+.im-paper-plane {
+    position: fixed; top: 15%; right: 8%;
+    width: 120px; height: 120px;
+    opacity: 0.15; z-index: 0;
+    pointer-events: none;
+    animation: im-fly 25s ease-in-out infinite;
+}
+[data-theme="light"] .im-paper-plane { opacity: 0.2; }
+@keyframes im-fly {
+    0%, 100% { transform: translate(0, 0) rotate(0deg); }
+    20% { transform: translate(60px, -40px) rotate(12deg); }
+    40% { transform: translate(120px, 30px) rotate(-8deg); }
+    60% { transform: translate(40px, 60px) rotate(15deg); }
+    80% { transform: translate(-30px, 20px) rotate(-5deg); }
+}
+
+/* ImpactMojo Footer */
+.im-footer {
+    background: var(--im-secondary-bg, #1E293B);
+    border-top: 1px solid var(--im-border, #334155);
+    padding: 2rem 1rem; margin-top: auto;
+    font-family: 'Inter', sans-serif;
+    color: var(--im-text-secondary, #94A3B8);
+}
+.im-footer-content {
+    max-width: 1100px; margin: 0 auto;
+}
+.im-footer-made {
+    text-align: center; margin-bottom: 1.5rem;
+    font-size: 0.9rem; color: var(--im-text-muted, #64748B);
+}
+.im-footer-made a { color: var(--im-accent, #0EA5E9); }
+.im-footer-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.5rem; margin-bottom: 1.5rem;
+}
+.im-footer-section h4 {
+    font-family: 'Inter', sans-serif;
+    color: var(--im-text-primary, #F1F5F9);
+    font-size: 0.9rem; margin-bottom: 0.75rem;
+    font-weight: 600;
+}
+.im-footer-section ul { list-style: none; padding: 0; margin: 0; }
+.im-footer-section li { margin-bottom: 0.4rem; }
+.im-footer-section a {
+    color: var(--im-text-secondary, #94A3B8);
+    text-decoration: none; font-size: 0.85rem;
+    transition: color 0.2s;
+}
+.im-footer-section a:hover { color: var(--im-accent, #0EA5E9); }
+.im-footer-bottom {
+    text-align: center; padding-top: 1rem;
+    border-top: 1px solid var(--im-border, #334155);
+    font-size: 0.8rem; color: var(--im-text-muted, #64748B);
+}
+.im-footer-bottom p { margin: 0.25rem 0; }
+.im-footer-bottom a { color: var(--im-accent, #0EA5E9); text-decoration: none; }
+
+/* Mobile Responsive */
+@media (max-width: 768px) {
+    .im-topbar { padding: 0.4rem 0.75rem; gap: 0.5rem; }
+    .im-topbar-home { font-size: 0.85rem; }
+    .im-topbar-home svg { width: 20px; height: 20px; }
+    .im-premium-btn { padding: 0.3rem 0.6rem; font-size: 0.75rem; }
+    .im-theme-btn { width: 26px; height: 26px; padding: 4px; }
+    .im-theme-btn svg { width: 14px; height: 14px; }
+    .im-paper-plane { width: 80px; height: 80px; top: 10%; right: 5%; }
+    .im-footer-grid { grid-template-columns: repeat(2, 1fr); gap: 1rem; }
+}
+@media (max-width: 480px) {
+    .im-footer-grid { grid-template-columns: 1fr; }
+    .im-topbar-home span { display: none; }
+}
+
+/* ImpactMojo Global Font Overrides */
+body { font-family: 'Amaranth', sans-serif !important; }
+h1, h2, h3, h4, h5, h6 { font-family: 'Inter', sans-serif !important; }
+code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !important; }
+
+/* WCAG 2.1 AA (1.4.1 Use of Color): inline anchors in content paragraphs must be distinguishable without relying on color alone. Scoped to <main> so nav/footer button-links are unaffected. */
+main p a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]),
+main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) {
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+}
+
 </style>
 </head>
 <body>
@@ -120,7 +309,15 @@ body.dark-mode .header { background: rgba(15,23,42,0.95); }
         <span class="free-pill" title="This tool is free to use">&#10003; Free</span>
     </div>
     <div class="header-actions">
-        <button class="btn" onclick="toggleDarkMode()" title="Toggle dark mode" aria-label="Toggle dark mode">&#9790;</button>
+        <a class="im-premium-btn" href="../premium.html" title="Go Premium">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+            Premium
+        </a>
+        <div class="im-theme-selector" aria-label="Theme selection">
+            <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="Use system theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
+            <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Use light theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg></button>
+            <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Use dark theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+        </div>
         <button class="btn btn-primary" onclick="restart()">Start Over</button>
     </div>
 </div>
@@ -285,10 +482,71 @@ function toggleDarkMode() {
     document.body.classList.toggle('dark-mode');
     localStorage.setItem('impactmojo_dark', document.body.classList.contains('dark-mode'));
 }
-if (localStorage.getItem('impactmojo_dark') === 'true') document.body.classList.add('dark-mode');
+/* theming handled by /js/theme.js (canonical im-theme controller) */
 
 renderTree(TREE);
 renderGallery();
 </script>
+
+<!-- ImpactMojo Paper Plane -->
+<svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M80,130 L150,50" stroke="#10B981" stroke-width="2" stroke-dasharray="4,4"/>
+    <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+    <circle cx="40" cy="155" r="2" fill="#0EA5E9" opacity="0.6"/>
+    <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
+    <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
+</svg>
+<!-- ImpactMojo Footer -->
+<footer class="im-footer" role="contentinfo">
+<div class="im-footer-content">
+<p class="im-footer-made">Made with &#10084; by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+<div class="im-footer-grid">
+<div class="im-footer-section">
+<h4>About ImpactMojo</h4>
+<ul>
+<li><a href="../about.html">About Us</a></li>
+<li><a href="../contact.html">Contact</a></li>
+<li><a href="https://github.com/ImpactMojo/ImpactMojo" rel="noopener noreferrer" target="_blank">GitHub</a></li>
+<li><a href="../transparency.html">Transparency</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Legal</h4>
+<ul>
+<li><a href="../privacy-policy.html">Privacy Policy</a></li>
+<li><a href="../terms-of-service.html">Terms of Service</a></li>
+<li><a href="../disclaimer.html">Disclaimer</a></li>
+<li><a href="../data-protection.html">Data Protection</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Quick Links</h4>
+<ul>
+<li><a href="../catalog.html">All Courses</a></li>
+<li><a href="../premium.html">Premium Content</a></li>
+<li><a href="../coaching.html">Coaching</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Resources</h4>
+<ul>
+<li><a href="../handouts.html">Handouts</a></li>
+<li><a href="../blog.html">Blog</a></li>
+<li><a href="../faq.html">FAQ</a></li>
+<li><a href="../sitemap.html">Sitemap</a></li>
+<li><a href="/docs/" rel="noopener noreferrer" target="_blank">Documentation</a></li>
+</ul>
+</div>
+</div>
+<div class="im-footer-bottom">
+<p>&copy; 2026 ImpactMojo. All content for educational purposes only.</p>
+<p>Released under <strong>MIT License</strong> | Supported by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+</div>
+</div>
+</footer>
+<!-- ImpactMojo canonical theme controller + translation -->
+<script src="/js/theme.js"></script>
+<script src="/js/translate-sarvam.js" defer></script>
 </body>
 </html>

--- a/premium-tools/chart-selector-pro.html
+++ b/premium-tools/chart-selector-pro.html
@@ -1,0 +1,294 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Data Visualization Chart Selector — free tool | ImpactMojo</title>
+<meta name="description" content="Interactive decision tree to help you choose the right chart type for your data. Free to use.">
+<link href="/assets/images/favicon.png" rel="icon" type="image/png">
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+:root {
+    --primary-bg: #FFFFFF; --secondary-bg: #F8FAFC; --accent-color: #0EA5E9;
+    --accent-hover: #0284C7; --text-primary: #0F172A; --text-secondary: #475569;
+    --card-bg: #FFFFFF; --border-color: #E2E8F0; --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+}
+body.dark-mode {
+    --primary-bg: #0F172A; --secondary-bg: #1E293B; --text-primary: #F1F5F9;
+    --text-secondary: #94A3B8; --card-bg: #1E293B; --border-color: #334155;
+}
+body { font-family: 'Amaranth', sans-serif; background: var(--primary-bg); color: var(--text-primary); }
+
+.header {
+    background: rgba(255,255,255,0.95); backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--border-color); padding: 1rem 2rem;
+    position: sticky; top: 0; z-index: 100; display: flex; align-items: center; justify-content: space-between;
+}
+body.dark-mode .header { background: rgba(15,23,42,0.95); }
+.header h1 { font-family: 'Inter', sans-serif; font-size: 1.25rem; }
+.btn { padding: 0.5rem 1rem; border-radius: 8px; border: 1px solid var(--border-color); background: var(--card-bg); color: var(--text-primary); cursor: pointer; font-size: 0.85rem; font-family: inherit; transition: all 0.2s; }
+.btn:hover { border-color: var(--accent-color); }
+.btn-primary { background: var(--accent-color); color: white; border-color: var(--accent-color); }
+
+.container { padding: 2rem; max-width: 800px; margin: 0 auto; }
+
+.instructions {
+    background: var(--secondary-bg); border: 1px solid var(--border-color); border-radius: 10px;
+    padding: 1.25rem; margin-bottom: 1.5rem; font-size: 0.85rem; color: var(--text-secondary);
+}
+
+.question-card {
+    background: var(--card-bg); border: 2px solid var(--border-color); border-radius: 12px;
+    padding: 2rem; text-align: center; margin-bottom: 1.5rem; transition: all 0.3s;
+    animation: fadeIn 0.3s ease;
+}
+@keyframes fadeIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
+
+.question-card h2 {
+    font-family: 'Inter', sans-serif; font-size: 1.15rem; margin-bottom: 0.5rem;
+}
+.question-card p { color: var(--text-secondary); font-size: 0.85rem; margin-bottom: 1.25rem; }
+
+.options { display: flex; flex-wrap: wrap; gap: 0.75rem; justify-content: center; }
+.option-btn {
+    padding: 0.75rem 1.5rem; border: 2px solid var(--border-color); border-radius: 10px;
+    background: var(--secondary-bg); color: var(--text-primary); cursor: pointer;
+    font-family: inherit; font-size: 0.9rem; font-weight: 500; transition: all 0.2s;
+    min-width: 140px;
+}
+.option-btn:hover { border-color: var(--accent-color); background: rgba(245,158,11,0.08); }
+
+.result-card {
+    background: var(--card-bg); border: 2px solid var(--accent-color); border-radius: 12px;
+    padding: 2rem; text-align: center; animation: fadeIn 0.3s ease;
+}
+.result-card .chart-icon { font-size: 3rem; margin-bottom: 1rem; }
+.result-card h2 { font-family: 'Inter', sans-serif; font-size: 1.3rem; color: var(--accent-color); margin-bottom: 0.5rem; }
+.result-card .chart-desc { color: var(--text-secondary); font-size: 0.9rem; margin-bottom: 1rem; line-height: 1.6; }
+.result-card .when-to-use {
+    text-align: left; background: var(--secondary-bg); border-radius: 8px;
+    padding: 1rem; font-size: 0.85rem; margin-bottom: 1rem;
+}
+.result-card .when-to-use strong { display: block; margin-bottom: 0.5rem; }
+.result-card .when-to-use li { margin-bottom: 0.25rem; color: var(--text-secondary); }
+.result-card .alternatives {
+    font-size: 0.82rem; color: var(--text-secondary); margin-top: 0.75rem;
+}
+
+.breadcrumb {
+    display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 1rem; align-items: center;
+    font-size: 0.8rem; color: var(--text-secondary);
+}
+.breadcrumb span { background: var(--secondary-bg); padding: 0.25rem 0.5rem; border-radius: 4px; }
+.breadcrumb .bc-arrow { background: none; }
+
+.chart-gallery {
+    display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; margin-top: 2rem;
+}
+.gallery-card {
+    background: var(--card-bg); border: 1px solid var(--border-color); border-radius: 10px;
+    padding: 1rem; text-align: center; cursor: pointer; transition: all 0.2s;
+}
+.gallery-card:hover { border-color: var(--accent-color); box-shadow: var(--shadow-md); }
+.gallery-card .gc-icon { font-size: 2rem; margin-bottom: 0.5rem; }
+.gallery-card .gc-name { font-weight: 600; font-size: 0.85rem; margin-bottom: 0.25rem; }
+.gallery-card .gc-use { font-size: 0.75rem; color: var(--text-secondary); }
+
+@media print { .header { display: none !important; } }
+
+/* ── Pro Studio branding ────────────────────────────────────── */
+.header { flex-wrap: wrap; gap: 0.75rem; }
+.header-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+.header-brand { display: flex; align-items: center; gap: 0.5rem; text-decoration: none; color: var(--text-primary); }
+.header-brand img { width: 30px; height: 30px; border-radius: 6px; }
+.header-brand .brand-name { font-family: 'Inter', sans-serif; font-weight: 700; font-size: 1rem; }
+.tool-name { font-family: 'Inter', sans-serif; font-size: 1.05rem; font-weight: 600; padding-left: 0.75rem; border-left: 2px solid var(--border-color); }
+.free-pill { display: inline-flex; align-items: center; gap: 0.2rem; background: rgba(16,185,129,0.12); color: #10B981; font-weight: 700; font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.4px; padding: 0.15rem 0.5rem; border-radius: 5px; white-space: nowrap; }
+@media (max-width: 640px) { .tool-name { font-size: 0.9rem; padding-left: 0.5rem; } .header-brand .brand-name { display: none; } }
+</style>
+</head>
+<body>
+
+<div class="header">
+    <div style="display:flex; align-items:center; gap:0.75rem; flex-wrap:wrap;">
+        <a class="header-brand" href="/" title="ImpactMojo home">
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="30" height="30">
+            <span class="brand-name">ImpactMojo</span>
+        </a>
+        <h1 class="tool-name">Data Visualization Chart Selector</h1>
+        <span class="free-pill" title="This tool is free to use">&#10003; Free</span>
+    </div>
+    <div class="header-actions">
+        <button class="btn" onclick="toggleDarkMode()" title="Toggle dark mode" aria-label="Toggle dark mode">&#9790;</button>
+        <button class="btn btn-primary" onclick="restart()">Start Over</button>
+    </div>
+</div>
+
+<div class="container">
+    <div class="instructions">
+        <strong>Not sure which chart to use?</strong> Answer a few questions about your data and we'll recommend the best visualization. Or scroll down to browse all chart types.
+    </div>
+
+    <div class="breadcrumb" id="breadcrumb"></div>
+    <div id="treeView"></div>
+
+    <h3 style="margin-top:2.5rem; font-family:'Inter',sans-serif; font-size:1rem;">All Chart Types</h3>
+    <div class="chart-gallery" id="gallery"></div>
+</div>
+
+<script>
+var CHARTS = {
+    bar: { icon: '&#9612;&#9612;&#9612;', name: 'Bar Chart', desc: 'Compare values across categories using horizontal or vertical bars.', when: ['Comparing quantities across categories', 'Showing survey results or rankings', 'Displaying before/after comparisons'], alt: 'Column chart, grouped bar, stacked bar' },
+    line: { icon: '&#128200;', name: 'Line Chart', desc: 'Show trends and changes over time with connected data points.', when: ['Tracking metrics over time', 'Showing growth or decline trends', 'Comparing multiple series over time'], alt: 'Area chart, sparkline' },
+    pie: { icon: '&#127856;', name: 'Pie / Donut Chart', desc: 'Show parts of a whole as proportional slices.', when: ['Showing budget allocation (max 5-6 categories)', 'Displaying demographic breakdowns', 'Illustrating market share'], alt: 'Donut chart, treemap, waffle chart' },
+    scatter: { icon: '&#11044;&#8943;', name: 'Scatter Plot', desc: 'Reveal relationships between two numeric variables.', when: ['Exploring correlation between variables', 'Identifying outliers or clusters', 'Showing distribution patterns'], alt: 'Bubble chart (add 3rd variable as size)' },
+    map: { icon: '&#127758;', name: 'Map / Choropleth', desc: 'Show geographic patterns using colors or markers on a map.', when: ['Displaying data by region/district', 'Showing coverage or reach', 'Comparing geographic performance'], alt: 'Dot density map, cartogram' },
+    table: { icon: '&#128203;', name: 'Table / Heatmap Table', desc: 'Present exact values in a structured format with optional color coding.', when: ['Showing precise numbers that matter', 'Comparing multiple dimensions', 'When audience needs to look up specific values'], alt: 'Heatmap, pivot table' },
+    stacked: { icon: '&#9617;&#9618;&#9619;', name: 'Stacked Bar / Area', desc: 'Show composition and totals simultaneously across categories or time.', when: ['Showing how parts contribute to total', 'Comparing composition across groups', 'Tracking component changes over time'], alt: '100% stacked bar, stacked area' },
+    histogram: { icon: '&#9615;&#9614;&#9613;&#9612;', name: 'Histogram', desc: 'Show the distribution and frequency of a single numeric variable.', when: ['Understanding data spread', 'Identifying skewness or outliers', 'Showing age/income distributions'], alt: 'Box plot, violin plot, density curve' },
+    sankey: { icon: '&#8669;', name: 'Sankey / Flow Diagram', desc: 'Show how values flow from one set of categories to another.', when: ['Tracking budget flow from sources to uses', 'Showing beneficiary pathways', 'Visualizing process stages and drop-offs'], alt: 'Alluvial chart, funnel chart' },
+    gauge: { icon: '&#9201;', name: 'Gauge / KPI Card', desc: 'Display a single key metric with context (target, status).', when: ['Dashboard headlines and KPIs', 'Showing progress toward a target', 'Communicating a single important number'], alt: 'Bullet chart, progress bar, big number' }
+};
+
+var TREE = {
+    id: 'root', q: 'What do you want to show?', hint: 'Pick the primary purpose of your visualization.',
+    options: [
+        { label: 'Comparison', next: {
+            id: 'compare', q: 'What are you comparing?', hint: '',
+            options: [
+                { label: 'Categories (e.g., regions, groups)', result: 'bar' },
+                { label: 'Parts of a whole', result: 'pie' },
+                { label: 'Composition + total', result: 'stacked' }
+            ]
+        }},
+        { label: 'Trend over time', next: {
+            id: 'trend', q: 'How many data series?', hint: '',
+            options: [
+                { label: '1-3 series', result: 'line' },
+                { label: 'Component breakdown over time', result: 'stacked' }
+            ]
+        }},
+        { label: 'Relationship', next: {
+            id: 'relationship', q: 'How many variables?', hint: '',
+            options: [
+                { label: '2 numeric variables', result: 'scatter' },
+                { label: 'Flow between categories', result: 'sankey' }
+            ]
+        }},
+        { label: 'Distribution', result: 'histogram' },
+        { label: 'Geographic patterns', result: 'map' },
+        { label: 'Single KPI / metric', result: 'gauge' },
+        { label: 'Exact values / lookup', result: 'table' }
+    ]
+};
+
+var path = [];
+
+function restart() { path = []; renderTree(TREE); }
+
+function renderTree(node) {
+    var view = document.getElementById('treeView');
+    var bc = document.getElementById('breadcrumb');
+
+    bc.innerHTML = '';
+    if (path.length) {
+        var startOver = document.createElement('span');
+        startOver.textContent = 'Start';
+        startOver.style.cursor = 'pointer';
+        startOver.style.color = 'var(--accent-color)';
+        startOver.addEventListener('click', restart);
+        bc.appendChild(startOver);
+        path.forEach(function(p) {
+            var arrow = document.createElement('span');
+            arrow.className = 'bc-arrow'; arrow.textContent = ' > ';
+            bc.appendChild(arrow);
+            var crumb = document.createElement('span');
+            crumb.textContent = p;
+            bc.appendChild(crumb);
+        });
+    }
+
+    view.innerHTML = '';
+    var card = document.createElement('div');
+    card.className = 'question-card';
+    card.innerHTML = '<h2>' + node.q + '</h2>' + (node.hint ? '<p>' + node.hint + '</p>' : '');
+
+    var opts = document.createElement('div');
+    opts.className = 'options';
+    node.options.forEach(function(opt) {
+        var btn = document.createElement('button');
+        btn.className = 'option-btn';
+        btn.textContent = opt.label;
+        btn.addEventListener('click', function() {
+            path.push(opt.label);
+            if (opt.result) { showResult(opt.result); }
+            else if (opt.next) { renderTree(opt.next); }
+        });
+        opts.appendChild(btn);
+    });
+    card.appendChild(opts);
+    view.appendChild(card);
+}
+
+function showResult(chartId) {
+    var chart = CHARTS[chartId];
+    var view = document.getElementById('treeView');
+    var bc = document.getElementById('breadcrumb');
+
+    bc.innerHTML = '';
+    var startOver = document.createElement('span');
+    startOver.textContent = 'Start'; startOver.style.cursor = 'pointer'; startOver.style.color = 'var(--accent-color)';
+    startOver.addEventListener('click', restart);
+    bc.appendChild(startOver);
+    path.forEach(function(p) {
+        var arrow = document.createElement('span'); arrow.className = 'bc-arrow'; arrow.textContent = ' > ';
+        bc.appendChild(arrow);
+        var crumb = document.createElement('span'); crumb.textContent = p; bc.appendChild(crumb);
+    });
+
+    view.innerHTML = '';
+    var card = document.createElement('div');
+    card.className = 'result-card';
+    var whenHtml = '<ul>' + chart.when.map(function(w) { return '<li>' + w + '</li>'; }).join('') + '</ul>';
+    card.innerHTML = '<div class="chart-icon">' + chart.icon + '</div>' +
+        '<h2>' + chart.name + '</h2>' +
+        '<p class="chart-desc">' + chart.desc + '</p>' +
+        '<div class="when-to-use"><strong>Best used when:</strong>' + whenHtml + '</div>' +
+        '<p class="alternatives"><strong>Alternatives:</strong> ' + chart.alt + '</p>';
+
+    var restartBtn = document.createElement('button');
+    restartBtn.className = 'btn btn-primary';
+    restartBtn.textContent = 'Try Again';
+    restartBtn.style.marginTop = '1rem';
+    restartBtn.addEventListener('click', restart);
+    card.appendChild(restartBtn);
+    view.appendChild(card);
+}
+
+function renderGallery() {
+    var gallery = document.getElementById('gallery');
+    Object.keys(CHARTS).forEach(function(id) {
+        var c = CHARTS[id];
+        var card = document.createElement('div');
+        card.className = 'gallery-card';
+        card.innerHTML = '<div class="gc-icon">' + c.icon + '</div><div class="gc-name">' + c.name + '</div><div class="gc-use">' + c.when[0] + '</div>';
+        card.addEventListener('click', function() {
+            path = ['Gallery']; showResult(id);
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+        });
+        gallery.appendChild(card);
+    });
+}
+
+function toggleDarkMode() {
+    document.body.classList.toggle('dark-mode');
+    localStorage.setItem('impactmojo_dark', document.body.classList.contains('dark-mode'));
+}
+if (localStorage.getItem('impactmojo_dark') === 'true') document.body.classList.add('dark-mode');
+
+renderTree(TREE);
+renderGallery();
+</script>
+</body>
+</html>

--- a/premium-tools/empathy-pro.html
+++ b/premium-tools/empathy-pro.html
@@ -129,6 +129,195 @@ body.dark-mode .sticky { background: #422006; border-color: #92400E; }
 .freemium-note a:hover { text-decoration: underline; }
 @media (max-width: 640px) { .tool-name { font-size: 0.9rem; padding-left: 0.5rem; } .header-brand .brand-name { display: none; } }
 @media print { .freemium-note { display: none !important; } }
+
+/* ===== ImpactMojo Design System ===== */
+:root {
+    --im-primary-bg: #0F172A;
+    --im-secondary-bg: #1E293B;
+    --im-accent: #0EA5E9;
+    --im-accent-hover: #0284C7;
+    --im-secondary-accent: #6366F1;
+    --im-success: #10B981;
+    --im-text-primary: #F1F5F9;
+    --im-text-secondary: #94A3B8;
+    --im-text-muted: #64748B;
+    --im-card-bg: #1E293B;
+    --im-hover-bg: #334155;
+    --im-border: #334155;
+    --im-nav-bg: rgba(15, 23, 42, 0.95);
+    --im-gradient: linear-gradient(135deg, #0EA5E9 0%, #6366F1 100%);
+}
+[data-theme="light"] {
+    --im-primary-bg: #F8FAFC;
+    --im-secondary-bg: #FFFFFF;
+    --im-accent: #0369A1;
+    --im-accent-hover: #0369A1;
+    --im-text-primary: #0F172A;
+    --im-text-secondary: #475569;
+    --im-text-muted: #64748B;
+    --im-card-bg: #FFFFFF;
+    --im-hover-bg: #F1F5F9;
+    --im-border: #E2E8F0;
+    --im-nav-bg: rgba(248, 250, 252, 0.95);
+}
+
+/* ImpactMojo Top Bar */
+.im-topbar {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 9999;
+    background: var(--im-nav-bg, rgba(15, 23, 42, 0.95));
+    backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px);
+    border-bottom: 1px solid var(--im-border, #334155);
+    padding: 0.5rem 1rem;
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 0.75rem; flex-wrap: wrap;
+    font-family: 'Inter', sans-serif;
+}
+.im-topbar a { text-decoration: none; }
+.im-topbar-left {
+    display: flex; align-items: center; gap: 0.75rem;
+}
+.im-topbar-home {
+    display: flex; align-items: center; gap: 0.5rem;
+    color: var(--im-text-primary, #F1F5F9);
+    font-weight: 700; font-size: 1rem;
+    background: var(--im-gradient);
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+.im-topbar-home svg { width: 24px; height: 24px; flex-shrink: 0; }
+.im-topbar-right {
+    display: flex; align-items: center; gap: 0.5rem;
+}
+.im-premium-btn {
+    background: var(--im-gradient);
+    color: #fff !important;
+    padding: 0.35rem 0.85rem;
+    border-radius: 6px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    display: flex; align-items: center; gap: 0.35rem;
+    transition: opacity 0.2s;
+    -webkit-text-fill-color: #fff;
+}
+.im-browse-btn { display: inline-flex; align-items: center; gap: 0.4rem; font-family: 'Inter', sans-serif; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: var(--im-text, #1C1917); background: var(--im-surface, #FFFFFF); border: 1.5px solid var(--im-border, #E2E8F0); padding: 0.5rem 1rem; border-radius: 0.5rem; text-decoration: none; transition: background 0.18s ease, border-color 0.18s ease, transform 0.15s ease, box-shadow 0.18s ease; }
+.im-browse-btn:hover { background: var(--im-accent, #0EA5E9); color: #FFFFFF; border-color: var(--im-accent, #0EA5E9); transform: translateY(-1px); box-shadow: 0 4px 12px rgba(14, 165, 233, 0.25); }
+.im-browse-btn svg { width: 14px; height: 14px; }
+@media (prefers-color-scheme: dark) { .im-browse-btn { color: rgba(255,255,255,0.9); background: rgba(255,255,255,0.05); border-color: rgba(255,255,255,0.18); } .im-browse-btn:hover { background: var(--im-accent, #0EA5E9); border-color: var(--im-accent, #0EA5E9); color: #FFFFFF; } }
+.im-premium-btn:hover { opacity: 0.9; }
+.im-premium-btn svg { width: 14px; height: 14px; }
+
+/* Theme Selector - 3 mode */
+.im-theme-selector {
+    display: flex; gap: 2px;
+    background: var(--im-card-bg, #1E293B);
+    border: 1px solid var(--im-border, #334155);
+    border-radius: 8px; padding: 2px;
+}
+.im-theme-btn {
+    background: transparent; border: none;
+    color: var(--im-text-secondary, #94A3B8);
+    padding: 6px; border-radius: 5px; cursor: pointer;
+    transition: all 0.2s; display: flex; align-items: center;
+    justify-content: center; width: 30px; height: 30px;
+}
+.im-theme-btn:hover {
+    background: var(--im-hover-bg, #334155);
+    color: var(--im-text-primary, #F1F5F9);
+}
+.im-theme-btn.active {
+    background: var(--im-accent, #0EA5E9);
+    color: #fff;
+}
+.im-theme-btn svg { width: 16px; height: 16px; }
+
+/* Paper Plane */
+.im-paper-plane {
+    position: fixed; top: 15%; right: 8%;
+    width: 120px; height: 120px;
+    opacity: 0.15; z-index: 0;
+    pointer-events: none;
+    animation: im-fly 25s ease-in-out infinite;
+}
+[data-theme="light"] .im-paper-plane { opacity: 0.2; }
+@keyframes im-fly {
+    0%, 100% { transform: translate(0, 0) rotate(0deg); }
+    20% { transform: translate(60px, -40px) rotate(12deg); }
+    40% { transform: translate(120px, 30px) rotate(-8deg); }
+    60% { transform: translate(40px, 60px) rotate(15deg); }
+    80% { transform: translate(-30px, 20px) rotate(-5deg); }
+}
+
+/* ImpactMojo Footer */
+.im-footer {
+    background: var(--im-secondary-bg, #1E293B);
+    border-top: 1px solid var(--im-border, #334155);
+    padding: 2rem 1rem; margin-top: auto;
+    font-family: 'Inter', sans-serif;
+    color: var(--im-text-secondary, #94A3B8);
+}
+.im-footer-content {
+    max-width: 1100px; margin: 0 auto;
+}
+.im-footer-made {
+    text-align: center; margin-bottom: 1.5rem;
+    font-size: 0.9rem; color: var(--im-text-muted, #64748B);
+}
+.im-footer-made a { color: var(--im-accent, #0EA5E9); }
+.im-footer-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.5rem; margin-bottom: 1.5rem;
+}
+.im-footer-section h4 {
+    font-family: 'Inter', sans-serif;
+    color: var(--im-text-primary, #F1F5F9);
+    font-size: 0.9rem; margin-bottom: 0.75rem;
+    font-weight: 600;
+}
+.im-footer-section ul { list-style: none; padding: 0; margin: 0; }
+.im-footer-section li { margin-bottom: 0.4rem; }
+.im-footer-section a {
+    color: var(--im-text-secondary, #94A3B8);
+    text-decoration: none; font-size: 0.85rem;
+    transition: color 0.2s;
+}
+.im-footer-section a:hover { color: var(--im-accent, #0EA5E9); }
+.im-footer-bottom {
+    text-align: center; padding-top: 1rem;
+    border-top: 1px solid var(--im-border, #334155);
+    font-size: 0.8rem; color: var(--im-text-muted, #64748B);
+}
+.im-footer-bottom p { margin: 0.25rem 0; }
+.im-footer-bottom a { color: var(--im-accent, #0EA5E9); text-decoration: none; }
+
+/* Mobile Responsive */
+@media (max-width: 768px) {
+    .im-topbar { padding: 0.4rem 0.75rem; gap: 0.5rem; }
+    .im-topbar-home { font-size: 0.85rem; }
+    .im-topbar-home svg { width: 20px; height: 20px; }
+    .im-premium-btn { padding: 0.3rem 0.6rem; font-size: 0.75rem; }
+    .im-theme-btn { width: 26px; height: 26px; padding: 4px; }
+    .im-theme-btn svg { width: 14px; height: 14px; }
+    .im-paper-plane { width: 80px; height: 80px; top: 10%; right: 5%; }
+    .im-footer-grid { grid-template-columns: repeat(2, 1fr); gap: 1rem; }
+}
+@media (max-width: 480px) {
+    .im-footer-grid { grid-template-columns: 1fr; }
+    .im-topbar-home span { display: none; }
+}
+
+/* ImpactMojo Global Font Overrides */
+body { font-family: 'Amaranth', sans-serif !important; }
+h1, h2, h3, h4, h5, h6 { font-family: 'Inter', sans-serif !important; }
+code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !important; }
+
+/* WCAG 2.1 AA (1.4.1 Use of Color): inline anchors in content paragraphs must be distinguishable without relying on color alone. Scoped to <main> so nav/footer button-links are unaffected. */
+main p a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]),
+main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) {
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+}
+
 </style>
 </head>
 <body>
@@ -142,7 +331,15 @@ body.dark-mode .sticky { background: #422006; border-color: #92400E; }
         <h1 class="tool-name">Empathy Mapping</h1>
     </div>
     <div class="header-actions">
-        <button class="btn" onclick="toggleDarkMode()" title="Toggle dark mode" aria-label="Toggle dark mode">&#9790;</button>
+        <a class="im-premium-btn" href="../premium.html" title="Go Premium">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+            Premium
+        </a>
+        <div class="im-theme-selector" aria-label="Theme selection">
+            <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="Use system theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
+            <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Use light theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg></button>
+            <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Use dark theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+        </div>
         <button class="btn" onclick="clearAll()">Clear All</button>
         <button class="btn" onclick="loadExample()">Load Example</button>
         <button class="btn btn-primary" onclick="exportToJSON()">Export <span class="pro-pill">&#9733; Premium</span></button>
@@ -292,7 +489,7 @@ function toggleDarkMode() {
     document.body.classList.toggle('dark-mode');
     localStorage.setItem('impactmojo_dark', document.body.classList.contains('dark-mode'));
 }
-if (localStorage.getItem('impactmojo_dark') === 'true') document.body.classList.add('dark-mode');
+/* theming handled by /js/theme.js (canonical im-theme controller) */
 init();
 </script>
 
@@ -322,5 +519,66 @@ function requirePremium() {
 if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initGate);
 else initGate();
 </script>
+
+<!-- ImpactMojo Paper Plane -->
+<svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M80,130 L150,50" stroke="#10B981" stroke-width="2" stroke-dasharray="4,4"/>
+    <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+    <circle cx="40" cy="155" r="2" fill="#0EA5E9" opacity="0.6"/>
+    <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
+    <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
+</svg>
+<!-- ImpactMojo Footer -->
+<footer class="im-footer" role="contentinfo">
+<div class="im-footer-content">
+<p class="im-footer-made">Made with &#10084; by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+<div class="im-footer-grid">
+<div class="im-footer-section">
+<h4>About ImpactMojo</h4>
+<ul>
+<li><a href="../about.html">About Us</a></li>
+<li><a href="../contact.html">Contact</a></li>
+<li><a href="https://github.com/ImpactMojo/ImpactMojo" rel="noopener noreferrer" target="_blank">GitHub</a></li>
+<li><a href="../transparency.html">Transparency</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Legal</h4>
+<ul>
+<li><a href="../privacy-policy.html">Privacy Policy</a></li>
+<li><a href="../terms-of-service.html">Terms of Service</a></li>
+<li><a href="../disclaimer.html">Disclaimer</a></li>
+<li><a href="../data-protection.html">Data Protection</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Quick Links</h4>
+<ul>
+<li><a href="../catalog.html">All Courses</a></li>
+<li><a href="../premium.html">Premium Content</a></li>
+<li><a href="../coaching.html">Coaching</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Resources</h4>
+<ul>
+<li><a href="../handouts.html">Handouts</a></li>
+<li><a href="../blog.html">Blog</a></li>
+<li><a href="../faq.html">FAQ</a></li>
+<li><a href="../sitemap.html">Sitemap</a></li>
+<li><a href="/docs/" rel="noopener noreferrer" target="_blank">Documentation</a></li>
+</ul>
+</div>
+</div>
+<div class="im-footer-bottom">
+<p>&copy; 2026 ImpactMojo. All content for educational purposes only.</p>
+<p>Released under <strong>MIT License</strong> | Supported by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+</div>
+</div>
+</footer>
+<!-- ImpactMojo canonical theme controller + translation -->
+<script src="/js/theme.js"></script>
+<script src="/js/translate-sarvam.js" defer></script>
 </body>
 </html>

--- a/premium-tools/empathy-pro.html
+++ b/premium-tools/empathy-pro.html
@@ -1,0 +1,326 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Empathy Mapping — free empathy map tool | ImpactMojo</title>
+<meta name="description" content="Interactive Empathy Map template for understanding stakeholders and beneficiaries. Free to build — exporting is a Premium feature.">
+<link href="/assets/images/favicon.png" rel="icon" type="image/png">
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+:root {
+    --primary-bg: #FFFFFF; --secondary-bg: #F8FAFC; --accent-color: #0EA5E9;
+    --accent-hover: #0284C7; --text-primary: #0F172A; --text-secondary: #475569;
+    --card-bg: #FFFFFF; --border-color: #E2E8F0; --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+}
+body.dark-mode {
+    --primary-bg: #0F172A; --secondary-bg: #1E293B; --text-primary: #F1F5F9;
+    --text-secondary: #94A3B8; --card-bg: #1E293B; --border-color: #334155;
+}
+body { font-family: 'Amaranth', sans-serif; background: var(--primary-bg); color: var(--text-primary); }
+
+.header {
+    background: rgba(255,255,255,0.95); backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--border-color); padding: 1rem 2rem;
+    position: sticky; top: 0; z-index: 100; display: flex; align-items: center; justify-content: space-between;
+}
+body.dark-mode .header { background: rgba(15,23,42,0.95); }
+.header h1 { font-family: 'Inter', sans-serif; font-size: 1.25rem; }
+.btn { padding: 0.5rem 1rem; border-radius: 8px; border: 1px solid var(--border-color); background: var(--card-bg); color: var(--text-primary); cursor: pointer; font-size: 0.85rem; font-family: inherit; transition: all 0.2s; }
+.btn:hover { border-color: var(--accent-color); }
+.btn-primary { background: var(--accent-color); color: white; border-color: var(--accent-color); }
+
+.container { padding: 2rem; max-width: 900px; margin: 0 auto; }
+
+.instructions {
+    background: var(--secondary-bg); border: 1px solid var(--border-color); border-radius: 10px;
+    padding: 1.25rem; margin-bottom: 1.5rem; font-size: 0.85rem; color: var(--text-secondary);
+}
+.instructions strong { color: var(--text-primary); }
+
+.persona-bar {
+    background: var(--card-bg); border: 1px solid var(--border-color); border-radius: 10px;
+    padding: 1rem; margin-bottom: 1.5rem; display: flex; align-items: center; gap: 1rem;
+}
+.persona-bar input {
+    flex: 1; padding: 0.6rem; border: 1px solid var(--border-color); border-radius: 6px;
+    background: var(--primary-bg); color: var(--text-primary); font-family: inherit; font-size: 0.9rem;
+}
+.persona-avatar {
+    width: 48px; height: 48px; border-radius: 50%; background: var(--accent-color);
+    display: flex; align-items: center; justify-content: center; font-size: 1.3rem; color: white;
+    flex-shrink: 0;
+}
+
+.empathy-grid {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 0;
+    border: 2px solid var(--border-color); border-radius: 12px; overflow: hidden;
+}
+.empathy-section {
+    min-height: 220px; padding: 1rem; border: 1px solid var(--border-color);
+    position: relative;
+}
+.section-header {
+    display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.75rem;
+}
+.section-icon { font-size: 1.2rem; }
+.section-title { font-family: 'Inter', sans-serif; font-size: 0.9rem; font-weight: 700; }
+.section-hint { font-size: 0.75rem; color: var(--text-secondary); margin-bottom: 0.5rem; }
+
+.thinks .section-header { color: #6366F1; }
+.feels .section-header { color: #EC4899; }
+.says .section-header { color: #10B981; }
+.does .section-header { color: #F59E0B; }
+
+.sticky-notes { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+.sticky {
+    background: #FEF3C7; border: 1px solid #FCD34D; border-radius: 6px;
+    padding: 0.5rem; min-width: 100px; max-width: 180px; position: relative;
+    font-size: 0.82rem; box-shadow: 1px 2px 4px rgba(0,0,0,0.06);
+}
+body.dark-mode .sticky { background: #422006; border-color: #92400E; }
+.sticky textarea {
+    width: 100%; border: none; background: transparent; color: var(--text-primary);
+    font-family: inherit; font-size: 0.82rem; resize: none; outline: none; line-height: 1.4;
+}
+.sticky .delete-sticky {
+    position: absolute; top: 2px; right: 4px; background: none; border: none;
+    color: var(--text-secondary); cursor: pointer; font-size: 0.9rem; opacity: 0; transition: opacity 0.2s;
+}
+.sticky:hover .delete-sticky { opacity: 1; }
+.sticky .delete-sticky:hover { color: #EF4444; }
+
+.add-sticky {
+    border: 2px dashed var(--border-color); border-radius: 6px; padding: 0.5rem 0.75rem;
+    background: transparent; color: var(--text-secondary); cursor: pointer; font-size: 0.78rem;
+    min-width: 80px; text-align: center; transition: all 0.2s; font-family: inherit;
+}
+.add-sticky:hover { border-color: var(--accent-color); color: var(--accent-color); }
+
+.pains-gains {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 0;
+    border: 2px solid var(--border-color); border-top: none; border-radius: 0 0 12px 12px;
+    overflow: hidden;
+}
+.pains-gains .empathy-section { min-height: 160px; }
+.pains .section-header { color: #EF4444; }
+.gains .section-header { color: #10B981; }
+
+@media (max-width: 600px) {
+    .empathy-grid { grid-template-columns: 1fr; }
+    .pains-gains { grid-template-columns: 1fr; }
+}
+@media print {
+    .header, .instructions { display: none !important; }
+    .sticky { break-inside: avoid; }
+}
+
+/* ── Pro Studio branding + freemium ─────────────────────────── */
+.header { flex-wrap: wrap; gap: 0.75rem; }
+.header-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+.header-brand { display: flex; align-items: center; gap: 0.5rem; text-decoration: none; color: var(--text-primary); }
+.header-brand img { width: 30px; height: 30px; border-radius: 6px; }
+.header-brand .brand-name { font-family: 'Inter', sans-serif; font-weight: 700; font-size: 1rem; }
+.tool-name { font-family: 'Inter', sans-serif; font-size: 1.05rem; font-weight: 600; padding-left: 0.75rem; border-left: 2px solid var(--border-color); }
+.pro-pill { display: inline-flex; align-items: center; gap: 0.2rem; background: linear-gradient(135deg,#F59E0B,#EF4444); color: #fff; font-weight: 700; font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.4px; padding: 0.15rem 0.45rem; border-radius: 5px; white-space: nowrap; }
+.freemium-note { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 1.5rem; padding: 0.6rem 0.9rem; background: rgba(245,158,11,0.08); border: 1px solid rgba(245,158,11,0.3); border-radius: 8px; font-size: 0.82rem; color: var(--text-secondary); }
+.freemium-note a { color: #F59E0B; font-weight: 700; text-decoration: none; }
+.freemium-note a:hover { text-decoration: underline; }
+@media (max-width: 640px) { .tool-name { font-size: 0.9rem; padding-left: 0.5rem; } .header-brand .brand-name { display: none; } }
+@media print { .freemium-note { display: none !important; } }
+</style>
+</head>
+<body>
+
+<div class="header">
+    <div style="display:flex; align-items:center; gap:0.75rem; flex-wrap:wrap;">
+        <a class="header-brand" href="/" title="ImpactMojo home">
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="30" height="30">
+            <span class="brand-name">ImpactMojo</span>
+        </a>
+        <h1 class="tool-name">Empathy Mapping</h1>
+    </div>
+    <div class="header-actions">
+        <button class="btn" onclick="toggleDarkMode()" title="Toggle dark mode" aria-label="Toggle dark mode">&#9790;</button>
+        <button class="btn" onclick="clearAll()">Clear All</button>
+        <button class="btn" onclick="loadExample()">Load Example</button>
+        <button class="btn btn-primary" onclick="exportToJSON()">Export <span class="pro-pill">&#9733; Premium</span></button>
+        <button class="btn btn-primary" onclick="printTemplate()">Print <span class="pro-pill">&#9733; Premium</span></button>
+    </div>
+</div>
+
+<div class="container">
+    <div class="instructions">
+        <strong>Empathy Mapping:</strong> Choose a specific person or persona (beneficiary, stakeholder, user). Fill each quadrant with what they <em>think, feel, say,</em> and <em>do</em>. Then identify their <em>pains</em> and <em>gains</em>. Add sticky notes by clicking "+ Add".
+    </div>
+
+    <div class="freemium-note">
+        <span class="pro-pill">&#9733; Premium</span>
+        <span>Building is free. Exporting is a Premium feature. <a href="/premium.html#detail-professional">Upgrade to Professional &rarr;</a></span>
+    </div>
+
+    <div class="persona-bar">
+        <div class="persona-avatar" id="avatar">?</div>
+        <input type="text" id="personaName" placeholder="Who are we empathizing with? (e.g., Smallholder farmer in Bihar)" maxlength="80">
+    </div>
+
+    <div class="empathy-grid">
+        <div class="empathy-section thinks" data-section="thinks">
+            <div class="section-header"><span class="section-icon">&#128173;</span><span class="section-title">Thinks</span></div>
+            <div class="section-hint">What occupies their mind? Worries, aspirations, beliefs?</div>
+            <div class="sticky-notes" id="thinks-notes"></div>
+        </div>
+        <div class="empathy-section feels" data-section="feels">
+            <div class="section-header"><span class="section-icon">&#10084;</span><span class="section-title">Feels</span></div>
+            <div class="section-hint">What emotions do they experience? Fears, hopes, frustrations?</div>
+            <div class="sticky-notes" id="feels-notes"></div>
+        </div>
+        <div class="empathy-section says" data-section="says">
+            <div class="section-header"><span class="section-icon">&#128172;</span><span class="section-title">Says</span></div>
+            <div class="section-hint">What do they tell others? Quotes, phrases, complaints?</div>
+            <div class="sticky-notes" id="says-notes"></div>
+        </div>
+        <div class="empathy-section does" data-section="does">
+            <div class="section-header"><span class="section-icon">&#9997;</span><span class="section-title">Does</span></div>
+            <div class="section-hint">What actions and behaviors do you observe?</div>
+            <div class="sticky-notes" id="does-notes"></div>
+        </div>
+    </div>
+    <div class="pains-gains">
+        <div class="empathy-section pains" data-section="pains">
+            <div class="section-header"><span class="section-icon">&#9888;</span><span class="section-title">Pains</span></div>
+            <div class="section-hint">Frustrations, obstacles, risks they face</div>
+            <div class="sticky-notes" id="pains-notes"></div>
+        </div>
+        <div class="empathy-section gains" data-section="gains">
+            <div class="section-header"><span class="section-icon">&#9733;</span><span class="section-title">Gains</span></div>
+            <div class="section-hint">What would make their life better? Desired outcomes?</div>
+            <div class="sticky-notes" id="gains-notes"></div>
+        </div>
+    </div>
+</div>
+
+<script>
+var STORAGE_KEY = 'impactmojo_empathy_map';
+var SECTIONS = ['thinks', 'feels', 'says', 'does', 'pains', 'gains'];
+var data = { persona: '', thinks: [], feels: [], says: [], does: [], pains: [], gains: [] };
+
+function init() {
+    var saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) { try { data = JSON.parse(saved); } catch(e) {} }
+    SECTIONS.forEach(function(s) { if (!data[s]) data[s] = []; });
+    document.getElementById('personaName').value = data.persona || '';
+    document.getElementById('personaName').addEventListener('input', function() {
+        data.persona = this.value;
+        document.getElementById('avatar').textContent = this.value ? this.value.charAt(0).toUpperCase() : '?';
+        save();
+    });
+    if (data.persona) document.getElementById('avatar').textContent = data.persona.charAt(0).toUpperCase();
+    render();
+}
+
+function save() { localStorage.setItem(STORAGE_KEY, JSON.stringify(data)); }
+
+function render() {
+    SECTIONS.forEach(function(s) {
+        var container = document.getElementById(s + '-notes');
+        container.innerHTML = '';
+        data[s].forEach(function(text, i) {
+            var sticky = document.createElement('div');
+            sticky.className = 'sticky';
+            var ta = document.createElement('textarea');
+            ta.value = text; ta.rows = 2; ta.placeholder = 'Type here...';
+            ta.addEventListener('input', function() {
+                this.style.height = 'auto'; this.style.height = this.scrollHeight + 'px';
+                data[s][i] = this.value; save();
+            });
+            setTimeout(function() { ta.style.height = ta.scrollHeight + 'px'; }, 0);
+            var del = document.createElement('button');
+            del.className = 'delete-sticky'; del.innerHTML = '&times;';
+            del.addEventListener('click', function() { data[s].splice(i, 1); save(); render(); });
+            sticky.appendChild(ta); sticky.appendChild(del);
+            container.appendChild(sticky);
+        });
+        var addBtn = document.createElement('button');
+        addBtn.className = 'add-sticky'; addBtn.textContent = '+ Add';
+        addBtn.addEventListener('click', function() {
+            data[s].push(''); save(); render();
+            var notes = container.querySelectorAll('.sticky textarea');
+            if (notes.length) notes[notes.length - 1].focus();
+        });
+        container.appendChild(addBtn);
+    });
+}
+
+function clearAll() {
+    if (!confirm('Clear all notes?')) return;
+    data = { persona: '', thinks: [], feels: [], says: [], does: [], pains: [], gains: [] };
+    document.getElementById('personaName').value = '';
+    document.getElementById('avatar').textContent = '?';
+    save(); render();
+}
+
+function loadExample() {
+    data = {
+        persona: 'Priya — Community Health Worker in rural Rajasthan',
+        thinks: ['Will I get paid on time this month?', 'Am I giving the right advice?', 'I want my community to see me as a professional'],
+        feels: ['Pride in helping families', 'Anxious about handling complications', 'Frustrated by lack of supplies', 'Isolated from support network'],
+        says: ['"The families trust me more than the clinic"', '"I need more training on nutrition"', '"The data forms take too long to fill"'],
+        does: ['Walks 5km daily to visit households', 'Tracks pregnancies on paper registers', 'Refers complicated cases to PHC', 'Attends monthly meetings at block office'],
+        pains: ['Delayed salary payments', 'No smartphone for digital reporting', 'Limited medical knowledge for edge cases', 'Low recognition from health system'],
+        gains: ['Consistent income and benefits', 'Digital tools that save time', 'Advanced training and certification', 'Career progression pathway']
+    };
+    document.getElementById('personaName').value = data.persona;
+    document.getElementById('avatar').textContent = 'P';
+    save(); render();
+}
+
+function exportToJSON() {
+    if (!requirePremium()) return; // building is free, exporting is Premium
+    var blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+    var a = document.createElement('a'); a.href = URL.createObjectURL(blob);
+    a.download = 'empathy-map.json'; a.click();
+}
+
+function printTemplate() {
+    if (!requirePremium()) return; // building is free, exporting is Premium
+    window.print();
+}
+
+function toggleDarkMode() {
+    document.body.classList.toggle('dark-mode');
+    localStorage.setItem('impactmojo_dark', document.body.classList.contains('dark-mode'));
+}
+if (localStorage.getItem('impactmojo_dark') === 'true') document.body.classList.add('dark-mode');
+init();
+</script>
+
+<!-- ImpactMojo auth + premium (Pro Studio freemium gate) -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
+<script src="/js/premium.js"></script>
+<script>
+// Pro Studio freemium: building is free for everyone; exporting is Premium.
+// The whole builder above is always visible — no sign-in wall to use it.
+window.TOOL_PREMIUM = false;
+var TOOL_TIER = 'professional';
+async function initGate() {
+  try { if (window.ImpactMojoAuth) await window.ImpactMojoAuth.waitForAuthReady(); } catch (e) {}
+  var auth = window.ImpactMojoAuth;
+  window.TOOL_PREMIUM = !!(auth && typeof auth.hasTierAccess === 'function' && auth.hasTierAccess(TOOL_TIER));
+}
+// Gate a Premium action (export/print). Free users get the upgrade path.
+function requirePremium() {
+  if (window.TOOL_PREMIUM) return true;
+  if (window.IMXPremium && typeof window.IMXPremium.showUpgradeModal === 'function') window.IMXPremium.showUpgradeModal(TOOL_TIER);
+  else window.location.href = '/premium.html#detail-' + TOOL_TIER;
+  return false;
+}
+if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initGate);
+else initGate();
+</script>
+</body>
+</html>

--- a/premium-tools/logframe-pro.html
+++ b/premium-tools/logframe-pro.html
@@ -1,0 +1,442 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Logical Framework Builder — free logframe tool | ImpactMojo</title>
+<meta name="description" content="Interactive Logical Framework Matrix builder for development programs. Free to build — exporting is a Premium feature.">
+<link href="/assets/images/favicon.png" rel="icon" type="image/png">
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+:root {
+    --primary-bg: #FFFFFF; --secondary-bg: #F8FAFC; --accent-color: #0EA5E9;
+    --accent-hover: #0284C7; --text-primary: #0F172A; --text-secondary: #475569;
+    --card-bg: #FFFFFF; --border-color: #E2E8F0; --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+}
+body.dark-mode {
+    --primary-bg: #0F172A; --secondary-bg: #1E293B; --text-primary: #F1F5F9;
+    --text-secondary: #94A3B8; --card-bg: #1E293B; --border-color: #334155;
+}
+body { font-family: 'Amaranth', sans-serif; background: var(--primary-bg); color: var(--text-primary); }
+
+.header {
+    background: rgba(255,255,255,0.95); backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--border-color); padding: 1rem 2rem;
+    position: sticky; top: 0; z-index: 100; display: flex; align-items: center; justify-content: space-between;
+}
+body.dark-mode .header { background: rgba(15,23,42,0.95); }
+.header h1 { font-family: 'Inter', sans-serif; font-size: 1.25rem; }
+.btn { padding: 0.5rem 1rem; border-radius: 8px; border: 1px solid var(--border-color); background: var(--card-bg); color: var(--text-primary); cursor: pointer; font-size: 0.85rem; font-family: inherit; transition: all 0.2s; }
+.btn:hover { border-color: var(--accent-color); }
+.btn-primary { background: var(--accent-color); color: white; border-color: var(--accent-color); }
+.btn-primary:hover { background: var(--accent-hover); }
+
+.container { padding: 2rem; max-width: 1200px; margin: 0 auto; }
+
+.instructions {
+    background: var(--secondary-bg); border: 1px solid var(--border-color); border-radius: 10px;
+    padding: 1.25rem; margin-bottom: 1.5rem; font-size: 0.85rem; color: var(--text-secondary);
+}
+.instructions strong { color: var(--text-primary); }
+
+.project-bar {
+    background: var(--card-bg); border: 1px solid var(--border-color); border-radius: 10px;
+    padding: 1rem; margin-bottom: 1.5rem; display: flex; gap: 1rem; flex-wrap: wrap;
+}
+.project-bar input {
+    flex: 1; min-width: 180px; padding: 0.6rem; border: 1px solid var(--border-color); border-radius: 6px;
+    background: var(--primary-bg); color: var(--text-primary); font-family: inherit; font-size: 0.9rem;
+}
+
+.logframe-table {
+    width: 100%; border-collapse: collapse; border: 2px solid var(--border-color);
+    border-radius: 12px; overflow: hidden;
+}
+.logframe-table thead th {
+    background: var(--accent-color); color: white; padding: 0.75rem;
+    font-family: 'Inter', sans-serif; font-size: 0.82rem; font-weight: 700;
+    text-align: left; border: 1px solid rgba(255,255,255,0.2);
+}
+.logframe-table thead th:first-child { width: 18%; }
+.logframe-table thead th:nth-child(2) { width: 28%; }
+.logframe-table thead th:nth-child(3) { width: 28%; }
+.logframe-table thead th:nth-child(4) { width: 26%; }
+
+.level-header {
+    font-family: 'Inter', sans-serif; font-weight: 700; font-size: 0.82rem;
+    padding: 0.6rem 0.75rem; white-space: nowrap; vertical-align: top;
+}
+.level-goal { background: rgba(16,185,129,0.08); color: #059669; border-left: 4px solid #10B981; }
+.level-purpose { background: rgba(99,102,241,0.08); color: #4F46E5; border-left: 4px solid #6366F1; }
+.level-outputs { background: rgba(245,158,11,0.08); color: #D97706; border-left: 4px solid #F59E0B; }
+.level-activities { background: rgba(236,72,153,0.08); color: #DB2777; border-left: 4px solid #EC4899; }
+
+.logframe-table td {
+    padding: 0.5rem; border: 1px solid var(--border-color); vertical-align: top;
+}
+.logframe-table textarea {
+    width: 100%; border: none; background: transparent; color: var(--text-primary);
+    font-family: inherit; font-size: 0.82rem; resize: none; outline: none; line-height: 1.5;
+    min-height: 60px;
+}
+.logframe-table textarea:focus {
+    background: rgba(245,158,11,0.04); border-radius: 4px;
+}
+.logframe-table textarea::placeholder { color: var(--text-secondary); opacity: 0.6; }
+
+.add-output-row {
+    margin-top: 1rem; display: flex; gap: 0.5rem;
+}
+
+.quality-checklist {
+    background: var(--card-bg); border: 1px solid var(--border-color); border-radius: 10px;
+    padding: 1.25rem; margin-top: 1.5rem;
+}
+.quality-checklist h3 { font-family: 'Inter', sans-serif; font-size: 0.95rem; margin-bottom: 0.75rem; }
+.checklist-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem; }
+.check-item {
+    display: flex; align-items: flex-start; gap: 0.5rem; font-size: 0.82rem; padding: 0.4rem;
+    border-radius: 6px; cursor: pointer; transition: background 0.2s;
+}
+.check-item:hover { background: var(--secondary-bg); }
+.check-item input[type="checkbox"] { margin-top: 2px; accent-color: var(--accent-color); flex-shrink: 0; }
+.check-item.checked { color: var(--text-secondary); text-decoration: line-through; }
+.progress-bar-outer {
+    height: 8px; background: var(--secondary-bg); border-radius: 4px; margin-top: 1rem; overflow: hidden;
+}
+.progress-bar-inner { height: 100%; background: var(--accent-color); border-radius: 4px; transition: width 0.3s; }
+
+@media (max-width: 768px) {
+    .logframe-table { font-size: 0.78rem; }
+    .logframe-table thead th { font-size: 0.75rem; padding: 0.5rem; }
+    .checklist-grid { grid-template-columns: 1fr; }
+}
+@media print {
+    .header, .instructions, .add-output-row, .quality-checklist { display: none !important; }
+    .logframe-table textarea { border: none; min-height: auto; }
+}
+
+/* ── Pro Studio branding + freemium ─────────────────────────── */
+.header { flex-wrap: wrap; gap: 0.75rem; }
+.header-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+.header-brand { display: flex; align-items: center; gap: 0.5rem; text-decoration: none; color: var(--text-primary); }
+.header-brand img { width: 30px; height: 30px; border-radius: 6px; }
+.header-brand .brand-name { font-family: 'Inter', sans-serif; font-weight: 700; font-size: 1rem; }
+.tool-name { font-family: 'Inter', sans-serif; font-size: 1.05rem; font-weight: 600; padding-left: 0.75rem; border-left: 2px solid var(--border-color); }
+.pro-pill { display: inline-flex; align-items: center; gap: 0.2rem; background: linear-gradient(135deg,#F59E0B,#EF4444); color: #fff; font-weight: 700; font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.4px; padding: 0.15rem 0.45rem; border-radius: 5px; white-space: nowrap; }
+.freemium-note { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 1.5rem; padding: 0.6rem 0.9rem; background: rgba(245,158,11,0.08); border: 1px solid rgba(245,158,11,0.3); border-radius: 8px; font-size: 0.82rem; color: var(--text-secondary); }
+.freemium-note a { color: #F59E0B; font-weight: 700; text-decoration: none; }
+.freemium-note a:hover { text-decoration: underline; }
+@media (max-width: 640px) { .tool-name { font-size: 0.9rem; padding-left: 0.5rem; } .header-brand .brand-name { display: none; } }
+@media print { .freemium-note { display: none !important; } }
+</style>
+</head>
+<body>
+
+<div class="header">
+    <div style="display:flex; align-items:center; gap:0.75rem; flex-wrap:wrap;">
+        <a class="header-brand" href="/" title="ImpactMojo home">
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="30" height="30">
+            <span class="brand-name">ImpactMojo</span>
+        </a>
+        <h1 class="tool-name">Logical Framework Builder</h1>
+    </div>
+    <div class="header-actions">
+        <button class="btn" onclick="toggleDarkMode()" title="Toggle dark mode" aria-label="Toggle dark mode">&#9790;</button>
+        <button class="btn" onclick="clearAll()">Clear All</button>
+        <button class="btn" onclick="loadExample()">Load Example</button>
+        <button class="btn btn-primary" onclick="exportToJSON()">Export <span class="pro-pill">&#9733; Premium</span></button>
+        <button class="btn btn-primary" onclick="printTemplate()">Print <span class="pro-pill">&#9733; Premium</span></button>
+    </div>
+</div>
+
+<div class="container">
+    <div class="instructions">
+        <strong>Logical Framework (Logframe):</strong> A 4-level results chain matrix linking your <em>Goal</em> (impact), <em>Purpose</em> (outcome), <em>Outputs</em> (deliverables), and <em>Activities</em> — each with indicators, means of verification, and assumptions. Type directly into cells. Add more output rows as needed.
+    </div>
+
+    <div class="freemium-note">
+        <span class="pro-pill">&#9733; Premium</span>
+        <span>Building is free. Exporting is a Premium feature. <a href="/premium.html#detail-professional">Upgrade to Professional &rarr;</a></span>
+    </div>
+
+    <div class="project-bar">
+        <input type="text" id="projectTitle" placeholder="Project / Program title" data-field="projectTitle">
+        <input type="text" id="donor" placeholder="Donor / Funder" data-field="donor">
+        <input type="text" id="period" placeholder="Period (e.g., 2026-2029)" data-field="period">
+    </div>
+
+    <table class="logframe-table">
+        <thead>
+            <tr>
+                <th>Results Level</th>
+                <th>Narrative Summary</th>
+                <th>Indicators &amp; Targets</th>
+                <th>Means of Verification</th>
+                <th style="width:20%;">Assumptions</th>
+            </tr>
+        </thead>
+        <tbody id="logframeBody">
+        </tbody>
+    </table>
+
+    <div class="add-output-row">
+        <button class="btn" onclick="addOutputRow()">+ Add Output Row</button>
+        <button class="btn" onclick="addActivityRow()">+ Add Activity Row</button>
+    </div>
+
+    <div class="quality-checklist">
+        <h3>Logframe Quality Checklist</h3>
+        <div class="checklist-grid" id="checklist"></div>
+        <div class="progress-bar-outer"><div class="progress-bar-inner" id="progressBar" style="width:0%"></div></div>
+    </div>
+</div>
+
+<script>
+var STORAGE_KEY = 'impactmojo_logframe';
+var LEVELS = ['goal', 'purpose'];
+var data = { meta: {}, rows: [], checklist: {} };
+var outputCount = 1;
+var activityCount = 1;
+
+var CHECKLIST_ITEMS = [
+    'Goal clearly states the long-term impact',
+    'Purpose is a single, measurable outcome',
+    'Each output is a concrete deliverable',
+    'Activities are sufficient to produce outputs',
+    'Indicators are SMART (Specific, Measurable, Achievable, Relevant, Time-bound)',
+    'Indicators include disaggregation (gender, geography, age)',
+    'Means of verification are realistic and affordable',
+    'Assumptions are external factors beyond your control',
+    'Logic flows vertically: if activities → then outputs → then purpose → then goal',
+    'No missing links in the causal chain'
+];
+
+function init() {
+    var saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) { try { data = JSON.parse(saved); } catch(e) { data = { meta: {}, rows: [], checklist: {} }; } }
+
+    ['projectTitle', 'donor', 'period'].forEach(function(f) {
+        var el = document.getElementById(f);
+        el.value = data.meta[f] || '';
+        el.addEventListener('input', function() { data.meta[f] = this.value; save(); });
+    });
+
+    if (!data.rows || !data.rows.length) {
+        data.rows = [
+            { level: 'goal', levelLabel: 'Goal (Impact)', levelClass: 'level-goal', narrative: '', indicators: '', verification: '', assumptions: '' },
+            { level: 'purpose', levelLabel: 'Purpose (Outcome)', levelClass: 'level-purpose', narrative: '', indicators: '', verification: '', assumptions: '' },
+            { level: 'output', levelLabel: 'Output 1', levelClass: 'level-outputs', narrative: '', indicators: '', verification: '', assumptions: '' },
+            { level: 'activity', levelLabel: 'Activities for Output 1', levelClass: 'level-activities', narrative: '', indicators: '', verification: '', assumptions: '' }
+        ];
+    }
+    outputCount = data.rows.filter(function(r) { return r.level === 'output'; }).length;
+    activityCount = data.rows.filter(function(r) { return r.level === 'activity'; }).length;
+
+    renderTable();
+    renderChecklist();
+}
+
+function save() { localStorage.setItem(STORAGE_KEY, JSON.stringify(data)); }
+
+function renderTable() {
+    var tbody = document.getElementById('logframeBody');
+    tbody.innerHTML = '';
+    data.rows.forEach(function(row, i) {
+        var tr = document.createElement('tr');
+        // Level cell
+        var levelTd = document.createElement('td');
+        levelTd.className = 'level-header ' + row.levelClass;
+        levelTd.textContent = row.levelLabel;
+        if (row.level === 'output' || row.level === 'activity') {
+            var delBtn = document.createElement('button');
+            delBtn.style.cssText = 'display:block; margin-top:4px; background:none; border:none; color:inherit; opacity:0.5; cursor:pointer; font-size:0.7rem;';
+            delBtn.textContent = 'remove';
+            delBtn.addEventListener('click', (function(idx) {
+                return function() { data.rows.splice(idx, 1); save(); renderTable(); };
+            })(i));
+            levelTd.appendChild(delBtn);
+        }
+        tr.appendChild(levelTd);
+
+        ['narrative', 'indicators', 'verification', 'assumptions'].forEach(function(field) {
+            var td = document.createElement('td');
+            var ta = document.createElement('textarea');
+            ta.value = row[field] || '';
+            ta.placeholder = getPlaceholder(row.level, field);
+            ta.addEventListener('input', (function(idx, f) {
+                return function() {
+                    this.style.height = 'auto'; this.style.height = this.scrollHeight + 'px';
+                    data.rows[idx][f] = this.value; save();
+                };
+            })(i, field));
+            setTimeout(function() { ta.style.height = ta.scrollHeight + 'px'; }, 0);
+            td.appendChild(ta);
+            tr.appendChild(td);
+        });
+        tbody.appendChild(tr);
+    });
+}
+
+function getPlaceholder(level, field) {
+    var p = {
+        goal: { narrative: 'The long-term change this project contributes to...', indicators: 'e.g., Under-5 mortality rate in target districts', verification: 'e.g., DHS survey, government health statistics', assumptions: 'e.g., National health policy remains supportive' },
+        purpose: { narrative: 'The specific outcome this project will achieve...', indicators: 'e.g., % of target households using improved practices', verification: 'e.g., Endline survey, program monitoring data', assumptions: 'e.g., No major drought or conflict disrupts services' },
+        output: { narrative: 'A concrete deliverable the project will produce...', indicators: 'e.g., # of health workers trained and certified', verification: 'e.g., Training records, certification database', assumptions: 'e.g., Trainees are released by their facilities' },
+        activity: { narrative: 'Key activities needed to produce this output...', indicators: 'e.g., Budget: $50K | Timeline: Q1-Q2 2026', verification: 'e.g., Financial reports, activity logs', assumptions: 'e.g., Procurement timelines met' }
+    };
+    return (p[level] && p[level][field]) || '';
+}
+
+function addOutputRow() {
+    outputCount++;
+    var insertIdx = -1;
+    for (var i = data.rows.length - 1; i >= 0; i--) {
+        if (data.rows[i].level === 'activity' || data.rows[i].level === 'output') { insertIdx = i + 1; break; }
+    }
+    if (insertIdx === -1) insertIdx = data.rows.length;
+    data.rows.splice(insertIdx, 0,
+        { level: 'output', levelLabel: 'Output ' + outputCount, levelClass: 'level-outputs', narrative: '', indicators: '', verification: '', assumptions: '' }
+    );
+    save(); renderTable();
+}
+
+function addActivityRow() {
+    activityCount++;
+    data.rows.push(
+        { level: 'activity', levelLabel: 'Activities ' + activityCount, levelClass: 'level-activities', narrative: '', indicators: '', verification: '', assumptions: '' }
+    );
+    save(); renderTable();
+}
+
+function renderChecklist() {
+    var container = document.getElementById('checklist');
+    container.innerHTML = '';
+    CHECKLIST_ITEMS.forEach(function(item, i) {
+        var div = document.createElement('div');
+        div.className = 'check-item' + (data.checklist[i] ? ' checked' : '');
+        var cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.checked = !!data.checklist[i];
+        cb.addEventListener('change', function() {
+            data.checklist[i] = this.checked;
+            div.className = 'check-item' + (this.checked ? ' checked' : '');
+            save(); updateProgress();
+        });
+        var label = document.createElement('span');
+        label.textContent = item;
+        div.appendChild(cb); div.appendChild(label);
+        div.addEventListener('click', function(e) { if (e.target !== cb) cb.click(); });
+        container.appendChild(div);
+    });
+    updateProgress();
+}
+
+function updateProgress() {
+    var total = CHECKLIST_ITEMS.length;
+    var checked = Object.keys(data.checklist).filter(function(k) { return data.checklist[k]; }).length;
+    document.getElementById('progressBar').style.width = ((checked / total) * 100) + '%';
+}
+
+function clearAll() {
+    if (!confirm('Clear entire logframe?')) return;
+    data = { meta: {}, rows: [], checklist: {} };
+    localStorage.removeItem(STORAGE_KEY);
+    ['projectTitle', 'donor', 'period'].forEach(function(f) { document.getElementById(f).value = ''; });
+    outputCount = 1; activityCount = 1;
+    init();
+}
+
+function loadExample() {
+    data = {
+        meta: { projectTitle: 'Community Health Strengthening Program', donor: 'USAID', period: '2026–2029' },
+        rows: [
+            { level: 'goal', levelLabel: 'Goal (Impact)', levelClass: 'level-goal',
+              narrative: 'Reduced under-5 mortality and improved maternal health outcomes in 5 target districts of Rajasthan',
+              indicators: 'Under-5 mortality rate reduced from 45 to 30 per 1,000 live births by 2029\nMaternal mortality ratio reduced by 25%',
+              verification: 'District Health Information System (DHIS2)\nNational Family Health Survey (NFHS)\nAnnual health statistics report',
+              assumptions: 'Government continues prioritizing primary healthcare\nNo major disease outbreaks disrupt baseline trends' },
+            { level: 'purpose', levelLabel: 'Purpose (Outcome)', levelClass: 'level-purpose',
+              narrative: 'Target communities adopt improved health-seeking behaviors and access quality primary healthcare services',
+              indicators: '80% of pregnant women complete 4+ ANC visits (baseline: 52%)\n70% of children fully immunized (baseline: 48%)\n60% of households practice recommended WASH behaviors',
+              verification: 'Endline household survey (n=2,000)\nFacility registers and HMIS data\nCommunity health worker monthly reports',
+              assumptions: 'Health facilities remain staffed and supplied\nCommunity leaders continue supporting health messaging' },
+            { level: 'output', levelLabel: 'Output 1', levelClass: 'level-outputs',
+              narrative: '200 community health workers trained, equipped, and providing regular household visits',
+              indicators: '200 CHWs complete 10-day training and pass competency assessment\n95% of CHWs conduct minimum 20 household visits/month\n90% retention rate at 12 months',
+              verification: 'Training attendance records and assessment scores\nCHW monthly activity reports (digital)\nQuarterly supervision visit reports',
+              assumptions: 'District health office approves CHW deployment plan\nCHW incentive payments disbursed on time' },
+            { level: 'output', levelLabel: 'Output 2', levelClass: 'level-outputs',
+              narrative: '10 primary health centers upgraded with essential equipment, drugs, and trained staff',
+              indicators: '10 PHCs meet Indian Public Health Standards (IPHS) minimum requirements\n100% stock availability of 20 essential medicines\n8/10 PHCs offer 24/7 delivery services',
+              verification: 'Facility assessment tool (quarterly)\nDrug stock monitoring system\nPHC utilization data from HMIS',
+              assumptions: 'Government provides matching staff positions\nSupply chain disruptions are manageable' },
+            { level: 'activity', levelLabel: 'Activities for Output 1', levelClass: 'level-activities',
+              narrative: '1.1 Recruit CHWs from target communities (criteria: female, literate, resident)\n1.2 Conduct 10-day residential training program (3 batches)\n1.3 Distribute CHW kits (weighing scale, thermometer, mobile phone, register)\n1.4 Implement monthly supportive supervision system\n1.5 Establish CHW peer support groups (monthly meetings)',
+              indicators: 'Budget: $180,000 | Timeline: Q1–Q3 2026\nTraining cost: $400/CHW | Kits: $150/CHW\nSupervision: $2,000/month ongoing',
+              verification: 'Financial reports (quarterly)\nProcurement records\nTraining evaluation forms\nSupervision visit logs',
+              assumptions: 'Qualified candidates available in each village\nTraining venue and logistics secured on time' },
+            { level: 'activity', levelLabel: 'Activities for Output 2', levelClass: 'level-activities',
+              narrative: '2.1 Conduct baseline facility assessments\n2.2 Procure and install medical equipment\n2.3 Train PHC staff on emergency obstetric care\n2.4 Establish drug supply chain management system\n2.5 Set up community feedback mechanism at each PHC',
+              indicators: 'Budget: $320,000 | Timeline: Q1–Q4 2026\nEquipment: $25K/facility | Training: $5K/facility',
+              verification: 'Procurement documentation\nEquipment installation certificates\nStaff training records\nDrug inventory reports',
+              assumptions: 'Government approves facility renovation plans\nEquipment vendors deliver on schedule' }
+        ],
+        checklist: { 0: true, 1: true, 2: true, 3: true, 4: true, 5: true, 6: true, 7: true, 8: true, 9: true }
+    };
+    ['projectTitle', 'donor', 'period'].forEach(function(f) { document.getElementById(f).value = data.meta[f] || ''; });
+    save();
+    outputCount = data.rows.filter(function(r) { return r.level === 'output'; }).length;
+    activityCount = data.rows.filter(function(r) { return r.level === 'activity'; }).length;
+    renderTable(); renderChecklist();
+}
+
+function exportToJSON() {
+    if (!requirePremium()) return; // building is free, exporting is Premium
+    var blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+    var a = document.createElement('a'); a.href = URL.createObjectURL(blob);
+    a.download = 'logframe.json'; a.click();
+}
+
+function printTemplate() {
+    if (!requirePremium()) return; // building is free, exporting is Premium
+    window.print();
+}
+
+function toggleDarkMode() {
+    document.body.classList.toggle('dark-mode');
+    localStorage.setItem('impactmojo_dark', document.body.classList.contains('dark-mode'));
+}
+if (localStorage.getItem('impactmojo_dark') === 'true') document.body.classList.add('dark-mode');
+init();
+</script>
+
+<!-- ImpactMojo auth + premium (Pro Studio freemium gate) -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
+<script src="/js/premium.js"></script>
+<script>
+// Pro Studio freemium: building is free for everyone; exporting is Premium.
+// The whole builder above is always visible — no sign-in wall to use it.
+window.TOOL_PREMIUM = false;
+var TOOL_TIER = 'professional';
+async function initGate() {
+  try { if (window.ImpactMojoAuth) await window.ImpactMojoAuth.waitForAuthReady(); } catch (e) {}
+  var auth = window.ImpactMojoAuth;
+  window.TOOL_PREMIUM = !!(auth && typeof auth.hasTierAccess === 'function' && auth.hasTierAccess(TOOL_TIER));
+}
+// Gate a Premium action (export/print). Free users get the upgrade path.
+function requirePremium() {
+  if (window.TOOL_PREMIUM) return true;
+  if (window.IMXPremium && typeof window.IMXPremium.showUpgradeModal === 'function') window.IMXPremium.showUpgradeModal(TOOL_TIER);
+  else window.location.href = '/premium.html#detail-' + TOOL_TIER;
+  return false;
+}
+if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initGate);
+else initGate();
+</script>
+</body>
+</html>

--- a/premium-tools/logframe-pro.html
+++ b/premium-tools/logframe-pro.html
@@ -130,6 +130,195 @@ body.dark-mode .header { background: rgba(15,23,42,0.95); }
 .freemium-note a:hover { text-decoration: underline; }
 @media (max-width: 640px) { .tool-name { font-size: 0.9rem; padding-left: 0.5rem; } .header-brand .brand-name { display: none; } }
 @media print { .freemium-note { display: none !important; } }
+
+/* ===== ImpactMojo Design System ===== */
+:root {
+    --im-primary-bg: #0F172A;
+    --im-secondary-bg: #1E293B;
+    --im-accent: #0EA5E9;
+    --im-accent-hover: #0284C7;
+    --im-secondary-accent: #6366F1;
+    --im-success: #10B981;
+    --im-text-primary: #F1F5F9;
+    --im-text-secondary: #94A3B8;
+    --im-text-muted: #64748B;
+    --im-card-bg: #1E293B;
+    --im-hover-bg: #334155;
+    --im-border: #334155;
+    --im-nav-bg: rgba(15, 23, 42, 0.95);
+    --im-gradient: linear-gradient(135deg, #0EA5E9 0%, #6366F1 100%);
+}
+[data-theme="light"] {
+    --im-primary-bg: #F8FAFC;
+    --im-secondary-bg: #FFFFFF;
+    --im-accent: #0369A1;
+    --im-accent-hover: #0369A1;
+    --im-text-primary: #0F172A;
+    --im-text-secondary: #475569;
+    --im-text-muted: #64748B;
+    --im-card-bg: #FFFFFF;
+    --im-hover-bg: #F1F5F9;
+    --im-border: #E2E8F0;
+    --im-nav-bg: rgba(248, 250, 252, 0.95);
+}
+
+/* ImpactMojo Top Bar */
+.im-topbar {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 9999;
+    background: var(--im-nav-bg, rgba(15, 23, 42, 0.95));
+    backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px);
+    border-bottom: 1px solid var(--im-border, #334155);
+    padding: 0.5rem 1rem;
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 0.75rem; flex-wrap: wrap;
+    font-family: 'Inter', sans-serif;
+}
+.im-topbar a { text-decoration: none; }
+.im-topbar-left {
+    display: flex; align-items: center; gap: 0.75rem;
+}
+.im-topbar-home {
+    display: flex; align-items: center; gap: 0.5rem;
+    color: var(--im-text-primary, #F1F5F9);
+    font-weight: 700; font-size: 1rem;
+    background: var(--im-gradient);
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+.im-topbar-home svg { width: 24px; height: 24px; flex-shrink: 0; }
+.im-topbar-right {
+    display: flex; align-items: center; gap: 0.5rem;
+}
+.im-premium-btn {
+    background: var(--im-gradient);
+    color: #fff !important;
+    padding: 0.35rem 0.85rem;
+    border-radius: 6px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    display: flex; align-items: center; gap: 0.35rem;
+    transition: opacity 0.2s;
+    -webkit-text-fill-color: #fff;
+}
+.im-browse-btn { display: inline-flex; align-items: center; gap: 0.4rem; font-family: 'Inter', sans-serif; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: var(--im-text, #1C1917); background: var(--im-surface, #FFFFFF); border: 1.5px solid var(--im-border, #E2E8F0); padding: 0.5rem 1rem; border-radius: 0.5rem; text-decoration: none; transition: background 0.18s ease, border-color 0.18s ease, transform 0.15s ease, box-shadow 0.18s ease; }
+.im-browse-btn:hover { background: var(--im-accent, #0EA5E9); color: #FFFFFF; border-color: var(--im-accent, #0EA5E9); transform: translateY(-1px); box-shadow: 0 4px 12px rgba(14, 165, 233, 0.25); }
+.im-browse-btn svg { width: 14px; height: 14px; }
+@media (prefers-color-scheme: dark) { .im-browse-btn { color: rgba(255,255,255,0.9); background: rgba(255,255,255,0.05); border-color: rgba(255,255,255,0.18); } .im-browse-btn:hover { background: var(--im-accent, #0EA5E9); border-color: var(--im-accent, #0EA5E9); color: #FFFFFF; } }
+.im-premium-btn:hover { opacity: 0.9; }
+.im-premium-btn svg { width: 14px; height: 14px; }
+
+/* Theme Selector - 3 mode */
+.im-theme-selector {
+    display: flex; gap: 2px;
+    background: var(--im-card-bg, #1E293B);
+    border: 1px solid var(--im-border, #334155);
+    border-radius: 8px; padding: 2px;
+}
+.im-theme-btn {
+    background: transparent; border: none;
+    color: var(--im-text-secondary, #94A3B8);
+    padding: 6px; border-radius: 5px; cursor: pointer;
+    transition: all 0.2s; display: flex; align-items: center;
+    justify-content: center; width: 30px; height: 30px;
+}
+.im-theme-btn:hover {
+    background: var(--im-hover-bg, #334155);
+    color: var(--im-text-primary, #F1F5F9);
+}
+.im-theme-btn.active {
+    background: var(--im-accent, #0EA5E9);
+    color: #fff;
+}
+.im-theme-btn svg { width: 16px; height: 16px; }
+
+/* Paper Plane */
+.im-paper-plane {
+    position: fixed; top: 15%; right: 8%;
+    width: 120px; height: 120px;
+    opacity: 0.15; z-index: 0;
+    pointer-events: none;
+    animation: im-fly 25s ease-in-out infinite;
+}
+[data-theme="light"] .im-paper-plane { opacity: 0.2; }
+@keyframes im-fly {
+    0%, 100% { transform: translate(0, 0) rotate(0deg); }
+    20% { transform: translate(60px, -40px) rotate(12deg); }
+    40% { transform: translate(120px, 30px) rotate(-8deg); }
+    60% { transform: translate(40px, 60px) rotate(15deg); }
+    80% { transform: translate(-30px, 20px) rotate(-5deg); }
+}
+
+/* ImpactMojo Footer */
+.im-footer {
+    background: var(--im-secondary-bg, #1E293B);
+    border-top: 1px solid var(--im-border, #334155);
+    padding: 2rem 1rem; margin-top: auto;
+    font-family: 'Inter', sans-serif;
+    color: var(--im-text-secondary, #94A3B8);
+}
+.im-footer-content {
+    max-width: 1100px; margin: 0 auto;
+}
+.im-footer-made {
+    text-align: center; margin-bottom: 1.5rem;
+    font-size: 0.9rem; color: var(--im-text-muted, #64748B);
+}
+.im-footer-made a { color: var(--im-accent, #0EA5E9); }
+.im-footer-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.5rem; margin-bottom: 1.5rem;
+}
+.im-footer-section h4 {
+    font-family: 'Inter', sans-serif;
+    color: var(--im-text-primary, #F1F5F9);
+    font-size: 0.9rem; margin-bottom: 0.75rem;
+    font-weight: 600;
+}
+.im-footer-section ul { list-style: none; padding: 0; margin: 0; }
+.im-footer-section li { margin-bottom: 0.4rem; }
+.im-footer-section a {
+    color: var(--im-text-secondary, #94A3B8);
+    text-decoration: none; font-size: 0.85rem;
+    transition: color 0.2s;
+}
+.im-footer-section a:hover { color: var(--im-accent, #0EA5E9); }
+.im-footer-bottom {
+    text-align: center; padding-top: 1rem;
+    border-top: 1px solid var(--im-border, #334155);
+    font-size: 0.8rem; color: var(--im-text-muted, #64748B);
+}
+.im-footer-bottom p { margin: 0.25rem 0; }
+.im-footer-bottom a { color: var(--im-accent, #0EA5E9); text-decoration: none; }
+
+/* Mobile Responsive */
+@media (max-width: 768px) {
+    .im-topbar { padding: 0.4rem 0.75rem; gap: 0.5rem; }
+    .im-topbar-home { font-size: 0.85rem; }
+    .im-topbar-home svg { width: 20px; height: 20px; }
+    .im-premium-btn { padding: 0.3rem 0.6rem; font-size: 0.75rem; }
+    .im-theme-btn { width: 26px; height: 26px; padding: 4px; }
+    .im-theme-btn svg { width: 14px; height: 14px; }
+    .im-paper-plane { width: 80px; height: 80px; top: 10%; right: 5%; }
+    .im-footer-grid { grid-template-columns: repeat(2, 1fr); gap: 1rem; }
+}
+@media (max-width: 480px) {
+    .im-footer-grid { grid-template-columns: 1fr; }
+    .im-topbar-home span { display: none; }
+}
+
+/* ImpactMojo Global Font Overrides */
+body { font-family: 'Amaranth', sans-serif !important; }
+h1, h2, h3, h4, h5, h6 { font-family: 'Inter', sans-serif !important; }
+code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !important; }
+
+/* WCAG 2.1 AA (1.4.1 Use of Color): inline anchors in content paragraphs must be distinguishable without relying on color alone. Scoped to <main> so nav/footer button-links are unaffected. */
+main p a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]),
+main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) {
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+}
+
 </style>
 </head>
 <body>
@@ -143,7 +332,15 @@ body.dark-mode .header { background: rgba(15,23,42,0.95); }
         <h1 class="tool-name">Logical Framework Builder</h1>
     </div>
     <div class="header-actions">
-        <button class="btn" onclick="toggleDarkMode()" title="Toggle dark mode" aria-label="Toggle dark mode">&#9790;</button>
+        <a class="im-premium-btn" href="../premium.html" title="Go Premium">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+            Premium
+        </a>
+        <div class="im-theme-selector" aria-label="Theme selection">
+            <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="Use system theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
+            <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Use light theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg></button>
+            <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Use dark theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+        </div>
         <button class="btn" onclick="clearAll()">Clear All</button>
         <button class="btn" onclick="loadExample()">Load Example</button>
         <button class="btn btn-primary" onclick="exportToJSON()">Export <span class="pro-pill">&#9733; Premium</span></button>
@@ -408,7 +605,7 @@ function toggleDarkMode() {
     document.body.classList.toggle('dark-mode');
     localStorage.setItem('impactmojo_dark', document.body.classList.contains('dark-mode'));
 }
-if (localStorage.getItem('impactmojo_dark') === 'true') document.body.classList.add('dark-mode');
+/* theming handled by /js/theme.js (canonical im-theme controller) */
 init();
 </script>
 
@@ -438,5 +635,66 @@ function requirePremium() {
 if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initGate);
 else initGate();
 </script>
+
+<!-- ImpactMojo Paper Plane -->
+<svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M80,130 L150,50" stroke="#10B981" stroke-width="2" stroke-dasharray="4,4"/>
+    <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+    <circle cx="40" cy="155" r="2" fill="#0EA5E9" opacity="0.6"/>
+    <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
+    <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
+</svg>
+<!-- ImpactMojo Footer -->
+<footer class="im-footer" role="contentinfo">
+<div class="im-footer-content">
+<p class="im-footer-made">Made with &#10084; by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+<div class="im-footer-grid">
+<div class="im-footer-section">
+<h4>About ImpactMojo</h4>
+<ul>
+<li><a href="../about.html">About Us</a></li>
+<li><a href="../contact.html">Contact</a></li>
+<li><a href="https://github.com/ImpactMojo/ImpactMojo" rel="noopener noreferrer" target="_blank">GitHub</a></li>
+<li><a href="../transparency.html">Transparency</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Legal</h4>
+<ul>
+<li><a href="../privacy-policy.html">Privacy Policy</a></li>
+<li><a href="../terms-of-service.html">Terms of Service</a></li>
+<li><a href="../disclaimer.html">Disclaimer</a></li>
+<li><a href="../data-protection.html">Data Protection</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Quick Links</h4>
+<ul>
+<li><a href="../catalog.html">All Courses</a></li>
+<li><a href="../premium.html">Premium Content</a></li>
+<li><a href="../coaching.html">Coaching</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Resources</h4>
+<ul>
+<li><a href="../handouts.html">Handouts</a></li>
+<li><a href="../blog.html">Blog</a></li>
+<li><a href="../faq.html">FAQ</a></li>
+<li><a href="../sitemap.html">Sitemap</a></li>
+<li><a href="/docs/" rel="noopener noreferrer" target="_blank">Documentation</a></li>
+</ul>
+</div>
+</div>
+<div class="im-footer-bottom">
+<p>&copy; 2026 ImpactMojo. All content for educational purposes only.</p>
+<p>Released under <strong>MIT License</strong> | Supported by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+</div>
+</div>
+</footer>
+<!-- ImpactMojo canonical theme controller + translation -->
+<script src="/js/theme.js"></script>
+<script src="/js/translate-sarvam.js" defer></script>
 </body>
 </html>

--- a/premium-tools/policy-canvas-pro.html
+++ b/premium-tools/policy-canvas-pro.html
@@ -126,6 +126,195 @@ body.dark-mode .header { background: rgba(15,23,42,0.95); }
 .freemium-note a:hover { text-decoration: underline; }
 @media (max-width: 640px) { .tool-name { font-size: 0.9rem; padding-left: 0.5rem; } .header-brand .brand-name { display: none; } }
 @media print { .freemium-note { display: none !important; } }
+
+/* ===== ImpactMojo Design System ===== */
+:root {
+    --im-primary-bg: #0F172A;
+    --im-secondary-bg: #1E293B;
+    --im-accent: #0EA5E9;
+    --im-accent-hover: #0284C7;
+    --im-secondary-accent: #6366F1;
+    --im-success: #10B981;
+    --im-text-primary: #F1F5F9;
+    --im-text-secondary: #94A3B8;
+    --im-text-muted: #64748B;
+    --im-card-bg: #1E293B;
+    --im-hover-bg: #334155;
+    --im-border: #334155;
+    --im-nav-bg: rgba(15, 23, 42, 0.95);
+    --im-gradient: linear-gradient(135deg, #0EA5E9 0%, #6366F1 100%);
+}
+[data-theme="light"] {
+    --im-primary-bg: #F8FAFC;
+    --im-secondary-bg: #FFFFFF;
+    --im-accent: #0369A1;
+    --im-accent-hover: #0369A1;
+    --im-text-primary: #0F172A;
+    --im-text-secondary: #475569;
+    --im-text-muted: #64748B;
+    --im-card-bg: #FFFFFF;
+    --im-hover-bg: #F1F5F9;
+    --im-border: #E2E8F0;
+    --im-nav-bg: rgba(248, 250, 252, 0.95);
+}
+
+/* ImpactMojo Top Bar */
+.im-topbar {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 9999;
+    background: var(--im-nav-bg, rgba(15, 23, 42, 0.95));
+    backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px);
+    border-bottom: 1px solid var(--im-border, #334155);
+    padding: 0.5rem 1rem;
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 0.75rem; flex-wrap: wrap;
+    font-family: 'Inter', sans-serif;
+}
+.im-topbar a { text-decoration: none; }
+.im-topbar-left {
+    display: flex; align-items: center; gap: 0.75rem;
+}
+.im-topbar-home {
+    display: flex; align-items: center; gap: 0.5rem;
+    color: var(--im-text-primary, #F1F5F9);
+    font-weight: 700; font-size: 1rem;
+    background: var(--im-gradient);
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+.im-topbar-home svg { width: 24px; height: 24px; flex-shrink: 0; }
+.im-topbar-right {
+    display: flex; align-items: center; gap: 0.5rem;
+}
+.im-premium-btn {
+    background: var(--im-gradient);
+    color: #fff !important;
+    padding: 0.35rem 0.85rem;
+    border-radius: 6px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    display: flex; align-items: center; gap: 0.35rem;
+    transition: opacity 0.2s;
+    -webkit-text-fill-color: #fff;
+}
+.im-browse-btn { display: inline-flex; align-items: center; gap: 0.4rem; font-family: 'Inter', sans-serif; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: var(--im-text, #1C1917); background: var(--im-surface, #FFFFFF); border: 1.5px solid var(--im-border, #E2E8F0); padding: 0.5rem 1rem; border-radius: 0.5rem; text-decoration: none; transition: background 0.18s ease, border-color 0.18s ease, transform 0.15s ease, box-shadow 0.18s ease; }
+.im-browse-btn:hover { background: var(--im-accent, #0EA5E9); color: #FFFFFF; border-color: var(--im-accent, #0EA5E9); transform: translateY(-1px); box-shadow: 0 4px 12px rgba(14, 165, 233, 0.25); }
+.im-browse-btn svg { width: 14px; height: 14px; }
+@media (prefers-color-scheme: dark) { .im-browse-btn { color: rgba(255,255,255,0.9); background: rgba(255,255,255,0.05); border-color: rgba(255,255,255,0.18); } .im-browse-btn:hover { background: var(--im-accent, #0EA5E9); border-color: var(--im-accent, #0EA5E9); color: #FFFFFF; } }
+.im-premium-btn:hover { opacity: 0.9; }
+.im-premium-btn svg { width: 14px; height: 14px; }
+
+/* Theme Selector - 3 mode */
+.im-theme-selector {
+    display: flex; gap: 2px;
+    background: var(--im-card-bg, #1E293B);
+    border: 1px solid var(--im-border, #334155);
+    border-radius: 8px; padding: 2px;
+}
+.im-theme-btn {
+    background: transparent; border: none;
+    color: var(--im-text-secondary, #94A3B8);
+    padding: 6px; border-radius: 5px; cursor: pointer;
+    transition: all 0.2s; display: flex; align-items: center;
+    justify-content: center; width: 30px; height: 30px;
+}
+.im-theme-btn:hover {
+    background: var(--im-hover-bg, #334155);
+    color: var(--im-text-primary, #F1F5F9);
+}
+.im-theme-btn.active {
+    background: var(--im-accent, #0EA5E9);
+    color: #fff;
+}
+.im-theme-btn svg { width: 16px; height: 16px; }
+
+/* Paper Plane */
+.im-paper-plane {
+    position: fixed; top: 15%; right: 8%;
+    width: 120px; height: 120px;
+    opacity: 0.15; z-index: 0;
+    pointer-events: none;
+    animation: im-fly 25s ease-in-out infinite;
+}
+[data-theme="light"] .im-paper-plane { opacity: 0.2; }
+@keyframes im-fly {
+    0%, 100% { transform: translate(0, 0) rotate(0deg); }
+    20% { transform: translate(60px, -40px) rotate(12deg); }
+    40% { transform: translate(120px, 30px) rotate(-8deg); }
+    60% { transform: translate(40px, 60px) rotate(15deg); }
+    80% { transform: translate(-30px, 20px) rotate(-5deg); }
+}
+
+/* ImpactMojo Footer */
+.im-footer {
+    background: var(--im-secondary-bg, #1E293B);
+    border-top: 1px solid var(--im-border, #334155);
+    padding: 2rem 1rem; margin-top: auto;
+    font-family: 'Inter', sans-serif;
+    color: var(--im-text-secondary, #94A3B8);
+}
+.im-footer-content {
+    max-width: 1100px; margin: 0 auto;
+}
+.im-footer-made {
+    text-align: center; margin-bottom: 1.5rem;
+    font-size: 0.9rem; color: var(--im-text-muted, #64748B);
+}
+.im-footer-made a { color: var(--im-accent, #0EA5E9); }
+.im-footer-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.5rem; margin-bottom: 1.5rem;
+}
+.im-footer-section h4 {
+    font-family: 'Inter', sans-serif;
+    color: var(--im-text-primary, #F1F5F9);
+    font-size: 0.9rem; margin-bottom: 0.75rem;
+    font-weight: 600;
+}
+.im-footer-section ul { list-style: none; padding: 0; margin: 0; }
+.im-footer-section li { margin-bottom: 0.4rem; }
+.im-footer-section a {
+    color: var(--im-text-secondary, #94A3B8);
+    text-decoration: none; font-size: 0.85rem;
+    transition: color 0.2s;
+}
+.im-footer-section a:hover { color: var(--im-accent, #0EA5E9); }
+.im-footer-bottom {
+    text-align: center; padding-top: 1rem;
+    border-top: 1px solid var(--im-border, #334155);
+    font-size: 0.8rem; color: var(--im-text-muted, #64748B);
+}
+.im-footer-bottom p { margin: 0.25rem 0; }
+.im-footer-bottom a { color: var(--im-accent, #0EA5E9); text-decoration: none; }
+
+/* Mobile Responsive */
+@media (max-width: 768px) {
+    .im-topbar { padding: 0.4rem 0.75rem; gap: 0.5rem; }
+    .im-topbar-home { font-size: 0.85rem; }
+    .im-topbar-home svg { width: 20px; height: 20px; }
+    .im-premium-btn { padding: 0.3rem 0.6rem; font-size: 0.75rem; }
+    .im-theme-btn { width: 26px; height: 26px; padding: 4px; }
+    .im-theme-btn svg { width: 14px; height: 14px; }
+    .im-paper-plane { width: 80px; height: 80px; top: 10%; right: 5%; }
+    .im-footer-grid { grid-template-columns: repeat(2, 1fr); gap: 1rem; }
+}
+@media (max-width: 480px) {
+    .im-footer-grid { grid-template-columns: 1fr; }
+    .im-topbar-home span { display: none; }
+}
+
+/* ImpactMojo Global Font Overrides */
+body { font-family: 'Amaranth', sans-serif !important; }
+h1, h2, h3, h4, h5, h6 { font-family: 'Inter', sans-serif !important; }
+code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !important; }
+
+/* WCAG 2.1 AA (1.4.1 Use of Color): inline anchors in content paragraphs must be distinguishable without relying on color alone. Scoped to <main> so nav/footer button-links are unaffected. */
+main p a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]),
+main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) {
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+}
+
 </style>
 </head>
 <body>
@@ -139,7 +328,15 @@ body.dark-mode .header { background: rgba(15,23,42,0.95); }
         <h1 class="tool-name">Policy Analysis Canvas</h1>
     </div>
     <div class="header-actions">
-        <button class="btn" onclick="toggleDarkMode()" title="Toggle dark mode" aria-label="Toggle dark mode">&#9790;</button>
+        <a class="im-premium-btn" href="../premium.html" title="Go Premium">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+            Premium
+        </a>
+        <div class="im-theme-selector" aria-label="Theme selection">
+            <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="Use system theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
+            <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Use light theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg></button>
+            <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Use dark theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+        </div>
         <button class="btn" onclick="clearAll()">Clear All</button>
         <button class="btn" onclick="loadExample()">Load Example</button>
         <button class="btn btn-primary" onclick="exportToJSON()">Export <span class="pro-pill">&#9733; Premium</span></button>
@@ -345,7 +542,7 @@ function toggleDarkMode() {
     document.body.classList.toggle('dark-mode');
     localStorage.setItem('impactmojo_dark', document.body.classList.contains('dark-mode'));
 }
-if (localStorage.getItem('impactmojo_dark') === 'true') document.body.classList.add('dark-mode');
+/* theming handled by /js/theme.js (canonical im-theme controller) */
 init();
 </script>
 
@@ -375,5 +572,66 @@ function requirePremium() {
 if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initGate);
 else initGate();
 </script>
+
+<!-- ImpactMojo Paper Plane -->
+<svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M80,130 L150,50" stroke="#10B981" stroke-width="2" stroke-dasharray="4,4"/>
+    <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+    <circle cx="40" cy="155" r="2" fill="#0EA5E9" opacity="0.6"/>
+    <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
+    <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
+</svg>
+<!-- ImpactMojo Footer -->
+<footer class="im-footer" role="contentinfo">
+<div class="im-footer-content">
+<p class="im-footer-made">Made with &#10084; by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+<div class="im-footer-grid">
+<div class="im-footer-section">
+<h4>About ImpactMojo</h4>
+<ul>
+<li><a href="../about.html">About Us</a></li>
+<li><a href="../contact.html">Contact</a></li>
+<li><a href="https://github.com/ImpactMojo/ImpactMojo" rel="noopener noreferrer" target="_blank">GitHub</a></li>
+<li><a href="../transparency.html">Transparency</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Legal</h4>
+<ul>
+<li><a href="../privacy-policy.html">Privacy Policy</a></li>
+<li><a href="../terms-of-service.html">Terms of Service</a></li>
+<li><a href="../disclaimer.html">Disclaimer</a></li>
+<li><a href="../data-protection.html">Data Protection</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Quick Links</h4>
+<ul>
+<li><a href="../catalog.html">All Courses</a></li>
+<li><a href="../premium.html">Premium Content</a></li>
+<li><a href="../coaching.html">Coaching</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Resources</h4>
+<ul>
+<li><a href="../handouts.html">Handouts</a></li>
+<li><a href="../blog.html">Blog</a></li>
+<li><a href="../faq.html">FAQ</a></li>
+<li><a href="../sitemap.html">Sitemap</a></li>
+<li><a href="/docs/" rel="noopener noreferrer" target="_blank">Documentation</a></li>
+</ul>
+</div>
+</div>
+<div class="im-footer-bottom">
+<p>&copy; 2026 ImpactMojo. All content for educational purposes only.</p>
+<p>Released under <strong>MIT License</strong> | Supported by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+</div>
+</div>
+</footer>
+<!-- ImpactMojo canonical theme controller + translation -->
+<script src="/js/theme.js"></script>
+<script src="/js/translate-sarvam.js" defer></script>
 </body>
 </html>

--- a/premium-tools/policy-canvas-pro.html
+++ b/premium-tools/policy-canvas-pro.html
@@ -1,0 +1,379 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Policy Analysis Canvas — free policy tool | ImpactMojo</title>
+<meta name="description" content="Structured canvas for analyzing public policy — problem framing, stakeholders, options, and recommendations. Free to build — exporting is a Premium feature.">
+<link href="/assets/images/favicon.png" rel="icon" type="image/png">
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+:root {
+    --primary-bg: #FFFFFF; --secondary-bg: #F8FAFC; --accent-color: #0EA5E9;
+    --accent-hover: #0284C7; --text-primary: #0F172A; --text-secondary: #475569;
+    --card-bg: #FFFFFF; --border-color: #E2E8F0; --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+}
+body.dark-mode {
+    --primary-bg: #0F172A; --secondary-bg: #1E293B; --text-primary: #F1F5F9;
+    --text-secondary: #94A3B8; --card-bg: #1E293B; --border-color: #334155;
+}
+body { font-family: 'Amaranth', sans-serif; background: var(--primary-bg); color: var(--text-primary); }
+
+.header {
+    background: rgba(255,255,255,0.95); backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--border-color); padding: 1rem 2rem;
+    position: sticky; top: 0; z-index: 100; display: flex; align-items: center; justify-content: space-between;
+}
+body.dark-mode .header { background: rgba(15,23,42,0.95); }
+.header h1 { font-family: 'Inter', sans-serif; font-size: 1.25rem; }
+.btn { padding: 0.5rem 1rem; border-radius: 8px; border: 1px solid var(--border-color); background: var(--card-bg); color: var(--text-primary); cursor: pointer; font-size: 0.85rem; font-family: inherit; transition: all 0.2s; }
+.btn:hover { border-color: var(--accent-color); }
+.btn-primary { background: var(--accent-color); color: white; border-color: var(--accent-color); }
+
+.container { padding: 2rem; max-width: 1100px; margin: 0 auto; }
+
+.instructions {
+    background: var(--secondary-bg); border: 1px solid var(--border-color); border-radius: 10px;
+    padding: 1.25rem; margin-bottom: 1.5rem; font-size: 0.85rem; color: var(--text-secondary);
+}
+.instructions strong { color: var(--text-primary); }
+
+.policy-bar {
+    background: var(--card-bg); border: 1px solid var(--border-color); border-radius: 10px;
+    padding: 1rem; margin-bottom: 1.5rem; display: flex; gap: 1rem; flex-wrap: wrap;
+}
+.policy-bar input {
+    flex: 1; min-width: 180px; padding: 0.6rem; border: 1px solid var(--border-color); border-radius: 6px;
+    background: var(--primary-bg); color: var(--text-primary); font-family: inherit; font-size: 0.9rem;
+}
+
+.canvas-grid {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 0;
+    border: 2px solid var(--border-color); border-radius: 12px; overflow: hidden;
+}
+.canvas-section {
+    padding: 1rem; border: 1px solid var(--border-color); min-height: 160px;
+}
+.canvas-section.full-width { grid-column: 1 / -1; }
+
+.section-header {
+    display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.25rem;
+}
+.section-num {
+    width: 22px; height: 22px; border-radius: 50%; color: white;
+    font-size: 0.7rem; font-weight: 700; display: flex; align-items: center;
+    justify-content: center; flex-shrink: 0;
+}
+.num-purple { background: #8B5CF6; }
+.num-blue { background: #3B82F6; }
+.num-amber { background: #F59E0B; }
+.num-green { background: #10B981; }
+.num-red { background: #EF4444; }
+.num-indigo { background: #6366F1; }
+
+.section-title { font-family: 'Inter', sans-serif; font-size: 0.85rem; font-weight: 700; }
+.section-prompt { font-size: 0.75rem; color: var(--text-secondary); margin-bottom: 0.5rem; }
+
+.note-area {
+    width: 100%; min-height: 80px; border: 1px solid var(--border-color); border-radius: 6px;
+    padding: 0.5rem; background: var(--secondary-bg); color: var(--text-primary);
+    font-family: inherit; font-size: 0.82rem; resize: vertical; outline: none; line-height: 1.5;
+}
+.note-area:focus { border-color: var(--accent-color); }
+
+/* Options comparison table */
+.options-table {
+    width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.82rem;
+}
+.options-table th {
+    background: var(--secondary-bg); padding: 0.5rem; text-align: left;
+    font-weight: 600; border: 1px solid var(--border-color); font-size: 0.78rem;
+}
+.options-table td {
+    padding: 0.25rem; border: 1px solid var(--border-color);
+}
+.options-table textarea {
+    width: 100%; border: none; background: transparent; color: var(--text-primary);
+    font-family: inherit; font-size: 0.8rem; resize: none; outline: none; min-height: 36px; line-height: 1.4;
+}
+.options-table textarea:focus { background: rgba(245,158,11,0.04); }
+.add-option-btn {
+    margin-top: 0.5rem; padding: 0.4rem 0.75rem; border: 2px dashed var(--border-color);
+    border-radius: 6px; background: transparent; color: var(--text-secondary); cursor: pointer;
+    font-size: 0.78rem; font-family: inherit; transition: all 0.2s;
+}
+.add-option-btn:hover { border-color: var(--accent-color); color: var(--accent-color); }
+
+@media (max-width: 768px) {
+    .canvas-grid { grid-template-columns: 1fr; }
+    .canvas-section.full-width { grid-column: 1; }
+}
+@media print {
+    .header, .instructions { display: none !important; }
+}
+
+/* ── Pro Studio branding + freemium ─────────────────────────── */
+.header { flex-wrap: wrap; gap: 0.75rem; }
+.header-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+.header-brand { display: flex; align-items: center; gap: 0.5rem; text-decoration: none; color: var(--text-primary); }
+.header-brand img { width: 30px; height: 30px; border-radius: 6px; }
+.header-brand .brand-name { font-family: 'Inter', sans-serif; font-weight: 700; font-size: 1rem; }
+.tool-name { font-family: 'Inter', sans-serif; font-size: 1.05rem; font-weight: 600; padding-left: 0.75rem; border-left: 2px solid var(--border-color); }
+.pro-pill { display: inline-flex; align-items: center; gap: 0.2rem; background: linear-gradient(135deg,#F59E0B,#EF4444); color: #fff; font-weight: 700; font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.4px; padding: 0.15rem 0.45rem; border-radius: 5px; white-space: nowrap; }
+.freemium-note { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 1.5rem; padding: 0.6rem 0.9rem; background: rgba(245,158,11,0.08); border: 1px solid rgba(245,158,11,0.3); border-radius: 8px; font-size: 0.82rem; color: var(--text-secondary); }
+.freemium-note a { color: #F59E0B; font-weight: 700; text-decoration: none; }
+.freemium-note a:hover { text-decoration: underline; }
+@media (max-width: 640px) { .tool-name { font-size: 0.9rem; padding-left: 0.5rem; } .header-brand .brand-name { display: none; } }
+@media print { .freemium-note { display: none !important; } }
+</style>
+</head>
+<body>
+
+<div class="header">
+    <div style="display:flex; align-items:center; gap:0.75rem; flex-wrap:wrap;">
+        <a class="header-brand" href="/" title="ImpactMojo home">
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="30" height="30">
+            <span class="brand-name">ImpactMojo</span>
+        </a>
+        <h1 class="tool-name">Policy Analysis Canvas</h1>
+    </div>
+    <div class="header-actions">
+        <button class="btn" onclick="toggleDarkMode()" title="Toggle dark mode" aria-label="Toggle dark mode">&#9790;</button>
+        <button class="btn" onclick="clearAll()">Clear All</button>
+        <button class="btn" onclick="loadExample()">Load Example</button>
+        <button class="btn btn-primary" onclick="exportToJSON()">Export <span class="pro-pill">&#9733; Premium</span></button>
+        <button class="btn btn-primary" onclick="printTemplate()">Print <span class="pro-pill">&#9733; Premium</span></button>
+    </div>
+</div>
+
+<div class="container">
+    <div class="instructions">
+        <strong>Policy Analysis Canvas:</strong> Work through this structured framework to analyze a public policy issue. Start with the problem, map stakeholders and political dynamics, generate and compare options, then formulate a recommendation with implementation strategy.
+    </div>
+
+    <div class="freemium-note">
+        <span class="pro-pill">&#9733; Premium</span>
+        <span>Building is free. Exporting is a Premium feature. <a href="/premium.html#detail-professional">Upgrade to Professional &rarr;</a></span>
+    </div>
+
+    <div class="policy-bar">
+        <input type="text" id="policyTitle" placeholder="Policy issue or question" data-field="policyTitle">
+        <input type="text" id="jurisdiction" placeholder="Jurisdiction (e.g., India, Bihar)" data-field="jurisdiction">
+        <input type="text" id="analysisDate" placeholder="Date" data-field="analysisDate">
+    </div>
+
+    <div class="canvas-grid" id="canvasGrid"></div>
+
+    <div class="canvas-section full-width" style="border:2px solid var(--border-color); border-radius:12px; margin-top:1.5rem;">
+        <div class="section-header"><span class="section-num num-amber">7</span><span class="section-title">Policy Options Comparison</span></div>
+        <div class="section-prompt">Compare 2-4 policy options across key criteria</div>
+        <table class="options-table" id="optionsTable">
+            <thead>
+                <tr>
+                    <th style="width:18%;">Criteria</th>
+                    <th id="opt-h-0">Option 1</th>
+                    <th id="opt-h-1">Option 2</th>
+                    <th id="opt-h-2">Option 3</th>
+                </tr>
+            </thead>
+            <tbody id="optionsBody"></tbody>
+        </table>
+        <button class="add-option-btn" onclick="addOptionColumn()">+ Add Option</button>
+    </div>
+</div>
+
+<script>
+var STORAGE_KEY = 'impactmojo_policy_canvas';
+var SECTIONS = [
+    { id: 'problem', num: 1, numClass: 'num-purple', title: 'Problem Definition', prompt: 'What is the policy problem? Who is affected? What is the scale and urgency? What happens if nothing changes?', width: 'full-width' },
+    { id: 'context', num: 2, numClass: 'num-blue', title: 'Context & Background', prompt: 'Historical context, existing policies, legal framework, recent developments. What has been tried before?', width: '' },
+    { id: 'stakeholders', num: 3, numClass: 'num-indigo', title: 'Stakeholder Landscape', prompt: 'Who are the key actors? What are their positions, interests, and power? Who supports/opposes change?', width: '' },
+    { id: 'political', num: 4, numClass: 'num-red', title: 'Political Economy', prompt: 'What are the political incentives and constraints? Electoral dynamics? Bureaucratic capacity? Veto players?', width: '' },
+    { id: 'evidence', num: 5, numClass: 'num-green', title: 'Evidence Base', prompt: 'What does the evidence say? Key data, research findings, international comparisons, case studies?', width: '' },
+    { id: 'equity', num: 6, numClass: 'num-purple', title: 'Equity & Rights', prompt: 'Who benefits and who bears costs? Gender, caste, class dimensions? Constitutional rights implications?', width: 'full-width' },
+    { id: 'recommendation', num: 8, numClass: 'num-green', title: 'Recommendation', prompt: 'Which option do you recommend and why? What are the key trade-offs acknowledged?', width: '' },
+    { id: 'implementation', num: 9, numClass: 'num-amber', title: 'Implementation Strategy', prompt: 'Sequencing, quick wins, coalition building, institutional requirements, monitoring plan?', width: '' },
+    { id: 'risks', num: 10, numClass: 'num-red', title: 'Risks & Mitigation', prompt: 'What could go wrong? Unintended consequences? Political backlash? How to mitigate each risk?', width: 'full-width' }
+];
+
+var CRITERIA = ['Effectiveness', 'Cost / Budget', 'Political Feasibility', 'Equity Impact', 'Administrative Feasibility', 'Sustainability'];
+
+var data = { meta: {}, sections: {}, options: { headers: ['Option 1', 'Option 2', 'Option 3'], cells: {} } };
+
+function init() {
+    var saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) { try { data = JSON.parse(saved); } catch(e) { data = { meta: {}, sections: {}, options: { headers: ['Option 1', 'Option 2', 'Option 3'], cells: {} } }; } }
+    if (!data.options) data.options = { headers: ['Option 1', 'Option 2', 'Option 3'], cells: {} };
+    if (!data.sections) data.sections = {};
+    if (!data.meta) data.meta = {};
+
+    ['policyTitle', 'jurisdiction', 'analysisDate'].forEach(function(f) {
+        var el = document.getElementById(f);
+        el.value = data.meta[f] || '';
+        el.addEventListener('input', function() { data.meta[f] = this.value; save(); });
+    });
+
+    renderCanvas();
+    renderOptions();
+}
+
+function save() { localStorage.setItem(STORAGE_KEY, JSON.stringify(data)); }
+
+function renderCanvas() {
+    var grid = document.getElementById('canvasGrid');
+    grid.innerHTML = '';
+    SECTIONS.forEach(function(s) {
+        var section = document.createElement('div');
+        section.className = 'canvas-section' + (s.width === 'full-width' ? ' full-width' : '');
+        section.innerHTML = '<div class="section-header"><span class="section-num ' + s.numClass + '">' + s.num + '</span><span class="section-title">' + s.title + '</span></div><div class="section-prompt">' + s.prompt + '</div>';
+        var ta = document.createElement('textarea');
+        ta.className = 'note-area';
+        ta.value = data.sections[s.id] || '';
+        ta.addEventListener('input', function() { data.sections[s.id] = this.value; save(); });
+        section.appendChild(ta);
+        grid.appendChild(section);
+    });
+}
+
+function renderOptions() {
+    var headers = data.options.headers || ['Option 1', 'Option 2', 'Option 3'];
+    // Update header row
+    var headerRow = document.querySelector('#optionsTable thead tr');
+    headerRow.innerHTML = '<th style="width:18%;">Criteria</th>';
+    headers.forEach(function(h, i) {
+        var th = document.createElement('th');
+        var inp = document.createElement('input');
+        inp.type = 'text'; inp.value = h;
+        inp.style.cssText = 'border:none; background:transparent; font-weight:600; font-size:0.78rem; width:100%; color:var(--text-primary); font-family:inherit;';
+        inp.addEventListener('input', function() { data.options.headers[i] = this.value; save(); });
+        th.appendChild(inp);
+        headerRow.appendChild(th);
+    });
+
+    var tbody = document.getElementById('optionsBody');
+    tbody.innerHTML = '';
+    CRITERIA.forEach(function(criterion) {
+        var tr = document.createElement('tr');
+        var labelTd = document.createElement('td');
+        labelTd.style.fontWeight = '500';
+        labelTd.textContent = criterion;
+        tr.appendChild(labelTd);
+        headers.forEach(function(h, i) {
+            var td = document.createElement('td');
+            var ta = document.createElement('textarea');
+            var key = criterion + '_' + i;
+            ta.value = data.options.cells[key] || '';
+            ta.placeholder = 'Assess...';
+            ta.addEventListener('input', function() { data.options.cells[key] = this.value; save(); });
+            td.appendChild(ta);
+            tr.appendChild(td);
+        });
+        tbody.appendChild(tr);
+    });
+}
+
+function addOptionColumn() {
+    if (data.options.headers.length >= 5) return;
+    data.options.headers.push('Option ' + (data.options.headers.length + 1));
+    save(); renderOptions();
+}
+
+function clearAll() {
+    if (!confirm('Clear entire canvas?')) return;
+    data = { meta: {}, sections: {}, options: { headers: ['Option 1', 'Option 2', 'Option 3'], cells: {} } };
+    localStorage.removeItem(STORAGE_KEY);
+    ['policyTitle', 'jurisdiction', 'analysisDate'].forEach(function(f) { document.getElementById(f).value = ''; });
+    renderCanvas(); renderOptions();
+}
+
+function loadExample() {
+    data = {
+        meta: { policyTitle: 'Should India implement Universal Basic Income (UBI)?', jurisdiction: 'India (National)', analysisDate: '2026-03-16' },
+        sections: {
+            problem: 'India\'s social protection system is fragmented across 950+ schemes with significant exclusion errors. Despite economic growth, ~230 million people remain below the poverty line. Current targeted transfers miss ~40% of intended beneficiaries (Drèze & Khera, 2017). Administrative costs of means-testing and beneficiary identification consume 15-20% of program budgets.',
+            context: 'India has a patchwork of transfer programs: PDS (food), MGNREGA (employment guarantee), PM-KISAN (farmer income support), old-age pensions, etc. The Jan Dhan–Aadhaar–Mobile (JAM) trinity has created infrastructure for direct benefit transfers to 500M+ accounts. The 2017 Economic Survey (Vol. 1, Ch. 9) explored UBI as a policy option. Several states have piloted cash transfers (MP UBI pilot by SEWA, Odisha KALIA scheme).',
+            stakeholders: 'Supporters: Economists (Jean Drèze wing vs. Arvind Subramanian wing disagree on design), tech companies (digital payments), progressive think tanks\nOpponents: State bureaucracies (lose discretion), PDS lobby (food distributors, FCI), fiscal conservatives\nAmbivalent: Finance Ministry (cost concerns but simplification appeal), state governments (lose scheme-level control)\nBeneficiaries: Urban informal workers (strongly favor), rural landless (favor but worried about PDS loss)',
+            political: 'Pre-election promise potential (Rahul Gandhi proposed NYAY in 2019). But: "replacing" PDS is politically toxic in most states. Bureaucratic resistance — UBI threatens the administrative empire of welfare delivery. States with strong PDS (Tamil Nadu, Kerala) will resist. Fiscal hawks in NITI Aayog and RBI concerned about inflation. Best window: first year of a new government mandate.',
+            evidence: 'Madhya Pradesh pilot (2011-13): reduced poverty, improved nutrition, increased economic activity, no increase in alcohol/tobacco spending. Finland pilot (2017-18): improved wellbeing and employment confidence, minimal labor supply reduction. Kenya GiveDirectly: significant positive effects on consumption and assets. Meta-analysis of 165 studies (Banerjee et al., 2019): cash transfers do NOT reduce labor supply.',
+            equity: 'Universal design avoids exclusion errors that disproportionately affect SC/ST, women, and disabled populations. However, flat per-capita transfer is regressive compared to needs-based targeting. Gender: direct transfers to women\'s accounts could improve intra-household bargaining power (evidence from Jan Dhan). Risk: replacing in-kind transfers (PDS food) could hurt food security in remote areas where markets are thin.',
+            recommendation: 'Phased approach: Start with a "quasi-universal" basic income replacing 3-4 of the most leaky schemes (not PDS), targeted at bottom 60% of population identified via SECC data. Set at ₹1,500/person/month (below poverty line but meaningful). Use JAM infrastructure for delivery. Run for 3 years with rigorous evaluation before deciding on full universalization. Estimated cost: 2.8% of GDP.',
+            implementation: 'Phase 1 (Year 1): Pilot in 50 districts across 10 states — deliberately choose diverse contexts\nPhase 2 (Year 2-3): Scale to all districts, consolidating 3 overlapping schemes\nPhase 3 (Year 4+): Evaluate and decide on universalization and PDS integration\nQuick win: Start with urban informal workers (no PDS access anyway, easy JAM enrollment)\nCoalition: Partner with state governments offering "top-up" flexibility',
+            risks: '1. Fiscal sustainability — mitigate with phased approach and scheme consolidation savings\n2. Inflation in local markets — monitor CPI in pilot districts, adjust transfer amount\n3. PDS lobby blocks reform — mitigate by NOT touching PDS initially\n4. Exclusion of digitally disconnected — maintain physical enrollment options, partner with CSOs\n5. Political capture — independent monitoring, social audits, RTI transparency'
+        },
+        options: {
+            headers: ['Full UBI (Universal)', 'Quasi-Universal (Bottom 60%)', 'UBI-Lite (Top-up existing)'],
+            cells: {
+                'Effectiveness_0': 'Eliminates all exclusion errors. Simplest design.',
+                'Effectiveness_1': 'Reaches most poor. Some exclusion errors remain at margins.',
+                'Effectiveness_2': 'Incremental improvement. Doesn\'t solve fragmentation.',
+                'Cost / Budget_0': '~5% of GDP. Requires major tax reform or deficit spending.',
+                'Cost / Budget_1': '~2.8% of GDP. Feasible with scheme consolidation.',
+                'Cost / Budget_2': '~1.2% of GDP. Affordable within current fiscal space.',
+                'Political Feasibility_0': 'Low. "Giving money to the rich" criticism. Fiscal hawks oppose.',
+                'Political Feasibility_1': 'Medium. Popular with target group. Fiscal concerns manageable.',
+                'Political Feasibility_2': 'High. No disruption to existing schemes. Easy sell.',
+                'Equity Impact_0': 'Regressive in relative terms (rich get same as poor). But eliminates exclusion.',
+                'Equity Impact_1': 'Progressive. Concentrates on bottom 60%. Risk of boundary effects.',
+                'Equity Impact_2': 'Neutral. Doesn\'t change the fundamental targeting problems.',
+                'Administrative Feasibility_0': 'Paradoxically simple — no targeting needed. JAM ready.',
+                'Administrative Feasibility_1': 'Moderate — needs updated SECC data for targeting.',
+                'Administrative Feasibility_2': 'Easy — builds on existing infrastructure.',
+                'Sustainability_0': 'Politically hard to sustain if fiscal stress. But hard to remove once universal.',
+                'Sustainability_1': 'Good balance of cost and political buy-in. Expandable.',
+                'Sustainability_2': 'Sustainable but doesn\'t solve underlying problems.'
+            }
+        }
+    };
+    ['policyTitle', 'jurisdiction', 'analysisDate'].forEach(function(f) { document.getElementById(f).value = data.meta[f] || ''; });
+    save(); renderCanvas(); renderOptions();
+}
+
+function exportToJSON() {
+    if (!requirePremium()) return; // building is free, exporting is Premium
+    var blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+    var a = document.createElement('a'); a.href = URL.createObjectURL(blob);
+    a.download = 'policy-analysis.json'; a.click();
+}
+
+function printTemplate() {
+    if (!requirePremium()) return; // building is free, exporting is Premium
+    window.print();
+}
+
+function toggleDarkMode() {
+    document.body.classList.toggle('dark-mode');
+    localStorage.setItem('impactmojo_dark', document.body.classList.contains('dark-mode'));
+}
+if (localStorage.getItem('impactmojo_dark') === 'true') document.body.classList.add('dark-mode');
+init();
+</script>
+
+<!-- ImpactMojo auth + premium (Pro Studio freemium gate) -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
+<script src="/js/premium.js"></script>
+<script>
+// Pro Studio freemium: building is free for everyone; exporting is Premium.
+// The whole builder above is always visible — no sign-in wall to use it.
+window.TOOL_PREMIUM = false;
+var TOOL_TIER = 'professional';
+async function initGate() {
+  try { if (window.ImpactMojoAuth) await window.ImpactMojoAuth.waitForAuthReady(); } catch (e) {}
+  var auth = window.ImpactMojoAuth;
+  window.TOOL_PREMIUM = !!(auth && typeof auth.hasTierAccess === 'function' && auth.hasTierAccess(TOOL_TIER));
+}
+// Gate a Premium action (export/print). Free users get the upgrade path.
+function requirePremium() {
+  if (window.TOOL_PREMIUM) return true;
+  if (window.IMXPremium && typeof window.IMXPremium.showUpgradeModal === 'function') window.IMXPremium.showUpgradeModal(TOOL_TIER);
+  else window.location.href = '/premium.html#detail-' + TOOL_TIER;
+  return false;
+}
+if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initGate);
+else initGate();
+</script>
+</body>
+</html>

--- a/premium-tools/stakeholder-pro.html
+++ b/premium-tools/stakeholder-pro.html
@@ -151,6 +151,195 @@ body.dark-mode .header { background: rgba(15,23,42,0.95); }
 .freemium-note a:hover { text-decoration: underline; }
 @media (max-width: 640px) { .tool-name { font-size: 0.9rem; padding-left: 0.5rem; } .header-brand .brand-name { display: none; } }
 @media print { .freemium-note { display: none !important; } }
+
+/* ===== ImpactMojo Design System ===== */
+:root {
+    --im-primary-bg: #0F172A;
+    --im-secondary-bg: #1E293B;
+    --im-accent: #0EA5E9;
+    --im-accent-hover: #0284C7;
+    --im-secondary-accent: #6366F1;
+    --im-success: #10B981;
+    --im-text-primary: #F1F5F9;
+    --im-text-secondary: #94A3B8;
+    --im-text-muted: #64748B;
+    --im-card-bg: #1E293B;
+    --im-hover-bg: #334155;
+    --im-border: #334155;
+    --im-nav-bg: rgba(15, 23, 42, 0.95);
+    --im-gradient: linear-gradient(135deg, #0EA5E9 0%, #6366F1 100%);
+}
+[data-theme="light"] {
+    --im-primary-bg: #F8FAFC;
+    --im-secondary-bg: #FFFFFF;
+    --im-accent: #0369A1;
+    --im-accent-hover: #0369A1;
+    --im-text-primary: #0F172A;
+    --im-text-secondary: #475569;
+    --im-text-muted: #64748B;
+    --im-card-bg: #FFFFFF;
+    --im-hover-bg: #F1F5F9;
+    --im-border: #E2E8F0;
+    --im-nav-bg: rgba(248, 250, 252, 0.95);
+}
+
+/* ImpactMojo Top Bar */
+.im-topbar {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 9999;
+    background: var(--im-nav-bg, rgba(15, 23, 42, 0.95));
+    backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px);
+    border-bottom: 1px solid var(--im-border, #334155);
+    padding: 0.5rem 1rem;
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 0.75rem; flex-wrap: wrap;
+    font-family: 'Inter', sans-serif;
+}
+.im-topbar a { text-decoration: none; }
+.im-topbar-left {
+    display: flex; align-items: center; gap: 0.75rem;
+}
+.im-topbar-home {
+    display: flex; align-items: center; gap: 0.5rem;
+    color: var(--im-text-primary, #F1F5F9);
+    font-weight: 700; font-size: 1rem;
+    background: var(--im-gradient);
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+.im-topbar-home svg { width: 24px; height: 24px; flex-shrink: 0; }
+.im-topbar-right {
+    display: flex; align-items: center; gap: 0.5rem;
+}
+.im-premium-btn {
+    background: var(--im-gradient);
+    color: #fff !important;
+    padding: 0.35rem 0.85rem;
+    border-radius: 6px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    display: flex; align-items: center; gap: 0.35rem;
+    transition: opacity 0.2s;
+    -webkit-text-fill-color: #fff;
+}
+.im-browse-btn { display: inline-flex; align-items: center; gap: 0.4rem; font-family: 'Inter', sans-serif; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: var(--im-text, #1C1917); background: var(--im-surface, #FFFFFF); border: 1.5px solid var(--im-border, #E2E8F0); padding: 0.5rem 1rem; border-radius: 0.5rem; text-decoration: none; transition: background 0.18s ease, border-color 0.18s ease, transform 0.15s ease, box-shadow 0.18s ease; }
+.im-browse-btn:hover { background: var(--im-accent, #0EA5E9); color: #FFFFFF; border-color: var(--im-accent, #0EA5E9); transform: translateY(-1px); box-shadow: 0 4px 12px rgba(14, 165, 233, 0.25); }
+.im-browse-btn svg { width: 14px; height: 14px; }
+@media (prefers-color-scheme: dark) { .im-browse-btn { color: rgba(255,255,255,0.9); background: rgba(255,255,255,0.05); border-color: rgba(255,255,255,0.18); } .im-browse-btn:hover { background: var(--im-accent, #0EA5E9); border-color: var(--im-accent, #0EA5E9); color: #FFFFFF; } }
+.im-premium-btn:hover { opacity: 0.9; }
+.im-premium-btn svg { width: 14px; height: 14px; }
+
+/* Theme Selector - 3 mode */
+.im-theme-selector {
+    display: flex; gap: 2px;
+    background: var(--im-card-bg, #1E293B);
+    border: 1px solid var(--im-border, #334155);
+    border-radius: 8px; padding: 2px;
+}
+.im-theme-btn {
+    background: transparent; border: none;
+    color: var(--im-text-secondary, #94A3B8);
+    padding: 6px; border-radius: 5px; cursor: pointer;
+    transition: all 0.2s; display: flex; align-items: center;
+    justify-content: center; width: 30px; height: 30px;
+}
+.im-theme-btn:hover {
+    background: var(--im-hover-bg, #334155);
+    color: var(--im-text-primary, #F1F5F9);
+}
+.im-theme-btn.active {
+    background: var(--im-accent, #0EA5E9);
+    color: #fff;
+}
+.im-theme-btn svg { width: 16px; height: 16px; }
+
+/* Paper Plane */
+.im-paper-plane {
+    position: fixed; top: 15%; right: 8%;
+    width: 120px; height: 120px;
+    opacity: 0.15; z-index: 0;
+    pointer-events: none;
+    animation: im-fly 25s ease-in-out infinite;
+}
+[data-theme="light"] .im-paper-plane { opacity: 0.2; }
+@keyframes im-fly {
+    0%, 100% { transform: translate(0, 0) rotate(0deg); }
+    20% { transform: translate(60px, -40px) rotate(12deg); }
+    40% { transform: translate(120px, 30px) rotate(-8deg); }
+    60% { transform: translate(40px, 60px) rotate(15deg); }
+    80% { transform: translate(-30px, 20px) rotate(-5deg); }
+}
+
+/* ImpactMojo Footer */
+.im-footer {
+    background: var(--im-secondary-bg, #1E293B);
+    border-top: 1px solid var(--im-border, #334155);
+    padding: 2rem 1rem; margin-top: auto;
+    font-family: 'Inter', sans-serif;
+    color: var(--im-text-secondary, #94A3B8);
+}
+.im-footer-content {
+    max-width: 1100px; margin: 0 auto;
+}
+.im-footer-made {
+    text-align: center; margin-bottom: 1.5rem;
+    font-size: 0.9rem; color: var(--im-text-muted, #64748B);
+}
+.im-footer-made a { color: var(--im-accent, #0EA5E9); }
+.im-footer-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.5rem; margin-bottom: 1.5rem;
+}
+.im-footer-section h4 {
+    font-family: 'Inter', sans-serif;
+    color: var(--im-text-primary, #F1F5F9);
+    font-size: 0.9rem; margin-bottom: 0.75rem;
+    font-weight: 600;
+}
+.im-footer-section ul { list-style: none; padding: 0; margin: 0; }
+.im-footer-section li { margin-bottom: 0.4rem; }
+.im-footer-section a {
+    color: var(--im-text-secondary, #94A3B8);
+    text-decoration: none; font-size: 0.85rem;
+    transition: color 0.2s;
+}
+.im-footer-section a:hover { color: var(--im-accent, #0EA5E9); }
+.im-footer-bottom {
+    text-align: center; padding-top: 1rem;
+    border-top: 1px solid var(--im-border, #334155);
+    font-size: 0.8rem; color: var(--im-text-muted, #64748B);
+}
+.im-footer-bottom p { margin: 0.25rem 0; }
+.im-footer-bottom a { color: var(--im-accent, #0EA5E9); text-decoration: none; }
+
+/* Mobile Responsive */
+@media (max-width: 768px) {
+    .im-topbar { padding: 0.4rem 0.75rem; gap: 0.5rem; }
+    .im-topbar-home { font-size: 0.85rem; }
+    .im-topbar-home svg { width: 20px; height: 20px; }
+    .im-premium-btn { padding: 0.3rem 0.6rem; font-size: 0.75rem; }
+    .im-theme-btn { width: 26px; height: 26px; padding: 4px; }
+    .im-theme-btn svg { width: 14px; height: 14px; }
+    .im-paper-plane { width: 80px; height: 80px; top: 10%; right: 5%; }
+    .im-footer-grid { grid-template-columns: repeat(2, 1fr); gap: 1rem; }
+}
+@media (max-width: 480px) {
+    .im-footer-grid { grid-template-columns: 1fr; }
+    .im-topbar-home span { display: none; }
+}
+
+/* ImpactMojo Global Font Overrides */
+body { font-family: 'Amaranth', sans-serif !important; }
+h1, h2, h3, h4, h5, h6 { font-family: 'Inter', sans-serif !important; }
+code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !important; }
+
+/* WCAG 2.1 AA (1.4.1 Use of Color): inline anchors in content paragraphs must be distinguishable without relying on color alone. Scoped to <main> so nav/footer button-links are unaffected. */
+main p a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]),
+main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) {
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+}
+
 </style>
 </head>
 <body>
@@ -164,7 +353,15 @@ body.dark-mode .header { background: rgba(15,23,42,0.95); }
         <h1 class="tool-name">Stakeholder Mapping</h1>
     </div>
     <div class="header-actions">
-        <button class="btn" onclick="toggleDarkMode()" title="Toggle dark mode" aria-label="Toggle dark mode">&#9790;</button>
+        <a class="im-premium-btn" href="../premium.html" title="Go Premium">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+            Premium
+        </a>
+        <div class="im-theme-selector" aria-label="Theme selection">
+            <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="Use system theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
+            <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Use light theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg></button>
+            <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Use dark theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+        </div>
         <button class="btn" onclick="clearAll()">Clear All</button>
         <button class="btn" onclick="loadExample()">Load Example</button>
         <button class="btn btn-primary" onclick="exportToJSON()">Export <span class="pro-pill">&#9733; Premium</span></button>
@@ -346,7 +543,7 @@ function toggleDarkMode() {
     document.body.classList.toggle('dark-mode');
     localStorage.setItem('impactmojo_dark', document.body.classList.contains('dark-mode'));
 }
-if (localStorage.getItem('impactmojo_dark') === 'true') document.body.classList.add('dark-mode');
+/* theming handled by /js/theme.js (canonical im-theme controller) */
 init();
 </script>
 
@@ -376,5 +573,66 @@ function requirePremium() {
 if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initGate);
 else initGate();
 </script>
+
+<!-- ImpactMojo Paper Plane -->
+<svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M80,130 L150,50" stroke="#10B981" stroke-width="2" stroke-dasharray="4,4"/>
+    <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+    <circle cx="40" cy="155" r="2" fill="#0EA5E9" opacity="0.6"/>
+    <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
+    <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
+</svg>
+<!-- ImpactMojo Footer -->
+<footer class="im-footer" role="contentinfo">
+<div class="im-footer-content">
+<p class="im-footer-made">Made with &#10084; by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+<div class="im-footer-grid">
+<div class="im-footer-section">
+<h4>About ImpactMojo</h4>
+<ul>
+<li><a href="../about.html">About Us</a></li>
+<li><a href="../contact.html">Contact</a></li>
+<li><a href="https://github.com/ImpactMojo/ImpactMojo" rel="noopener noreferrer" target="_blank">GitHub</a></li>
+<li><a href="../transparency.html">Transparency</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Legal</h4>
+<ul>
+<li><a href="../privacy-policy.html">Privacy Policy</a></li>
+<li><a href="../terms-of-service.html">Terms of Service</a></li>
+<li><a href="../disclaimer.html">Disclaimer</a></li>
+<li><a href="../data-protection.html">Data Protection</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Quick Links</h4>
+<ul>
+<li><a href="../catalog.html">All Courses</a></li>
+<li><a href="../premium.html">Premium Content</a></li>
+<li><a href="../coaching.html">Coaching</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Resources</h4>
+<ul>
+<li><a href="../handouts.html">Handouts</a></li>
+<li><a href="../blog.html">Blog</a></li>
+<li><a href="../faq.html">FAQ</a></li>
+<li><a href="../sitemap.html">Sitemap</a></li>
+<li><a href="/docs/" rel="noopener noreferrer" target="_blank">Documentation</a></li>
+</ul>
+</div>
+</div>
+<div class="im-footer-bottom">
+<p>&copy; 2026 ImpactMojo. All content for educational purposes only.</p>
+<p>Released under <strong>MIT License</strong> | Supported by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+</div>
+</div>
+</footer>
+<!-- ImpactMojo canonical theme controller + translation -->
+<script src="/js/theme.js"></script>
+<script src="/js/translate-sarvam.js" defer></script>
 </body>
 </html>

--- a/premium-tools/stakeholder-pro.html
+++ b/premium-tools/stakeholder-pro.html
@@ -1,0 +1,380 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Stakeholder Mapping — free power-interest grid | ImpactMojo</title>
+<meta name="description" content="Interactive Power-Interest Stakeholder Mapping tool for development programs. Free to build — exporting is a Premium feature.">
+<link href="/assets/images/favicon.png" rel="icon" type="image/png">
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+:root {
+    --primary-bg: #FFFFFF; --secondary-bg: #F8FAFC; --accent-color: #0EA5E9;
+    --accent-hover: #0284C7; --text-primary: #0F172A; --text-secondary: #475569;
+    --card-bg: #FFFFFF; --border-color: #E2E8F0; --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+}
+body.dark-mode {
+    --primary-bg: #0F172A; --secondary-bg: #1E293B; --text-primary: #F1F5F9;
+    --text-secondary: #94A3B8; --card-bg: #1E293B; --border-color: #334155;
+}
+body { font-family: 'Amaranth', sans-serif; background: var(--primary-bg); color: var(--text-primary); }
+
+.header {
+    background: rgba(255,255,255,0.95); backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--border-color); padding: 1rem 2rem;
+    position: sticky; top: 0; z-index: 100; display: flex; align-items: center; justify-content: space-between;
+}
+body.dark-mode .header { background: rgba(15,23,42,0.95); }
+.header h1 { font-family: 'Inter', sans-serif; font-size: 1.25rem; }
+.btn { padding: 0.5rem 1rem; border-radius: 8px; border: 1px solid var(--border-color); background: var(--card-bg); color: var(--text-primary); cursor: pointer; font-size: 0.85rem; font-family: inherit; transition: all 0.2s; }
+.btn:hover { border-color: var(--accent-color); }
+.btn-primary { background: var(--accent-color); color: white; border-color: var(--accent-color); }
+.btn-primary:hover { background: var(--accent-hover); }
+
+.container { padding: 2rem; max-width: 1100px; margin: 0 auto; }
+
+.instructions {
+    background: var(--secondary-bg); border: 1px solid var(--border-color); border-radius: 10px;
+    padding: 1.25rem; margin-bottom: 1.5rem; font-size: 0.85rem; color: var(--text-secondary);
+}
+.instructions strong { color: var(--text-primary); }
+
+.grid-wrapper {
+    position: relative; width: 100%; aspect-ratio: 1; max-width: 700px; margin: 0 auto;
+    border: 2px solid var(--border-color); border-radius: 12px; overflow: hidden;
+    background: var(--secondary-bg);
+}
+.quadrant {
+    position: absolute; width: 50%; height: 50%; display: flex; align-items: center;
+    justify-content: center; font-size: 0.75rem; font-weight: 600; color: var(--text-secondary);
+    opacity: 0.6; pointer-events: none;
+}
+.q-tl { top: 0; left: 0; background: rgba(239,68,68,0.06); }
+.q-tr { top: 0; right: 0; background: rgba(245,158,11,0.06); }
+.q-bl { bottom: 0; left: 0; background: rgba(100,116,139,0.06); }
+.q-br { bottom: 0; right: 0; background: rgba(16,185,129,0.06); }
+
+.quadrant-label {
+    text-align: center; padding: 0.5rem; line-height: 1.3;
+}
+.quadrant-label .q-title { font-size: 0.85rem; display: block; }
+.quadrant-label .q-action { font-size: 0.7rem; font-weight: 400; display: block; margin-top: 2px; }
+
+.axis-label {
+    position: absolute; font-size: 0.75rem; font-weight: 600; color: var(--text-secondary);
+    text-transform: uppercase; letter-spacing: 0.05em;
+}
+.axis-x { bottom: -28px; left: 50%; transform: translateX(-50%); }
+.axis-y { top: 50%; left: -40px; transform: translateY(-50%) rotate(-90deg); }
+.axis-arrow-x {
+    position: absolute; bottom: -20px; left: 0; right: 0; height: 2px;
+    background: var(--text-secondary); opacity: 0.3;
+}
+.axis-arrow-x::after { content: ''; position: absolute; right: -2px; top: -4px; border: 5px solid transparent; border-left-color: var(--text-secondary); }
+.axis-arrow-y {
+    position: absolute; top: 0; bottom: 0; left: -12px; width: 2px;
+    background: var(--text-secondary); opacity: 0.3;
+}
+.axis-arrow-y::after { content: ''; position: absolute; top: -2px; left: -4px; border: 5px solid transparent; border-bottom-color: var(--text-secondary); }
+
+.midline-h, .midline-v {
+    position: absolute; background: var(--border-color);
+}
+.midline-h { left: 0; right: 0; top: 50%; height: 1px; }
+.midline-v { top: 0; bottom: 0; left: 50%; width: 1px; }
+
+.stakeholder-dot {
+    position: absolute; width: 36px; height: 36px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 0.7rem; font-weight: 700; color: white; cursor: grab;
+    transition: box-shadow 0.2s; z-index: 10; user-select: none;
+}
+.stakeholder-dot:hover { box-shadow: 0 0 0 3px rgba(245,158,11,0.4); }
+.stakeholder-dot .dot-label {
+    position: absolute; top: 40px; left: 50%; transform: translateX(-50%);
+    white-space: nowrap; font-size: 0.7rem; font-weight: 500;
+    color: var(--text-primary); background: var(--card-bg);
+    padding: 2px 6px; border-radius: 4px; border: 1px solid var(--border-color);
+    pointer-events: none;
+}
+
+.sidebar {
+    margin-top: 2rem; display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;
+}
+.add-form {
+    background: var(--card-bg); border: 1px solid var(--border-color); border-radius: 10px;
+    padding: 1rem;
+}
+.add-form h3 { font-size: 0.9rem; margin-bottom: 0.75rem; }
+.form-row { display: flex; gap: 0.5rem; margin-bottom: 0.5rem; }
+.form-row input, .form-row select {
+    flex: 1; padding: 0.5rem; border: 1px solid var(--border-color); border-radius: 6px;
+    background: var(--primary-bg); color: var(--text-primary); font-family: inherit; font-size: 0.85rem;
+}
+.stakeholder-list {
+    background: var(--card-bg); border: 1px solid var(--border-color); border-radius: 10px;
+    padding: 1rem; max-height: 300px; overflow-y: auto;
+}
+.stakeholder-list h3 { font-size: 0.9rem; margin-bottom: 0.75rem; }
+.sh-item {
+    display: flex; align-items: center; gap: 0.5rem; padding: 0.4rem 0;
+    border-bottom: 1px solid var(--border-color); font-size: 0.82rem;
+}
+.sh-item:last-child { border-bottom: none; }
+.sh-color { width: 14px; height: 14px; border-radius: 50%; flex-shrink: 0; }
+.sh-item .sh-remove {
+    margin-left: auto; background: none; border: none; color: var(--text-secondary);
+    cursor: pointer; font-size: 1rem;
+}
+.sh-item .sh-remove:hover { color: #EF4444; }
+
+@media (max-width: 768px) {
+    .sidebar { grid-template-columns: 1fr; }
+    .grid-wrapper { max-width: 100%; }
+}
+@media print {
+    .header, .sidebar, .instructions { display: none !important; }
+    .grid-wrapper { max-width: 100%; border: 2px solid #333; }
+}
+
+/* ── Pro Studio branding + freemium ─────────────────────────── */
+.header { flex-wrap: wrap; gap: 0.75rem; }
+.header-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+.header-brand { display: flex; align-items: center; gap: 0.5rem; text-decoration: none; color: var(--text-primary); }
+.header-brand img { width: 30px; height: 30px; border-radius: 6px; }
+.header-brand .brand-name { font-family: 'Inter', sans-serif; font-weight: 700; font-size: 1rem; }
+.tool-name { font-family: 'Inter', sans-serif; font-size: 1.05rem; font-weight: 600; padding-left: 0.75rem; border-left: 2px solid var(--border-color); }
+.pro-pill { display: inline-flex; align-items: center; gap: 0.2rem; background: linear-gradient(135deg,#F59E0B,#EF4444); color: #fff; font-weight: 700; font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.4px; padding: 0.15rem 0.45rem; border-radius: 5px; white-space: nowrap; }
+.freemium-note { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 1.5rem; padding: 0.6rem 0.9rem; background: rgba(245,158,11,0.08); border: 1px solid rgba(245,158,11,0.3); border-radius: 8px; font-size: 0.82rem; color: var(--text-secondary); }
+.freemium-note a { color: #F59E0B; font-weight: 700; text-decoration: none; }
+.freemium-note a:hover { text-decoration: underline; }
+@media (max-width: 640px) { .tool-name { font-size: 0.9rem; padding-left: 0.5rem; } .header-brand .brand-name { display: none; } }
+@media print { .freemium-note { display: none !important; } }
+</style>
+</head>
+<body>
+
+<div class="header">
+    <div style="display:flex; align-items:center; gap:0.75rem; flex-wrap:wrap;">
+        <a class="header-brand" href="/" title="ImpactMojo home">
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="30" height="30">
+            <span class="brand-name">ImpactMojo</span>
+        </a>
+        <h1 class="tool-name">Stakeholder Mapping</h1>
+    </div>
+    <div class="header-actions">
+        <button class="btn" onclick="toggleDarkMode()" title="Toggle dark mode" aria-label="Toggle dark mode">&#9790;</button>
+        <button class="btn" onclick="clearAll()">Clear All</button>
+        <button class="btn" onclick="loadExample()">Load Example</button>
+        <button class="btn btn-primary" onclick="exportToJSON()">Export <span class="pro-pill">&#9733; Premium</span></button>
+        <button class="btn btn-primary" onclick="printTemplate()">Print <span class="pro-pill">&#9733; Premium</span></button>
+    </div>
+</div>
+
+<div class="container">
+    <div class="instructions">
+        <strong>Power-Interest Grid:</strong> Place stakeholders on the grid based on their <strong>power</strong> (ability to influence your program) and <strong>interest</strong> (how much they care about it). Drag dots to reposition. Each quadrant suggests a different engagement strategy.
+    </div>
+
+    <div class="freemium-note">
+        <span class="pro-pill">&#9733; Premium</span>
+        <span>Building is free. Exporting is a Premium feature. <a href="/premium.html#detail-professional">Upgrade to Professional &rarr;</a></span>
+    </div>
+
+    <div style="position:relative; padding: 0 0 40px 50px;">
+        <div class="axis-label axis-x">Interest &#8594;</div>
+        <div class="axis-label axis-y">Power &#8594;</div>
+        <div class="grid-wrapper" id="grid">
+            <div class="quadrant q-tl"><div class="quadrant-label"><span class="q-title">Keep Satisfied</span><span class="q-action">High power, low interest</span></div></div>
+            <div class="quadrant q-tr"><div class="quadrant-label"><span class="q-title">Manage Closely</span><span class="q-action">High power, high interest</span></div></div>
+            <div class="quadrant q-bl"><div class="quadrant-label"><span class="q-title">Monitor</span><span class="q-action">Low power, low interest</span></div></div>
+            <div class="quadrant q-br"><div class="quadrant-label"><span class="q-title">Keep Informed</span><span class="q-action">Low power, high interest</span></div></div>
+            <div class="midline-h"></div>
+            <div class="midline-v"></div>
+        </div>
+    </div>
+
+    <div class="sidebar">
+        <div class="add-form">
+            <h3>Add Stakeholder</h3>
+            <div class="form-row">
+                <input type="text" id="shName" placeholder="Stakeholder name" maxlength="30">
+            </div>
+            <div class="form-row">
+                <select id="shColor">
+                    <option value="#6366F1">Purple</option>
+                    <option value="#EC4899">Pink</option>
+                    <option value="#10B981">Green</option>
+                    <option value="#F59E0B">Amber</option>
+                    <option value="#EF4444">Red</option>
+                    <option value="#3B82F6">Blue</option>
+                    <option value="#8B5CF6">Violet</option>
+                </select>
+                <button class="btn btn-primary" onclick="addStakeholder()">Add</button>
+            </div>
+        </div>
+        <div class="stakeholder-list">
+            <h3>Stakeholders</h3>
+            <div id="shList"><p style="font-size:0.82rem; color:var(--text-secondary);">No stakeholders yet. Add one above.</p></div>
+        </div>
+    </div>
+</div>
+
+<script>
+var STORAGE_KEY = 'impactmojo_stakeholder_map';
+var stakeholders = [];
+var dragState = null;
+
+function init() {
+    var saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) { try { stakeholders = JSON.parse(saved); } catch(e) { stakeholders = []; } }
+    render();
+    var grid = document.getElementById('grid');
+    grid.addEventListener('mousemove', onDrag);
+    grid.addEventListener('mouseup', endDrag);
+    grid.addEventListener('mouseleave', endDrag);
+    grid.addEventListener('touchmove', onDragTouch, { passive: false });
+    grid.addEventListener('touchend', endDrag);
+    document.getElementById('shName').addEventListener('keydown', function(e) { if (e.key === 'Enter') addStakeholder(); });
+}
+
+function save() { localStorage.setItem(STORAGE_KEY, JSON.stringify(stakeholders)); }
+
+function render() {
+    var grid = document.getElementById('grid');
+    grid.querySelectorAll('.stakeholder-dot').forEach(function(d) { d.remove(); });
+    stakeholders.forEach(function(sh, i) {
+        var dot = document.createElement('div');
+        dot.className = 'stakeholder-dot';
+        dot.style.background = sh.color;
+        dot.style.left = (sh.x * 100) + '%';
+        dot.style.top = ((1 - sh.y) * 100) + '%';
+        dot.style.transform = 'translate(-50%, -50%)';
+        dot.textContent = sh.name.charAt(0).toUpperCase();
+        dot.title = sh.name;
+        var label = document.createElement('span');
+        label.className = 'dot-label';
+        label.textContent = sh.name;
+        dot.appendChild(label);
+        dot.addEventListener('mousedown', function(e) { e.preventDefault(); dragState = { idx: i }; });
+        dot.addEventListener('touchstart', function(e) { dragState = { idx: i }; }, { passive: true });
+        grid.appendChild(dot);
+    });
+    renderList();
+}
+
+function onDrag(e) {
+    if (!dragState) return;
+    var grid = document.getElementById('grid');
+    var rect = grid.getBoundingClientRect();
+    var x = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+    var y = Math.max(0, Math.min(1, 1 - (e.clientY - rect.top) / rect.height));
+    stakeholders[dragState.idx].x = x;
+    stakeholders[dragState.idx].y = y;
+    save(); render();
+}
+function onDragTouch(e) {
+    if (!dragState) return;
+    e.preventDefault();
+    var t = e.touches[0];
+    var grid = document.getElementById('grid');
+    var rect = grid.getBoundingClientRect();
+    var x = Math.max(0, Math.min(1, (t.clientX - rect.left) / rect.width));
+    var y = Math.max(0, Math.min(1, 1 - (t.clientY - rect.top) / rect.height));
+    stakeholders[dragState.idx].x = x;
+    stakeholders[dragState.idx].y = y;
+    save(); render();
+}
+function endDrag() { dragState = null; }
+
+function renderList() {
+    var list = document.getElementById('shList');
+    if (!stakeholders.length) { list.innerHTML = '<p style="font-size:0.82rem; color:var(--text-secondary);">No stakeholders yet.</p>'; return; }
+    list.innerHTML = '';
+    stakeholders.forEach(function(sh, i) {
+        var item = document.createElement('div');
+        item.className = 'sh-item';
+        item.innerHTML = '<span class="sh-color" style="background:' + sh.color + '"></span><span>' + sh.name + '</span><button class="sh-remove" title="Remove">&times;</button>';
+        item.querySelector('.sh-remove').addEventListener('click', function() {
+            stakeholders.splice(i, 1); save(); render();
+        });
+        list.appendChild(item);
+    });
+}
+
+function addStakeholder() {
+    var name = document.getElementById('shName').value.trim();
+    if (!name) return;
+    var color = document.getElementById('shColor').value;
+    stakeholders.push({ name: name, color: color, x: 0.5 + (Math.random() - 0.5) * 0.3, y: 0.5 + (Math.random() - 0.5) * 0.3 });
+    document.getElementById('shName').value = '';
+    save(); render();
+}
+
+function clearAll() {
+    if (!confirm('Remove all stakeholders?')) return;
+    stakeholders = []; save(); render();
+}
+
+function loadExample() {
+    stakeholders = [
+        { name: 'Ministry of Health', color: '#EF4444', x: 0.3, y: 0.85 },
+        { name: 'USAID', color: '#3B82F6', x: 0.8, y: 0.9 },
+        { name: 'District Officers', color: '#F59E0B', x: 0.7, y: 0.6 },
+        { name: 'Community Leaders', color: '#10B981', x: 0.85, y: 0.45 },
+        { name: 'Beneficiaries', color: '#EC4899', x: 0.9, y: 0.25 },
+        { name: 'Media', color: '#8B5CF6', x: 0.35, y: 0.35 },
+        { name: 'Private Sector', color: '#6366F1', x: 0.2, y: 0.55 }
+    ];
+    save(); render();
+}
+
+function exportToJSON() {
+    if (!requirePremium()) return; // building is free, exporting is Premium
+    var blob = new Blob([JSON.stringify(stakeholders, null, 2)], { type: 'application/json' });
+    var a = document.createElement('a'); a.href = URL.createObjectURL(blob);
+    a.download = 'stakeholder-map.json'; a.click();
+}
+
+function printTemplate() {
+    if (!requirePremium()) return; // building is free, exporting is Premium
+    window.print();
+}
+
+function toggleDarkMode() {
+    document.body.classList.toggle('dark-mode');
+    localStorage.setItem('impactmojo_dark', document.body.classList.contains('dark-mode'));
+}
+if (localStorage.getItem('impactmojo_dark') === 'true') document.body.classList.add('dark-mode');
+init();
+</script>
+
+<!-- ImpactMojo auth + premium (Pro Studio freemium gate) -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
+<script src="/js/premium.js"></script>
+<script>
+// Pro Studio freemium: building is free for everyone; exporting is Premium.
+// The whole builder above is always visible — no sign-in wall to use it.
+window.TOOL_PREMIUM = false;
+var TOOL_TIER = 'professional';
+async function initGate() {
+  try { if (window.ImpactMojoAuth) await window.ImpactMojoAuth.waitForAuthReady(); } catch (e) {}
+  var auth = window.ImpactMojoAuth;
+  window.TOOL_PREMIUM = !!(auth && typeof auth.hasTierAccess === 'function' && auth.hasTierAccess(TOOL_TIER));
+}
+// Gate a Premium action (export/print). Free users get the upgrade path.
+function requirePremium() {
+  if (window.TOOL_PREMIUM) return true;
+  if (window.IMXPremium && typeof window.IMXPremium.showUpgradeModal === 'function') window.IMXPremium.showUpgradeModal(TOOL_TIER);
+  else window.location.href = '/premium.html#detail-' + TOOL_TIER;
+  return false;
+}
+if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initGate);
+else initGate();
+</script>
+</body>
+</html>

--- a/premium-tools/toc-pro.html
+++ b/premium-tools/toc-pro.html
@@ -118,6 +118,195 @@ body.dark-mode .header { background: rgba(15,23,42,0.95); }
 .freemium-note a:hover { text-decoration: underline; }
 @media (max-width: 640px) { .tool-name { font-size: 0.9rem; padding-left: 0.5rem; } .header-brand .brand-name { display: none; } }
 @media print { .freemium-note { display: none !important; } }
+
+/* ===== ImpactMojo Design System ===== */
+:root {
+    --im-primary-bg: #0F172A;
+    --im-secondary-bg: #1E293B;
+    --im-accent: #0EA5E9;
+    --im-accent-hover: #0284C7;
+    --im-secondary-accent: #6366F1;
+    --im-success: #10B981;
+    --im-text-primary: #F1F5F9;
+    --im-text-secondary: #94A3B8;
+    --im-text-muted: #64748B;
+    --im-card-bg: #1E293B;
+    --im-hover-bg: #334155;
+    --im-border: #334155;
+    --im-nav-bg: rgba(15, 23, 42, 0.95);
+    --im-gradient: linear-gradient(135deg, #0EA5E9 0%, #6366F1 100%);
+}
+[data-theme="light"] {
+    --im-primary-bg: #F8FAFC;
+    --im-secondary-bg: #FFFFFF;
+    --im-accent: #0369A1;
+    --im-accent-hover: #0369A1;
+    --im-text-primary: #0F172A;
+    --im-text-secondary: #475569;
+    --im-text-muted: #64748B;
+    --im-card-bg: #FFFFFF;
+    --im-hover-bg: #F1F5F9;
+    --im-border: #E2E8F0;
+    --im-nav-bg: rgba(248, 250, 252, 0.95);
+}
+
+/* ImpactMojo Top Bar */
+.im-topbar {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 9999;
+    background: var(--im-nav-bg, rgba(15, 23, 42, 0.95));
+    backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px);
+    border-bottom: 1px solid var(--im-border, #334155);
+    padding: 0.5rem 1rem;
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 0.75rem; flex-wrap: wrap;
+    font-family: 'Inter', sans-serif;
+}
+.im-topbar a { text-decoration: none; }
+.im-topbar-left {
+    display: flex; align-items: center; gap: 0.75rem;
+}
+.im-topbar-home {
+    display: flex; align-items: center; gap: 0.5rem;
+    color: var(--im-text-primary, #F1F5F9);
+    font-weight: 700; font-size: 1rem;
+    background: var(--im-gradient);
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+.im-topbar-home svg { width: 24px; height: 24px; flex-shrink: 0; }
+.im-topbar-right {
+    display: flex; align-items: center; gap: 0.5rem;
+}
+.im-premium-btn {
+    background: var(--im-gradient);
+    color: #fff !important;
+    padding: 0.35rem 0.85rem;
+    border-radius: 6px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    display: flex; align-items: center; gap: 0.35rem;
+    transition: opacity 0.2s;
+    -webkit-text-fill-color: #fff;
+}
+.im-browse-btn { display: inline-flex; align-items: center; gap: 0.4rem; font-family: 'Inter', sans-serif; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: var(--im-text, #1C1917); background: var(--im-surface, #FFFFFF); border: 1.5px solid var(--im-border, #E2E8F0); padding: 0.5rem 1rem; border-radius: 0.5rem; text-decoration: none; transition: background 0.18s ease, border-color 0.18s ease, transform 0.15s ease, box-shadow 0.18s ease; }
+.im-browse-btn:hover { background: var(--im-accent, #0EA5E9); color: #FFFFFF; border-color: var(--im-accent, #0EA5E9); transform: translateY(-1px); box-shadow: 0 4px 12px rgba(14, 165, 233, 0.25); }
+.im-browse-btn svg { width: 14px; height: 14px; }
+@media (prefers-color-scheme: dark) { .im-browse-btn { color: rgba(255,255,255,0.9); background: rgba(255,255,255,0.05); border-color: rgba(255,255,255,0.18); } .im-browse-btn:hover { background: var(--im-accent, #0EA5E9); border-color: var(--im-accent, #0EA5E9); color: #FFFFFF; } }
+.im-premium-btn:hover { opacity: 0.9; }
+.im-premium-btn svg { width: 14px; height: 14px; }
+
+/* Theme Selector - 3 mode */
+.im-theme-selector {
+    display: flex; gap: 2px;
+    background: var(--im-card-bg, #1E293B);
+    border: 1px solid var(--im-border, #334155);
+    border-radius: 8px; padding: 2px;
+}
+.im-theme-btn {
+    background: transparent; border: none;
+    color: var(--im-text-secondary, #94A3B8);
+    padding: 6px; border-radius: 5px; cursor: pointer;
+    transition: all 0.2s; display: flex; align-items: center;
+    justify-content: center; width: 30px; height: 30px;
+}
+.im-theme-btn:hover {
+    background: var(--im-hover-bg, #334155);
+    color: var(--im-text-primary, #F1F5F9);
+}
+.im-theme-btn.active {
+    background: var(--im-accent, #0EA5E9);
+    color: #fff;
+}
+.im-theme-btn svg { width: 16px; height: 16px; }
+
+/* Paper Plane */
+.im-paper-plane {
+    position: fixed; top: 15%; right: 8%;
+    width: 120px; height: 120px;
+    opacity: 0.15; z-index: 0;
+    pointer-events: none;
+    animation: im-fly 25s ease-in-out infinite;
+}
+[data-theme="light"] .im-paper-plane { opacity: 0.2; }
+@keyframes im-fly {
+    0%, 100% { transform: translate(0, 0) rotate(0deg); }
+    20% { transform: translate(60px, -40px) rotate(12deg); }
+    40% { transform: translate(120px, 30px) rotate(-8deg); }
+    60% { transform: translate(40px, 60px) rotate(15deg); }
+    80% { transform: translate(-30px, 20px) rotate(-5deg); }
+}
+
+/* ImpactMojo Footer */
+.im-footer {
+    background: var(--im-secondary-bg, #1E293B);
+    border-top: 1px solid var(--im-border, #334155);
+    padding: 2rem 1rem; margin-top: auto;
+    font-family: 'Inter', sans-serif;
+    color: var(--im-text-secondary, #94A3B8);
+}
+.im-footer-content {
+    max-width: 1100px; margin: 0 auto;
+}
+.im-footer-made {
+    text-align: center; margin-bottom: 1.5rem;
+    font-size: 0.9rem; color: var(--im-text-muted, #64748B);
+}
+.im-footer-made a { color: var(--im-accent, #0EA5E9); }
+.im-footer-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.5rem; margin-bottom: 1.5rem;
+}
+.im-footer-section h4 {
+    font-family: 'Inter', sans-serif;
+    color: var(--im-text-primary, #F1F5F9);
+    font-size: 0.9rem; margin-bottom: 0.75rem;
+    font-weight: 600;
+}
+.im-footer-section ul { list-style: none; padding: 0; margin: 0; }
+.im-footer-section li { margin-bottom: 0.4rem; }
+.im-footer-section a {
+    color: var(--im-text-secondary, #94A3B8);
+    text-decoration: none; font-size: 0.85rem;
+    transition: color 0.2s;
+}
+.im-footer-section a:hover { color: var(--im-accent, #0EA5E9); }
+.im-footer-bottom {
+    text-align: center; padding-top: 1rem;
+    border-top: 1px solid var(--im-border, #334155);
+    font-size: 0.8rem; color: var(--im-text-muted, #64748B);
+}
+.im-footer-bottom p { margin: 0.25rem 0; }
+.im-footer-bottom a { color: var(--im-accent, #0EA5E9); text-decoration: none; }
+
+/* Mobile Responsive */
+@media (max-width: 768px) {
+    .im-topbar { padding: 0.4rem 0.75rem; gap: 0.5rem; }
+    .im-topbar-home { font-size: 0.85rem; }
+    .im-topbar-home svg { width: 20px; height: 20px; }
+    .im-premium-btn { padding: 0.3rem 0.6rem; font-size: 0.75rem; }
+    .im-theme-btn { width: 26px; height: 26px; padding: 4px; }
+    .im-theme-btn svg { width: 14px; height: 14px; }
+    .im-paper-plane { width: 80px; height: 80px; top: 10%; right: 5%; }
+    .im-footer-grid { grid-template-columns: repeat(2, 1fr); gap: 1rem; }
+}
+@media (max-width: 480px) {
+    .im-footer-grid { grid-template-columns: 1fr; }
+    .im-topbar-home span { display: none; }
+}
+
+/* ImpactMojo Global Font Overrides */
+body { font-family: 'Amaranth', sans-serif !important; }
+h1, h2, h3, h4, h5, h6 { font-family: 'Inter', sans-serif !important; }
+code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !important; }
+
+/* WCAG 2.1 AA (1.4.1 Use of Color): inline anchors in content paragraphs must be distinguishable without relying on color alone. Scoped to <main> so nav/footer button-links are unaffected. */
+main p a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]),
+main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) {
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+}
+
 </style>
 </head>
 <body>
@@ -131,7 +320,15 @@ body.dark-mode .header { background: rgba(15,23,42,0.95); }
         <h1 class="tool-name">Theory of Change Workbench</h1>
     </div>
     <div class="header-actions">
-        <button class="btn" onclick="toggleDarkMode()" title="Toggle dark mode" aria-label="Toggle dark mode">&#9790;</button>
+        <a class="im-premium-btn" href="../premium.html" title="Go Premium">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+            Premium
+        </a>
+        <div class="im-theme-selector" aria-label="Theme selection">
+            <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="Use system theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
+            <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Use light theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg></button>
+            <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Use dark theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+        </div>
         <button class="btn" onclick="clearAll()">Clear All</button>
         <button class="btn" onclick="loadExample()">Load Example</button>
         <button class="btn btn-primary" onclick="exportToJSON()">Export JSON <span class="pro-pill">&#9733; Premium</span></button>
@@ -314,7 +511,7 @@ function toggleDarkMode() {
     localStorage.setItem('impactmojo_dark', document.body.classList.contains('dark-mode'));
 }
 
-if (localStorage.getItem('impactmojo_dark') === 'true') document.body.classList.add('dark-mode');
+/* theming handled by /js/theme.js (canonical im-theme controller) */
 init();
 </script>
 
@@ -344,5 +541,66 @@ function requirePremium() {
 if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initGate);
 else initGate();
 </script>
+
+<!-- ImpactMojo Paper Plane -->
+<svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M80,130 L150,50" stroke="#10B981" stroke-width="2" stroke-dasharray="4,4"/>
+    <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+    <circle cx="40" cy="155" r="2" fill="#0EA5E9" opacity="0.6"/>
+    <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
+    <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
+</svg>
+<!-- ImpactMojo Footer -->
+<footer class="im-footer" role="contentinfo">
+<div class="im-footer-content">
+<p class="im-footer-made">Made with &#10084; by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+<div class="im-footer-grid">
+<div class="im-footer-section">
+<h4>About ImpactMojo</h4>
+<ul>
+<li><a href="../about.html">About Us</a></li>
+<li><a href="../contact.html">Contact</a></li>
+<li><a href="https://github.com/ImpactMojo/ImpactMojo" rel="noopener noreferrer" target="_blank">GitHub</a></li>
+<li><a href="../transparency.html">Transparency</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Legal</h4>
+<ul>
+<li><a href="../privacy-policy.html">Privacy Policy</a></li>
+<li><a href="../terms-of-service.html">Terms of Service</a></li>
+<li><a href="../disclaimer.html">Disclaimer</a></li>
+<li><a href="../data-protection.html">Data Protection</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Quick Links</h4>
+<ul>
+<li><a href="../catalog.html">All Courses</a></li>
+<li><a href="../premium.html">Premium Content</a></li>
+<li><a href="../coaching.html">Coaching</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Resources</h4>
+<ul>
+<li><a href="../handouts.html">Handouts</a></li>
+<li><a href="../blog.html">Blog</a></li>
+<li><a href="../faq.html">FAQ</a></li>
+<li><a href="../sitemap.html">Sitemap</a></li>
+<li><a href="/docs/" rel="noopener noreferrer" target="_blank">Documentation</a></li>
+</ul>
+</div>
+</div>
+<div class="im-footer-bottom">
+<p>&copy; 2026 ImpactMojo. All content for educational purposes only.</p>
+<p>Released under <strong>MIT License</strong> | Supported by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+</div>
+</div>
+</footer>
+<!-- ImpactMojo canonical theme controller + translation -->
+<script src="/js/theme.js"></script>
+<script src="/js/translate-sarvam.js" defer></script>
 </body>
 </html>

--- a/premium-tools/toc-pro.html
+++ b/premium-tools/toc-pro.html
@@ -1,0 +1,348 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Theory of Change Workbench — free builder | ImpactMojo</title>
+<meta name="description" content="Interactive Theory of Change builder for development programs. Free to build — drag, edit, and connect your impact chain. Exporting is a Premium feature.">
+<link href="/assets/images/favicon.png" rel="icon" type="image/png">
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+:root {
+    --primary-bg: #FFFFFF; --secondary-bg: #F8FAFC; --accent-color: #0EA5E9;
+    --accent-hover: #0284C7; --text-primary: #0F172A; --text-secondary: #475569;
+    --card-bg: #FFFFFF; --border-color: #E2E8F0; --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
+}
+body.dark-mode {
+    --primary-bg: #0F172A; --secondary-bg: #1E293B; --text-primary: #F1F5F9;
+    --text-secondary: #94A3B8; --card-bg: #1E293B; --border-color: #334155;
+}
+body { font-family: 'Amaranth', sans-serif; background: var(--primary-bg); color: var(--text-primary); }
+
+.header {
+    background: rgba(255,255,255,0.95); backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--border-color); padding: 1rem 2rem;
+    position: sticky; top: 0; z-index: 100; display: flex; align-items: center; justify-content: space-between;
+}
+body.dark-mode .header { background: rgba(15,23,42,0.95); }
+.header h1 { font-family: 'Inter', sans-serif; font-size: 1.25rem; }
+.header-actions { display: flex; gap: 0.5rem; }
+.btn { padding: 0.5rem 1rem; border-radius: 8px; border: 1px solid var(--border-color); background: var(--card-bg); color: var(--text-primary); cursor: pointer; font-size: 0.85rem; font-family: inherit; transition: all 0.2s; }
+.btn:hover { border-color: var(--accent-color); }
+.btn-primary { background: var(--accent-color); color: white; border-color: var(--accent-color); }
+.btn-primary:hover { background: var(--accent-hover); }
+
+.canvas-container { padding: 2rem; min-height: calc(100vh - 60px); }
+
+.toc-flow {
+    display: flex; gap: 1.5rem; align-items: flex-start; overflow-x: auto; padding-bottom: 2rem;
+}
+.toc-column {
+    min-width: 240px; max-width: 280px; flex-shrink: 0;
+}
+.column-header {
+    font-family: 'Inter', sans-serif; font-size: 0.9rem; font-weight: 700;
+    padding: 0.75rem 1rem; border-radius: 10px 10px 0 0; color: white; text-align: center;
+    position: relative;
+}
+.column-header .column-info {
+    font-size: 0.7rem; font-weight: 400; opacity: 0.9; display: block; margin-top: 2px;
+}
+.col-inputs .column-header { background: #6366F1; }
+.col-activities .column-header { background: #8B5CF6; }
+.col-outputs .column-header { background: #EC4899; }
+.col-outcomes .column-header { background: #F59E0B; }
+.col-impact .column-header { background: #10B981; }
+.col-assumptions .column-header { background: #64748B; }
+
+.card-list {
+    background: var(--secondary-bg); border: 1px solid var(--border-color);
+    border-top: none; border-radius: 0 0 10px 10px; padding: 0.75rem; min-height: 200px;
+}
+.toc-card {
+    background: var(--card-bg); border: 1px solid var(--border-color); border-radius: 8px;
+    padding: 0.75rem; margin-bottom: 0.5rem; cursor: grab; transition: all 0.2s;
+    position: relative; font-size: 0.85rem;
+}
+.toc-card:hover { box-shadow: var(--shadow-md); border-color: var(--accent-color); }
+.toc-card.dragging { opacity: 0.5; }
+.toc-card textarea {
+    width: 100%; border: none; background: transparent; color: var(--text-primary);
+    font-family: inherit; font-size: 0.85rem; resize: none; outline: none; line-height: 1.4;
+}
+.toc-card .delete-card {
+    position: absolute; top: 4px; right: 6px; background: none; border: none;
+    color: var(--text-secondary); cursor: pointer; font-size: 1rem; opacity: 0;
+    transition: opacity 0.2s;
+}
+.toc-card:hover .delete-card { opacity: 1; }
+.toc-card .delete-card:hover { color: #EF4444; }
+
+.add-card-btn {
+    width: 100%; padding: 0.5rem; border: 2px dashed var(--border-color); border-radius: 8px;
+    background: transparent; color: var(--text-secondary); cursor: pointer; font-size: 0.8rem;
+    transition: all 0.2s; font-family: inherit;
+}
+.add-card-btn:hover { border-color: var(--accent-color); color: var(--accent-color); }
+
+.arrow-connector {
+    display: flex; align-items: center; justify-content: center; min-width: 32px;
+    color: var(--text-secondary); font-size: 1.5rem; flex-shrink: 0; align-self: center;
+}
+
+.instructions {
+    background: var(--secondary-bg); border: 1px solid var(--border-color); border-radius: 10px;
+    padding: 1.25rem; margin-bottom: 1.5rem; font-size: 0.85rem; color: var(--text-secondary);
+}
+.instructions strong { color: var(--text-primary); }
+.instructions ol { padding-left: 1.25rem; margin-top: 0.5rem; }
+.instructions li { margin-bottom: 0.25rem; }
+
+@media (max-width: 768px) {
+    .toc-flow { flex-direction: column; align-items: stretch; }
+    .toc-column { max-width: 100%; min-width: 100%; }
+    .arrow-connector { transform: rotate(90deg); min-width: auto; padding: 0.5rem 0; }
+}
+
+/* ── Pro Studio branding + freemium ─────────────────────────── */
+.header { flex-wrap: wrap; gap: 0.75rem; }
+.header-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+.header-brand { display: flex; align-items: center; gap: 0.5rem; text-decoration: none; color: var(--text-primary); }
+.header-brand img { width: 30px; height: 30px; border-radius: 6px; }
+.header-brand .brand-name { font-family: 'Inter', sans-serif; font-weight: 700; font-size: 1rem; }
+.tool-name { font-family: 'Inter', sans-serif; font-size: 1.05rem; font-weight: 600; padding-left: 0.75rem; border-left: 2px solid var(--border-color); }
+.pro-pill { display: inline-flex; align-items: center; gap: 0.2rem; background: linear-gradient(135deg,#F59E0B,#EF4444); color: #fff; font-weight: 700; font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.4px; padding: 0.15rem 0.45rem; border-radius: 5px; white-space: nowrap; }
+.freemium-note { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 1.5rem; padding: 0.6rem 0.9rem; background: rgba(245,158,11,0.08); border: 1px solid rgba(245,158,11,0.3); border-radius: 8px; font-size: 0.82rem; color: var(--text-secondary); }
+.freemium-note a { color: #F59E0B; font-weight: 700; text-decoration: none; }
+.freemium-note a:hover { text-decoration: underline; }
+@media (max-width: 640px) { .tool-name { font-size: 0.9rem; padding-left: 0.5rem; } .header-brand .brand-name { display: none; } }
+@media print { .freemium-note { display: none !important; } }
+</style>
+</head>
+<body>
+
+<div class="header">
+    <div style="display:flex; align-items:center; gap:0.75rem; flex-wrap:wrap;">
+        <a class="header-brand" href="/" title="ImpactMojo home">
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="30" height="30">
+            <span class="brand-name">ImpactMojo</span>
+        </a>
+        <h1 class="tool-name">Theory of Change Workbench</h1>
+    </div>
+    <div class="header-actions">
+        <button class="btn" onclick="toggleDarkMode()" title="Toggle dark mode" aria-label="Toggle dark mode">&#9790;</button>
+        <button class="btn" onclick="clearAll()">Clear All</button>
+        <button class="btn" onclick="loadExample()">Load Example</button>
+        <button class="btn btn-primary" onclick="exportToJSON()">Export JSON <span class="pro-pill">&#9733; Premium</span></button>
+        <button class="btn btn-primary" onclick="printTemplate()">Print / PDF <span class="pro-pill">&#9733; Premium</span></button>
+    </div>
+</div>
+
+<div class="canvas-container">
+    <div class="instructions">
+        <strong>How to use this Theory of Change builder:</strong>
+        <ol>
+            <li>Work <strong>backwards from Impact</strong> &mdash; start with the change you want to see, then fill in what's needed to get there.</li>
+            <li>Click <strong>"+ Add card"</strong> to add items to each column. Type directly into cards to edit.</li>
+            <li>Use the <strong>Assumptions</strong> column to capture what must hold true for your logic to work.</li>
+            <li><strong>Export</strong> as JSON to save your work, or <strong>Print</strong> to create a PDF.</li>
+        </ol>
+    </div>
+
+    <div class="freemium-note">
+        <span class="pro-pill">&#9733; Premium</span>
+        <span>Building is free. Exporting is a Premium feature. <a href="/premium.html#detail-practitioner">Upgrade to Practitioner &rarr;</a></span>
+    </div>
+
+    <div class="toc-flow" id="tocFlow">
+        <!-- Columns rendered by JS -->
+    </div>
+</div>
+
+<script>
+var COLUMNS = [
+    { id: 'inputs', label: 'Inputs / Resources', info: 'What you invest', class: 'col-inputs', placeholder: 'e.g., Funding, staff, equipment...' },
+    { id: 'activities', label: 'Activities', info: 'What you do', class: 'col-activities', placeholder: 'e.g., Training workshops, data collection...' },
+    { id: 'outputs', label: 'Outputs', info: 'What you produce', class: 'col-outputs', placeholder: 'e.g., 200 people trained, 5 reports...' },
+    { id: 'outcomes', label: 'Outcomes', info: 'Short & medium-term changes', class: 'col-outcomes', placeholder: 'e.g., Improved practices, policy changes...' },
+    { id: 'impact', label: 'Impact', info: 'Long-term change', class: 'col-impact', placeholder: 'e.g., Reduced poverty, improved health...' },
+    { id: 'assumptions', label: 'Assumptions', info: 'What must hold true', class: 'col-assumptions', placeholder: 'e.g., Political stability, community buy-in...' }
+];
+
+var tocData = {};
+var STORAGE_KEY = 'impactmojo_toc';
+
+function init() {
+    var saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+        try { tocData = JSON.parse(saved); } catch(e) { tocData = {}; }
+    }
+    COLUMNS.forEach(function(col) {
+        if (!tocData[col.id]) tocData[col.id] = [];
+    });
+    render();
+}
+
+function save() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(tocData));
+}
+
+function render() {
+    var flow = document.getElementById('tocFlow');
+    flow.innerHTML = '';
+    COLUMNS.forEach(function(col, i) {
+        if (i > 0 && i < 5) {
+            var arrow = document.createElement('div');
+            arrow.className = 'arrow-connector';
+            arrow.innerHTML = '&#8594;';
+            flow.appendChild(arrow);
+        }
+        if (i === 5) {
+            var spacer = document.createElement('div');
+            spacer.style.cssText = 'min-width:24px;flex-shrink:0;';
+            flow.appendChild(spacer);
+        }
+        var column = document.createElement('div');
+        column.className = 'toc-column ' + col.class;
+        column.innerHTML = '<div class="column-header">' + col.label + '<span class="column-info">' + col.info + '</span></div>';
+
+        var list = document.createElement('div');
+        list.className = 'card-list';
+        list.dataset.column = col.id;
+
+        list.addEventListener('dragover', function(e) { e.preventDefault(); this.style.background = 'rgba(245,158,11,0.08)'; });
+        list.addEventListener('dragleave', function() { this.style.background = ''; });
+        list.addEventListener('drop', function(e) {
+            e.preventDefault(); this.style.background = '';
+            var from = e.dataTransfer.getData('text/plain');
+            var parts = from.split(':');
+            var fromCol = parts[0], fromIdx = parseInt(parts[1]);
+            var toCol = this.dataset.column;
+            if (fromCol === toCol) return;
+            var item = tocData[fromCol].splice(fromIdx, 1)[0];
+            tocData[toCol].push(item);
+            save(); render();
+        });
+
+        (tocData[col.id] || []).forEach(function(text, idx) {
+            var card = document.createElement('div');
+            card.className = 'toc-card';
+            card.draggable = true;
+            card.addEventListener('dragstart', function(e) {
+                e.dataTransfer.setData('text/plain', col.id + ':' + idx);
+                this.classList.add('dragging');
+            });
+            card.addEventListener('dragend', function() { this.classList.remove('dragging'); });
+
+            var ta = document.createElement('textarea');
+            ta.value = text;
+            ta.rows = 2;
+            ta.placeholder = col.placeholder;
+            ta.addEventListener('input', function() {
+                this.style.height = 'auto';
+                this.style.height = this.scrollHeight + 'px';
+                tocData[col.id][idx] = this.value;
+                save();
+            });
+            setTimeout(function() { ta.style.height = ta.scrollHeight + 'px'; }, 0);
+
+            var del = document.createElement('button');
+            del.className = 'delete-card';
+            del.innerHTML = '&times;';
+            del.title = 'Remove';
+            del.addEventListener('click', function() {
+                tocData[col.id].splice(idx, 1);
+                save(); render();
+            });
+
+            card.appendChild(ta);
+            card.appendChild(del);
+            list.appendChild(card);
+        });
+
+        var addBtn = document.createElement('button');
+        addBtn.className = 'add-card-btn';
+        addBtn.textContent = '+ Add card';
+        addBtn.addEventListener('click', function() {
+            tocData[col.id].push('');
+            save(); render();
+            var cards = list.querySelectorAll('.toc-card textarea');
+            if (cards.length) cards[cards.length - 1].focus();
+        });
+        list.appendChild(addBtn);
+
+        column.appendChild(list);
+        flow.appendChild(column);
+    });
+}
+
+function clearAll() {
+    if (!confirm('Clear all cards? This cannot be undone.')) return;
+    COLUMNS.forEach(function(c) { tocData[c.id] = []; });
+    save(); render();
+}
+
+function loadExample() {
+    tocData = {
+        inputs: ['$500K grant funding', '5 field staff + 2 data analysts', 'Community health centers (10 sites)', 'Training materials & curricula'],
+        activities: ['Train 200 community health workers', 'Deploy mobile data collection system', 'Conduct monthly supervision visits', 'Run quarterly community feedback sessions'],
+        outputs: ['200 CHWs trained and certified', '10,000 household visits/month', '12 data dashboards published', '40 community feedback sessions held'],
+        outcomes: ['80% of target households receive regular health check-ups', 'Early detection of malnutrition cases increases by 60%', 'Community trust in health services improves', 'District health office uses data for resource allocation'],
+        impact: ['Under-5 mortality reduced by 15% in target districts', 'Sustainable community-led health monitoring system established'],
+        assumptions: ['Government maintains health budget allocations', 'Community leaders support the program', 'Mobile network coverage remains stable', 'No major disease outbreaks disrupt services']
+    };
+    save(); render();
+}
+
+function exportToJSON() {
+    if (!requirePremium()) return; // building is free, exporting is Premium
+    var blob = new Blob([JSON.stringify(tocData, null, 2)], { type: 'application/json' });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = url; a.download = 'theory-of-change.json'; a.click();
+    URL.revokeObjectURL(url);
+}
+
+function printTemplate() {
+    if (!requirePremium()) return; // building is free, exporting is Premium
+    window.print();
+}
+
+function toggleDarkMode() {
+    document.body.classList.toggle('dark-mode');
+    localStorage.setItem('impactmojo_dark', document.body.classList.contains('dark-mode'));
+}
+
+if (localStorage.getItem('impactmojo_dark') === 'true') document.body.classList.add('dark-mode');
+init();
+</script>
+
+<!-- ImpactMojo auth + premium (Pro Studio freemium gate) -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
+<script src="/js/premium.js"></script>
+<script>
+// Pro Studio freemium: building is free for everyone; exporting is Premium.
+// The whole builder above is always visible — no sign-in wall to use it.
+window.TOOL_PREMIUM = false;
+var TOOL_TIER = 'practitioner';
+async function initGate() {
+  try { if (window.ImpactMojoAuth) await window.ImpactMojoAuth.waitForAuthReady(); } catch (e) {}
+  var auth = window.ImpactMojoAuth;
+  window.TOOL_PREMIUM = !!(auth && typeof auth.hasTierAccess === 'function' && auth.hasTierAccess(TOOL_TIER));
+}
+// Gate a Premium action (export/print). Free users get the upgrade path.
+function requirePremium() {
+  if (window.TOOL_PREMIUM) return true;
+  if (window.IMXPremium && typeof window.IMXPremium.showUpgradeModal === 'function') window.IMXPremium.showUpgradeModal(TOOL_TIER);
+  else window.location.href = '/premium.html#detail-' + TOOL_TIER;
+  return false;
+}
+if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initGate);
+else initGate();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Moves the 7 **Pro Studio** workshop tools into `premium-tools/` (alongside `rq-builder.html`) and repoints the homepage cards to them — so the ImpactMojo Supabase session is **same-origin** and **Premium actually unlocks**.

### Why this is needed

The Supabase session lives in `localStorage` (key `impactmojo-auth`), which is **origin-scoped**. The homepage cards previously linked to `https://impactmojo-workshop-pro.netlify.app/*.html` — a **separate origin** where the session is invisible, so `hasTierAccess()` was always `false` and export could never unlock for subscribers. Hosting the files here (same origin as `www.impactmojo.in`) fixes it. This is the "cleaner long-term option" flagged in the workshop-repo PR.

## What's in this PR

**7 new tools under `premium-tools/`** (freemium — building is free for everyone, export/print gated via `requirePremium()`):

| File | Tool | Tier |
|------|------|------|
| `premium-tools/toc-pro.html` | Theory of Change Workbench | Practitioner |
| `premium-tools/logframe-pro.html` | Logical Framework Builder | Professional |
| `premium-tools/chart-selector-pro.html` | Data Visualization Chart Selector | *Free* (no export action) |
| `premium-tools/stakeholder-pro.html` | Stakeholder Mapping | Professional |
| `premium-tools/empathy-pro.html` | Empathy Mapping | Professional |
| `premium-tools/policy-canvas-pro.html` | Policy Analysis Canvas | Professional |
| `premium-tools/ai-canvas-pro.html` | AI Strategy Canvas | Professional |

Each loads the site auth stack via **root-relative** paths (`/js/state-manager.js`, `/js/config.js`, `/js/auth.js`, `/js/premium.js`), gates export with `IMXPremium.showUpgradeModal(tier)`, and shows a ★ Premium pill + *"Building is free. Exporting is a Premium feature."* Branding matches the suite: ImpactMojo logo top bar, Amaranth/Inter, light+dark, responsive, accessible labels.

**`index.html`** — repointed all 16 Pro Studio card/modal links from the workshop Netlify domain → `/premium-tools/*.html`.

## Verification

Driven with Playwright against the **real auth stack served same-origin**:
- Tools load and build **logged-out** (free); Chart Selector fully free (no gate).
- `window.ImpactMojoAuth.hasTierAccess` and `window.IMXPremium.showUpgradeModal` wire up correctly same-origin.
- Export is **blocked while free** → upgrade modal.
- With a subscribed profile, `hasTierAccess()` returns true → `TOOL_PREMIUM` flips → **export unlocks** (the path that was impossible cross-domain).

## Notes / follow-ups

- The tools carry their own clean header/footer (logo + tool name + actions). Full `im-topbar`/`im-footer` parity with `rq-builder.html` can be a follow-up polish if desired.
- The source of these files lives in `Varnasr/impactmojo-workshop-pro` (PR #1 there). Once this ships, that repo can be treated as the dev source or retired. `_redirects` from the old workshop domain paths could be added if any external links point at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjA2YggbarV9Sw7m65c6Df

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjA2YggbarV9Sw7m65c6Df)_