### PR TITLE
Homepage: fix Freemium Pro Studio card styling + tier placement

### DIFF
--- a/css/imx-main.css
+++ b/css/imx-main.css
@@ -101,7 +101,7 @@
         section[id] { scroll-margin-top: 80px; }
         /* Defer rendering of below-fold sections until they scroll into view.
            This is a major speed win: the browser skips layout+paint for ~60% of the page. */
-        #popular-courses, #labs, #premium,
+        #popular-courses, #labs, #pro-studio,
         #support-us, #about {
             content-visibility: auto;
             contain-intrinsic-size: auto 600px;
@@ -6038,24 +6038,28 @@ footer::before {
 }
 
 /* === GRID: 2-col on desktop, wider cards === */
-#premium .cards-grid {
+#pro-studio .cards-grid {
     grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)) !important;
     gap: 1.5rem !important;
 }
-#premium .card {
+#pro-studio .imx-resource-grid {
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)) !important;
+    gap: 1.5rem !important;
+}
+#pro-studio .card {
     padding: 1.5rem;
 }
-#premium .card-header {
+#pro-studio .card-header {
     flex-direction: column;
     align-items: flex-start;
     gap: 0.5rem;
 }
-#premium .card-number,
-#premium .learner-badge {
+#pro-studio .card-number,
+#pro-studio .learner-badge {
     font-size: 0.72rem;
     white-space: nowrap;
 }
-#premium .card-title {
+#pro-studio .card-title {
     font-size: 1.1rem;
     margin-top: 0.25rem;
 }
@@ -6491,7 +6495,7 @@ footer::before {
     .premium-lock-overlay {
         height: 48px !important;
     }
-    #premium .cards-grid {
+    #pro-studio .cards-grid {
         grid-template-columns: 1fr !important;
     }
     

--- a/index.html
+++ b/index.html
@@ -2916,6 +2916,16 @@ window.addEventListener('authStateChanged', function(e) {
 <span id="premium" aria-hidden="true"></span><section class="imx-libraries-grid-section" id="pro-studio">
 <h2 class="section-title"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" style="vertical-align: middle; margin-right: 0.4rem;"><use href="#si_Flare"/></svg>Freemium Pro Studio</h2>
 <p class="section-subtitle">Free to build — no sign-in needed. Only exporting your finished work and advanced modes are Premium.</p>
+<div class="imx-premium-tiers">
+    <div style="padding: 1.25rem 1.5rem; border-radius: 12px; background: rgba(99, 102, 241, 0.08); border: 1px solid rgba(99, 102, 241, 0.15);">
+        <div style="font-weight: 700; font-size: 0.88rem; color: #4338CA; margin-bottom: 0.4rem;">Practitioner Tier</div>
+        <div style="font-size: 0.8rem; color: var(--text-secondary, #475569); line-height: 1.5;">Theory of Change Workbench, completion certificates, and community access</div>
+    </div>
+    <div style="padding: 1.25rem 1.5rem; border-radius: 12px; background: rgba(139, 92, 246, 0.08); border: 1px solid rgba(139, 92, 246, 0.15);">
+        <div style="font-weight: 700; font-size: 0.88rem; color: #6D28D9; margin-bottom: 0.4rem;">Professional Tier</div>
+        <div style="font-size: 0.8rem; color: var(--text-secondary, #475569); line-height: 1.5;">Advisory Board, VaniScribe AI, DevData Practice, Viz Cookbook, DevEcon Toolkit, Field Notes, 7 workshop tools (ToC, LogFrame, Chart Selector, Stakeholder Map, Empathy Map, Policy Canvas, AI Canvas), and priority coaching</div>
+    </div>
+</div>
 <div class="imx-resource-grid">
     <a href="/labs/sampling-toolkit.html" class="imx-resource-card">
         <div class="imx-resource-icon" style="background: #0EA5E922; color: #0EA5E9;">
@@ -2959,16 +2969,6 @@ window.addEventListener('authStateChanged', function(e) {
     </a>
 </div>
 
-<div class="imx-premium-tiers">
-    <div style="padding: 1.25rem 1.5rem; border-radius: 12px; background: rgba(99, 102, 241, 0.08); border: 1px solid rgba(99, 102, 241, 0.15);">
-        <div style="font-weight: 700; font-size: 0.88rem; color: #4338CA; margin-bottom: 0.4rem;">Practitioner Tier</div>
-        <div style="font-size: 0.8rem; color: var(--text-secondary, #475569); line-height: 1.5;">Theory of Change Workbench, completion certificates, and community access</div>
-    </div>
-    <div style="padding: 1.25rem 1.5rem; border-radius: 12px; background: rgba(139, 92, 246, 0.08); border: 1px solid rgba(139, 92, 246, 0.15);">
-        <div style="font-weight: 700; font-size: 0.88rem; color: #6D28D9; margin-bottom: 0.4rem;">Professional Tier</div>
-        <div style="font-size: 0.8rem; color: var(--text-secondary, #475569); line-height: 1.5;">Advisory Board, VaniScribe AI, DevData Practice, Viz Cookbook, DevEcon Toolkit, Field Notes, 7 workshop tools (ToC, LogFrame, Chart Selector, Stakeholder Map, Empathy Map, Policy Canvas, AI Canvas), and priority coaching</div>
-    </div>
-</div>
 <div class="cards-grid">
 <div class="card">
 <a href="/premium-tools/advisory-board-pro.html" data-resource-id="advisory-board-pro" rel="noopener noreferrer" target="_blank">


### PR DESCRIPTION
## What & why

Two issues surfaced after merging the sections into `#pro-studio`:

1. **Card styling regressed.** Renaming the section id `premium` → `pro-studio` (for the shareable anchor) orphaned all the `#premium`-scoped CSS in `imx-main.css` — the cards-grid column template, `.card` / `.card-header` / `.card-title` / badge styling, and a `content-visibility` perf rule. So the tool cards lost their intended look. Repointed every one of those selectors to `#pro-studio`.
2. **Two mismatched card grids.** The 5 utility cards (`imx-resource-grid`, 2-col) sat next to the 13 premium cards (`cards-grid`, auto-fill). Aligned the utility grid to the same `auto-fill / minmax(340px)` rhythm so both groups read as one consistent grid.
3. **Tier boxes were in the middle.** Moved the Practitioner/Professional tier boxes up under the heading (they were sandwiched between the two card groups).

Badges are unchanged — all Pro Studio cards stay FREEMIUM and free-to-open per the product decision.

## Verification

Rendered at 1280px: one coherent Freemium Pro Studio section — tiers on top, then a single consistent card grid with the premium card styling restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjA2YggbarV9Sw7m65c6Df

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjA2YggbarV9Sw7m65c6Df)_