### PR TITLE
Fix pa11y CI: add alt text to icon-only Home link in site bar

### DIFF
--- a/js/site-chrome.js
+++ b/js/site-chrome.js
@@ -97,9 +97,12 @@
 
   // ── Icons: Sargam (site-standard), recoloured to the bar's fg via CSS filter ──
   var SI = 'https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/';
-  function ic(name) { return '<img class="im-sc-i" src="' + SI + name + '.svg" alt="" width="15" height="15" loading="lazy" onerror="this.style.display=\'none\'">'; }
+  // alt defaults to "" (decorative — the button carries a visible label or an aria-label
+  // on a <button>). Pass an explicit alt for icon-only <a> links: HTMLCS H30.2 requires the
+  // sole <img> content of a link to have non-empty alt text (a link's aria-label doesn't count).
+  function ic(name, alt) { return '<img class="im-sc-i" src="' + SI + name + '.svg" alt="' + (alt || '') + '" width="15" height="15" loading="lazy" onerror="this.style.display=\'none\'">'; }
   var I = {
-    globe: ic('si_Globe_detailed'), star: ic('si_Star'), info: ic('si_Info'), home: ic('si_Home'),
+    globe: ic('si_Globe_detailed'), star: ic('si_Star'), info: ic('si_Info'), home: ic('si_Home', 'Home'),
     sys: ic('si_Monitor'), sun: ic('si_Sun'), moon: ic('si_Moon')
   };
   var LOGO = SITE + '/assets/images/apple-touch-icon.png'; // 7KB vs the 599KB full logo


### PR DESCRIPTION
## Problem

The `pa11y-ci` accessibility audit in `ci.yml` has been failing on every push to `main` since the site-chrome redesign wave (July 9 evening). It was **one defect repeating across 12 of 13 audited pages**, not many separate failures — Deploy, axe-core, Mobile, encoding, and i18n all pass, and the site deploys fine (a11y failures don't block Netlify).

## Root cause

`js/site-chrome.js` renders an icon-only Home button in the top bar:

```html
<a class="im-sc-btn im-sc-icon" href="/" aria-label="Home"><img class="im-sc-i" alt=""></a>
```

HTMLCS rule **H30.2** (`WCAG2AA.Principle1.Guideline1_1.1_1_1.H30.2`) flags an image with empty `alt` when it is the *only* content of a link — a link-level `aria-label` does **not** satisfy it. Because site-chrome injects on every page, all 12 audited URLs carrying it failed identically (the homepage is the 1 pass — it opts out via `data-im-home`).

## Fix

The shared `ic()` icon helper now accepts an optional `alt`, and the Home icon renders `alt="Home"`. Every other icon stays `alt=""` — correctly decorative, since each sits beside a visible label or lives on a `<button>` (which H30.2 does not apply to).

## Verification

Reproduced deterministically with pa11y's own HTML_CodeSniffer engine loaded into Chromium:
- `alt=""` variant → reproduces the exact H30.2 error
- `alt="Home"` variant → **0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZJVUELWTXytJLQvurs8CJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZJVUELWTXytJLQvurs8CJ)_