### PR TITLE
Fix oversized in-flow paper-plane SVG on nvc-rj & sel flagships

### DIFF
--- a/courses/nvc-rj/index.html
+++ b/courses/nvc-rj/index.html
@@ -3089,6 +3089,15 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 .concept-table thead { background:var(--secondary-bg); }
 .nv-quote { border-left:4px solid var(--color-accent); padding:0.4rem 0 0.4rem 1.25rem; margin:1.5rem 0; font-style:italic; color:var(--text-secondary); }
 .nv-quote cite { display:block; margin-top:0.5rem; font-style:normal; font-size:0.85rem; color:var(--text-muted); }
+/* Paper-plane decoration: size + fix it (the cloned SEL shell shipped the <svg>
+   but not this rule, so it rendered full-size in-flow). Matches gandhi/mel. */
+.im-paper-plane {
+    position: fixed; top: 14%; right: 6%;
+    width: 78px; height: 78px;
+    opacity: 0.13; z-index: 0; pointer-events: none;
+}
+[data-theme="light"] .im-paper-plane { opacity: 0.18; }
+@media (max-width: 900px) { .im-paper-plane { display: none !important; } }
 </style>
 
 

--- a/courses/sel/index.html
+++ b/courses/sel/index.html
@@ -3024,6 +3024,15 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 }
 /* MOBILE-FIX-2026-05-20 END */
 
+/* Paper-plane decoration: size + fix it. This shell shipped the <svg class="im-paper-plane">
+   but not this rule, so it rendered full-size in-flow. Matches gandhi/mel. */
+.im-paper-plane {
+    position: fixed; top: 14%; right: 6%;
+    width: 78px; height: 78px;
+    opacity: 0.13; z-index: 0; pointer-events: none;
+}
+[data-theme="light"] .im-paper-plane { opacity: 0.18; }
+@media (max-width: 900px) { .im-paper-plane { display: none !important; } }
 </style>
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes a formatting bug on the **Nonviolence in Practice** (`/courses/nvc-rj/`) and **SEL** (`/courses/sel/`) flagships: both shipped the decorative `<svg class="im-paper-plane">` element but were **missing the `.im-paper-plane` sizing rule** every other flagship carries. Without it the plane rendered at full size in the document flow, forcing layout/overflow that showed up as broken desktop margins and a giant plane graphic. `nvc-rj` inherited this from the SEL shell it was cloned from.

Adds the standard rule (`position:fixed; 78px; opacity ~0.13; pointer-events:none;` hidden ≤900px) to both.

Found via a component audit across all 17 flagships — these two were the only ones with the element-present-but-unsized combination (every other flagship either sizes it or omits the element).

## Type of change

- [x] Bug fix (broken link, layout, JS error)

## Checklist

- [x] Tested on desktop browser (headless Chromium render — plane now a small fixed decoration; layout clean top-to-bottom)
- [ ] Tested on mobile browser (plane hidden ≤900px)
- [x] No console errors
- [x] Links are working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKcnNxSMz2sigxi4L4KwAm)_