### PR TITLE
Complete site-chrome rollout — remaining 110 pages

### DIFF
--- a/BookCompanionTools/budget-template-generator.html
+++ b/BookCompanionTools/budget-template-generator.html
@@ -1280,5 +1280,6 @@ function showToast(msg) {
 <script src="/js/config.js"></script>
 <script src="/js/auth.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/BookCompanionTools/sample-size-calculator.html
+++ b/BookCompanionTools/sample-size-calculator.html
@@ -14,5 +14,6 @@
 <h1>This tool has moved</h1>
 <p>The Sample Size Calculator is now part of the <strong>Sampling Design Studio</strong> — a guided tool that sizes your study and helps you design the whole sampling strategy.</p>
 <p><a href="/labs/sampling-design-lab.html">Continue to the Sampling Design Studio →</a></p>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/SupportGifts/thankyou.html
+++ b/SupportGifts/thankyou.html
@@ -753,5 +753,6 @@ body { padding-top: 56px; }
 <script src="/js/config.js"></script>
 <script src="/js/auth.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/causal-attribution-audit/annual-report-extract.html
+++ b/challenges/causal-attribution-audit/annual-report-extract.html
@@ -182,5 +182,6 @@ relied upon &mdash; remained dry for much of the year, underlining the value of 
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/causal-attribution-audit/programme-rollout-plan.html
+++ b/challenges/causal-attribution-audit/programme-rollout-plan.html
@@ -210,5 +210,6 @@ shortlist of 128 villages; C &mdash; unit-cost workings for the survey budget.</
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/dataviz-dashboard-critique/current-dashboard.html
+++ b/challenges/dataviz-dashboard-critique/current-dashboard.html
@@ -286,5 +286,6 @@ footer{margin-top:2.2rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 })();
 </script>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/dataviz-dashboard-critique/nutrition-data.html
+++ b/challenges/dataviz-dashboard-critique/nutrition-data.html
@@ -114,5 +114,6 @@ footer{margin-top:2.2rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/dataviz-dashboard-critique/tufte-quick-reference.html
+++ b/challenges/dataviz-dashboard-critique/tufte-quick-reference.html
@@ -168,5 +168,6 @@ footer{margin-top:2.5rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/devai-bias-audit/demographic-breakdown.html
+++ b/challenges/devai-bias-audit/demographic-breakdown.html
@@ -194,5 +194,6 @@ footer{margin-top:2.2rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/devai-bias-audit/feature-importance.html
+++ b/challenges/devai-bias-audit/feature-importance.html
@@ -122,5 +122,6 @@ footer{margin-top:2.2rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/devai-bias-audit/model-outputs.html
+++ b/challenges/devai-bias-audit/model-outputs.html
@@ -180,5 +180,6 @@ footer{margin-top:2.2rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/devecon-cost-effectiveness/intervention-a-costs.html
+++ b/challenges/devecon-cost-effectiveness/intervention-a-costs.html
@@ -153,5 +153,6 @@ footer{margin-top:2.2rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/devecon-cost-effectiveness/intervention-b-costs.html
+++ b/challenges/devecon-cost-effectiveness/intervention-b-costs.html
@@ -155,5 +155,6 @@ footer{margin-top:2.2rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/devecon-cost-effectiveness/outcome-data.html
+++ b/challenges/devecon-cost-effectiveness/outcome-data.html
@@ -173,5 +173,6 @@ footer{margin-top:2.2rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/gandhi-nonviolence-contemporary/gandhi-writings.html
+++ b/challenges/gandhi-nonviolence-contemporary/gandhi-writings.html
@@ -172,5 +172,6 @@ code{font-family:'JetBrains Mono',monospace;background:var(--border);padding:0.1
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/gandhi-nonviolence-contemporary/satyagraha-framework.html
+++ b/challenges/gandhi-nonviolence-contemporary/satyagraha-framework.html
@@ -196,5 +196,6 @@ code{font-family:'JetBrains Mono',monospace;background:var(--border);padding:0.1
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/gender-gesi-audit/demographic-profile.html
+++ b/challenges/gender-gesi-audit/demographic-profile.html
@@ -163,5 +163,6 @@ footer{margin-top:2.2rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/gender-gesi-audit/mid-term-review.html
+++ b/challenges/gender-gesi-audit/mid-term-review.html
@@ -227,5 +227,6 @@ code{font-family:'JetBrains Mono',monospace;background:var(--border);padding:0.1
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/gender-gesi-audit/program-design.html
+++ b/challenges/gender-gesi-audit/program-design.html
@@ -197,5 +197,6 @@ code{font-family:'JetBrains Mono',monospace;background:var(--border);padding:0.1
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/law-rti-strategy/pmgsy-guidelines.html
+++ b/challenges/law-rti-strategy/pmgsy-guidelines.html
@@ -196,5 +196,6 @@ code{font-family:'JetBrains Mono',monospace;background:var(--border);padding:0.1
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/law-rti-strategy/rti-act-key-sections.html
+++ b/challenges/law-rti-strategy/rti-act-key-sections.html
@@ -283,5 +283,6 @@ code{font-family:'JetBrains Mono',monospace;background:var(--border);padding:0.1
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/law-rti-strategy/sample-rti-application.html
+++ b/challenges/law-rti-strategy/sample-rti-application.html
@@ -262,5 +262,6 @@ Enclosures: copy of RTI application + fee receipt; copy of PIO's reply (if any).
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/livelihoods-graduation-design/budget-envelope.html
+++ b/challenges/livelihoods-graduation-design/budget-envelope.html
@@ -186,5 +186,6 @@ organisational overheads (overheads capped at 10% of total) must all come from i
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/livelihoods-graduation-design/district-livelihood-profile.html
+++ b/challenges/livelihoods-graduation-design/district-livelihood-profile.html
@@ -225,5 +225,6 @@ assumption and how you would verify it in month 1.
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/media-bcc-campaign/bcc-strategy-template.html
+++ b/challenges/media-bcc-campaign/bcc-strategy-template.html
@@ -182,5 +182,6 @@ footer{margin-top:2.4rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/media-bcc-campaign/district-health-profile.html
+++ b/challenges/media-bcc-campaign/district-health-profile.html
@@ -198,5 +198,6 @@ footer{margin-top:2.4rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/media-bcc-campaign/kap-survey-summary.html
+++ b/challenges/media-bcc-campaign/kap-survey-summary.html
@@ -191,5 +191,6 @@ footer{margin-top:2.4rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/mel-logframe-redesign/baseline-data.html
+++ b/challenges/mel-logframe-redesign/baseline-data.html
@@ -107,5 +107,6 @@ footer{margin-top:2.2rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/mel-logframe-redesign/flawed-logframe.html
+++ b/challenges/mel-logframe-redesign/flawed-logframe.html
@@ -146,5 +146,6 @@ footer{margin-top:2.2rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/mel-logframe-redesign/program-description.html
+++ b/challenges/mel-logframe-redesign/program-description.html
@@ -145,5 +145,6 @@ code{font-family:'JetBrains Mono',monospace;background:var(--border);padding:0.1
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/poa-donor-exit-transition/exit-announcement-memo.html
+++ b/challenges/poa-donor-exit-transition/exit-announcement-memo.html
@@ -160,5 +160,6 @@ footer{margin-top:2.2rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/poa-donor-exit-transition/programme-factsheet.html
+++ b/challenges/poa-donor-exit-transition/programme-factsheet.html
@@ -221,5 +221,6 @@ annually and countersigned by the Directorate. <em>Status: register exists but w
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/powerbi-education-dashboard/data-landscape.html
+++ b/challenges/powerbi-education-dashboard/data-landscape.html
@@ -157,5 +157,6 @@ footer{margin-top:2.2rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/powerbi-education-dashboard/director-brief.html
+++ b/challenges/powerbi-education-dashboard/director-brief.html
@@ -149,5 +149,6 @@ footer{margin-top:2.2rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/pubchoice-textbook-procurement/actor-map.html
+++ b/challenges/pubchoice-textbook-procurement/actor-map.html
@@ -160,5 +160,6 @@ footer{margin-top:2.2rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/pubchoice-textbook-procurement/procurement-timeline.html
+++ b/challenges/pubchoice-textbook-procurement/procurement-timeline.html
@@ -193,5 +193,6 @@ footer{margin-top:2.2rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/pubpol-policy-window-memo/evidence-pack.html
+++ b/challenges/pubpol-policy-window-memo/evidence-pack.html
@@ -220,5 +220,6 @@ footer{margin-top:2.2rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/pubpol-policy-window-memo/political-context-brief.html
+++ b/challenges/pubpol-policy-window-memo/political-context-brief.html
@@ -219,5 +219,6 @@ footer{margin-top:2.2rem;padding-top:1.2rem;border-top:1px solid var(--border);c
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/sel-conflict-resolution/sel-competency-framework.html
+++ b/challenges/sel-conflict-resolution/sel-competency-framework.html
@@ -241,5 +241,6 @@ code{font-family:'JetBrains Mono',monospace;background:var(--border);padding:0.1
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/challenges/sel-conflict-resolution/team-profile.html
+++ b/challenges/sel-conflict-resolution/team-profile.html
@@ -223,5 +223,6 @@ code{font-family:'JetBrains Mono',monospace;background:var(--border);padding:0.1
 </footer>
 </div>
 <script>(function(){try{var t=localStorage.getItem('im-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/community/index.html
+++ b/community/index.html
@@ -1579,5 +1579,6 @@ document.querySelectorAll('a[href^="#"]').forEach(anchor => {
 <script src="/js/config.js"></script>
 <script src="/js/auth.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -759,5 +759,6 @@
   <!-- Theme toggle -->
   <script src="/js/theme.js"></script>
 
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/impactlex/index.html
+++ b/impactlex/index.html
@@ -334,5 +334,6 @@
   }
 </script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/impactlex/review.html
+++ b/impactlex/review.html
@@ -196,5 +196,6 @@
 })();
 </script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/impactlex/term.html
+++ b/impactlex/term.html
@@ -206,5 +206,6 @@
 })();
 </script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/practice-packs/climate-evaluation/index.html
+++ b/practice-packs/climate-evaluation/index.html
@@ -261,5 +261,6 @@ attachSaveHandlers();loadAll();
 <script>window.IM_PACK={slug:'climate-evaluation',title:'Climate Adaptation Evaluation',artefact:'adaptation evaluation design',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
 <script src="/js/practice-pack-gate.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/practice-packs/critiquing-evidence/index.html
+++ b/practice-packs/critiquing-evidence/index.html
@@ -282,5 +282,6 @@ attachSaveHandlers();loadAll();
 <script>window.IM_PACK={slug:'critiquing-evidence',title:'Reading & Critiquing an Evidence Paper',artefact:'1-page critique',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
 <script src="/js/practice-pack-gate.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/practice-packs/donor-reporting/index.html
+++ b/practice-packs/donor-reporting/index.html
@@ -286,5 +286,6 @@ attachSaveHandlers();loadAll();
 <script>window.IM_PACK={slug:'donor-reporting',title:'Donor Reporting That Funders Read',artefact:'report skeleton',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
 <script src="/js/practice-pack-gate.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/practice-packs/education-evaluation/index.html
+++ b/practice-packs/education-evaluation/index.html
@@ -479,5 +479,6 @@ attachSaveHandlers();loadAll();
 <script>window.IM_PACK={slug:'education-evaluation',title:'Education Programme Evaluation',artefact:'education evaluation design',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
 <script src="/js/practice-pack-gate.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/practice-packs/focus-group-discussion/index.html
+++ b/practice-packs/focus-group-discussion/index.html
@@ -283,5 +283,6 @@ attachSaveHandlers();loadAll();
 <script>window.IM_PACK={slug:'focus-group-discussion',title:'Running a Real Focus Group Discussion',artefact:'FGD facilitator\'s guide',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
 <script src="/js/practice-pack-gate.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/practice-packs/gender-impact/index.html
+++ b/practice-packs/gender-impact/index.html
@@ -687,5 +687,6 @@ attachSaveHandlers();loadAll();
 <script>window.IM_PACK={slug:'gender-impact',title:'Gender Impact Assessment Design',artefact:'GIA design',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
 <script src="/js/practice-pack-gate.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/practice-packs/governance-evaluation/index.html
+++ b/practice-packs/governance-evaluation/index.html
@@ -146,5 +146,6 @@ attachSaveHandlers();loadAll();
 <script>window.IM_PACK={slug:'governance-evaluation',title:'Governance Reform Evaluation',artefact:'governance evaluation design',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
 <script src="/js/practice-pack-gate.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/practice-packs/health-evaluation/index.html
+++ b/practice-packs/health-evaluation/index.html
@@ -313,5 +313,6 @@ attachSaveHandlers();loadAll();
 <script>window.IM_PACK={slug:'health-evaluation',title:'Health Intervention Evaluation',artefact:'health evaluation design',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
 <script src="/js/practice-pack-gate.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/practice-packs/index.html
+++ b/practice-packs/index.html
@@ -354,5 +354,6 @@ document.querySelectorAll('.theme-btn').forEach(b=>b.addEventListener('click',()
 </script>
 
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/practice-packs/livelihoods-evaluation/index.html
+++ b/practice-packs/livelihoods-evaluation/index.html
@@ -922,5 +922,6 @@ loadAll();
 <script>window.IM_PACK={slug:'livelihoods-evaluation',title:'Livelihoods Evaluation: Design & Instruments',artefact:'evaluation design',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
 <script src="/js/practice-pack-gate.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/practice-packs/logframe-building/index.html
+++ b/practice-packs/logframe-building/index.html
@@ -312,5 +312,6 @@ attachSaveHandlers();loadAll();
 <script>window.IM_PACK={slug:'logframe-building',title:'Building a Logframe That Actually Tracks',artefact:'DAC-compatible logframe',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
 <script src="/js/practice-pack-gate.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/practice-packs/media-evaluation/index.html
+++ b/practice-packs/media-evaluation/index.html
@@ -144,5 +144,6 @@ attachSaveHandlers();loadAll();
 <script>window.IM_PACK={slug:'media-evaluation',title:'Media Campaign Evaluation',artefact:'media evaluation design',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
 <script src="/js/practice-pack-gate.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/practice-packs/mel-from-scratch/index.html
+++ b/practice-packs/mel-from-scratch/index.html
@@ -839,5 +839,6 @@ loadAll();
 <script>window.IM_PACK={slug:'mel-from-scratch',title:'Building an MEL System from Scratch',artefact:'90-day MEL setup plan',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
 <script src="/js/practice-pack-gate.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/practice-packs/policy-evaluation/index.html
+++ b/practice-packs/policy-evaluation/index.html
@@ -146,5 +146,6 @@ attachSaveHandlers();loadAll();
 <script>window.IM_PACK={slug:'policy-evaluation',title:'Public Policy Evaluation',artefact:'policy evaluation design',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
 <script src="/js/practice-pack-gate.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/practice-packs/programme-costing/index.html
+++ b/practice-packs/programme-costing/index.html
@@ -309,5 +309,6 @@ attachSaveHandlers();loadAll();
 <script>window.IM_PACK={slug:'programme-costing',title:'Costing a Programme from Activities Up',artefact:'activity-based budget',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
 <script src="/js/practice-pack-gate.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/practice-packs/sel-evaluation/index.html
+++ b/practice-packs/sel-evaluation/index.html
@@ -934,5 +934,6 @@ loadAll();
 <script>window.IM_PACK={slug:'sel-evaluation',title:'SEL Evaluation: Design & Instruments',artefact:'evaluation design',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
 <script src="/js/practice-pack-gate.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/practice-packs/stakeholder-mapping/index.html
+++ b/practice-packs/stakeholder-mapping/index.html
@@ -270,5 +270,6 @@ attachSaveHandlers();loadAll();
 <script>window.IM_PACK={slug:'stakeholder-mapping',title:'Stakeholder Mapping for Influence',artefact:'power-interest-alignment map',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
 <script src="/js/practice-pack-gate.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/practice-packs/survey-instrument/index.html
+++ b/practice-packs/survey-instrument/index.html
@@ -323,5 +323,6 @@ attachSaveHandlers();loadAll();
 <script>window.IM_PACK={slug:'survey-instrument',title:'Designing a Survey Instrument',artefact:'survey instrument',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
 <script src="/js/practice-pack-gate.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/practice-packs/tor-writing/index.html
+++ b/practice-packs/tor-writing/index.html
@@ -698,5 +698,6 @@ attachSaveHandlers();loadAll();
 <script>window.IM_PACK={slug:'tor-writing',title:'Writing a ToR That Gets You Useful Research',artefact:'ToR + costing sheet',freeModules:2,price:'₹299',requiredTier:'practitioner',tierPrice:'₹399/mo'};</script>
 <script src="/js/practice-pack-gate.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/premium-tools/advisory-board-pro.html
+++ b/premium-tools/advisory-board-pro.html
@@ -405,5 +405,6 @@
     if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", initGate);
     else initGate();
     </script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/premium-tools/ai-canvas-pro.html
+++ b/premium-tools/ai-canvas-pro.html
@@ -588,5 +588,6 @@ else initGate();
 <!-- ImpactMojo canonical theme controller + translation -->
 <script src="/js/theme.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/premium-tools/chart-selector-pro.html
+++ b/premium-tools/chart-selector-pro.html
@@ -548,5 +548,6 @@ renderGallery();
 <!-- ImpactMojo canonical theme controller + translation -->
 <script src="/js/theme.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/premium-tools/code-converter-pro.html
+++ b/premium-tools/code-converter-pro.html
@@ -1004,5 +1004,6 @@ function ccRequirePremium() {
 if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", initGate);
 else initGate();
 </script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/premium-tools/devdata-practice.html
+++ b/premium-tools/devdata-practice.html
@@ -1794,5 +1794,6 @@
 })();
 </script>
 
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/premium-tools/empathy-pro.html
+++ b/premium-tools/empathy-pro.html
@@ -580,5 +580,6 @@ else initGate();
 <!-- ImpactMojo canonical theme controller + translation -->
 <script src="/js/theme.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/premium-tools/field-notes.html
+++ b/premium-tools/field-notes.html
@@ -642,5 +642,6 @@ async function initGate(){ try{ if(window.ImpactMojoAuth) await window.ImpactMoj
 function requirePremium(){ if(window.TOOL_PREMIUM) return true; if(window.IMXPremium&&typeof window.IMXPremium.showUpgradeModal==='function') window.IMXPremium.showUpgradeModal(TOOL_TIER); else window.location.href='/premium.html#detail-'+TOOL_TIER; return false; }
 if(document.readyState==='loading') document.addEventListener('DOMContentLoaded',initGate); else initGate();
 </script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/premium-tools/logframe-pro.html
+++ b/premium-tools/logframe-pro.html
@@ -696,5 +696,6 @@ else initGate();
 <!-- ImpactMojo canonical theme controller + translation -->
 <script src="/js/theme.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/premium-tools/policy-canvas-pro.html
+++ b/premium-tools/policy-canvas-pro.html
@@ -633,5 +633,6 @@ else initGate();
 <!-- ImpactMojo canonical theme controller + translation -->
 <script src="/js/theme.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/premium-tools/qual-insights-lab.html
+++ b/premium-tools/qual-insights-lab.html
@@ -1024,5 +1024,6 @@ function qilRequirePremium() {
 if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", initGate);
 else initGate();
 </script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/premium-tools/rq-builder.html
+++ b/premium-tools/rq-builder.html
@@ -944,5 +944,6 @@ if (document.readyState === "loading") document.addEventListener("DOMContentLoad
 else initGate();
 </script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/premium-tools/stakeholder-pro.html
+++ b/premium-tools/stakeholder-pro.html
@@ -634,5 +634,6 @@ else initGate();
 <!-- ImpactMojo canonical theme controller + translation -->
 <script src="/js/theme.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/premium-tools/toc-pro.html
+++ b/premium-tools/toc-pro.html
@@ -602,5 +602,6 @@ else initGate();
 <!-- ImpactMojo canonical theme controller + translation -->
 <script src="/js/theme.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/premium-tools/tor-builder.html
+++ b/premium-tools/tor-builder.html
@@ -762,5 +762,6 @@ function torRequirePremium(){
 if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", initGate);
 else initGate();
 </script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/premium-tools/vaniscribe.html
+++ b/premium-tools/vaniscribe.html
@@ -1155,5 +1155,6 @@ function requirePremium() {
 if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initGate);
 else initGate();
 </script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/premium-tools/viz-cookbook.html
+++ b/premium-tools/viz-cookbook.html
@@ -1237,5 +1237,6 @@ async function initGate(){ try{ if(window.ImpactMojoAuth) await window.ImpactMoj
 function requirePremium(){ if(window.TOOL_PREMIUM) return true; if(window.IMXPremium&&typeof window.IMXPremium.showUpgradeModal==='function') window.IMXPremium.showUpgradeModal(TOOL_TIER); else window.location.href='/premium.html#detail-'+TOOL_TIER; return false; }
 if(document.readyState==='loading') document.addEventListener('DOMContentLoaded',initGate); else initGate();
 </script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/research-to-action/index.html
+++ b/research-to-action/index.html
@@ -582,5 +582,6 @@ body.dark-mode .rta-plane, [data-theme="dark"] .rta-plane, html.dark .rta-plane 
 })();
 </script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/scripts/templates/book-companion.template.html
+++ b/scripts/templates/book-companion.template.html
@@ -774,5 +774,6 @@ function switchTab(id) {
   <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
 </svg>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/specials/capacity-for-irony/index.html
+++ b/specials/capacity-for-irony/index.html
@@ -526,5 +526,6 @@ body {
 <script defer src="/js/config.js"></script>
 <script defer src="/js/auth.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/specials/marginalia/index.html
+++ b/specials/marginalia/index.html
@@ -367,5 +367,6 @@ body {
 <script defer src="/js/config.js"></script>
 <script defer src="/js/auth.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/specials/the-beneficiary-is-not-a-job-title/index.html
+++ b/specials/the-beneficiary-is-not-a-job-title/index.html
@@ -524,5 +524,6 @@ body {
 <script defer src="/js/config.js"></script>
 <script defer src="/js/auth.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/specials/the-fine-print/index.html
+++ b/specials/the-fine-print/index.html
@@ -507,5 +507,6 @@ body {
 <script defer src="/js/config.js"></script>
 <script defer src="/js/auth.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/specials/the-indicator-ate-the-village/index.html
+++ b/specials/the-indicator-ate-the-village/index.html
@@ -512,5 +512,6 @@ body {
 <script defer src="/js/config.js"></script>
 <script defer src="/js/auth.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/subscribe/index.html
+++ b/subscribe/index.html
@@ -74,5 +74,6 @@ function go(e){
   return false;
 }
 </script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/subscribe/pay/index.html
+++ b/subscribe/pay/index.html
@@ -75,5 +75,6 @@ function waOrder(){location.href="https://wa.me/"+WA+"?text="+encodeURIComponent
 function submitPay(e){e.preventDefault();var f=e.target,data=new URLSearchParams(new FormData(f)).toString();
 fetch('/',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:data}).then(function(){f.querySelector('button[type=submit]').style.display='none';document.getElementById('okMsg').style.display='block';toast('Recorded — thank you');}).catch(function(){toast('Error — please WhatsApp us');});return false;}
 </script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/templates/ai-opportunity-canvas.html
+++ b/templates/ai-opportunity-canvas.html
@@ -517,5 +517,6 @@ init();
 </div>
 </div>
 </footer>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/templates/chart-decision-tree.html
+++ b/templates/chart-decision-tree.html
@@ -518,5 +518,6 @@ renderGallery();
 </div>
 </div>
 </footer>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/templates/empathy-map.html
+++ b/templates/empathy-map.html
@@ -509,5 +509,6 @@ init();
 </div>
 </div>
 </footer>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/templates/logframe-builder.html
+++ b/templates/logframe-builder.html
@@ -625,5 +625,6 @@ init();
 </div>
 </div>
 </footer>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/templates/policy-analysis-canvas.html
+++ b/templates/policy-analysis-canvas.html
@@ -562,5 +562,6 @@ init();
 </div>
 </div>
 </footer>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/templates/stakeholder-map.html
+++ b/templates/stakeholder-map.html
@@ -563,5 +563,6 @@ init();
 </div>
 </div>
 </footer>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/templates/theory-of-change.html
+++ b/templates/theory-of-change.html
@@ -533,5 +533,6 @@ init();
 </div>
 </div>
 </footer>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/the-long-view/chart.html
+++ b/the-long-view/chart.html
@@ -123,5 +123,6 @@ h1{font-size:clamp(1.8rem,4vw,2.6rem);margin:0 0 .6rem;}
   if(document.readyState!=='loading')init();else document.addEventListener('DOMContentLoaded',init);
 })();
 </script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/the-long-view/evidence-map.html
+++ b/the-long-view/evidence-map.html
@@ -303,5 +303,6 @@ function emShow(ri,ci){
 }
 document.addEventListener('DOMContentLoaded',function(){emStats();emBuild();});
 </script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/the-long-view/gallery.html
+++ b/the-long-view/gallery.html
@@ -144,5 +144,6 @@
 <script>
 (function(){function init(){LV.reveal&&LV.reveal();LV.drawMasters();LV.buildCards();LV.wireFilters();new MutationObserver(function(ms){ms.forEach(function(m){if(m.attributeName==='data-theme')LV.drawMasters();});}).observe(document.documentElement,{attributes:true});}if(document.readyState!=='loading')init();else document.addEventListener('DOMContentLoaded',init);})();
 </script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/the-long-view/numbers-in-the-news.html
+++ b/the-long-view/numbers-in-the-news.html
@@ -485,5 +485,6 @@ document.addEventListener('DOMContentLoaded',function(){
   nnSurv('seen',document.querySelector('[data-sv="seen"]'));
 });
 </script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/timelines/climate-policy.html
+++ b/timelines/climate-policy.html
@@ -582,5 +582,6 @@ if (location.hash) {
 </script>
 
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/timelines/development-thinking.html
+++ b/timelines/development-thinking.html
@@ -794,5 +794,6 @@ if (location.hash) {
 </script>
 
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/timelines/gender-work-india.html
+++ b/timelines/gender-work-india.html
@@ -626,5 +626,6 @@ if (location.hash) {
 </script>
 
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/timelines/index.html
+++ b/timelines/index.html
@@ -245,5 +245,6 @@ h1{font-family:var(--font-head);font-weight:800;font-size:44px;color:var(--ink);
 </footer>
 
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/timelines/indian-policy.html
+++ b/timelines/indian-policy.html
@@ -756,5 +756,6 @@ if (location.hash) {
 </script>
 
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/timelines/indian-rights.html
+++ b/timelines/indian-rights.html
@@ -646,5 +646,6 @@ if (location.hash) {
 </script>
 
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/timelines/mel-methods.html
+++ b/timelines/mel-methods.html
@@ -583,5 +583,6 @@ if (location.hash) {
 </script>
 
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/work-samples/03_mel_architecture_diagram.html
+++ b/work-samples/03_mel_architecture_diagram.html
@@ -422,5 +422,6 @@
 
 </div>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/work-samples/04_thinking_note.html
+++ b/work-samples/04_thinking_note.html
@@ -237,5 +237,6 @@
 
 </div>
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/work-samples/05_wage_gap_visualisation.html
+++ b/work-samples/05_wage_gap_visualisation.html
@@ -529,5 +529,6 @@ new Chart(ctx3, {
 </script>
 
 <script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## What does this PR do?

Follow-up to #708. Adds the `<script src="/js/site-chrome.js" defer></script>` tag to the **110 remaining pages** that were missed in the initial rollout staging — under `premium-tools/`, `challenges/`, `templates/`, `timelines/`, `BookCompanionTools/`, `SupportGifts/`, `impactlex/`, `the-long-view/`, `work-samples/` and a few others. This completes the standard thin top bar + footer across the whole site (homepage still exempt).

Tag-only change — no other edits.

## Type of change

- [x] New feature or tool — completes the shared site chrome rollout

## Checklist

- [x] Tested on desktop browser — chrome mechanism validated in #708 across page types
- [x] No console errors
- [x] Links are working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZJVUELWTXytJLQvurs8CJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZJVUELWTXytJLQvurs8CJ)_