### PR TITLE
Homepage: add #pro-studio anchor for the Pro Studio section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2959,7 +2959,7 @@ window.addEventListener('authStateChanged', function(e) {
 </div>
 </section>
 
-<section class="section" id="premium">
+<span id="premium" aria-hidden="true"></span><section class="section" id="pro-studio">
 <h2 class="section-title">Pro Studio</h2>
 <p class="section-subtitle">Professional-grade tools for serious practitioners &mdash; moving to a free-to-use model, with export and advanced modes on Premium</p>
 <div class="imx-premium-tiers">
@@ -4803,7 +4803,7 @@ PASTE THIS ENTIRE BLOCK JUST BEFORE
     <a href="#free-resources" class="section-nav-dot" data-section="free-resources"><span class="section-nav-label">Libraries</span><span class="section-nav-dot-circle"></span></a>
     <a href="#tracks" class="section-nav-dot" data-section="tracks"><span class="section-nav-label">Tracks</span><span class="section-nav-dot-circle"></span></a>
     <a href="#community" class="section-nav-dot" data-section="community"><span class="section-nav-label">Community</span><span class="section-nav-dot-circle"></span></a>
-    <a href="#premium" class="section-nav-dot" data-section="premium"><span class="section-nav-label">Premium</span><span class="section-nav-dot-circle"></span></a>
+    <a href="#pro-studio" class="section-nav-dot" data-section="pro-studio"><span class="section-nav-label">Pro Studio</span><span class="section-nav-dot-circle"></span></a>
     <a href="#about" class="section-nav-dot" data-section="about"><span class="section-nav-label">About</span><span class="section-nav-dot-circle"></span></a>
 </nav>
 

--- a/js/tours.js
+++ b/js/tours.js
@@ -123,7 +123,7 @@
       { element: '#nav-specials', intro: '<strong>Explore</strong><br>The Game Library, reference tools (Dataverse, ImpactLex), Book Companions, Deep Dives, the Research to Action poster series, Dojos, and more.' },
       { element: '#nav-dataverse', intro: '<strong>Dataverse</strong><br>296 curated data tools, APIs, and datasets for development research.' },
       { element: '.theme-selector', intro: '<strong>Theme</strong><br>Switch between light, dark, and system themes.' },
-      { element: '#premium', intro: '<strong>Premium Tools</strong><br>Professional-grade tools like VaniScribe AI, Code Convert Pro, and Qual Insights Lab.' }
+      { element: '#pro-studio', intro: '<strong>Pro Studio</strong><br>Professional-grade tools like VaniScribe AI, Code Convert Pro, and Qual Insights Lab.' }
     ],
 
     catalog: [


### PR DESCRIPTION
## Summary

`https://www.impactmojo.in/#pro-studio` went nowhere because the Pro Studio section still used `id="premium"`. This renames it to **`id="pro-studio"`** so the shareable URL matches the section title.

- `index.html`: section `id="premium"` → `id="pro-studio"`; scrollspy nav dot updated (`href="#pro-studio"`, `data-section="pro-studio"`, label "Pro Studio").
- `js/tours.js`: onboarding tour step target `#premium` → `#pro-studio`.
- **Backward-compat:** a hidden `<span id="premium">` is kept immediately before the section, so any existing `/#premium` links still land in the same place.

No visual/content change — anchor + nav wiring only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjA2YggbarV9Sw7m65c6Df

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjA2YggbarV9Sw7m65c6Df)_