### PR TITLE
fix(mint-resource-token): validate session by passing the JWT explicitly

### DIFF
--- a/supabase/functions/mint-resource-token/index.ts
+++ b/supabase/functions/mint-resource-token/index.ts
@@ -168,7 +168,10 @@ serve(async (req: Request) => {
     const userClient = createClient(supabaseUrl, supabaseAnonKey, {
       global: { headers: { Authorization: `Bearer ${accessToken}` } },
     });
-    const { data: { user }, error: userError } = await userClient.auth.getUser();
+    // Pass the JWT explicitly: in an edge function there is no persisted
+    // session for getUser() to read, and with the project's JWT signing keys
+    // the token must be validated against the auth server directly.
+    const { data: { user }, error: userError } = await userClient.auth.getUser(accessToken);
     if (userError || !user) {
       return new Response(
         JSON.stringify({ error: "Invalid session" }),


### PR DESCRIPTION
## Problem

Launching any off-platform premium tool (Field Notes Pro, DevEcon Toolkit, Workshop Pro, DevData, VaniScribe…) redirected users to the premium upgrade page even when they were logged in with a valid Professional/Organization subscription.

Root cause: the `mint-resource-token` Edge Function verified the caller's session with `userClient.auth.getUser()` — **no argument**. In an Edge Function there is no persisted auth session for `getUser()` to read, and with the project's JWT signing keys this call fails. Every mint request returned `401 Invalid session`, so `resource-launch.js` sent users to `/premium.html`.

This was verified end-to-end: a freshly issued, valid user access token passed `GET /auth/v1/user` (200) but was rejected by the function.

## Fix

Pass the caller's access token explicitly:

```diff
- const { data: { user }, error: userError } = await userClient.auth.getUser();
+ const { data: { user }, error: userError } = await userClient.auth.getUser(accessToken);
```

This validates the JWT against the auth server on every request, independent of any stored session.

## Verification

After deploying this change and aligning the signing secret, the full `mint → Netlify auth-gate` flow was confirmed working (session cookie set) for:

- `field-notes-pro`
- `devecon-toolkit`
- `toc-workshop-pro`

## Note (config, outside this diff)

The Netlify sites' `RESOURCE_TOKEN_SECRET` (verify) must equal Supabase's `RESOURCE_TOKEN_SECRET` (sign) — the **raw** secret, not the SHA-256 digest shown in the Supabase dashboard. This was corrected in the project secrets as part of the same fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gv5ZL8C9gQbqizNPbCr9Q

---
_Generated by [Claude Code](https://claude.ai/code/session_014gv5ZL8C9gQbqizNPbCr9Q)_