### PR TITLE
Homepage: fix in-page #anchor landing on the tall homepage (mobile)

### DIFF
--- a/index.html
+++ b/index.html
@@ -321,6 +321,7 @@ window.addEventListener('click', function(e) {
   ]
 }
 </script>
+<style>html{scroll-padding-top:88px;}</style>
 </head>
 <body>
 <svg xmlns="http://www.w3.org/2000/svg" style="display:none" aria-hidden="true"><symbol id="spr-1" viewBox="0 0 24 24"><polyline points="6 9 12 15 18 9"></polyline></symbol><symbol id="spr-2" viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></symbol><symbol id="spr-3" viewBox="0 0 24 24"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></symbol><symbol id="spr-4" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3"/></symbol><symbol id="spr-5" viewBox="0 0 24 24"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></symbol><symbol id="spr-6" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></symbol><symbol id="spr-7" viewBox="0 0 24 24"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></symbol><symbol id="spr-8" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></symbol><symbol id="spr-9" viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></symbol><symbol id="spr-10" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></symbol><symbol id="spr-11" viewBox="0 0 24 24"><path d="M9 18V5l12-2v13"></path><circle cx="6" cy="18" r="3"></circle><circle cx="18" cy="16" r="3"></circle></symbol><symbol id="spr-12" viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></symbol><symbol id="spr-13" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></symbol></svg>
@@ -5852,5 +5853,41 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 </script>
 <script src="/js/translate-sarvam.js" defer></script>
+<script>
+/* Robust in-page anchor landing. The homepage is very tall and lazy-loads /
+   reflows content, so the browser's native jump to a #hash is left stranded
+   above the real target (badly on mobile). Re-scroll to the target as the page
+   settles, offsetting the ~88px fixed header. Cancels on first user scroll. */
+(function () {
+  var HEADER_OFFSET = 88;
+  function targetFromHash() {
+    var h = location.hash; if (!h || h.length < 2) return null;
+    var id; try { id = decodeURIComponent(h.slice(1)); } catch (e) { id = h.slice(1); }
+    return document.getElementById(id);
+  }
+  function scrollTo(el, smooth) {
+    var top = el.getBoundingClientRect().top + window.pageYOffset - HEADER_OFFSET;
+    window.scrollTo({ top: top < 0 ? 0 : top, behavior: smooth ? 'smooth' : 'auto' });
+  }
+  function settle() {
+    if (!targetFromHash()) return;
+    var cancelled = false;
+    function cancel() { cancelled = true; }
+    ['wheel', 'touchmove', 'keydown'].forEach(function (ev) {
+      window.addEventListener(ev, cancel, { passive: true, once: true });
+    });
+    [0, 150, 400, 800, 1400, 2200, 3200].forEach(function (t) {
+      setTimeout(function () { if (cancelled) return; var el = targetFromHash(); if (el) scrollTo(el, false); }, t);
+    });
+  }
+  if (location.hash) {
+    if (document.readyState === 'complete') settle();
+    else window.addEventListener('load', settle);
+  }
+  window.addEventListener('hashchange', function () {
+    var el = targetFromHash(); if (el) setTimeout(function () { scrollTo(el, true); }, 0);
+  });
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Problem

Opening an in-page anchor like `https://www.impactmojo.in/#pro-studio` scrolled to a **random spot** (e.g. a "Climate Migration" card), especially on mobile.

**Root cause (reproduced at 390px):** the homepage is ~34,000px tall and lazy-loads / reflows content after first paint. The browser's native jump to the hash happens early — it lands at the section's *then*-position (~29,600px), but content above keeps loading and pushes the section down ~2,400–4,800px, leaving the viewport stranded thousands of px above the target. It never self-corrects. The 88px fixed header offset is negligible next to this drift.

## Fix

`index.html` only:
- A small **settle-to-hash** handler that re-scrolls to the hash target across a few timed passes after `load` (0–3.2s), offsetting the ~88px fixed header, and **cancels on the first user scroll/touch/key** so it never fights the user. Also handles `hashchange`.
- `html { scroll-padding-top: 88px }` so native jumps / `hashchange` land just below the fixed header.

No content or visual changes; purely scroll behavior. Benefits **all** section anchors (`#home`, `#free-tools`, `#pro-studio`, `#about`, …), not just Pro Studio.

## Verification

Playwright at 390px (mobile), after full settle:
| hash | lands on | section top in viewport |
|------|----------|-------------------------|
| `#pro-studio` | "Pro Studio" | 88px (just under header) ✅ |
| `#premium` (back-compat) | same section | 88px ✅ |
| `#free-tools` | "Free Tools" | 88px ✅ |

Before the fix, `#pro-studio` stranded ~2,500px above the section on "Climate Migration in South Asia."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjA2YggbarV9Sw7m65c6Df

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjA2YggbarV9Sw7m65c6Df)_