### PR TITLE
Field Notes: import to premium-tools + freemium convert

### DIFF
--- a/index.html
+++ b/index.html
@@ -3025,7 +3025,7 @@ window.addEventListener('authStateChanged', function(e) {
 </a>
 </div>
 <div class="card">
-<a href="https://impactmojo-field-notes-pro.netlify.app/" data-resource-id="field-notes-pro" rel="noopener noreferrer" target="_blank">
+<a href="/premium-tools/field-notes.html" data-resource-id="field-notes-pro" rel="noopener noreferrer" target="_blank">
 <div class="card-header">
 <span class="card-number premium">
 <svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Direction_alt"/></svg>
@@ -3876,7 +3876,7 @@ window.addEventListener('authStateChanged', function(e) {
 <div class="modal-item" data-required-tier="professional" data-tier-benefits="Professional (₹999/mo): Unlock 70+ field observations from development fieldwork!">
 <div class="modal-item-icon"><svg fill="none" stroke="white" stroke-width="2" viewBox="0 0 24 24"><use href="#imx-star"/></svg></div>
 <div class="modal-item-content">
-<a href="https://impactmojo-field-notes-pro.netlify.app/" data-resource-id="field-notes-pro" target="_blank" rel="noopener noreferrer">
+<a href="/premium-tools/field-notes.html" data-resource-id="field-notes-pro" target="_blank" rel="noopener noreferrer">
 <div class="modal-item-title">
                         Field Notes Pro
                         <div class="stars" style="display: inline-flex; margin-left: 0.5rem;">

--- a/premium-tools/field-notes-data/notes.json
+++ b/premium-tools/field-notes-data/notes.json
@@ -1,0 +1,1224 @@
+[
+  {
+    "id": 1,
+    "text": "Monitoring and evaluation consultant visits revealing interesting organizational dynamics. Local NGO staff present polished success stories when evaluators from Delhi arrive, but informal conversations reveal different picture. Program adaptations happening on ground but not documented in official reports because they deviate from donor-approved design. Real innovation getting lost because reporting systems can't capture emergent learning. Need evaluation frameworks that reward adaptation, not just compliance.",
+    "category": "MEL & Research",
+    "tags": [
+      "Measurement"
+    ],
+    "location": "Delhi",
+    "featured": true
+  },
+  {
+    "id": 2,
+    "text": "Effective altruism workshop in Bangalore highlighting cultural assumptions embedded in utilitarian frameworks. Participants struggling with idea of maximizing aggregate welfare when local ethics emphasize relational obligations and community harmony. \"Greatest good for greatest number\" conflicts with duty-based moral systems. EA movement needs cross-cultural dialogue about moral foundations, not just better impact measurement. Western philosophy isn't universal foundation for doing good.",
+    "category": "MEL & Research",
+    "tags": [
+      "Effective Altruism",
+      "Measurement",
+      "Capacity Building"
+    ],
+    "location": "Karnataka",
+    "featured": false
+  },
+  {
+    "id": 3,
+    "text": "Digital literacy program for women's groups showing interesting technology adoption patterns. Older women learning smartphones faster than expected when training focuses on family communication rather than abstract digital skills. WhatsApp groups for coordinating SHG activities becoming platform for wider knowledge sharing. Technology adoption accelerates when aligned with existing social practices rather than imposing new behaviors. Start with familiar use cases, expand from there.",
+    "category": "Data & Technology",
+    "tags": [
+      "SHGs",
+      "Gender",
+      "Education",
+      "Technology"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 4,
+    "text": "Randomized controlled trial in rural Jharkhand facing unexpected contamination effects. Control villages learning about intervention through marriage networks and seasonal migration patterns. Randomization assumes neat boundaries between treatment and control that don't exist in practice. Social networks don't respect research design constraints. Need better methods for handling spillover effects in highly connected communities. Pure control groups might be impossible in small-world settings.",
+    "category": "Policy & Economics",
+    "tags": [
+      "RCTs",
+      "Migration"
+    ],
+    "location": "Jharkhand",
+    "featured": false
+  },
+  {
+    "id": 5,
+    "text": "Capacity building workshop on participatory research methods revealing power dynamics within research teams. Senior researchers talking about \"giving voice\" to communities while junior local researchers doing actual listening and translation work. Participatory rhetoric masking hierarchical research practices. Most important insights coming from research assistants who spend months in field, but they're excluded from analysis and writing phases. Need to decolonize research practice, not just research topics.",
+    "category": "Health & Communication",
+    "tags": [
+      "Fieldwork",
+      "Capacity Building"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 6,
+    "text": "Social emotional learning program in Haryana showing unexpected results. Kids from lower castes responding better to SEL interventions than upper caste children. Working theory: marginalized children already develop emotional regulation skills as survival mechanism - formal SEL just gives them vocabulary and frameworks they intuitively understand. Privileged kids less practiced at emotional self-management. SEL isn't neutral - it interacts with existing social hierarchies in complex ways.",
+    "category": "Health & Communication",
+    "tags": [
+      "Caste",
+      "Education"
+    ],
+    "location": "Haryana",
+    "featured": false
+  },
+  {
+    "id": 7,
+    "text": "Art-based education pilot in government schools facing resistance not from teachers but from parents. \"Why is my child drawing when they should be learning math?\" Art seen as luxury, not learning tool. But follow-up assessments show kids in art program scoring better on creative problem-solving tasks, which correlates with better performance in math word problems. Need to rebrand creative education as \"analytical thinking\" rather than \"art\" to get community buy-in.",
+    "category": "Health & Communication",
+    "tags": [
+      "Education"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 8,
+    "text": "ImpactMojo dashboard development hitting classic user experience problems. Program managers want simple red/green indicators, but development work is inherently messy. Binary success/failure metrics miss most interesting insights. Building toggle between \"board presentation view\" and \"researcher view\" - same data, different framings. Lesson: impact visualization needs multiple audiences, not one-size-fits-all approach.",
+    "category": "MEL & Research",
+    "tags": [
+      "Technology",
+      "Data",
+      "Measurement"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 9,
+    "text": "Open source data stack for NGOs keeps hitting the same bottleneck: institutional knowledge locked in Excel sheets on individual laptops. Technical solution exists, but organizational behavior change harder. Convinced one organization to migrate by starting with their donor reporting requirements - everyone understands that pain point. Sometimes need to find the burning platform to drive adoption of better systems.",
+    "category": "Data & Technology",
+    "tags": [
+      "Technology",
+      "Data"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 10,
+    "text": "Climate resilience study in Sundarbans revealing interesting gender dynamics. Women more accurate at predicting weather patterns and flood timing than men, but their knowledge rarely incorporated into formal early warning systems. Traditional ecological knowledge coded as \"women's intuition\" rather than valuable data. Development programs keep reinventing weather monitoring when local expertise already exists - just not valued by formal institutions.",
+    "category": "MEL & Research",
+    "tags": [
+      "Gender",
+      "Climate",
+      "Data"
+    ],
+    "location": "Sundarbans",
+    "featured": false
+  },
+  {
+    "id": 11,
+    "text": "Animal welfare evaluation in dairy cooperatives challenging utilitarian assumptions. Higher animal welfare standards increase costs, reduce profits for small farmers. But also reduce veterinary expenses, improve milk quality, create premium market access. Classic cost-benefit analysis misses temporal dimension - upfront costs, delayed benefits. Effective altruism framework needs better modeling of transition pathways, not just equilibrium outcomes.",
+    "category": "MEL & Research",
+    "tags": [
+      "Effective Altruism",
+      "Agriculture",
+      "Measurement"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 12,
+    "text": "Forest rights implementation varying dramatically based on local political economy. In areas with strong leftist movements, communities more successful at claiming rights under Forest Rights Act. In areas dominated by traditional elites, same legal framework produces different outcomes. Institutions don't work in vacuum - they interact with existing power structures. Policy evaluation needs to control for political context, not just demographic variables.",
+    "category": "MEL & Research",
+    "tags": [
+      "Environment",
+      "Policy",
+      "Measurement",
+      "Governance"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 13,
+    "text": "Caste census discussions revealing measurement challenges familiar from development economics. How do you categorize fluid, contextual social identities? Same family might claim different caste status for different government programs. Enumeration process itself changes what's being measured - people start thinking strategically about classification. Census as intervention, not just measurement tool.",
+    "category": "MEL & Research",
+    "tags": [
+      "Caste",
+      "Data",
+      "Measurement"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 14,
+    "text": "Professional development workshop on machine learning for development hitting classic garbage-in-garbage-out problems. Beautiful algorithms, terrible data quality. Participants excited about fancy techniques but haven't solved basic data collection problems. Machine learning can't fix fundamental attribution issues in impact evaluation. Need to teach data foundations before advanced methods.",
+    "category": "MEL & Research",
+    "tags": [
+      "Technology",
+      "Data",
+      "Measurement",
+      "Capacity Building"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 15,
+    "text": "Econometrics training focusing too much on internal validity, not enough on external validity. Perfect randomization in one village doesn't tell us about scalability across different contexts. Field experience shows implementation varying dramatically across sites even within same program. Need ethnographic methods alongside experimental ones. Mixed methods isn't compromise - it's necessity.",
+    "category": "Policy & Economics",
+    "tags": [
+      "RCTs",
+      "Capacity Building"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 16,
+    "text": "Inequality measurement missing crucial dimensions visible from field perspective. Wealth indices capture material possessions but miss social capital, political access, cultural legitimacy. Upper caste landless farmers have different opportunities than lower caste farmers with same land holdings. Standard economic measures of inequality missing most important forms of stratification in Indian context.",
+    "category": "MEL & Research",
+    "tags": [
+      "Caste",
+      "Agriculture",
+      "Measurement"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 17,
+    "text": "Public health program evaluation caught in classic attribution trap. Maternal mortality declining, but multiple interventions happening simultaneously - new hospital, ASHA worker training, cash transfer program, better roads. Rigorous evaluation would require isolating each component, but real world doesn't work that way. Sometimes need to evaluate packages of interventions, not individual components.",
+    "category": "MEL & Research",
+    "tags": [
+      "Health",
+      "Measurement",
+      "Capacity Building"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 18,
+    "text": "Data operations for development sector incredibly primitive compared to tech industry. NGOs spending weeks on Excel gymnastics that could be automated in hours. But resistance isn't just technical - it's about control and job security. Data democratization threatens existing hierarchies. Change management as important as technical architecture.",
+    "category": "Data & Technology",
+    "tags": [
+      "Data"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 19,
+    "text": "Education evaluation missing classroom realities. Teacher training program shows improvement in test scores, but field observation shows teachers teaching to the test, abandoning other subjects. Gaming the metrics while defeating program purpose. Need measures of educational breadth, not just performance on specific assessments. Goodhart's law in full effect - when measure becomes target, it ceases to be good measure.",
+    "category": "MEL & Research",
+    "tags": [
+      "Education",
+      "Measurement",
+      "Fieldwork",
+      "Capacity Building"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 20,
+    "text": "Climate adaptation project in Odisha cyclone-prone areas showing interesting migration patterns. Families sending one member to city not as distress migration but as risk diversification strategy. Urban earnings provide insurance against climate shocks to rural livelihoods. Migration as adaptation, not failure of rural development. Policy framework needs to facilitate circular migration rather than trying to prevent it.",
+    "category": "Policy & Economics",
+    "tags": [
+      "Climate",
+      "Migration",
+      "Policy"
+    ],
+    "location": "Odisha",
+    "featured": false
+  },
+  {
+    "id": 21,
+    "text": "Gender program targeting women's economic empowerment inadvertently increasing domestic violence in some households. Economic empowerment challenging existing power dynamics, creating backlash. Need safety measures alongside economic interventions. Women's empowerment isn't just about access to resources - it's about renegotiating household and community power relations.",
+    "category": "Gender & Equity",
+    "tags": [
+      "Gender",
+      "Measurement"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 22,
+    "text": "Forest conservation program using payments for ecosystem services showing elite capture problems. Large landowners claiming payments for forest conservation they were doing anyway. Small farmers can't access program due to documentation requirements. Environmental programs replicating existing inequalities unless explicitly designed to address them. Conservation and social justice can't be separated.",
+    "category": "Gender & Equity",
+    "tags": [
+      "Environment",
+      "Agriculture"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 23,
+    "text": "Effective altruism cost-effectiveness calculations breaking down when applied to complex social interventions. Easy to calculate cost per malaria net, harder to value institutional capacity building or social norm change. Long-term transformative change doesn't fit neatly into QALY frameworks. Need better methods for valuing systems change alongside direct service delivery.",
+    "category": "Philosophy & Governance",
+    "tags": [
+      "Effective Altruism",
+      "Measurement",
+      "Capacity Building"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 24,
+    "text": "Open source technology adoption in development sector following classic diffusion patterns but with twist - donor requirements often drive adoption before organizational readiness. Organizations implementing complex systems to satisfy funder mandates, then struggling with maintenance and capacity. Technology adoption needs to match organizational development stage, not just donor preferences.",
+    "category": "Data & Technology",
+    "tags": [
+      "Technology"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 25,
+    "text": "Social emotional learning research showing measurement challenges similar to other \"soft skills\" work. How do you measure empathy, emotional regulation, social awareness without culturally biased instruments? Western-developed SEL assessments missing important cultural dimensions of emotional intelligence. Need locally-adapted measures, not just translated versions of US instruments.",
+    "category": "MEL & Research",
+    "tags": [
+      "Education",
+      "Measurement"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 26,
+    "text": "Participatory evaluation workshop revealing power dynamics invisible in standard evaluation frameworks. Community members giving different feedback when NGO staff present vs absent. \"Beneficiary\" voices change based on who's listening. Participation isn't neutral - it's shaped by existing hierarchies. Need to design evaluation processes that account for these dynamics, not pretend they don't exist.",
+    "category": "MEL & Research",
+    "tags": [
+      "Measurement",
+      "Fieldwork",
+      "Capacity Building"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 27,
+    "text": "Impact measurement for arts education programs struggling with attribution challenges. How do you isolate effect of drama therapy on trauma recovery when kids are also receiving counseling, family support, improved nutrition? Arts interventions work holistically but evaluation frameworks demand component-wise analysis. Maybe need to evaluate arts programs as part of integrated support systems rather than standalone interventions.",
+    "category": "MEL & Research",
+    "tags": [
+      "Health",
+      "Education",
+      "Measurement"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 28,
+    "text": "Building open data infrastructure for small NGOs revealing interesting capacity building needs. Organizations want dashboards and automation but lack basic data hygiene practices. Garbage in, garbage out applies to fancy visualization tools too. Need to sequence capacity building - data collection standards before analysis tools, analysis skills before machine learning workshops.",
+    "category": "MEL & Research",
+    "tags": [
+      "Technology",
+      "Data",
+      "Capacity Building"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 29,
+    "text": "Climate resilience evaluation in coastal Andhra Pradesh showing interesting intergenerational dynamics. Older fishermen's traditional knowledge about weather patterns more accurate than meteorological forecasts for local conditions. But younger generation dismissing traditional knowledge as superstition. Climate adaptation programs need to bridge traditional and scientific knowledge systems, not replace one with other.",
+    "category": "MEL & Research",
+    "tags": [
+      "Climate",
+      "Measurement"
+    ],
+    "location": "Andhra Pradesh",
+    "featured": false
+  },
+  {
+    "id": 30,
+    "text": "Animal welfare measurement in poultry sector revealing cultural and economic tensions. Consumers say they care about animal welfare in surveys but price sensitivity dominates purchasing decisions. Middle-class urban consumers willing to pay premium for \"cage-free\" but rural consumers focus on affordability. Effective altruism interventions need to account for economic constraints, not just moral preferences.",
+    "category": "MEL & Research",
+    "tags": [
+      "Effective Altruism",
+      "Agriculture",
+      "Measurement"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 31,
+    "text": "Forest rights documentation process creating interesting legal anthropology insights. Same forest land claimed by different communities using different legal frameworks - traditional use rights vs formal titles vs environmental regulations. Legal pluralism in action. Forest Rights Act trying to reconcile different property regimes but implementation varying based on local power dynamics.",
+    "category": "Policy & Economics",
+    "tags": [
+      "Environment",
+      "Agriculture",
+      "Governance"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 32,
+    "text": "Caste dynamics in education programs more complex than simple discrimination narratives. Dalit children sometimes performing better in mixed-caste classes due to peer effects, sometimes worse due to social exclusion. Context matters enormously - teacher attitudes, community norms, school leadership. Anti-discrimination policies need locally-adapted implementation strategies.",
+    "category": "Health & Communication",
+    "tags": [
+      "Caste",
+      "Education"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 33,
+    "text": "Gender programming evaluation missing male engagement dimensions. Women's empowerment programs focusing exclusively on women while ignoring need to work with men and boys. Unaddressed masculinity norms undermining program effectiveness. Gender transformation requires working with entire community, not just target demographic.",
+    "category": "MEL & Research",
+    "tags": [
+      "Gender",
+      "Measurement"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 34,
+    "text": "Data governance for development sector lagging behind data collection capabilities. Organizations collecting sensitive information about vulnerable populations but lacking proper data protection protocols. GDPR-style frameworks needed for development sector but adapted for low-resource contexts. Data ethics isn't luxury - it's necessity for maintaining community trust.",
+    "category": "MEL & Research",
+    "tags": [
+      "Data",
+      "Governance"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 35,
+    "text": "Professional development in international development sector showing interesting geographic biases. Training opportunities concentrated in major cities, leaving field-based practitioners underserved. Remote learning helps but bandwidth and device limitations real constraints. Need to decentralize capacity building, not just program implementation.",
+    "category": "Health & Communication",
+    "tags": [
+      "Capacity Building"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 36,
+    "text": "Econometric methods training overemphasizing technique sophistication at expense of contextual understanding. Students learning advanced panel data methods but can't identify when sample selection bias might be problem. Field experience suggests methodological pluralism more valuable than technique purism. Need more mixed-methods training, less method wars.",
+    "category": "Data & Technology",
+    "tags": [
+      "Education",
+      "Data",
+      "Fieldwork",
+      "Capacity Building"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 37,
+    "text": "Inequality research showing interesting patterns when incorporating social mobility measures. Static wealth measurements miss dynamic aspects of stratification. Families may have similar asset levels but very different trajectory expectations based on caste, gender, geographic location. Social mobility aspirations affect current behavior in ways standard economic models don't capture.",
+    "category": "MEL & Research",
+    "tags": [
+      "Caste",
+      "Gender",
+      "Measurement"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 38,
+    "text": "Traditional surveys miss so much. Spent two hours at a roadside chai stall in Rajasthan - learned more about informal credit networks than any structured questionnaire would capture. The chai wallah knows everyone's business, tracks who's borrowing from whom, notices when remittances arrive. Next time: budget formal time for \"informal\" data collection. The margins are where the real economy lives.",
+    "category": "MEL & Research",
+    "tags": [
+      "Finance",
+      "Migration",
+      "Data",
+      "Fieldwork"
+    ],
+    "location": "Rajasthan",
+    "featured": false
+  },
+  {
+    "id": 39,
+    "text": "Annual Status of Education Report data goes back to 2005 - publicly available, district-level learning outcomes. But buried in appendices: school infrastructure data nobody talks about. Single-teacher schools, lack of toilets, mid-day meal disruptions. Could link this to long-term earnings data from IHDS panels. Why isn't anyone doing this longitudinal infrastructure-outcome analysis?",
+    "category": "Data & Technology",
+    "tags": [
+      "Education",
+      "Data"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 40,
+    "text": "Textbook says credit constraints bind investment. Reality: farmers in Sitapur district have access to formal credit but don't use it for inputs. Why? Trust issues with bank officers, paperwork hassles, timing mismatches with seasonal needs. It's not about access - it's about usability. Need better measures of \"effective\" financial inclusion beyond account ownership.",
+    "category": "Gender & Equity",
+    "tags": [
+      "Finance",
+      "Agriculture",
+      "Measurement"
+    ],
+    "location": "Uttar Pradesh",
+    "featured": false
+  },
+  {
+    "id": 41,
+    "text": "Key players not obvious from org charts: Retired IAS officer now consulting for multiple NGOs, has real influence on state water policy. PhD student at IISc whose father is in irrigation department - knows technical and political sides. Local journalists who've covered droughts for decades. Academic collaborations need these \"bridge\" people who speak multiple languages of expertise.",
+    "category": "Policy & Economics",
+    "tags": [
+      "Climate",
+      "Education",
+      "Policy",
+      "Agriculture"
+    ],
+    "location": "Karnataka",
+    "featured": false
+  },
+  {
+    "id": 42,
+    "text": "Women's self-help groups in Tamil Nadu villages incredibly sophisticated about financial management - detailed tracking, peer monitoring systems. But smartphone adoption for agriculture apps much slower than among male farmers. Not about capability - about social norms around technology as \"male domain.\" Intervention design needs to account for gendered spaces of learning.",
+    "category": "MEL & Research",
+    "tags": [
+      "SHGs",
+      "Gender",
+      "Technology",
+      "Agriculture"
+    ],
+    "location": "Tamil Nadu",
+    "featured": false
+  },
+  {
+    "id": 43,
+    "text": "Still using British-era revenue maps from 1920s in some areas. Land fragmentation patterns today reflect colonial administrative decisions. Current microfinance repayment issues trace back to historical jotedar-cultivator relationships. Development economists treat history as \"background\" but it's actively shaping present outcomes. Need more papers linking historical data to contemporary puzzles.",
+    "category": "Data & Technology",
+    "tags": [
+      "Finance",
+      "Agriculture",
+      "Data"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 44,
+    "text": "Learned the hard way: village elections happened during baseline survey period. Completely changed household participation patterns. Political affiliations suddenly mattered for research participation. Sample selection bias through the roof. Lesson: political calendars are as important as agricultural calendars for research timing. Local partners should flag these windows.",
+    "category": "MEL & Research",
+    "tags": [
+      "Agriculture",
+      "Fieldwork"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 45,
+    "text": "Aadhaar rollout creating natural experiments everywhere. Administrative data linkages getting easier. But privacy concerns rising - need to strike research agreements now before access gets restricted. JAM trinity (Jan Dhan, Aadhaar, Mobile) changing how we can measure financial inclusion in real-time. Window for baseline studies closing fast.",
+    "category": "Data & Technology",
+    "tags": [
+      "Aadhaar & DBT",
+      "Finance",
+      "RCTs",
+      "Technology"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 46,
+    "text": "Everyone studying climate-agriculture links. But what about climate-education? Extreme heat days affect school attendance. Flooding disrupts learning continuity. Air pollution and cognitive development. ASER data has geographic coordinates - could match with weather station data. Surprised this isn't a bigger research area given climate urgency.",
+    "category": "Data & Technology",
+    "tags": [
+      "Climate",
+      "Education",
+      "Agriculture",
+      "Data"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 47,
+    "text": "Same development challenge, different institutional responses. Rural employment guarantee works differently in India (MGNREGA) vs Bangladesh (Employment Generation Program). India's federal structure allows state-level variation - natural experiment. Bangladesh's centralized approach more uniform implementation but less local adaptation. Need systematic comparison of federal vs unitary approaches to social protection.",
+    "category": "Health & Communication",
+    "tags": [
+      "MGNREGA",
+      "RCTs"
+    ],
+    "location": "Bangladesh",
+    "featured": false
+  },
+  {
+    "id": 48,
+    "text": "June-September: Don't schedule rural surveys - farming season, people unavailable. October-November: Post-harvest, good time for income/consumption surveys. December-February: Wedding season affects spending patterns. March-May: Pre-monsoon anxiety affects behavior. Research timing isn't just about weather - it's about emotional and economic cycles.",
+    "category": "MEL & Research",
+    "tags": [
+      "Climate",
+      "Agriculture"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 49,
+    "text": "Best paper used administrative data on teacher transfers to identify impact of corruption on education outcomes. Methodological insight: corruption creates quasi-random variation in teacher quality if you can identify clean vs corrupt transfers. Could apply similar logic to health worker postings, agricultural extension officer assignments.",
+    "category": "Data & Technology",
+    "tags": [
+      "Health",
+      "Education",
+      "Agriculture",
+      "Data"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 50,
+    "text": "Science, Technology & Innovation Policy fellowship specifically wants India-focused development research. Perfect fit for technology adoption studies. Deadline usually October. Need to start thinking about mobile money, digital agriculture platforms, telemedicine adoption. Make sure to emphasize innovation ecosystem angle - they love \"startup India\" connections.",
+    "category": "Data & Technology",
+    "tags": [
+      "Health",
+      "Environment",
+      "Technology",
+      "Policy"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 51,
+    "text": "Standard asset indices miss crucial items for rural South Asia. Include: quality of roof (tin vs thatch vs concrete), number of rooms, separate kitchen, type of toilet facility, irrigation access, livestock ownership, mobile phone types (smartphone vs basic), two-wheeler vs four-wheeler. Rural-urban asset indices need different weights - don't just transplant urban measures.",
+    "category": "Policy & Economics",
+    "tags": [
+      "Technology",
+      "Agriculture",
+      "Measurement"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 52,
+    "text": "Economic Research Unit has amazing long-term datasets from West Bengal villages. Professor Banerjee's successors still maintaining panels from 1970s. Could be goldmine for intergenerational studies. Need to reach out through proper channels - institutional MOUs take time but worth it for data access. Their economic anthropology approach complements standard econometrics nicely.",
+    "category": "Data & Technology",
+    "tags": [
+      "Data"
+    ],
+    "location": "West Bengal",
+    "featured": false
+  },
+  {
+    "id": 53,
+    "text": "Poor Economics experimental approach: start with specific behavior puzzle, design intervention, measure mechanisms not just outcomes. Key insight from their work - don't just ask \"does it work?\" but \"why does it work and for whom?\" Always include heterogeneity analysis. Survey modules should capture psychological/social mechanisms, not just economic outcomes.",
+    "category": "MEL & Research",
+    "tags": [
+      "RCTs",
+      "Measurement",
+      "Fieldwork"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 54,
+    "text": "Women's self-help groups work at household level but scale up to state-level policy influence. Tracked one federation in Andhra Pradesh - household savings discipline leads to collective bargaining power with government schemes. Micro-level behavior change enables macro-level institutional change. Need more papers tracing these scaling mechanisms.",
+    "category": "Policy & Economics",
+    "tags": [
+      "SHGs",
+      "Gender",
+      "Finance",
+      "Policy"
+    ],
+    "location": "Andhra Pradesh",
+    "featured": false
+  },
+  {
+    "id": 55,
+    "text": "Spent morning with ASHA worker in Jharkhand village. She tracks every pregnancy, immunization, birth in her catchment area but gets paid per task completed, not for preventive counseling. Result: she focuses on deliverables that pay rather than education that prevents problems. Perverse incentives embedded in well-meaning programs. Wonder how many development interventions fail because we measure outputs instead of outcomes.",
+    "category": "Health & Communication",
+    "tags": [
+      "Health",
+      "Education",
+      "Measurement"
+    ],
+    "location": "Jharkhand",
+    "featured": false
+  },
+  {
+    "id": 56,
+    "text": "Reading old Planning Commission documents from 1960s. Same problems, different decade. Rural credit access, agricultural productivity, urban migration patterns - identical language to current policy papers. Either we've learned nothing in 60 years or these are genuinely persistent structural challenges. Probably both. Historical perspective should be required reading for every development economist.",
+    "category": "Policy & Economics",
+    "tags": [
+      "Finance",
+      "Migration",
+      "Policy",
+      "Agriculture"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 57,
+    "text": "Fascinating conversation with microfinance borrower in Kerala. She takes loan ostensibly for tailoring business but actually uses money for daughter's college fees. Repays from husband's remittances from Gulf. Loan officer knows but doesn't care as long as repayment happens. Fungibility of money makes program evaluation tricky - measuring impact on business income misses actual welfare improvements.",
+    "category": "MEL & Research",
+    "tags": [
+      "Finance",
+      "Migration",
+      "Measurement"
+    ],
+    "location": "Kerala",
+    "featured": false
+  },
+  {
+    "id": 58,
+    "text": "Administrative data from Pradhan Mantri Awas Yojana shows interesting spatial patterns. House construction completion rates vary dramatically within same district based on distance from block office. Last-mile bureaucracy matters more than state-level policy design. Could use GIS data to measure \"administrative distance\" as development constraint. Physical infrastructure and bureaucratic infrastructure are both binding.",
+    "category": "Data & Technology",
+    "tags": [
+      "Welfare Delivery",
+      "Policy",
+      "Data",
+      "Measurement"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 59,
+    "text": "Village in Odisha has three different SHG programs running simultaneously - government scheme, two different NGOs. Women belong to multiple groups, taking loans from each. Coordination failure at policy level creating opportunities for over-borrowing at household level. Need better mapping of overlapping programs before designing new interventions. The development sector's left hand doesn't know what the right hand is doing.",
+    "category": "Policy & Economics",
+    "tags": [
+      "SHGs",
+      "Gender",
+      "Policy"
+    ],
+    "location": "Odisha",
+    "featured": false
+  },
+  {
+    "id": 60,
+    "text": "Child malnutrition data from NFHS-5 shows puzzling patterns. Districts with better healthcare infrastructure don't always have better nutrition outcomes. Talked to pediatrician in Madhya Pradesh - she says it's about maternal education and food practices, not just access to treatment. Supply-side investments won't work without demand-side understanding. Culture eats policy for breakfast.",
+    "category": "Data & Technology",
+    "tags": [
+      "Health",
+      "Education",
+      "Policy",
+      "Data"
+    ],
+    "location": "Madhya Pradesh",
+    "featured": false
+  },
+  {
+    "id": 61,
+    "text": "Interesting natural experiment emerging from Goods and Services Tax implementation. Different tax rates for agricultural inputs vs processed foods creating weird substitution effects. Farmers switching from fertilizer to organic inputs not for environmental reasons but for tax arbitrage. Unintended consequences of complex tax structures. Could track this using agricultural input sales data.",
+    "category": "Data & Technology",
+    "tags": [
+      "RCTs",
+      "Policy",
+      "Agriculture",
+      "Data"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 62,
+    "text": "Technology adoption patterns in Punjab wheat farming don't follow standard diffusion models. Early adopters are often medium-sized farmers, not largest ones. Large farmers have too much to lose if new technology fails. Smallest farmers can't afford initial investment. Sweet spot for innovation adoption might be middle of wealth distribution, not top. Standard models assume monotonic relationship between wealth and risk-taking.",
+    "category": "Data & Technology",
+    "tags": [
+      "Agriculture",
+      "Technology"
+    ],
+    "location": "Punjab",
+    "featured": false
+  },
+  {
+    "id": 63,
+    "text": "Gender bias in data collection: male enumerators get different responses than female enumerators for questions about domestic violence, women's mobility, household decision-making. But training materials rarely address this. Our baseline survey shows 15% difference in reported domestic violence rates based on enumerator gender. Need to budget for gender-matched interviews, not just assume training eliminates bias.",
+    "category": "MEL & Research",
+    "tags": [
+      "Gender",
+      "Data",
+      "Fieldwork",
+      "Capacity Building"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 64,
+    "text": "Talking to municipal corporation official in Tamil Nadu about urban MGNREGA implementation. Rural program being adapted for urban slums but nobody thought about how different social networks function in cities. Rural MGNREGA works through village hierarchies and kinship networks. Urban poor have weaker community ties, higher mobility. Same program, completely different social infrastructure.",
+    "category": "Gender & Equity",
+    "tags": [
+      "MGNREGA"
+    ],
+    "location": "Tamil Nadu",
+    "featured": false
+  },
+  {
+    "id": 65,
+    "text": "Following up on families from 2015 drought study in Maharashtra. Found kids who missed school during crisis never fully caught up academically. But standard education surveys would show they're \"enrolled\" and \"attending\" now. Duration effects of temporary shocks get lost in cross-sectional data. Need longitudinal studies to capture these scarring effects. Development isn't just about levels, it's about trajectories.",
+    "category": "MEL & Research",
+    "tags": [
+      "Climate",
+      "Education",
+      "Data"
+    ],
+    "location": "Maharashtra",
+    "featured": false
+  },
+  {
+    "id": 66,
+    "text": "Sanitation program evaluation missing crucial behavioral insights. Toilets get built but usage patterns vary by caste, gender, age within same household. Teenage girls use them consistently, elderly women prefer traditional practices. Infrastructure provision without social change creates white elephants. Should be measuring sustained behavior change over 2-3 years, not just construction completion.",
+    "category": "MEL & Research",
+    "tags": [
+      "Caste",
+      "Gender",
+      "Health",
+      "Measurement"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 67,
+    "text": "Remittances from Gulf countries to Kerala follow predictable seasonal patterns tied to Eid, Onam festivals, school fee cycles. But recent analysis shows growing volatility - oil price shocks creating employment uncertainty for migrant workers. Household consumption smoothing strategies breaking down when remittance income becomes unpredictable. External economic shocks reaching rural Indian households through migration channels.",
+    "category": "Policy & Economics",
+    "tags": [
+      "Finance",
+      "Education",
+      "Migration"
+    ],
+    "location": "Kerala",
+    "featured": false
+  },
+  {
+    "id": 68,
+    "text": "Land fragmentation in Bangladesh showing different patterns than India despite similar demographic pressures. Islamic inheritance law creates different subdivision patterns than Hindu succession practices. Same economic forces, different institutional responses. Could use this variation to identify causal effects of land titling systems on agricultural productivity. Religion as instrumental variable for land institutions.",
+    "category": "Data & Technology",
+    "tags": [
+      "Agriculture"
+    ],
+    "location": "Bangladesh",
+    "featured": false
+  },
+  {
+    "id": 69,
+    "text": "Mobile phone tower data from telecom companies could revolutionize development research. Real-time population movement, economic activity proxies, social network mapping. But accessing this data requires navigating privacy laws, corporate partnerships, technical capacity building. Academic institutions need better infrastructure for big data partnerships. Current grant cycles too short for these complex data acquisition processes.",
+    "category": "Data & Technology",
+    "tags": [
+      "Technology",
+      "Data",
+      "Capacity Building"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 70,
+    "text": "Noticed interesting correlation in IHDS panel data - households that experienced major health shocks more likely to invest in children's education, not less. Contrary to expected liquidity constraint story. Talking to families, seems like health crises create urgency about human capital as insurance against future shocks. \"We realized money can disappear but education stays with you.\" Need to model education investment as risk management strategy, not just consumption.",
+    "category": "Data & Technology",
+    "tags": [
+      "Health",
+      "Education",
+      "Data"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 71,
+    "text": "Kudumbashree neighbourhood groups in Kerala running real microenterprises, but the bank account sits in the husband's name for \"official\" convenience. Legal ownership and economic control quietly diverge. Empowerment dashboards count registered women members and miss who actually signs the cheque. We should be measuring decision authority over money, not membership on a register. Access to a group is not access to control.",
+    "category": "Gender & Equity",
+    "tags": [
+      "SHGs",
+      "Gender",
+      "Technology",
+      "Measurement"
+    ],
+    "location": "Kerala",
+    "featured": false
+  },
+  {
+    "id": 72,
+    "text": "Skilling program in Uttar Pradesh reports 50% women enrolled - looks like a success. But two-month dropout runs three times higher for women. The reason isn't motivation: it's the 6pm batch timing, an unlit walk home, and no childcare. Access without safety and logistics is enrolment theatre. If you want women to finish, design the last mile home, not just the seat in the classroom.",
+    "category": "Gender & Equity",
+    "tags": [
+      "Gender",
+      "Education",
+      "Capacity Building"
+    ],
+    "location": "Uttar Pradesh",
+    "featured": false
+  },
+  {
+    "id": 73,
+    "text": "Widow pension scheme in Rajasthan. Eligible women can't claim because the death certificate needs the late husband's Aadhaar, which was never linked. Documentation failures cascade - one missing paper blocks an entire entitlement chain. The poorest are the least documented, so every means-test filters out exactly the people it's meant to reach. Verification burdens fall hardest on those with the least paper.",
+    "category": "Gender & Equity",
+    "tags": [
+      "Aadhaar & DBT",
+      "Gender",
+      "Technology",
+      "Policy"
+    ],
+    "location": "Rajasthan",
+    "featured": false
+  },
+  {
+    "id": 74,
+    "text": "Menstrual health program measured success by pads distributed. Follow-up visit: girls storing them unused, because disposal is the real taboo, not access. No private bins, shared latrines, incineration shame. We solved the visible constraint and ignored the binding one. Always ask what happens after the intervention object changes hands - the object is easy, the practice around it is the program.",
+    "category": "Gender & Equity",
+    "tags": [
+      "Gender",
+      "Health",
+      "Measurement"
+    ],
+    "location": null,
+    "featured": true
+  },
+  {
+    "id": 75,
+    "text": "Panchayat seat reservation for women produced the \"sarpanch pati\" problem - husband governs, wife signs. But tracking cohorts across terms, women who served one term under proxy rule start exercising real authority in the next. Quotas work on a lag. Evaluating them within a single term systematically understates them. Institutional change moves at the speed of learned confidence, not the election cycle.",
+    "category": "Gender & Equity",
+    "tags": [
+      "Gender"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 76,
+    "text": "Time-use survey in Odisha makes the invisible economy visible. Women's unpaid care work, valued even at minimum wage, exceeds the district's entire MGNREGA wage bill. GDP ignores it, so policy ignores it. What we don't measure, we don't fund; what we don't fund, women subsidise with unpaid hours. Care infrastructure is economic infrastructure - crèches and water access are labour policy.",
+    "category": "Gender & Equity",
+    "tags": [
+      "MGNREGA",
+      "Gender",
+      "Policy",
+      "Measurement"
+    ],
+    "location": "Odisha",
+    "featured": true
+  },
+  {
+    "id": 77,
+    "text": "Cash transfers to women's accounts versus the household head produce different spending - transfers to women shift consumption toward children's food and schooling. But in-laws now pressure daughters-in-law to hand over the PIN. The account is hers; the control migrates. Financial inclusion without financial privacy is only half done. The banking rail is easy, the intra-household bargaining is the intervention.",
+    "category": "Gender & Equity",
+    "tags": [
+      "Gender",
+      "Finance",
+      "Education"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 78,
+    "text": "Adolescent girls' clubs in Jharkhand. The thing that actually moved delayed-marriage outcomes wasn't the curriculum content - it was giving girls a legitimate, respectable reason to leave the house once a week. Mobility itself was the treatment. Sometimes the content of a program matters less than the social permission it manufactures. Measure the exposure the program creates, not just the lessons it delivers.",
+    "category": "Gender & Equity",
+    "tags": [
+      "Gender",
+      "Measurement"
+    ],
+    "location": "Jharkhand",
+    "featured": false
+  },
+  {
+    "id": 79,
+    "text": "Sat through a district grievance-redressal meeting. Citizens frame every entitlement as a favour they're begging for; officials frame delivery as personal benevolence. Nobody in the room speaks the language of rights. A legal entitlement means little without a political culture that treats it as claimable. Statutes don't change the relationship between citizen and state - organising does. Paper rights need social power to become real.",
+    "category": "Philosophy & Governance",
+    "tags": [
+      "Governance"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 80,
+    "text": "The randomista debate keeps missing a governance point. Even when an RCT proves an intervention works, the bureaucracy that scales it isn't the NGO that piloted it. Evidence of efficacy under near-ideal implementation says little about delivery under actual state capacity. \"Does it work?\" and \"will the state deliver it at scale?\" are different questions - and we mostly fund answers to the first while pretending we've answered the second.",
+    "category": "Philosophy & Governance",
+    "tags": [
+      "RCTs",
+      "Governance"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 81,
+    "text": "Reading Sen and Dreze against my own field notes. Their argument about \"public action\" keeps proving itself - the districts with better health outcomes aren't the richer ones, they're the ones with active local demand-making. Development as freedom is also development as organised pressure. Passive beneficiaries get passive delivery. Agency isn't a soft outcome of development; it's an input into whether services function at all.",
+    "category": "Philosophy & Governance",
+    "tags": [
+      "Health",
+      "Agriculture"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 82,
+    "text": "Anti-corruption technology - transparency portals, direct benefit transfer - cuts some leakage but relocates discretion upward. The petty official who took a cut is bypassed; the algorithm and the people who designed its eligibility rules now decide invisibly. We traded visible corruption for invisible exclusion errors. Transparency of process is not the same as accountability for outcomes. Someone still decides who's out; now you can't see them.",
+    "category": "Philosophy & Governance",
+    "tags": [
+      "Aadhaar & DBT",
+      "Technology",
+      "Governance"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 83,
+    "text": "The effective-altruism neartermist/longtermist split looks strange from the field. Here the \"long term\" is a child's stunting locking in cognitive deficits over a whole lifetime - deeply longtermist and completely measurable. The framing that longtermism means speculative far-future causes is a rich-world luxury. Poverty already forces intergenerational thinking onto the poor; they were doing longtermism before it had a name.",
+    "category": "Philosophy & Governance",
+    "tags": [
+      "Effective Altruism",
+      "Measurement"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 84,
+    "text": "Whose counterfactual? Every impact claim rests on \"what would have happened otherwise,\" and that is a moral choice dressed up as a technical one. Compared to nothing, almost every program looks good. Compared to the best alternative use of the same money, many don't. Evaluators quietly pick the comparison that flatters the funder. Name the counterfactual out loud or the impact number is just rhetoric with a decimal point.",
+    "category": "Philosophy & Governance",
+    "tags": [
+      "Measurement"
+    ],
+    "location": null,
+    "featured": true
+  },
+  {
+    "id": 85,
+    "text": "PM-KISAN income support lands in accounts on schedule, but the timing misaligns with the sowing-season credit crunch. Farmers still go to the moneylender for input finance, then repay when the transfer arrives. The state's money effectively subsidises the moneylender's interest. Cash transfers have to match the household's liquidity calendar, not the government's fiscal calendar. Right amount, wrong month, is a design failure.",
+    "category": "Policy & Economics",
+    "tags": [
+      "Welfare Delivery",
+      "Finance",
+      "Agriculture"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 86,
+    "text": "The Minimum Support Price debate is really an information debate. In the mandis I've watched, small farmers don't know the day's MSP, arrive with no storage option, and take the trader's price. The floor exists on paper and evaporates at the point of sale. A price guarantee without procurement infrastructure and price information is a subsidy to whoever already has both - the trader, not the farmer it was written for.",
+    "category": "Policy & Economics",
+    "tags": [
+      "Policy",
+      "Agriculture"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 87,
+    "text": "Interstate migrant workers fall through every scheme because entitlements are domicile-bound. The ration card works in the home village, not in the city where the worker actually lives and eats. \"One Nation One Ration Card\" is the right idea, but portability is only as strong as the weakest PDS shop's connectivity. A welfare architecture designed for a sedentary population keeps failing the mobile poor who need it most.",
+    "category": "Policy & Economics",
+    "tags": [
+      "Welfare Delivery",
+      "Migration",
+      "Policy"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 88,
+    "text": "Watching the urban informal sector recover after the 2020 lockdown. The workers who bounced back fastest weren't the ones with savings - they were the ones with a return-to-village option. Rural land functioning as social insurance for urban precarity. The village isn't backward; it's the informal welfare state that catches people the formal one drops. Policy that assumes a clean rural-to-urban transition misreads the actual risk strategy.",
+    "category": "Policy & Economics",
+    "tags": [
+      "Finance",
+      "Policy",
+      "Agriculture"
+    ],
+    "location": null,
+    "featured": true
+  },
+  {
+    "id": 89,
+    "text": "The fertiliser subsidy is regressive in a way aggregate numbers hide - it scales with land, so the largest farmers capture the most. But every attempt to cap it collides with the political economy of the rural elite, who also happen to be the local vote mobilisers. Bad economics survives because it's good politics for someone specific. Reform design has to route around the veto players, not win the argument against them.",
+    "category": "Policy & Economics",
+    "tags": [
+      "Policy",
+      "Agriculture"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 90,
+    "text": "Studying state-level variation in the same central scheme is the closest thing India offers to a natural policy laboratory. Tamil Nadu and Bihar implement identical guidelines to opposite effect - administrative culture, not policy design, explains most of the gap. We keep redesigning schemes when we should be studying the states that already deliver them well and asking what, concretely, is transferable and what is local.",
+    "category": "Policy & Economics",
+    "tags": [
+      "Policy"
+    ],
+    "location": "Tamil Nadu",
+    "featured": false
+  },
+  {
+    "id": 91,
+    "text": "TB program in Mumbai: treatment is free, adherence is the problem. Patients stop the six-month course when symptoms fade around month two. The health system counts pills dispensed; the disease counts courses completed. Digital adherence tech - pill boxes that text - helps the already-motivated and ignores the ones who simply stop showing up. For the hardest cases, a well-set default beats another reminder. Design for the person who won't come back.",
+    "category": "Health & Communication",
+    "tags": [
+      "Health",
+      "Technology"
+    ],
+    "location": "Maharashtra",
+    "featured": false
+  },
+  {
+    "id": 92,
+    "text": "Revisiting the ASHA incentive structure. She earns per institutional delivery but nothing for a healthy home birth she safely referred. So she over-refers to hit targets, clogging the district hospital with normal deliveries. Pay-for-performance imported from a textbook, calibrated wrong on the ground. The incentive shapes the practice - get the metric wrong and you get the medicine wrong. The frontline worker optimises exactly what you pay her for.",
+    "category": "Health & Communication",
+    "tags": [
+      "Health",
+      "Measurement"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 93,
+    "text": "Nutrition counselling in Anganwadis uses flip charts designed in Delhi showing foods the family can't afford. The advice is technically correct and materially useless. Behaviour-change communication assumes the binding constraint is knowledge; here it's the food budget. Telling a hungry family to diversify their plate is a category error wearing the costume of health education. Fix the constraint that binds, not the one that's easy to print.",
+    "category": "Health & Communication",
+    "tags": [
+      "Health",
+      "Education"
+    ],
+    "location": "Delhi",
+    "featured": false
+  },
+  {
+    "id": 94,
+    "text": "Vaccine hesitancy in a western Uttar Pradesh district traces not to ideology but to a single bad experience - an adverse event years ago, never explained, now local folklore. Trust is a stock that depletes fast and rebuilds slowly. The health system logged the event and moved on; the community remembered it for a decade. Risk communication is an ongoing relationship, not a one-off campaign you switch on before a drive.",
+    "category": "Health & Communication",
+    "tags": [
+      "Health"
+    ],
+    "location": "Uttar Pradesh",
+    "featured": false
+  },
+  {
+    "id": 95,
+    "text": "Telemedicine pilot connecting a village to the district doctor. Uptake collapsed - not from bandwidth, but from language and touch. The doctor spoke clinical Hindi; patients wanted to show, not describe, the ailment. The ASHA in the room became the real interface, translating symptoms in both directions. The technology worked fine; the human relay was the actual intervention. Fund the relay, not just the router.",
+    "category": "Health & Communication",
+    "tags": [
+      "Health",
+      "Technology"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 96,
+    "text": "Mental health is the silent line item. Added a distress-screening module to an agrarian livelihoods survey in Vidarbha - indebtedness correlated with clinical-range anxiety far more strongly than any material asset measure did. We treat farmer suicides as an economic statistic and ignore the psychiatric epidemiology sitting underneath. Livelihoods programs need a mental health arm they almost never budget for, and the survey needs to ask the question first.",
+    "category": "Health & Communication",
+    "tags": [
+      "Health",
+      "Agriculture",
+      "Measurement",
+      "Fieldwork"
+    ],
+    "location": "Maharashtra",
+    "featured": false
+  },
+  {
+    "id": 97,
+    "text": "Health-seeking behaviour follows the road, not the guideline. Villages sort themselves to the nearest provider regardless of quality - the unqualified \"doctor\" 2km away beats the qualified PHC 15km away, every time. Quality-of-care metrics that ignore distance-decay describe a system patients don't actually use. Measure the care people get, not the care that officially exists on the facility register. Proximity is a clinical variable.",
+    "category": "Health & Communication",
+    "tags": [
+      "Health",
+      "Measurement"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 98,
+    "text": "Satellite nightlights as a GDP proxy break down at exactly the village scale everyone wants to use them for. A new streetlight scheme brightens a poor village overnight without a rupee of extra income. Proxies validated at the national level get borrowed for local inference where they were never tested. Every proxy has a scale of validity; using it below that scale is measurement laundering. Cite the validation scale or don't cite the proxy.",
+    "category": "Data & Technology",
+    "tags": [
+      "Technology",
+      "Policy",
+      "Measurement"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 99,
+    "text": "Built a data pipeline for an NGO and the hardest part wasn't the code - it was name-matching. The same beneficiary shows up as three different transliterations across three schemes. Without a clean identity spine, every \"linked administrative dataset\" is quietly full of false splits and false merges. Deduplication is where most development data analysis silently dies, long before the regression. Budget weeks for it, not an afternoon.",
+    "category": "Data & Technology",
+    "tags": [
+      "Technology",
+      "Policy",
+      "Data"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 100,
+    "text": "LLM-based coding of open-ended survey responses looks magical until you check it against local context. The model reads \"adjustment\" in a domestic-violence response as neutral when respondents mean coercion. Automated qualitative coding inherits the model's cultural priors, which are not the field's. Use it to triage and route, never to conclude - and keep a human coder who knows the dialect on the loop. Speed is worthless if it launders the meaning.",
+    "category": "Data & Technology",
+    "tags": [
+      "Technology",
+      "Fieldwork"
+    ],
+    "location": null,
+    "featured": true
+  },
+  {
+    "id": 101,
+    "text": "Everyone wants a dashboard; almost nobody looks at one twice. The dashboards that survive are wired to a decision someone has to make on a schedule - the monthly review, the funder report, the stock reorder. A number nobody is accountable for is a number nobody reads. Design analytics around the decision cadence, not around what data happens to be available. The question comes first; the chart is downstream of the meeting.",
+    "category": "Data & Technology",
+    "tags": [
+      "Technology",
+      "Data",
+      "Governance"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 102,
+    "text": "Pre-registration is spreading in development economics and I'm genuinely ambivalent. It disciplines fishing expeditions, but the most important findings I've had were things I never predicted and couldn't have. Locking the analysis before fieldwork privileges the hypotheses of people who've never been to the site. Register the confirmatory tests, but protect room for honest discovery. Rigour and curiosity aren't opposites - bad incentives make them look that way.",
+    "category": "MEL & Research",
+    "tags": [
+      "Fieldwork"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 103,
+    "text": "The attrition nobody reports isn't survey dropout - it's the villages that refused enrolment at baseline. They're systematically the ones with prior bad experiences of researchers: extracted from, never returned to. Our samples are quietly selected on communities still willing to trust outsiders again. External validity has a trust dimension we never write into the limitations section. The refusals are data about us, not just missing rows.",
+    "category": "MEL & Research",
+    "tags": [
+      "Data",
+      "Fieldwork"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 104,
+    "text": "Cost-effectiveness league tables compare interventions as if they're substitutes, but in a real district they're complements. The cash transfer works because the health system exists because the road exists. Ranking them and funding only the \"top\" one dismantles the system that made it effective in the first place. Marginal-value thinking about a single intervention misses the portfolio it silently depends on. Rank bundles, not line items.",
+    "category": "MEL & Research",
+    "tags": [
+      "Health",
+      "Measurement"
+    ],
+    "location": null,
+    "featured": false
+  },
+  {
+    "id": 105,
+    "text": "Went back to a village we studied five years ago to share the results. They remembered the survey but not a single finding, and asked why we never returned. Extractive research is a slow-acting poison for the whole field's future access - every unreturned study makes the next team's baseline harder. The most important line in a protocol should be the dissemination-back plan, and it's usually the one left blank. Close the loop or don't open it.",
+    "category": "MEL & Research",
+    "tags": [
+      "Fieldwork"
+    ],
+    "location": null,
+    "featured": true
+  }
+]

--- a/premium-tools/field-notes.html
+++ b/premium-tools/field-notes.html
@@ -1,0 +1,646 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Field Notes — free notes reader | ImpactMojo</title>
+<meta name="description" content="Behind-the-scenes field notes from a development economist. Observations from MEL work, policy research, and program evaluation across South Asia.">
+<meta name="theme-color" content="#FFFDF7">
+<link href="https://www.impactmojo.in/assets/images/favicon.png" rel="icon" type="image/png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&family=Special+Elite&family=Finger+Paint&display=swap" rel="stylesheet">
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+:root {
+    --primary-bg: #FFFDF7; --secondary-bg: #F5F0E8;
+    --accent-color: #0EA5E9; --accent-hover: #0284C7;
+    --secondary-accent: #6366F1; --success-color: #10B981;
+    --text-primary: #1A1A1A; --text-secondary: #555;
+    --text-muted: #888; --card-bg: #FFFFF0;
+    --border-color: #D4C9A8; --ink-color: #2C2C2C;
+    --paper-line: rgba(180,170,150,0.22);
+    --gradient-primary: linear-gradient(135deg, #0EA5E9 0%, #6366F1 100%);
+    --shadow-sm: 0 1px 3px rgba(60,50,30,0.08);
+    --shadow-md: 0 6px 20px rgba(60,50,30,0.12);
+    --shadow-lg: 0 14px 40px rgba(60,50,30,0.16);
+    /* Category accents */
+    --cat-mel: #0EA5E9; --cat-data: #6366F1; --cat-policy: #E08A1E;
+    --cat-gender: #DB2777; --cat-health: #0D9488; --cat-phil: #8B5CF6;
+    --radius: 10px;
+}
+body.dark-mode {
+    --primary-bg: #14120C; --secondary-bg: #1E1B14;
+    --text-primary: #ECE4D4; --text-secondary: #B6AE98;
+    --text-muted: #7E7563; --card-bg: #221F17;
+    --border-color: #3A352C; --ink-color: #D8CDB0;
+    --paper-line: rgba(120,110,90,0.16);
+    --shadow-sm: 0 1px 3px rgba(0,0,0,0.4);
+    --shadow-md: 0 6px 20px rgba(0,0,0,0.45);
+    --shadow-lg: 0 14px 40px rgba(0,0,0,0.55);
+    --cat-policy: #EAB35A; --cat-gender: #F472B6; --cat-health: #2DD4BF;
+}
+html { scroll-behavior: smooth; }
+body {
+    font-family: 'Amaranth', sans-serif; background: var(--primary-bg);
+    color: var(--text-primary); min-height: 100vh;
+    transition: background 0.3s ease, color 0.3s ease;
+}
+::selection { background: rgba(14,165,233,0.22); }
+
+/* ── Header ── */
+.header {
+    background: color-mix(in srgb, var(--primary-bg) 88%, transparent);
+    backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border-color); padding: 0.7rem 1.5rem;
+    position: sticky; top: 0; z-index: 100;
+    display: flex; align-items: center; justify-content: space-between; gap: 1rem;
+}
+.header-brand { display: flex; align-items: center; gap: 0.7rem; text-decoration: none; color: var(--text-primary); flex-shrink: 0; }
+.header-brand svg { width: 30px; height: 30px; }
+.header-brand h1 { font-family: 'Inter', sans-serif; font-size: 1.05rem; font-weight: 700; letter-spacing: -0.01em; white-space: nowrap; }
+.header-brand h1 span { background: var(--gradient-primary); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }
+.header-actions { display: flex; gap: 0.4rem; align-items: center; }
+.btn {
+    padding: 0.45rem 0.8rem; border-radius: 8px; border: 1px solid var(--border-color);
+    background: var(--card-bg); color: var(--text-primary); cursor: pointer; font-size: 0.8rem;
+    font-family: 'Inter', sans-serif; font-weight: 500; transition: all 0.18s ease;
+    text-decoration: none; display: inline-flex; align-items: center; gap: 0.35rem;
+}
+.btn:hover { border-color: var(--accent-color); color: var(--accent-color); transform: translateY(-1px); }
+.btn:focus-visible { outline: 2px solid var(--accent-color); outline-offset: 2px; }
+.icon-btn { padding: 0.45rem; }
+
+/* ── Hero ── */
+.hero {
+    text-align: center; padding: 2.75rem 1.5rem 1.75rem; position: relative; overflow: hidden;
+    border-bottom: 2px solid var(--border-color);
+}
+.hero-title { font-family: 'Finger Paint', cursive; font-size: 2.4rem; color: var(--ink-color); margin-bottom: 0.6rem; line-height: 1.1; }
+.hero-subtitle { font-family: 'Special Elite', monospace; color: var(--text-secondary); font-size: 1rem; max-width: 560px; margin: 0 auto; line-height: 1.5; }
+.hero .paper-plane { position: absolute; top: 1.5rem; right: 7%; opacity: 0.13; animation: float 6s ease-in-out infinite; pointer-events: none; }
+@keyframes float { 0%,100% { transform: translateY(0) rotate(-5deg); } 50% { transform: translateY(-12px) rotate(5deg); } }
+
+/* ── Stats strip ── */
+.stats {
+    display: flex; justify-content: center; gap: 2.2rem; flex-wrap: wrap;
+    margin-top: 1.5rem;
+}
+.stat { text-align: center; }
+.stat-num { font-family: 'Inter', sans-serif; font-size: 1.5rem; font-weight: 800; color: var(--accent-color); line-height: 1; }
+.stat-label { font-family: 'Inter', sans-serif; font-size: 0.65rem; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.08em; margin-top: 0.3rem; }
+
+/* ── Controls ── */
+.controls {
+    position: sticky; top: 55px; z-index: 90;
+    background: color-mix(in srgb, var(--primary-bg) 90%, transparent);
+    backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--border-color); padding: 0.85rem 1.5rem;
+}
+.controls-row { display: flex; gap: 0.6rem; align-items: center; max-width: 960px; margin: 0 auto; flex-wrap: wrap; }
+.search-wrap { position: relative; flex: 1 1 260px; min-width: 200px; }
+.search-wrap svg { position: absolute; left: 0.7rem; top: 50%; transform: translateY(-50%); color: var(--text-muted); pointer-events: none; }
+#search {
+    width: 100%; padding: 0.55rem 2rem 0.55rem 2.2rem; border-radius: 8px;
+    border: 1px solid var(--border-color); background: var(--card-bg); color: var(--text-primary);
+    font-family: 'Inter', sans-serif; font-size: 0.85rem; transition: all 0.18s ease;
+}
+#search::placeholder { color: var(--text-muted); }
+#search:focus { outline: none; border-color: var(--accent-color); box-shadow: 0 0 0 3px rgba(14,165,233,0.12); }
+.search-clear {
+    position: absolute; right: 0.5rem; top: 50%; transform: translateY(-50%);
+    background: none; border: none; color: var(--text-muted); cursor: pointer;
+    font-size: 1.1rem; line-height: 1; padding: 0.2rem; display: none;
+}
+.search-clear:hover { color: var(--accent-color); }
+#sort {
+    padding: 0.55rem 0.7rem; border-radius: 8px; border: 1px solid var(--border-color);
+    background: var(--card-bg); color: var(--text-primary); font-family: 'Inter', sans-serif;
+    font-size: 0.8rem; cursor: pointer;
+}
+#sort:focus { outline: none; border-color: var(--accent-color); }
+
+/* Category filters */
+.filters { display: flex; gap: 0.4rem; justify-content: center; padding: 0.75rem 1.5rem 0; flex-wrap: wrap; max-width: 960px; margin: 0 auto; }
+.filter-btn {
+    padding: 0.35rem 0.8rem; border-radius: 20px; border: 1px solid var(--border-color);
+    background: transparent; color: var(--text-secondary); cursor: pointer;
+    font-family: 'Inter', sans-serif; font-size: 0.75rem; font-weight: 500; transition: all 0.18s ease;
+    display: inline-flex; align-items: center; gap: 0.35rem;
+}
+.filter-btn .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--dot, var(--text-muted)); }
+.filter-btn:hover { border-color: var(--accent-color); color: var(--text-primary); }
+.filter-btn.active { background: var(--accent-color); color: #fff; border-color: var(--accent-color); }
+.filter-btn.active .dot { background: rgba(255,255,255,0.85); }
+
+/* Active tag/filter chips */
+.active-filters { display: flex; gap: 0.4rem; justify-content: center; flex-wrap: wrap; max-width: 960px; margin: 0.7rem auto 0; padding: 0 1.5rem; }
+.chip {
+    display: inline-flex; align-items: center; gap: 0.35rem; padding: 0.25rem 0.6rem;
+    border-radius: 20px; background: rgba(14,165,233,0.12); color: var(--accent-color);
+    font-family: 'Inter', sans-serif; font-size: 0.72rem; font-weight: 600; border: none; cursor: pointer;
+}
+.chip:hover { background: rgba(14,165,233,0.2); }
+.chip .x { font-size: 0.85rem; line-height: 1; opacity: 0.75; }
+
+/* ── Notes ── */
+.notes-container { max-width: 720px; margin: 0 auto; padding: 1.5rem; }
+.note-count { font-family: 'Inter', sans-serif; font-size: 0.78rem; color: var(--text-muted); margin-bottom: 1.1rem; display: flex; align-items: center; gap: 0.5rem; }
+
+.note-card {
+    background: var(--card-bg); border: 1px solid var(--border-color);
+    border-radius: var(--radius); padding: 1.6rem 1.6rem 1.1rem; margin-bottom: 1.1rem;
+    position: relative; transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+    border-left: 4px solid var(--cat, var(--border-color));
+    background-image: repeating-linear-gradient(transparent, transparent 27px, var(--paper-line) 27px, var(--paper-line) 28px);
+    background-position: 0 1.55rem;
+    animation: cardIn 0.45s ease both;
+}
+@keyframes cardIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
+.note-card:hover { box-shadow: var(--shadow-md); transform: translateY(-2px); border-color: var(--cat, var(--accent-color)); }
+.note-card:target { box-shadow: 0 0 0 3px rgba(14,165,233,0.35), var(--shadow-md); }
+.note-card.featured { background-image: repeating-linear-gradient(transparent, transparent 27px, var(--paper-line) 27px, var(--paper-line) 28px), linear-gradient(180deg, color-mix(in srgb, var(--cat) 6%, transparent), transparent 40%); }
+
+.featured-badge {
+    position: absolute; top: -1px; right: 14px;
+    font-family: 'Inter', sans-serif; font-size: 0.58rem; font-weight: 700;
+    padding: 0.2rem 0.55rem; background: var(--gradient-primary);
+    color: #fff; border-radius: 0 0 6px 6px; text-transform: uppercase; letter-spacing: 0.06em;
+    display: inline-flex; align-items: center; gap: 0.25rem;
+}
+.note-text {
+    font-family: 'Special Elite', monospace; font-size: 0.94rem;
+    line-height: 1.78; color: var(--ink-color); letter-spacing: 0.01em;
+}
+.note-text mark { background: rgba(245,200,60,0.45); color: inherit; border-radius: 2px; padding: 0 1px; }
+body.dark-mode .note-text mark { background: rgba(234,179,90,0.35); }
+
+.note-tags { display: flex; flex-wrap: wrap; gap: 0.35rem; margin-top: 0.9rem; }
+.tag {
+    font-family: 'Inter', sans-serif; font-size: 0.68rem; font-weight: 500;
+    padding: 0.15rem 0.5rem; border-radius: 5px; cursor: pointer;
+    background: color-mix(in srgb, var(--cat, var(--accent-color)) 12%, transparent);
+    color: var(--cat, var(--accent-color)); border: 1px solid transparent; transition: all 0.15s ease;
+}
+.tag::before { content: "#"; opacity: 0.55; }
+.tag:hover { border-color: currentColor; }
+.tag.tag-on { background: var(--cat, var(--accent-color)); color: #fff; }
+
+.note-meta {
+    display: flex; justify-content: space-between; align-items: center; gap: 0.75rem;
+    margin-top: 0.85rem; padding-top: 0.6rem; border-top: 1px dashed var(--border-color);
+    font-family: 'Inter', sans-serif; font-size: 0.7rem;
+}
+.note-meta-left { display: flex; align-items: center; gap: 0.7rem; flex-wrap: wrap; }
+.note-category { font-weight: 600; color: var(--cat, var(--accent-color)); display: inline-flex; align-items: center; gap: 0.3rem; }
+.note-location { color: var(--text-muted); display: inline-flex; align-items: center; gap: 0.25rem; }
+.note-actions { display: flex; align-items: center; gap: 0.5rem; }
+.note-number { color: var(--text-muted); }
+.act-btn { background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 0.15rem; display: inline-flex; border-radius: 4px; transition: color 0.15s ease; }
+.act-btn:hover { color: var(--accent-color); }
+.act-btn.copied { color: var(--success-color); }
+
+/* Empty state */
+.empty-state { text-align: center; padding: 3rem 1rem; color: var(--text-muted); }
+.empty-state svg { opacity: 0.4; margin-bottom: 1rem; }
+.empty-state p { font-family: 'Inter', sans-serif; font-size: 0.9rem; }
+.empty-state button { margin-top: 1rem; }
+
+/* Load more */
+.load-more { text-align: center; padding: 0.5rem 0 2rem; }
+.load-more-btn {
+    padding: 0.65rem 1.6rem; border-radius: 9px; border: 1px solid var(--border-color);
+    background: var(--card-bg); color: var(--text-primary); cursor: pointer;
+    font-family: 'Inter', sans-serif; font-size: 0.85rem; font-weight: 600; transition: all 0.18s ease;
+}
+.load-more-btn:hover { background: var(--accent-color); color: #fff; border-color: var(--accent-color); }
+
+/* Toast */
+.toast {
+    position: fixed; bottom: 1.5rem; left: 50%; transform: translateX(-50%) translateY(20px);
+    background: var(--ink-color); color: var(--primary-bg); padding: 0.6rem 1.1rem; border-radius: 8px;
+    font-family: 'Inter', sans-serif; font-size: 0.8rem; font-weight: 500; box-shadow: var(--shadow-lg);
+    opacity: 0; pointer-events: none; transition: all 0.25s ease; z-index: 200;
+}
+.toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
+
+/* Back to top */
+.to-top {
+    position: fixed; bottom: 1.3rem; right: 1.3rem; width: 42px; height: 42px; border-radius: 50%;
+    background: var(--card-bg); border: 1px solid var(--border-color); color: var(--accent-color);
+    cursor: pointer; display: flex; align-items: center; justify-content: center; box-shadow: var(--shadow-md);
+    opacity: 0; pointer-events: none; transition: all 0.25s ease; z-index: 95;
+}
+.to-top.show { opacity: 1; pointer-events: auto; }
+.to-top:hover { transform: translateY(-2px); border-color: var(--accent-color); }
+
+/* Footer */
+.footer { text-align: center; padding: 1.75rem 1.5rem; border-top: 1px solid var(--border-color); color: var(--text-muted); font-size: 0.8rem; font-family: 'Inter', sans-serif; }
+.footer a { color: var(--accent-color); text-decoration: none; font-weight: 600; }
+.footer a:hover { text-decoration: underline; }
+.footer .tagline { font-family: 'Special Elite', monospace; margin-bottom: 0.5rem; color: var(--text-secondary); }
+
+/* Mobile */
+@media (max-width: 640px) {
+    .header { padding: 0.6rem 1rem; }
+    .header-brand h1 { font-size: 0.95rem; }
+    .hero { padding: 2rem 1rem 1.4rem; }
+    .hero-title { font-size: 1.75rem; }
+    .hero-subtitle { font-size: 0.9rem; }
+    .stats { gap: 1.5rem; }
+    .stat-num { font-size: 1.25rem; }
+    .controls { top: 51px; padding: 0.7rem 1rem; }
+    .notes-container { padding: 1rem; }
+    .note-card { padding: 1.2rem 1.1rem 1rem; }
+    .btn-label { display: none; }
+}
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; }
+    html { scroll-behavior: auto; }
+}
+.pro-pill{display:inline-flex;align-items:center;gap:.2rem;background:linear-gradient(135deg,#F59E0B,#EF4444);color:#fff;font-weight:700;font-size:.6rem;text-transform:uppercase;letter-spacing:.4px;padding:.1rem .4rem;border-radius:5px;vertical-align:middle;}
+.freemium-note{margin:.75rem auto 0;display:inline-flex;align-items:center;gap:.5rem;flex-wrap:wrap;justify-content:center;padding:.5rem .85rem;background:rgba(245,158,11,.1);border:1px solid rgba(245,158,11,.3);border-radius:8px;font-size:.85rem;}
+.freemium-note a{color:#F59E0B;font-weight:700;text-decoration:none;}
+</style>
+</head>
+<body>
+<header class="header">
+    <a href="https://www.impactmojo.in" class="header-brand" aria-label="ImpactMojo home">
+        <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M80,130 L150,50" stroke="#10B981" stroke-width="3" stroke-dasharray="4,4"/>
+            <circle cx="150" cy="50" r="5" fill="#6366F1"/>
+        </svg>
+        <h1>Field Notes <span>Pro</span></h1>
+    </a>
+    <div class="header-actions">
+        <button class="btn icon-btn" id="randomBtn" title="Jump to a random note" aria-label="Random note">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M8 8h.01M16 16h.01M12 12h.01"/></svg>
+        </button>
+        <button class="btn icon-btn" id="themeBtn" title="Toggle theme" aria-label="Toggle light or dark theme"></button>
+        <a href="https://www.impactmojo.in" class="btn">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <span class="btn-label">Home</span>
+        </a>
+    </div>
+</header>
+
+<section class="hero">
+    <svg class="paper-plane" width="100" height="100" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M80,130 L150,50" stroke="#10B981" stroke-width="2" stroke-dasharray="4,4"/>
+        <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+    </svg>
+    <h2 class="hero-title">Field Notes</h2>
+    <div class="freemium-note"><span class="pro-pill">&#9733; Premium</span> Reading the notes is free. Copying a note is a Premium feature. <a href="/premium.html#detail-professional">Upgrade &rarr;</a></div>
+    <p class="hero-subtitle">Behind-the-scenes observations from development fieldwork, program evaluation, and policy research across South Asia &mdash; raw, opinionated, and grounded in practice.</p>
+    <div class="stats" id="stats"></div>
+</section>
+
+<div class="controls">
+    <div class="controls-row">
+        <div class="search-wrap">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+            <input type="search" id="search" placeholder="Search notes, tags, places&hellip;  (press /)" autocomplete="off" aria-label="Search field notes">
+            <button class="search-clear" id="searchClear" aria-label="Clear search">&times;</button>
+        </div>
+        <select id="sort" aria-label="Sort notes">
+            <option value="newest">Newest first</option>
+            <option value="oldest">Oldest first</option>
+            <option value="featured">Featured first</option>
+        </select>
+    </div>
+    <div class="filters" id="filters"></div>
+    <div class="active-filters" id="activeFilters"></div>
+</div>
+
+<main class="notes-container">
+    <div class="note-count" id="noteCount"></div>
+    <div id="notesGrid"></div>
+    <div class="load-more" id="loadMore" style="display:none;">
+        <button class="load-more-btn" id="loadMoreBtn">Load more notes</button>
+    </div>
+</main>
+
+<button class="to-top" id="toTop" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"/></svg>
+</button>
+<div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+<footer class="footer">
+    <p class="tagline">The margins are where the real economy lives.</p>
+    <p>Powered by <a href="https://www.impactmojo.in">ImpactMojo</a> &mdash; Free Development Education for South Asia</p>
+</footer>
+
+<script>
+(function() {
+    'use strict';
+
+    const CATEGORIES = [
+        { name: 'MEL & Research', color: 'var(--cat-mel)' },
+        { name: 'Data & Technology', color: 'var(--cat-data)' },
+        { name: 'Policy & Economics', color: 'var(--cat-policy)' },
+        { name: 'Gender & Equity', color: 'var(--cat-gender)' },
+        { name: 'Health & Communication', color: 'var(--cat-health)' },
+        { name: 'Philosophy & Governance', color: 'var(--cat-phil)' },
+    ];
+    const CAT_COLOR = Object.fromEntries(CATEGORIES.map(c => [c.name, c.color]));
+
+    let allNotes = [];
+    const state = { search: '', category: 'all', tags: new Set(), sort: 'newest' };
+    let visibleCount = 12;
+    const BATCH_SIZE = 12;
+
+    const $ = id => document.getElementById(id);
+
+    async function init() {
+        setupTheme();
+        try {
+            const res = await fetch('field-notes-data/notes.json', { cache: 'no-cache' });
+            allNotes = await res.json();
+        } catch (err) {
+            console.error('Failed to load notes:', err);
+            $('notesGrid').innerHTML = '<div class="empty-state"><p>Unable to load field notes. Please refresh.</p></div>';
+            return;
+        }
+        renderStats();
+        renderFilters();
+        wireControls();
+        render();
+        handleDeepLink();
+    }
+
+    // ── Stats ──
+    function renderStats() {
+        const locations = new Set(allNotes.map(n => n.location).filter(Boolean));
+        const featured = allNotes.filter(n => n.featured).length;
+        const stats = [
+            { num: allNotes.length, label: 'Field Notes' },
+            { num: CATEGORIES.length, label: 'Themes' },
+            { num: locations.size, label: 'Regions' },
+            { num: featured, label: 'Featured' },
+        ];
+        $('stats').innerHTML = stats.map(s =>
+            `<div class="stat"><div class="stat-num">${s.num}</div><div class="stat-label">${s.label}</div></div>`
+        ).join('');
+    }
+
+    // ── Filters ──
+    function renderFilters() {
+        const counts = {};
+        allNotes.forEach(n => { counts[n.category] = (counts[n.category] || 0) + 1; });
+        let html = `<button class="filter-btn active" data-category="all">All Notes</button>`;
+        html += CATEGORIES.map(c =>
+            `<button class="filter-btn" data-category="${c.name}" style="--dot:${c.color}">
+                <span class="dot"></span>${c.name} <span style="opacity:.6">${counts[c.name] || 0}</span>
+            </button>`
+        ).join('');
+        $('filters').innerHTML = html;
+        $('filters').addEventListener('click', e => {
+            const btn = e.target.closest('.filter-btn');
+            if (!btn) return;
+            document.querySelectorAll('.filter-btn').forEach(b => b.classList.toggle('active', b === btn));
+            state.category = btn.dataset.category;
+            visibleCount = BATCH_SIZE;
+            render();
+        });
+    }
+
+    function renderActiveFilters() {
+        const wrap = $('activeFilters');
+        const chips = [];
+        state.tags.forEach(t => {
+            chips.push(`<button class="chip" data-tag="${escAttr(t)}">#${escHtml(t)} <span class="x">&times;</span></button>`);
+        });
+        wrap.innerHTML = chips.join('');
+        wrap.querySelectorAll('.chip').forEach(chip => {
+            chip.addEventListener('click', () => toggleTag(chip.dataset.tag));
+        });
+    }
+
+    // ── Core filter + render ──
+    function getFiltered() {
+        const q = state.search.trim().toLowerCase();
+        let notes = allNotes.filter(n => {
+            if (state.category !== 'all' && n.category !== state.category) return false;
+            if (state.tags.size && ![...state.tags].every(t => (n.tags || []).includes(t))) return false;
+            if (q) {
+                const hay = (n.text + ' ' + n.category + ' ' + (n.location || '') + ' ' + (n.tags || []).join(' ')).toLowerCase();
+                if (!hay.includes(q)) return false;
+            }
+            return true;
+        });
+        if (state.sort === 'oldest') notes.sort((a, b) => a.id - b.id);
+        else if (state.sort === 'featured') notes.sort((a, b) => (b.featured - a.featured) || (b.id - a.id));
+        else notes.sort((a, b) => b.id - a.id);
+        return notes;
+    }
+
+    function render() {
+        renderActiveFilters();
+        const notes = getFiltered();
+        const grid = $('notesGrid');
+        const toShow = notes.slice(0, visibleCount);
+
+        if (notes.length === 0) {
+            grid.innerHTML = `<div class="empty-state">
+                <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+                <p>No field notes match your filters.</p>
+                <button class="btn" id="resetBtn">Clear all filters</button>
+            </div>`;
+            $('resetBtn').addEventListener('click', resetFilters);
+        } else {
+            grid.innerHTML = toShow.map((n, i) => cardHtml(n, i)).join('');
+            grid.querySelectorAll('.tag').forEach(el => el.addEventListener('click', () => toggleTag(el.dataset.tag)));
+            grid.querySelectorAll('.act-copy').forEach(el => el.addEventListener('click', () => copyNote(el)));
+            grid.querySelectorAll('.act-link').forEach(el => el.addEventListener('click', () => copyLink(el)));
+        }
+
+        const q = state.search.trim();
+        $('noteCount').innerHTML =
+            `<strong style="color:var(--text-secondary)">${notes.length}</strong> note${notes.length !== 1 ? 's' : ''}` +
+            (state.category !== 'all' ? ` in ${escHtml(state.category)}` : '') +
+            (q ? ` matching &ldquo;${escHtml(q)}&rdquo;` : '') +
+            (notes.length > visibleCount ? ` &middot; showing ${toShow.length}` : '');
+
+        $('loadMore').style.display = visibleCount < notes.length ? 'block' : 'none';
+    }
+
+    function cardHtml(n, i) {
+        const cat = CAT_COLOR[n.category] || 'var(--accent-color)';
+        const q = state.search.trim();
+        const tags = (n.tags || []).map(t =>
+            `<span class="tag ${state.tags.has(t) ? 'tag-on' : ''}" data-tag="${escAttr(t)}" role="button" tabindex="0">${escHtml(t)}</span>`
+        ).join('');
+        const loc = n.location
+            ? `<span class="note-location"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M12 21s-7-6.3-7-11a7 7 0 0 1 14 0c0 4.7-7 11-7 11Z"/><circle cx="12" cy="10" r="2.4"/></svg>${escHtml(n.location)}</span>`
+            : '';
+        return `<article class="note-card ${n.featured ? 'featured' : ''}" id="note-${n.id}" style="--cat:${cat}; animation-delay:${Math.min(i, 12) * 0.03}s">
+            ${n.featured ? '<span class="featured-badge">&#9733; Featured</span>' : ''}
+            <div class="note-text">${highlight(n.text, q)}</div>
+            ${tags ? `<div class="note-tags">${tags}</div>` : ''}
+            <div class="note-meta">
+                <div class="note-meta-left">
+                    <span class="note-category"><span class="dot" style="width:7px;height:7px;border-radius:50%;background:${cat};display:inline-block"></span>${escHtml(n.category)}</span>
+                    ${loc}
+                </div>
+                <div class="note-actions">
+                    <button class="act-btn act-copy" data-id="${n.id}" title="Copy note text" aria-label="Copy note text"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>
+                    <button class="act-btn act-link" data-id="${n.id}" title="Copy link to this note" aria-label="Copy link to this note"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 13a5 5 0 0 0 7 0l3-3a5 5 0 0 0-7-7l-1 1"/><path d="M14 11a5 5 0 0 0-7 0l-3 3a5 5 0 0 0 7 7l1-1"/></svg></button>
+                    <span class="note-number">#${n.id}</span>
+                </div>
+            </div>
+        </article>`;
+    }
+
+    // ── Tag toggle ──
+    function toggleTag(tag) {
+        if (state.tags.has(tag)) state.tags.delete(tag);
+        else state.tags.add(tag);
+        visibleCount = BATCH_SIZE;
+        render();
+    }
+
+    function resetFilters() {
+        state.search = ''; state.category = 'all'; state.tags.clear();
+        $('search').value = ''; $('searchClear').style.display = 'none';
+        document.querySelectorAll('.filter-btn').forEach(b => b.classList.toggle('active', b.dataset.category === 'all'));
+        visibleCount = BATCH_SIZE;
+        render();
+    }
+
+    // ── Copy / share ──
+    function copyNote(btn) {
+        if (!requirePremium()) return; // reading is free, copying a note is Premium
+        const note = allNotes.find(n => n.id == btn.dataset.id);
+        if (!note) return;
+        const text = `${note.text}\n\n— Field Notes, ImpactMojo (#${note.id})`;
+        writeClipboard(text, btn, 'Note copied to clipboard');
+    }
+    function copyLink(btn) {
+        const url = location.origin + location.pathname + '#note-' + btn.dataset.id;
+        writeClipboard(url, btn, 'Link copied to clipboard');
+    }
+    function writeClipboard(text, btn, msg) {
+        const done = () => { btn.classList.add('copied'); setTimeout(() => btn.classList.remove('copied'), 1200); toast(msg); };
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(done).catch(() => fallbackCopy(text, done));
+        } else fallbackCopy(text, done);
+    }
+    function fallbackCopy(text, done) {
+        const ta = document.createElement('textarea');
+        ta.value = text; ta.style.position = 'fixed'; ta.style.opacity = '0';
+        document.body.appendChild(ta); ta.select();
+        try { document.execCommand('copy'); done(); } catch (e) {}
+        document.body.removeChild(ta);
+    }
+
+    // ── Controls wiring ──
+    function wireControls() {
+        const search = $('search'), clear = $('searchClear');
+        let t;
+        search.addEventListener('input', () => {
+            clear.style.display = search.value ? 'block' : 'none';
+            clearTimeout(t);
+            t = setTimeout(() => { state.search = search.value; visibleCount = BATCH_SIZE; render(); }, 120);
+        });
+        clear.addEventListener('click', () => { search.value = ''; state.search = ''; clear.style.display = 'none'; search.focus(); visibleCount = BATCH_SIZE; render(); });
+        $('sort').addEventListener('change', e => { state.sort = e.target.value; render(); });
+        $('loadMoreBtn').addEventListener('click', () => { visibleCount += BATCH_SIZE; render(); });
+        $('randomBtn').addEventListener('click', gotoRandom);
+
+        document.addEventListener('keydown', e => {
+            if (e.key === '/' && document.activeElement !== search) { e.preventDefault(); search.focus(); }
+            else if (e.key === 'Escape' && document.activeElement === search) { search.blur(); }
+        });
+
+        const toTop = $('toTop');
+        window.addEventListener('scroll', () => { toTop.classList.toggle('show', window.scrollY > 500); }, { passive: true });
+        toTop.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
+    }
+
+    function gotoRandom() {
+        // Random from the currently filtered set, or all if empty
+        const pool = getFiltered();
+        const list = pool.length ? pool : allNotes;
+        const note = list[Math.floor(Math.random() * list.length)];
+        const idx = getFiltered().findIndex(n => n.id === note.id);
+        if (idx >= 0 && idx >= visibleCount) { visibleCount = Math.ceil((idx + 1) / BATCH_SIZE) * BATCH_SIZE; render(); }
+        setTimeout(() => {
+            const el = $('note-' + note.id);
+            if (el) { el.scrollIntoView({ behavior: 'smooth', block: 'center' }); flash(el); }
+        }, 60);
+    }
+
+    function handleDeepLink() {
+        const m = location.hash.match(/^#note-(\d+)$/);
+        if (!m) return;
+        const id = +m[1];
+        const idx = getFiltered().findIndex(n => n.id === id);
+        if (idx >= visibleCount) { visibleCount = Math.ceil((idx + 1) / BATCH_SIZE) * BATCH_SIZE; render(); }
+        setTimeout(() => { const el = $('note-' + id); if (el) { el.scrollIntoView({ behavior: 'smooth', block: 'center' }); flash(el); } }, 120);
+    }
+
+    function flash(el) {
+        el.style.transition = 'box-shadow 0.3s ease';
+        el.style.boxShadow = '0 0 0 3px rgba(14,165,233,0.4), var(--shadow-md)';
+        setTimeout(() => { el.style.boxShadow = ''; }, 1400);
+    }
+
+    // ── Theme ──
+    function setupTheme() {
+        const saved = localStorage.getItem('fn-theme');
+        const dark = saved ? saved === 'dark' : (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        document.body.classList.toggle('dark-mode', dark);
+        updateThemeIcon();
+        $('themeBtn').addEventListener('click', () => {
+            const isDark = document.body.classList.toggle('dark-mode');
+            localStorage.setItem('fn-theme', isDark ? 'dark' : 'light');
+            document.querySelector('meta[name=theme-color]').setAttribute('content', isDark ? '#14120C' : '#FFFDF7');
+            updateThemeIcon();
+        });
+    }
+    function updateThemeIcon() {
+        const dark = document.body.classList.contains('dark-mode');
+        $('themeBtn').innerHTML = dark
+            ? '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>'
+            : '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+    }
+
+    // ── Toast ──
+    let toastT;
+    function toast(msg) {
+        const el = $('toast');
+        el.textContent = msg; el.classList.add('show');
+        clearTimeout(toastT);
+        toastT = setTimeout(() => el.classList.remove('show'), 1800);
+    }
+
+    // ── Helpers ──
+    function escHtml(str) { const d = document.createElement('div'); d.textContent = str == null ? '' : str; return d.innerHTML; }
+    function escAttr(str) { return escHtml(str).replace(/"/g, '&quot;'); }
+    function highlight(text, q) {
+        const safe = escHtml(text);
+        if (!q || q.length < 2) return safe;
+        const re = new RegExp('(' + q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + ')', 'gi');
+        return safe.replace(re, '<mark>$1</mark>');
+    }
+
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+    else init();
+})();
+</script>
+<!-- ImpactMojo auth + premium (Pro Studio freemium gate) -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
+<script src="/js/premium.js"></script>
+<script>
+window.TOOL_PREMIUM=false; var TOOL_TIER='professional';
+async function initGate(){ try{ if(window.ImpactMojoAuth) await window.ImpactMojoAuth.waitForAuthReady(); }catch(e){} var a=window.ImpactMojoAuth; window.TOOL_PREMIUM=!!(a&&typeof a.hasTierAccess==='function'&&a.hasTierAccess(TOOL_TIER)); }
+function requirePremium(){ if(window.TOOL_PREMIUM) return true; if(window.IMXPremium&&typeof window.IMXPremium.showUpgradeModal==='function') window.IMXPremium.showUpgradeModal(TOOL_TIER); else window.location.href='/premium.html#detail-'+TOOL_TIER; return false; }
+if(document.readyState==='loading') document.addEventListener('DOMContentLoaded',initGate); else initGate();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What

Imports **Field Notes** from the standalone `impactmojo-field-notes-pro` repo into the main site (**same-origin**, so Premium actually unlocks) and makes it freemium.

- `premium-tools/field-notes.html` + `premium-tools/field-notes-data/notes.json` — the notes reader, now served same-origin. The old repo sat behind the server-side `auth-gate` edge function (fully paywalled); hosting it here (no edge gate) makes **reading free**.
- Dropped "Pro" from the title and hero → **Field Notes**.
- Loads the ImpactMojo auth stack (`/js/…`); gates `copyNote()` with `requirePremium()` (Professional) — **reading is free, copying a note is Premium**. `copyLink` (share a URL) stays free.
- "★ Premium" pill + note: *"Reading the notes is free. Copying a note is a Premium feature."*
- `index.html`: repointed the homepage Field Notes card from the external netlify domain → `/premium-tools/field-notes.html`.

## Verification

Playwright (5/5): notes load and read freely; `copyNote` blocked when logged out (upgrade modal, nothing copied); auth/premium stack loads same-origin; Professional tier.

## Follow-up

The standalone `impactmojo-field-notes-pro` Netlify deployment can be retired once this is live (a `_redirects` from the old domain → the new path is optional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjA2YggbarV9Sw7m65c6Df

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjA2YggbarV9Sw7m65c6Df)_