### PR TITLE
Fix mobile top bar: stop the language globe jamming the wordmark

### DIFF
--- a/js/site-chrome.js
+++ b/js/site-chrome.js
@@ -74,6 +74,11 @@
 '.im-sc-tbtn{width:26px;height:24px;border:0;border-radius:6px;background:transparent;cursor:pointer;display:inline-flex;align-items:center;justify-content:center}',
 '.im-sc-tbtn[aria-pressed="true"]{background:var(--sc-grad);color:#fff}',
 '@media(max-width:720px){.im-sc-label{display:none}.im-sc-btn{padding:0 8px}.im-sc-icon{width:32px}.im-sc-path{display:none}}',
+// Phones: the full control row + wordmark overflow a narrow bar, which collapses
+// the flex spacer and jams the language globe against the "impactmojo.in" wordmark
+// (reads like "impactmojo.<globe>"). Drop the bar wordmark below 600px — the logo
+// stays as the brand/home link — so the bar fits and the spacer pushes controls right.
+'@media(max-width:600px){.im-sc-bar{gap:8px;padding:0 12px}.im-sc-bar .im-sc-site{display:none}.im-sc-theme{padding:2px}.im-sc-tbtn{width:24px}}',
 // footer
 '.im-sc-foot{background:var(--sc-bg);border-top:1px solid var(--sc-bd);color:var(--sc-fg);font-family:\'Inter\',system-ui,sans-serif;padding:40px clamp(16px,4vw,32px) 28px;margin-top:48px}',
 'html[data-theme="dark"] .im-sc-foot,html.dark .im-sc-foot{--sc-bg:#0B1120}',

--- a/js/translate-sarvam.js
+++ b/js/translate-sarvam.js
@@ -312,6 +312,11 @@
         var ph = document.querySelector(".im-sc-lang"); if (ph) ph.remove();
         fab.style.width = "34px"; fab.style.height = "34px";
         fab.style.background = "transparent"; fab.style.border = "none"; fab.style.boxShadow = "none";
+        // Match the site-chrome icon row: inherit the bar foreground instead of the
+        // standalone blue, so the globe reads as a control, not a stray domain glyph.
+        fab.style.color = "var(--sc-fg,#0F172A)";
+        var gsvg = fab.querySelector("svg");
+        if (gsvg) { gsvg.setAttribute("stroke", "currentColor"); gsvg.style.opacity = ".78"; }
       }
     } else document.body.appendChild(wrap);
   }


### PR DESCRIPTION
## Problem

On phones the top bar reads like **`impactmojo.🌐`** — the language globe is glued to the "impactmojo.in" wordmark (see the reported mobile screenshot).

## Root cause

It's an **overflow** problem, not a mount problem. The bar lays out as `logo + impactmojo.in wordmark · [flex spacer] · globe · Premium · About · theme-trio · Home`. On a narrow viewport the content is wider than the bar, so `.im-sc-spacer{flex:1}` collapses to zero width — which slides the right-hand cluster (whose **first** item is the language globe) right up against the wordmark.

## Fix

- **`js/site-chrome.js`** — below 600px, hide the wordmark **in the bar only** (`.im-sc-bar .im-sc-site`, scoped so the footer brand is untouched); the logo remains the brand/home link (keeps its `aria-label="ImpactMojo home"`). Also tighten the bar gap/padding and shrink the theme buttons. The bar now fits, so the spacer can push the controls back to the right, clear of the logo. Tablets/desktop (>600px) are unchanged.
- **`js/translate-sarvam.js`** — when the globe mounts inside the site-chrome bar, it now inherits the bar foreground (`currentColor` at `.78` opacity) instead of its standalone blue, so it reads as a control in the icon row rather than a stray domain glyph.

## Verification

- `node --check` passes on both files; media-query braces balanced; the `display:none` is scoped to `.im-sc-bar .im-sc-site` so the footer wordmark is unaffected.
- Width budget at 360px: logo (22) + gaps + right cluster (~226) + padding (24) ≈ 280px < 360px, leaving room for the spacer to push controls right. (Headless browser rendering is unavailable in the build sandbox; verified by layout reasoning + syntax checks.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZJVUELWTXytJLQvurs8CJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZJVUELWTXytJLQvurs8CJ)_