### PR TITLE
Events: blank placeholder join_urls so no dead link is shown

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -9,7 +9,7 @@
     "track": "MEL",
     "description": "Bring a programme you are working on and build its theory of change live. We will map outcomes, assumptions, and the causal logic that connects activities to impact — then stress-test it together. Come with a real project; leave with a defensible ToC.",
     "capacity": 100,
-    "join_url": "https://meet.google.com/REPLACE",
+    "join_url": "",
     "level": "All levels"
   },
   {
@@ -22,7 +22,7 @@
     "track": "Data",
     "description": "A plain-language walkthrough of how to decide how many people you need to survey — power, margin of error, and confidence — using free tools. No prior statistics required. We will work through two real evaluation scenarios end to end.",
     "capacity": 150,
-    "join_url": "https://meet.google.com/REPLACE",
+    "join_url": "",
     "level": "Beginner"
   },
   {
@@ -35,7 +35,7 @@
     "track": "Gender",
     "description": "How to build monitoring and evaluation frameworks that surface gendered outcomes instead of hiding them. We cover sex-disaggregated indicators, intersectional analysis, and ethical data collection with women and marginalised groups.",
     "capacity": 120,
-    "join_url": "https://meet.google.com/REPLACE",
+    "join_url": "",
     "level": "Intermediate"
   }
 ]


### PR DESCRIPTION
## Problem

The three webinars in `data/events.json` carried a `https://meet.google.com/REPLACE` placeholder join link (roadmap operational follow-up on the Live Workshops item). That placeholder leaked into two places: the generated `.ics` calendar file, and the post-registration success screen (a "Join link: …REPLACE" dead link shown to registrants).

## Fix (registration fallback)

Blank the three placeholder `join_url` values. The events page already routes the CTA through a **Register** modal (Netlify form) rather than a direct join link, and:

- the success copy already reads *"we'll email the join link"*,
- the `.ics` `URL` falls back to `https://www.impactmojo.in/events.html` when `join_url` is empty,
- the post-registration join box is hidden when no link is set.

So nothing is broken while real links are pending — registrants sign up and get the link by email. Real Zoom/Meet URLs can be dropped in per event when each is scheduled.

## Verification

`events.json` validates as JSON; all three `join_url`s are now `""`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZJVUELWTXytJLQvurs8CJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZJVUELWTXytJLQvurs8CJ)_