### PR TITLE
Fix BookSummaries landing-page counts (hero 50→106, filter counts)

### DIFF
--- a/BookSummaries/index.html
+++ b/BookSummaries/index.html
@@ -914,7 +914,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     <p>Deep-dive, interactive summaries of essential texts in development economics, data visualisation, productivity, and public policy. Navigate chapters, explore key concepts, and build real understanding.</p>
     <div class="hero-stats">
         <div class="stat-item">
-            <div class="stat-number">50</div>
+            <div class="stat-number">106</div>
             <div class="stat-label">Books Available</div>
         </div>
         <div class="stat-item">
@@ -934,12 +934,12 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     <p class="section-subtitle">Click on a book to explore its interactive companion</p>
 
     <div class="category-filters">
-        <button class="filter-btn active" data-category="all">All <span class="count">55</span></button>
-        <button class="filter-btn" data-category="data-viz">Data Visualization <span class="count">8</span></button>
-        <button class="filter-btn" data-category="dev-econ">Development Economics <span class="count">21</span></button>
-        <button class="filter-btn" data-category="productivity">Productivity <span class="count">7</span></button>
+        <button class="filter-btn active" data-category="all">All <span class="count">106</span></button>
+        <button class="filter-btn" data-category="data-viz">Data Visualization <span class="count">17</span></button>
+        <button class="filter-btn" data-category="dev-econ">Development Economics <span class="count">40</span></button>
+        <button class="filter-btn" data-category="productivity">Productivity <span class="count">8</span></button>
         <button class="filter-btn" data-category="leadership">Leadership & Communication <span class="count">9</span></button>
-        <button class="filter-btn" data-category="policy">Policy & Social Protection <span class="count">9</span></button>
+        <button class="filter-btn" data-category="policy">Policy & Social Protection <span class="count">31</span></button>
         <button class="filter-btn" data-category="design">Design & Innovation <span class="count">1</span></button>
     </div>
 


### PR DESCRIPTION
## What does this PR do?

Fixes the stale counts on the BookSummaries landing page (`/BookSummaries/`) that weren't updated during the 55 → 106 expansion:

- **Hero stat:** "50 Books Available" → **106**
- **Category filter counts** updated to the real per-category card distribution:
  - All: 55 → **106**
  - Data Visualization: 8 → **17**
  - Development Economics: 21 → **40**
  - Productivity: 7 → **8**
  - Leadership & Communication: 9 → **9** (unchanged)
  - Policy & Social Protection: 9 → **31**
  - Design & Innovation: 1 → **1** (unchanged)

The six category counts now sum to 106, matching the card count.

## Type of change

- [x] Bug fix (broken link, layout, JS error)

## Checklist

- [ ] Tested on desktop browser
- [ ] Tested on mobile browser
- [x] No console errors *(mojibake check passes; counts verified against the actual `data-category` distribution)*
- [x] Links are working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfggsDUpQgzET12dvRbAA1

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfggsDUpQgzET12dvRbAA1)_