### PR TITLE
Backend: move CI + Netlify runtime from Node 20 (EOL) to Node 22 LTS

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Test service worker routing & lifecycle
         run: node scripts/test-service-worker.mjs
@@ -97,7 +97,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install pa11y-ci and http-server
         run: npm install -g pa11y-ci http-server
@@ -220,7 +220,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install html-validate
         run: npm install -g html-validate

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,11 @@
   publish = "."
   functions = "netlify/functions"
 
+# Pin the build + Functions runtime to Node 22 (Active LTS). Node 20 reached
+# end-of-life in 2026; 22 keeps Functions on a supported, security-patched runtime.
+[build.environment]
+  NODE_VERSION = "22"
+
 # HTML pages — short edge cache so TTFB drops from ~1.4s to <100ms on
 # repeat hits. must-revalidate + Netlify's auto-cache-purge on deploy
 # means visitors still see fresh content within seconds of a push.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "description": "ImpactMojo — Monitoring, Evaluation & Learning platform",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "prepare": "git config core.hooksPath .githooks",
     "test:a11y": "node tests/axe-accessibility.js",


### PR DESCRIPTION
## Why

You're seeing GitHub nag about old/deprecated tooling. The real cause: **CI was running Node 20, which reached end-of-life in 2026** — an unsupported, no-longer-patched runtime. This aligns everything on **Node 22 (Active LTS)**, which the MCP publish workflow already used.

## Changes

- **`.github/workflows/ci.yml`** + **`accessibility.yml`** — `node-version: 20 → 22` (4 jobs).
- **`netlify.toml`** — pin the build + Functions runtime with `NODE_VERSION = "22"` (previously unpinned → Netlify's shifting default).
- **`package.json`** — add `"engines": { "node": ">=22" }`.

## What was checked and is fine (no change needed)

- **Direct dependencies are current:** `puppeteer ^24`, `axe-core / @axe-core/* ^4.11`, `@modelcontextprotocol/sdk ^1.12`, `typescript ^5.7`, `@types/node ^22`, `http-server ^14`.
- **GitHub Actions are current:** `checkout@v7`, `setup-node@v6`, `upload-artifact@v7` — none on the deprecated node16/node20 action runtimes.
- **Dependabot** is already configured (weekly npm + actions).
- The `npm warn deprecated` lines you may see in CI logs (`inflight`, `glob@7`, `whatwg-encoding`) are **transitive** deps of the globally-installed dev tools (`pa11y-ci`, `http-server`, `html-validate`) — not project dependencies, and cosmetic. They resolve upstream when those tools update; nothing to fix here.

## Verification

`package.json` and `netlify.toml` parse; both workflow YAMLs parse. No dependency versions changed, so no lockfile churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZJVUELWTXytJLQvurs8CJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZJVUELWTXytJLQvurs8CJ)_