### PR TITLE
Add wiki-sync workflow (mirrors changelog + roadmap)

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,0 +1,66 @@
+name: Sync Wiki
+
+# Mirrors the repo's changelog and roadmap into the GitHub Wiki.
+# Runs automatically when either source file changes on main, or on demand.
+# Needs a repo-scoped PAT stored as the WIKI_PAT secret (the default
+# GITHUB_TOKEN cannot push to wikis). Skips gracefully if the secret is absent.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/changelog.md'
+      - 'ROADMAP.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Mirror changelog + roadmap into the wiki
+        env:
+          WIKI_PAT: ${{ secrets.WIKI_PAT }}
+        run: |
+          set -euo pipefail
+          if [ -z "${WIKI_PAT:-}" ]; then
+            echo "::warning::WIKI_PAT secret is not set — skipping wiki sync. Add a repo-scoped PAT as the WIKI_PAT repository secret to enable it."
+            exit 0
+          fi
+
+          git config --global user.email "actions@users.noreply.github.com"
+          git config --global user.name "Wiki Sync Bot"
+
+          git clone --depth 1 "https://x-access-token:${WIKI_PAT}@github.com/${GITHUB_REPOSITORY}.wiki.git" wiki
+
+          REPO_URL="https://github.com/${GITHUB_REPOSITORY}/blob/main"
+
+          {
+            echo "# Changelog"
+            echo
+            echo "_Mirrored automatically from [docs/changelog.md](${REPO_URL}/docs/changelog.md) — edit the source, not this page._"
+            echo
+            sed '1{/^# Changelog$/d}' docs/changelog.md
+          } > wiki/Changelog.md
+
+          {
+            echo "# Roadmap"
+            echo
+            echo "_Mirrored automatically from [ROADMAP.md](${REPO_URL}/ROADMAP.md) — edit the source, not this page._"
+            echo
+            sed '1{/^# Roadmap$/d}' ROADMAP.md
+          } > wiki/Roadmap.md
+
+          cd wiki
+          if git diff --quiet; then
+            echo "Wiki already up to date — nothing to push."
+            exit 0
+          fi
+          git add -A
+          git commit -m "Sync wiki: changelog + roadmap from repo"
+          git push
+          echo "### ✅ Wiki synced (Changelog + Roadmap)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What does this PR do?

Adds `.github/workflows/sync-wiki.yml` — mirrors `docs/changelog.md` → wiki **Changelog** and `ROADMAP.md` → wiki **Roadmap**, automatically on push to those files (and on manual dispatch).

**Why a workflow:** the wiki is a separate git repo that the session's egress proxy won't authorize, and the default `GITHUB_TOKEN` can't push wikis. Inside an Actions runner (not behind the proxy) a repo-scoped PAT can. The workflow **skips gracefully with a warning if `WIKI_PAT` is unset**, so it's inert until the secret is added.

**To activate:** add a repo-scoped PAT as a repository secret named `WIKI_PAT`, then run the workflow once (Actions → Sync Wiki → Run workflow) or just merge any changelog/roadmap change.

## Type of change

- [x] New feature or tool — hands-free wiki mirroring

## Checklist

- [x] YAML validated
- [x] Least-privilege (`contents: read`); no-op when secret absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZJVUELWTXytJLQvurs8CJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZJVUELWTXytJLQvurs8CJ)_