### PR TITLE
Homepage: unify Freemium Pro Studio into one card style

### DIFF
--- a/index.html
+++ b/index.html
@@ -2934,7 +2934,7 @@ window.addEventListener('authStateChanged', function(e) {
 <span class="learner-badge">Free tool</span>
 </div>
 <h3 class="card-title">Sampling Toolkit</h3>
-<div class="star-rating"><span class="rating-text" style="color:var(--success-color,#10B981)">Free to use</span><span class="rating-count">&middot; export is Premium</span></div>
+<div class="star-rating"><span class="rating-text"><strong>Free</strong> to use</span><span class="rating-count">&middot; export is Premium</span></div>
 <p class="card-description">Learn the ideas, then design a defensible sampling strategy and size it properly — with the maths shown. A free primer plus the Sampling Design Studio.</p>
 </a>
 </div>
@@ -2945,7 +2945,7 @@ window.addEventListener('authStateChanged', function(e) {
 <span class="learner-badge">Free tool</span>
 </div>
 <h3 class="card-title">Research Question Builder</h3>
-<div class="star-rating"><span class="rating-text" style="color:var(--success-color,#10B981)">Free to use</span><span class="rating-count">&middot; export is Premium</span></div>
+<div class="star-rating"><span class="rating-text"><strong>Free</strong> to use</span><span class="rating-count">&middot; export is Premium</span></div>
 <p class="card-description">Turn a vague idea into a testable, fundable research question with PICO and SPIDER framing, a quality checklist and method suggestions.</p>
 </a>
 </div>
@@ -2956,7 +2956,7 @@ window.addEventListener('authStateChanged', function(e) {
 <span class="learner-badge">Free tool</span>
 </div>
 <h3 class="card-title">ToR Builder</h3>
-<div class="star-rating"><span class="rating-text" style="color:var(--success-color,#10B981)">Free to use</span><span class="rating-count">&middot; export is Premium</span></div>
+<div class="star-rating"><span class="rating-text"><strong>Free</strong> to use</span><span class="rating-count">&middot; export is Premium</span></div>
 <p class="card-description">Write a complete Terms of Reference plus a costing sheet from structured prompts — the interactive companion to the ToR Practice Pack.</p>
 </a>
 </div>
@@ -2967,7 +2967,7 @@ window.addEventListener('authStateChanged', function(e) {
 <span class="learner-badge">Free tool</span>
 </div>
 <h3 class="card-title">Qualitative Insights Lab</h3>
-<div class="star-rating"><span class="rating-text" style="color:var(--success-color,#10B981)">Free to use</span><span class="rating-count">&middot; export is Premium</span></div>
+<div class="star-rating"><span class="rating-text"><strong>Free</strong> to use</span><span class="rating-count">&middot; export is Premium</span></div>
 <p class="card-description">Thematic coding, memo generation and cross-case comparison for interview and FGD transcripts — built for researchers without NVivo.</p>
 </a>
 </div>
@@ -2978,7 +2978,7 @@ window.addEventListener('authStateChanged', function(e) {
 <span class="learner-badge">Free tool</span>
 </div>
 <h3 class="card-title">Statistical Code Converter</h3>
-<div class="star-rating"><span class="rating-text" style="color:var(--success-color,#10B981)">Free to use</span><span class="rating-count">&middot; export is Premium</span></div>
+<div class="star-rating"><span class="rating-text"><strong>Free</strong> to use</span><span class="rating-count">&middot; export is Premium</span></div>
 <p class="card-description">Translate statistical code between R, Stata, SPSS and Python, with diagnostics and power analysis.</p>
 </a>
 </div>

--- a/index.html
+++ b/index.html
@@ -2926,50 +2926,63 @@ window.addEventListener('authStateChanged', function(e) {
         <div style="font-size: 0.8rem; color: var(--text-secondary, #475569); line-height: 1.5;">Advisory Board, VaniScribe AI, DevData Practice, Viz Cookbook, DevEcon Toolkit, Field Notes, 7 workshop tools (ToC, LogFrame, Chart Selector, Stakeholder Map, Empathy Map, Policy Canvas, AI Canvas), and priority coaching</div>
     </div>
 </div>
-<div class="imx-resource-grid">
-    <a href="/labs/sampling-toolkit.html" class="imx-resource-card">
-        <div class="imx-resource-icon" style="background: #0EA5E922; color: #0EA5E9;">
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none"><use href="#si_Bar_chart"/></svg>
-        </div>
-        <h3 class="imx-resource-title">Sampling Toolkit</h3>
-        <p class="imx-resource-desc">Learn the ideas, then design a defensible sampling strategy and size it properly — with the maths shown. A free primer plus the Sampling Design Studio.</p>
-        <div class="imx-resource-stats"><span><strong>Free</strong> to use</span><span>export is Premium</span></div>
-    </a>
-    <a href="/premium-tools/rq-builder.html" class="imx-resource-card">
-        <div class="imx-resource-icon" style="background: #6366F122; color: #6366F1;">
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none"><use href="#si_Search"/></svg>
-        </div>
-        <h3 class="imx-resource-title">Research Question Builder</h3>
-        <p class="imx-resource-desc">Turn a vague idea into a testable, fundable research question with PICO and SPIDER framing, a quality checklist and method suggestions.</p>
-        <div class="imx-resource-stats"><span><strong>Free</strong> to use</span><span>export is Premium</span></div>
-    </a>
-    <a href="/premium-tools/tor-builder.html" class="imx-resource-card">
-        <div class="imx-resource-icon" style="background: #10B98122; color: #10B981;">
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none"><use href="#si_Article"/></svg>
-        </div>
-        <h3 class="imx-resource-title">ToR Builder</h3>
-        <p class="imx-resource-desc">Write a complete Terms of Reference plus a costing sheet from structured prompts — the interactive companion to the ToR Practice Pack.</p>
-        <div class="imx-resource-stats"><span><strong>Free</strong> to use</span><span>export is Premium</span></div>
-    </a>
-    <a href="/premium-tools/qual-insights-lab.html" class="imx-resource-card">
-        <div class="imx-resource-icon" style="background: #F59E0B22; color: #F59E0B;">
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none"><use href="#si_Library_books"/></svg>
-        </div>
-        <h3 class="imx-resource-title">Qualitative Insights Lab</h3>
-        <p class="imx-resource-desc">Thematic coding, memo generation and cross-case comparison for interview and FGD transcripts — built for researchers without NVivo.</p>
-        <div class="imx-resource-stats"><span><strong>Free</strong> to use</span><span>export is Premium</span></div>
-    </a>
-    <a href="/premium-tools/code-converter-pro.html" class="imx-resource-card">
-        <div class="imx-resource-icon" style="background: #EC489922; color: #EC4899;">
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none"><use href="#si_Activity"/></svg>
-        </div>
-        <h3 class="imx-resource-title">Statistical Code Converter</h3>
-        <p class="imx-resource-desc">Translate statistical code between R, Stata, SPSS and Python, with diagnostics and power analysis.</p>
-        <div class="imx-resource-stats"><span><strong>Free</strong> to use</span><span>export is Premium</span></div>
-    </a>
+<div class="cards-grid">
+<div class="card">
+<a href="/labs/sampling-toolkit.html" rel="noopener noreferrer" target="_blank">
+<div class="card-header">
+<span class="card-number premium"><svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Bar_chart"/></svg> FREEMIUM </span>
+<span class="learner-badge">Free tool</span>
+</div>
+<h3 class="card-title">Sampling Toolkit</h3>
+<div class="star-rating"><span class="rating-text" style="color:var(--success-color,#10B981)">Free to use</span><span class="rating-count">&middot; export is Premium</span></div>
+<p class="card-description">Learn the ideas, then design a defensible sampling strategy and size it properly — with the maths shown. A free primer plus the Sampling Design Studio.</p>
+</a>
+</div>
+<div class="card">
+<a href="/premium-tools/rq-builder.html" rel="noopener noreferrer" target="_blank">
+<div class="card-header">
+<span class="card-number premium"><svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Search"/></svg> FREEMIUM </span>
+<span class="learner-badge">Free tool</span>
+</div>
+<h3 class="card-title">Research Question Builder</h3>
+<div class="star-rating"><span class="rating-text" style="color:var(--success-color,#10B981)">Free to use</span><span class="rating-count">&middot; export is Premium</span></div>
+<p class="card-description">Turn a vague idea into a testable, fundable research question with PICO and SPIDER framing, a quality checklist and method suggestions.</p>
+</a>
+</div>
+<div class="card">
+<a href="/premium-tools/tor-builder.html" rel="noopener noreferrer" target="_blank">
+<div class="card-header">
+<span class="card-number premium"><svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Article"/></svg> FREEMIUM </span>
+<span class="learner-badge">Free tool</span>
+</div>
+<h3 class="card-title">ToR Builder</h3>
+<div class="star-rating"><span class="rating-text" style="color:var(--success-color,#10B981)">Free to use</span><span class="rating-count">&middot; export is Premium</span></div>
+<p class="card-description">Write a complete Terms of Reference plus a costing sheet from structured prompts — the interactive companion to the ToR Practice Pack.</p>
+</a>
+</div>
+<div class="card">
+<a href="/premium-tools/qual-insights-lab.html" rel="noopener noreferrer" target="_blank">
+<div class="card-header">
+<span class="card-number premium"><svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Library_books"/></svg> FREEMIUM </span>
+<span class="learner-badge">Free tool</span>
+</div>
+<h3 class="card-title">Qualitative Insights Lab</h3>
+<div class="star-rating"><span class="rating-text" style="color:var(--success-color,#10B981)">Free to use</span><span class="rating-count">&middot; export is Premium</span></div>
+<p class="card-description">Thematic coding, memo generation and cross-case comparison for interview and FGD transcripts — built for researchers without NVivo.</p>
+</a>
+</div>
+<div class="card">
+<a href="/premium-tools/code-converter-pro.html" rel="noopener noreferrer" target="_blank">
+<div class="card-header">
+<span class="card-number premium"><svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Activity"/></svg> FREEMIUM </span>
+<span class="learner-badge">Free tool</span>
+</div>
+<h3 class="card-title">Statistical Code Converter</h3>
+<div class="star-rating"><span class="rating-text" style="color:var(--success-color,#10B981)">Free to use</span><span class="rating-count">&middot; export is Premium</span></div>
+<p class="card-description">Translate statistical code between R, Stata, SPSS and Python, with diagnostics and power analysis.</p>
+</a>
 </div>
 
-<div class="cards-grid">
 <div class="card">
 <a href="/premium-tools/advisory-board-pro.html" data-resource-id="advisory-board-pro" rel="noopener noreferrer" target="_blank">
 <div class="card-header">


### PR DESCRIPTION
## What

The Freemium Pro Studio section had **two card styles** — 5 lightweight "resource" cards (icon + title + blurb) next to 13 full tool cards (badge + title + rating + Save/Compare). This converts the 5 utility cards (Sampling Toolkit, RQ Builder, ToR Builder, Qual Insights Lab, Code Converter) into the **same `.card` structure** and merges everything into one `cards-grid`, so all **18 cards read as one family**.

- No fabricated ratings: the 5 converted cards show their honest **"Free to use · export is Premium"** line where the star row sits, with a FREEMIUM badge + a "Free tool" chip.
- Links stay ungated (free to open).

## Verification

Rendered at 1280px: one uniform grid, consistent card frame / header / badges / Save-Compare across all 18 cards (screenshot-checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjA2YggbarV9Sw7m65c6Df

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjA2YggbarV9Sw7m65c6Df)_