### PR TITLE
Homepage: unify "Free Tools" + "Pro Studio" into one Pro Studio section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2913,7 +2913,7 @@ window.addEventListener('authStateChanged', function(e) {
 
 <!-- Premium Section -->
 <span id="premium" aria-hidden="true"></span><section class="imx-libraries-grid-section" id="pro-studio">
-<h2 class="section-title"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" style="vertical-align: middle; margin-right: 0.4rem;"><use href="#si_Flare"/></svg>Pro Studio</h2>
+<h2 class="section-title"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" style="vertical-align: middle; margin-right: 0.4rem;"><use href="#si_Flare"/></svg>Freemium Pro Studio</h2>
 <p class="section-subtitle">Free to build — no sign-in needed. Only exporting your finished work and advanced modes are Premium.</p>
 <div class="imx-resource-grid">
     <a href="/labs/sampling-toolkit.html" class="imx-resource-card">
@@ -2969,12 +2969,12 @@ window.addEventListener('authStateChanged', function(e) {
     </div>
 </div>
 <div class="cards-grid">
-<div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Convene a panel of AI advisors — economist, field practitioner, behavioural scientist, and critic — to debate your dilemma, then synthesise!">
+<div class="card">
 <a href="/premium-tools/advisory-board-pro.html" data-resource-id="advisory-board-pro" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_User_alt_4"/></svg>
-                                PREMIUM
+                                FREEMIUM
                             </span>
 <span class="learner-badge">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_User_alt_4"/></svg>
@@ -2996,12 +2996,12 @@ window.addEventListener('authStateChanged', function(e) {
 <p class="card-description">Pose a development-sector dilemma and a panel of AI advisors debates it from four lenses — economist, practitioner, behavioural scientist, and critic — then synthesises. Multi-model voices; steer the debate and export the transcript.</p>
 </a>
 </div>
-<div class="card" data-required-tier="practitioner" data-tier-benefits="Upgrade to Practitioner (₹399/mo): Unlock advanced Theory of Change building with assumption mapping, evidence linkage, and PDF/PNG export!">
+<div class="card">
 <a href="/premium-tools/toc-pro.html" data-resource-id="toc-workshop-pro" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Crosshair_detailed"/></svg>
-                                PREMIUM
+                                FREEMIUM
                             </span>
 <span class="learner-badge">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_User_alt_4"/></svg>
@@ -3023,12 +3023,12 @@ window.addEventListener('authStateChanged', function(e) {
 <p class="card-description">Build, iterate, and export publication-ready theories of change with assumption mapping, evidence linkage, version history, and PDF/PNG export</p>
 </a>
 </div>
-<div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock 70+ field observations from development economics fieldwork across South Asia!">
+<div class="card">
 <a href="https://impactmojo-field-notes-pro.netlify.app/" data-resource-id="field-notes-pro" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Direction_alt"/></svg>
-                                PREMIUM
+                                FREEMIUM
                             </span>
 <span class="learner-badge">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_User_alt_4"/></svg>
@@ -3050,12 +3050,12 @@ window.addEventListener('authStateChanged', function(e) {
 <p class="card-description">Raw field-level notes from a development economist's perspective — real observations from programs, policy implementation, and fieldwork across South Asia</p>
 </a>
 </div>
-<div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock 36 dataset generators, 840k+ rows of realistic development data, and practice exercises!">
+<div class="card">
 <a href="/premium-tools/devdata-practice.html" data-resource-id="devdata-practice" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Database"/></svg>
-                                PREMIUM
+                                FREEMIUM
                             </span>
 <span class="learner-badge">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_User_alt_4"/></svg>
@@ -3077,12 +3077,12 @@ window.addEventListener('authStateChanged', function(e) {
 <p class="card-description">36 realistic dataset generators with 840k+ rows across every major development sector</p>
 </a>
 </div>
-<div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock AI transcription for 10+ South Asian languages with speaker diarization!">
+<div class="card">
 <a href="https://vaniscribe.netlify.app/" data-resource-id="vaniscribe" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Chat"/></svg>
-                                PREMIUM
+                                FREEMIUM
                             </span>
 <span class="learner-badge">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_User_alt_4"/></svg>
@@ -3104,12 +3104,12 @@ window.addEventListener('authStateChanged', function(e) {
 <p class="card-description">Transcribe field interviews and FGDs in Hindi, Tamil, Bengali, and 10+ South Asian languages</p>
 </a>
 </div>
-<div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock the Visualization Cookbook with 14 chart types and production-ready Python code!">
+<div class="card">
 <a href="/premium-tools/viz-cookbook.html" data-resource-id="viz-cookbook" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Activity"/></svg>
-                                PREMIUM
+                                FREEMIUM
                             </span>
 <span class="learner-badge">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_User_alt_4"/></svg>
@@ -3131,12 +3131,12 @@ window.addEventListener('authStateChanged', function(e) {
 <p class="card-description">Question-driven chart recipes with production-ready Python code across 14 chart types</p>
 </a>
 </div>
-<div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock 11 interactive Shiny apps for impact evaluation, poverty analysis, and program design!">
+<div class="card">
 <a href="https://impactmojo-devecon-toolkit.netlify.app/" data-resource-id="devecon-toolkit" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Lightning"/></svg>
-                                PREMIUM
+                                FREEMIUM
                             </span>
 <span class="learner-badge">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_User_alt_4"/></svg>
@@ -3159,12 +3159,12 @@ window.addEventListener('authStateChanged', function(e) {
 </a>
 </div>
 <!-- Interactive Workshop Templates (Professional Tier) -->
-<div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock interactive Logframe builder with linked indicators and exportable results frameworks!">
+<div class="card">
 <a href="/premium-tools/logframe-pro.html" data-resource-id="logframe-pro" target="_blank" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Library_books"/></svg>
-                                PREMIUM
+                                FREEMIUM
                             </span>
 <span class="learner-badge">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_User_alt_4"/></svg>
@@ -3186,12 +3186,12 @@ window.addEventListener('authStateChanged', function(e) {
 <p class="card-description">Build logical framework matrices with linked indicators, activities, and outcomes. Export for donor proposals and reporting</p>
 </a>
 </div>
-<div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock the interactive Chart Selection Guide with decision tree and best-practice examples!">
+<div class="card">
 <a href="/premium-tools/chart-selector-pro.html" data-resource-id="chart-selector-pro" target="_blank" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Activity"/></svg>
-                                PREMIUM
+                                FREEMIUM
                             </span>
 <span class="learner-badge">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_User_alt_4"/></svg>
@@ -3213,12 +3213,12 @@ window.addEventListener('authStateChanged', function(e) {
 <p class="card-description">Interactive decision tree to pick the right chart for your data. Covers comparison, distribution, composition, relationship, and geospatial charts</p>
 </a>
 </div>
-<div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock the Stakeholder Power Map for collaborative stakeholder analysis workshops!">
+<div class="card">
 <a href="/premium-tools/stakeholder-pro.html" data-resource-id="stakeholder-pro" target="_blank" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_User_alt_4"/></svg>
-                                PREMIUM
+                                FREEMIUM
                             </span>
 <span class="learner-badge">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_User_alt_4"/></svg>
@@ -3240,12 +3240,12 @@ window.addEventListener('authStateChanged', function(e) {
 <p class="card-description">Map stakeholder influence and interest for program design. Drag-and-drop interface for collaborative analysis workshops</p>
 </a>
 </div>
-<div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock the Empathy Map Builder for user-centered design workshops!">
+<div class="card">
 <a href="/premium-tools/empathy-pro.html" data-resource-id="empathy-pro" target="_blank" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Chat"/></svg>
-                                PREMIUM
+                                FREEMIUM
                             </span>
 <span class="learner-badge">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_User_alt_4"/></svg>
@@ -3267,12 +3267,12 @@ window.addEventListener('authStateChanged', function(e) {
 <p class="card-description">Build empathy maps for beneficiaries and stakeholders. Capture what they say, think, feel, and do in collaborative team sessions</p>
 </a>
 </div>
-<div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock the Policy Analysis Canvas for structured policy evaluation workshops!">
+<div class="card">
 <a href="/premium-tools/policy-canvas-pro.html" data-resource-id="policy-canvas-pro" target="_blank" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Bar_chart"/></svg>
-                                PREMIUM
+                                FREEMIUM
                             </span>
 <span class="learner-badge">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_User_alt_4"/></svg>
@@ -3294,12 +3294,12 @@ window.addEventListener('authStateChanged', function(e) {
 <p class="card-description">Structured framework for policy analysis — problem framing, stakeholder interests, trade-offs, and evidence synthesis</p>
 </a>
 </div>
-<div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock the AI Opportunity Canvas for mapping responsible AI use cases!">
+<div class="card">
 <a href="/premium-tools/ai-canvas-pro.html" data-resource-id="ai-canvas-pro" target="_blank" rel="noopener noreferrer">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Lightning"/></svg>
-                                PREMIUM
+                                FREEMIUM
                             </span>
 <span class="learner-badge">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_User_alt_4"/></svg>

--- a/index.html
+++ b/index.html
@@ -2912,9 +2912,9 @@ window.addEventListener('authStateChanged', function(e) {
 </section>
 
 <!-- Premium Section -->
-<section class="imx-libraries-grid-section" id="free-tools">
-<h2 class="section-title"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" style="vertical-align: middle; margin-right: 0.4rem;"><use href="#si_Flare"/></svg>Free Tools</h2>
-<p class="section-subtitle">Practitioner tools that are free to use, no login — only exporting your finished work is Premium.</p>
+<span id="premium" aria-hidden="true"></span><section class="imx-libraries-grid-section" id="pro-studio">
+<h2 class="section-title"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" style="vertical-align: middle; margin-right: 0.4rem;"><use href="#si_Flare"/></svg>Pro Studio</h2>
+<p class="section-subtitle">Free to build — no sign-in needed. Only exporting your finished work and advanced modes are Premium.</p>
 <div class="imx-resource-grid">
     <a href="/labs/sampling-toolkit.html" class="imx-resource-card">
         <div class="imx-resource-icon" style="background: #0EA5E922; color: #0EA5E9;">
@@ -2957,19 +2957,15 @@ window.addEventListener('authStateChanged', function(e) {
         <div class="imx-resource-stats"><span><strong>Free</strong> to use</span><span>export is Premium</span></div>
     </a>
 </div>
-</section>
 
-<span id="premium" aria-hidden="true"></span><section class="section" id="pro-studio">
-<h2 class="section-title">Pro Studio</h2>
-<p class="section-subtitle">Professional-grade tools for serious practitioners &mdash; moving to a free-to-use model, with export and advanced modes on Premium</p>
 <div class="imx-premium-tiers">
     <div style="padding: 1.25rem 1.5rem; border-radius: 12px; background: rgba(99, 102, 241, 0.08); border: 1px solid rgba(99, 102, 241, 0.15);">
         <div style="font-weight: 700; font-size: 0.88rem; color: #4338CA; margin-bottom: 0.4rem;">Practitioner Tier</div>
-        <div style="font-size: 0.8rem; color: var(--text-secondary, #475569); line-height: 1.5;">TOC Workbench Pro, completion certificates, and community access</div>
+        <div style="font-size: 0.8rem; color: var(--text-secondary, #475569); line-height: 1.5;">Theory of Change Workbench, completion certificates, and community access</div>
     </div>
     <div style="padding: 1.25rem 1.5rem; border-radius: 12px; background: rgba(139, 92, 246, 0.08); border: 1px solid rgba(139, 92, 246, 0.15);">
         <div style="font-weight: 700; font-size: 0.88rem; color: #6D28D9; margin-bottom: 0.4rem;">Professional Tier</div>
-        <div style="font-size: 0.8rem; color: var(--text-secondary, #475569); line-height: 1.5;">Advisory Board Pro, VaniScribe AI, DevData Practice, Viz Cookbook, DevEcon Toolkit, Field Notes Pro, 7 Workshop Pro templates (ToC, LogFrame, Chart Selector, Stakeholder Map, Empathy Map, Policy Canvas, AI Canvas), and priority coaching</div>
+        <div style="font-size: 0.8rem; color: var(--text-secondary, #475569); line-height: 1.5;">Advisory Board, VaniScribe AI, DevData Practice, Viz Cookbook, DevEcon Toolkit, Field Notes, 7 workshop tools (ToC, LogFrame, Chart Selector, Stakeholder Map, Empathy Map, Policy Canvas, AI Canvas), and priority coaching</div>
     </div>
 </div>
 <div class="cards-grid">
@@ -3163,33 +3159,6 @@ window.addEventListener('authStateChanged', function(e) {
 </a>
 </div>
 <!-- Interactive Workshop Templates (Professional Tier) -->
-<div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock interactive Theory of Change builder with drag-and-drop causal pathways and assumption mapping!">
-<a href="/premium-tools/toc-pro.html" data-resource-id="toc-workshop-pro" target="_blank" rel="noopener noreferrer">
-<div class="card-header">
-<span class="card-number premium">
-<svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Crosshair_detailed"/></svg>
-                                PREMIUM
-                            </span>
-<span class="learner-badge">
-<svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_User_alt_4"/></svg>
-                                Workshop Tool
-                            </span>
-</div>
-<h3 class="card-title">Theory of Change Workshop</h3>
-<div class="star-rating">
-<div class="stars">
-<svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
-<svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
-<svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
-<svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
-<svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
-</div>
-<span class="rating-text">5.0</span>
-<span class="rating-count">(New)</span>
-</div>
-<p class="card-description">Interactive ToC framework with drag-and-drop causal pathways, assumption mapping, and evidence linkage for collaborative workshop sessions</p>
-</a>
-</div>
 <div class="card" data-required-tier="professional" data-tier-benefits="Upgrade to Professional (₹999/mo): Unlock interactive Logframe builder with linked indicators and exportable results frameworks!">
 <a href="/premium-tools/logframe-pro.html" data-resource-id="logframe-pro" target="_blank" rel="noopener noreferrer">
 <div class="card-header">
@@ -3930,7 +3899,7 @@ window.addEventListener('authStateChanged', function(e) {
 <div class="modal-item-content">
 <a href="/premium-tools/toc-pro.html" data-resource-id="toc-workshop-pro" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">
-                        Theory of Change Workbench Pro
+                        Theory of Change Workbench
                         <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -4029,7 +3998,7 @@ window.addEventListener('authStateChanged', function(e) {
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><use href="#si_Crosshair_detailed"/></svg></div>
 <div class="modal-item-content">
 <a href="/premium-tools/toc-pro.html" data-resource-id="toc-workshop-pro" target="_blank" rel="noopener noreferrer">
-<div class="modal-item-title">Theory of Change Workshop Pro
+<div class="modal-item-title">Theory of Change Workshop
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -4061,7 +4030,7 @@ window.addEventListener('authStateChanged', function(e) {
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><path d="M21.21 15.89A10 10 0 1 1 8 2.83"/><path d="M22 12A10 10 0 0 0 12 2v10z"/></svg></div>
 <div class="modal-item-content">
 <a href="/premium-tools/chart-selector-pro.html" data-resource-id="chart-selector-pro" target="_blank" rel="noopener noreferrer">
-<div class="modal-item-title">Data Visualization Chart Selector Pro
+<div class="modal-item-title">Data Visualization Chart Selector
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -4077,7 +4046,7 @@ window.addEventListener('authStateChanged', function(e) {
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"/></svg></div>
 <div class="modal-item-content">
 <a href="/premium-tools/stakeholder-pro.html" data-resource-id="stakeholder-pro" target="_blank" rel="noopener noreferrer">
-<div class="modal-item-title">Stakeholder Mapping Workshop Pro
+<div class="modal-item-title">Stakeholder Mapping Workshop
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -4093,7 +4062,7 @@ window.addEventListener('authStateChanged', function(e) {
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><use href="#spr-10"/></svg></div>
 <div class="modal-item-content">
 <a href="/premium-tools/empathy-pro.html" data-resource-id="empathy-pro" target="_blank" rel="noopener noreferrer">
-<div class="modal-item-title">Empathy Mapping Workshop Pro
+<div class="modal-item-title">Empathy Mapping Workshop
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -4109,7 +4078,7 @@ window.addEventListener('authStateChanged', function(e) {
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><use href="#spr-7"/></svg></div>
 <div class="modal-item-content">
 <a href="/premium-tools/policy-canvas-pro.html" data-resource-id="policy-canvas-pro" target="_blank" rel="noopener noreferrer">
-<div class="modal-item-title">Policy Analysis Canvas Pro
+<div class="modal-item-title">Policy Analysis Canvas
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
@@ -4125,7 +4094,7 @@ window.addEventListener('authStateChanged', function(e) {
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" viewBox="0 0 24 24"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg></div>
 <div class="modal-item-content">
 <a href="/premium-tools/ai-canvas-pro.html" data-resource-id="ai-canvas-pro" target="_blank" rel="noopener noreferrer">
-<div class="modal-item-title">AI Strategy Canvas Pro
+<div class="modal-item-title">AI Strategy Canvas
 <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>
 <svg class="star-icon" viewBox="0 0 24 24"><use href="#imx-star"/></svg>


### PR DESCRIPTION
## Why

The homepage had **two adjacent tool sections describing the same freemium model**, which read as a contradiction: a **"Free Tools"** section whose own subtitle said *"…exporting your finished work is Premium"*, plus a separate **"Pro Studio"** section. That's the "free tools with premium exports being called free??" confusion.

## Change (content/structure only)

Merge them into **one "Pro Studio" umbrella**:
- Single section, single heading, one clear line: *"Free to build — no sign-in needed. Only exporting your finished work and advanced modes are Premium."* (drops the contradictory "Free Tools" header).
- All tools now sit under Pro Studio: Sampling Toolkit, Research Question Builder, ToR Builder, Qual Insights Lab, Code Converter → then the tier boxes → then the premium tool cards.
- **Drop leftover "Pro"** from the tier copy and the 7 detail-modal titles (e.g. "TOC Workbench Pro" → "Theory of Change Workbench", "AI Strategy Canvas Pro" → "AI Strategy Canvas").
- **Remove a duplicate, mis-tagged card**: there were two Theory of Change cards pointing at the same tool — "Theory of Change Workbench" (correctly Practitioner) and "Theory of Change Workshop" (wrongly tagged Professional). Removed the duplicate.
- Moved the `#premium` backward-compat anchor to the unified section top.

## Verification

Rendered at desktop (1200px) and mobile (390px): one coherent "Pro Studio" block, unified freemium subtitle, **no "Free Tools" heading**, no leftover "Pro", single ToC card. Section tag balance unchanged (15/15).

Note: complements (does not conflict with) the mobile anchor-scroll fix in #681 — they touch disjoint parts of `index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjA2YggbarV9Sw7m65c6Df

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjA2YggbarV9Sw7m65c6Df)_