### PR TITLE
Rebuild sitemap.html as a full, filterable, on-brand site map

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,16 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.89.0 — July 10, 2026 (Rebuilt Site Map)
+
+### For Learners
+
+- **A new, searchable Site Map** — [sitemap.html](https://www.impactmojo.in/sitemap.html) now lists every page on the platform (courses, 101 decks, labs, games, deep dives, practice packs, tools, credentials and more) in one filterable, theme-aware page. Type to filter 249 destinations; jump straight to any section.
+
+### Changed
+
+- Replaced the old static `sitemap.html` (84 links) with a filterable, brand-consistent map of 249 destinations across 15 sections, using the standard site chrome. The machine-readable `sitemap.xml` is unchanged.
+
 ## v10.88.0 — July 10, 2026 (Three new Assessed Tracks + a credential upgrade for free-pathway completers)
 
 ### For Learners

--- a/sitemap.html
+++ b/sitemap.html
@@ -1,1327 +1,160 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <!-- Version 1.1.0 - December 5, 2025 - Corrected newsletter URL -->
-    
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', 'G-JRCMEB9TBW');
-    </script>
-    
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- Cache Control -->
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate, max-age=0">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="-1">
-    <meta name="version" content="1.1.0.20251205">
-    
-    <!-- Auto-refresh mechanism -->
-    <script>
-    (function() {
-        var CURRENT_VERSION = '1.1.0.20251205';
-        var STORAGE_KEY = 'imx_sitemap_version';
-        try {
-            var storedVersion = localStorage.getItem(STORAGE_KEY);
-            if (storedVersion && storedVersion !== CURRENT_VERSION) {
-                localStorage.setItem(STORAGE_KEY, CURRENT_VERSION);
-                if ('caches' in window) {
-                    caches.keys().then(function(names) {
-                        names.forEach(function(name) { caches.delete(name); });
-                    });
-                }
-                if (window.location.href.indexOf('v=') === -1) {
-                    var separator = window.location.href.indexOf('?') !== -1 ? '&' : '?';
-                    window.location.href = window.location.href + separator + 'v=' + CURRENT_VERSION;
-                }
-            } else {
-                localStorage.setItem(STORAGE_KEY, CURRENT_VERSION);
-            }
-        } catch(e) {}
-    })();
-    </script>
-    
-    <title>Sitemap - All Pages | ImpactMojo</title>
-    <meta name="description" content="Complete sitemap of ImpactMojo - find all our pages including courses, tools, resources, blog, podcast, and legal pages.">
-    
-    <!-- Open Graph -->
-    <meta property="og:title" content="Sitemap | ImpactMojo">
-    <meta property="og:description" content="Navigate all pages on ImpactMojo - courses, tools, resources, and more.">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://www.impactmojo.in/sitemap.html">
-<meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
-<meta property="og:site_name" content="ImpactMojo">
-    
-    <!-- Favicons -->
-    <link href="assets/images/favicon.png" rel="icon" type="image/png">
-    <link href="assets/images/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png">
-    <link href="assets/images/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png">
-    <link href="assets/images/apple-touch-icon.png" rel="apple-touch-icon">
-    
-    <!-- Google Fonts -->
-    <link href="https://fonts.googleapis.com" rel="preconnect">
-    <link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
-    <link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/impact-bold.css">
-    
-    <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        
-        :root {
-            --primary-bg: #FFFFFF;
-            --secondary-bg: #F8FAFC;
-            --text-primary: #0F172A;
-            --text-secondary: #475569;
-            --text-muted: #52627A;
-            --card-bg: #FFFFFF;
-            --hover-bg: #F1F5F9;
-            --border-color: #E2E8F0;
-            --nav-bg: rgba(255, 255, 255, 0.95);
-            --shadow-lg: 0 10px 25px rgba(0, 0, 0, 0.1);
-        }
-        
-        body.dark-mode {
-            --primary-bg: #0F172A;
-            --secondary-bg: #1E293B;
-            --accent-color: #0EA5E9;
-            --accent-hover: #0284C7;
-            --secondary-accent: #6366F1;
-            --success-color: #10B981;
-            --warning-color: #F59E0B;
-            --text-primary: #F1F5F9;
-            --text-secondary: #CBD5E1;
-            --text-muted: #94A3B8;
-            --card-bg: #1E293B;
-            --hover-bg: #334155;
-            --border-color: #334155;
-            --gradient-primary: linear-gradient(135deg, #0369A1 0%, #4338CA 100%);
-            --nav-bg: rgba(15, 23, 42, 0.95);
-            --shadow-lg: 0 10px 25px rgba(0, 0, 0, 0.2);
-        }
-
-        [data-theme="light"] {
-            --primary-bg: #FFFFFF;
-            --secondary-bg: #F8FAFC;
-            --text-primary: #0F172A;
-            --text-secondary: #475569;
-            --text-muted: #52627A;
-            --card-bg: #FFFFFF;
-            --hover-bg: #F1F5F9;
-            --border-color: #E2E8F0;
-            --nav-bg: rgba(255, 255, 255, 0.95);
-            --shadow-lg: 0 10px 25px rgba(0, 0, 0, 0.1);
-        }
-
-        [data-theme="dark"] {
-            --primary-bg: #0F172A;
-            --secondary-bg: #1E293B;
-            --accent-color: #0EA5E9;
-            --accent-hover: #0284C7;
-            --secondary-accent: #6366F1;
-            --success-color: #10B981;
-            --warning-color: #F59E0B;
-            --text-primary: #F1F5F9;
-            --text-secondary: #CBD5E1;
-            --text-muted: #94A3B8;
-            --card-bg: #1E293B;
-            --hover-bg: #334155;
-            --border-color: #334155;
-            --gradient-primary: linear-gradient(135deg, #0369A1 0%, #4338CA 100%);
-            --nav-bg: rgba(15, 23, 42, 0.95);
-            --shadow-lg: 0 10px 25px rgba(0, 0, 0, 0.2);
-        }
-
-        body {
-            font-family: 'Amaranth', sans-serif;
-            background: var(--primary-bg);
-            color: var(--text-primary);
-            line-height: 1.6;
-            min-height: 100vh;
-        }
-        
-        /* Navigation */
-        .navbar {
-            position: fixed;
-            top: 0;
-            left: 0;
-            right: 0;
-            z-index: 1000;
-            background: var(--nav-bg);
-            backdrop-filter: blur(20px);
-            border-bottom: 1px solid var(--border-color);
-            padding: 1rem 2rem;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-        }
-        
-        .logo {
-            font-family: 'Inter', sans-serif;
-            font-size: 1.5rem;
-            font-weight: 700;
-            background: var(--gradient-primary);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-            text-decoration: none;
-        }
-        
-        .nav-links {
-            display: flex;
-            gap: 2rem;
-            align-items: center;
-            list-style: none;
-        }
-        
-        .nav-links a {
-            color: var(--text-secondary);
-            text-decoration: none;
-            font-weight: 500;
-            transition: color 0.3s ease;
-        }
-        
-        .nav-links a:hover {
-            color: var(--accent-color);
-        }
-        
-        /* Three-way Theme Selector */
-        .theme-selector { display: flex; gap: 4px; background: var(--hover-bg); border: 1px solid var(--border-color); border-radius: 10px; padding: 4px; }
-        .theme-btn { background: transparent; border: none; color: var(--text-secondary); padding: 8px; border-radius: 6px; cursor: pointer; transition: all 0.2s ease; display: flex; align-items: center; justify-content: center; width: 36px; height: 36px; }
-        .theme-btn:hover { background: var(--hover-bg); color: var(--text-primary); }
-        .theme-btn.active { background: var(--accent-color); color: white; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
-        .theme-btn svg { width: 18px; height: 18px; }
-        
-        .mobile-menu-btn {
-            display: none;
-            background: none;
-            border: none;
-            color: var(--text-primary);
-            font-size: 1.5rem;
-            cursor: pointer;
-        }
-        
-        /* Main Content */
-        .main-content {
-            padding-top: 100px;
-            min-height: 100vh;
-        }
-        
-        .container {
-            max-width: 1000px;
-            margin: 0 auto;
-            padding: 2rem;
-        }
-        
-        /* Hero Section */
-        .page-hero {
-            text-align: center;
-            padding: 3rem 0;
-            margin-bottom: 2rem;
-        }
-        
-        .page-hero h1 {
-            font-family: 'Inter', sans-serif;
-            font-size: 2.5rem;
-            font-weight: 700;
-            margin-bottom: 1rem;
-            background: var(--gradient-primary);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-        }
-        
-        .page-hero p {
-            color: var(--text-secondary);
-            font-size: 1.1rem;
-            max-width: 600px;
-            margin: 0 auto;
-        }
-        
-        /* Quick Links Banner */
-        .quick-links-banner {
-            background: var(--gradient-primary);
-            border-radius: 16px;
-            padding: 1.5rem 2rem;
-            margin-bottom: 3rem;
-            display: flex;
-            justify-content: center;
-            flex-wrap: wrap;
-            gap: 1rem;
-        }
-        
-        .quick-link {
-            background: rgba(255, 255, 255, 0.15);
-            padding: 0.75rem 1.5rem;
-            border-radius: 8px;
-            color: white;
-            text-decoration: none;
-            font-weight: 500;
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-            transition: all 0.3s ease;
-        }
-        
-        .quick-link:hover {
-            background: rgba(255, 255, 255, 0.25);
-            transform: translateY(-2px);
-        }
-        
-        .quick-link .badge {
-            background: rgba(255, 255, 255, 0.3);
-            padding: 0.15rem 0.5rem;
-            border-radius: 4px;
-            font-size: 0.7rem;
-            text-transform: uppercase;
-        }
-        
-        /* Sitemap Sections */
-        .sitemap-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-            gap: 2rem;
-        }
-        
-        .sitemap-section {
-            background: var(--card-bg);
-            border: 1px solid var(--border-color);
-            border-radius: 16px;
-            padding: 1.5rem;
-            transition: all 0.3s ease;
-        }
-        
-        .sitemap-section:hover {
-            border-color: var(--accent-color);
-            transform: translateY(-4px);
-            box-shadow: var(--shadow-lg);
-        }
-        
-        .section-header {
-            display: flex;
-            align-items: center;
-            gap: 0.75rem;
-            margin-bottom: 1.25rem;
-            padding-bottom: 1rem;
-            border-bottom: 1px solid var(--border-color);
-        }
-        
-        .section-icon {
-            width: 40px;
-            height: 40px;
-            background: var(--gradient-primary);
-            border-radius: 10px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            color: white;
-        }
-        
-        .section-title {
-            font-family: 'Inter', sans-serif;
-            font-size: 1.1rem;
-            font-weight: 600;
-            color: var(--text-primary);
-        }
-        
-        .sitemap-links {
-            list-style: none;
-        }
-        
-        .sitemap-links li {
-            margin-bottom: 0.5rem;
-        }
-        
-        .sitemap-links a {
-            color: var(--text-secondary);
-            text-decoration: none;
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-            padding: 0.5rem 0.75rem;
-            border-radius: 8px;
-            transition: all 0.3s ease;
-        }
-        
-        .sitemap-links a:hover {
-            background: var(--hover-bg);
-            color: var(--accent-color);
-        }
-        
-        .sitemap-links a svg {
-            width: 16px;
-            height: 16px;
-            opacity: 0.6;
-        }
-        
-        /* Badges */
-        .link-badge {
-            font-size: 0.65rem;
-            padding: 0.15rem 0.5rem;
-            border-radius: 4px;
-            text-transform: uppercase;
-            font-weight: 600;
-            margin-left: auto;
-        }
-        
-        .badge-new {
-            background: rgba(16, 185, 129, 0.15);
-            color: #10B981;
-        }
-        
-        .badge-coming {
-            background: rgba(245, 158, 11, 0.15);
-            color: #F59E0B;
-        }
-        
-        .badge-popular {
-            background: rgba(99, 102, 241, 0.15);
-            color: #6366F1;
-        }
-        
-        .external-icon {
-            width: 12px;
-            height: 12px;
-            opacity: 0.5;
-        }
-        
-        /* XML Sitemap Notice */
-        .xml-notice {
-            background: var(--secondary-bg);
-            border: 1px solid var(--border-color);
-            border-radius: 12px;
-            padding: 1.5rem;
-            margin-top: 3rem;
-            text-align: center;
-        }
-        
-        .xml-notice h3 {
-            font-size: 1rem;
-            margin-bottom: 0.5rem;
-            color: var(--text-primary);
-        }
-        
-        .xml-notice p {
-            color: var(--text-secondary);
-            font-size: 0.9rem;
-        }
-        
-        .xml-notice a {
-            color: var(--accent-color);
-            text-decoration: none;
-        }
-        
-        .xml-notice a:hover {
-            text-decoration: underline;
-        }
-        
-        /* Footer */
-        .footer {
-            background: var(--secondary-bg);
-            border-top: 1px solid var(--border-color);
-            padding: 3rem 2rem;
-            margin-top: 4rem;
-        }
-        
-        .footer-content {
-            max-width: 1200px;
-            margin: 0 auto;
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 2rem;
-        }
-        
-        .footer-section h4 {
-            font-family: 'Inter', sans-serif;
-            font-size: 1rem;
-            margin-bottom: 1rem;
-            color: var(--text-primary);
-        }
-        
-        .footer-section a {
-            display: block;
-            color: var(--text-secondary);
-            text-decoration: none;
-            margin-bottom: 0.5rem;
-            font-size: 0.9rem;
-            transition: color 0.3s ease;
-        }
-        
-        .footer-section a:hover {
-            color: var(--accent-color);
-        }
-        
-        .footer-bottom {
-            max-width: 1200px;
-            margin: 2rem auto 0;
-            padding-top: 2rem;
-            border-top: 1px solid var(--border-color);
-            text-align: center;
-            color: var(--text-muted);
-            font-size: 0.875rem;
-        }
-        
-        .footer-bottom a {
-            color: var(--accent-color);
-            text-decoration: none;
-        }
-        
-        /* Mobile Responsive */
-        @media (max-width: 768px) {
-            .nav-links {
-                display: none;
-                position: absolute;
-                top: 100%;
-                left: 0;
-                right: 0;
-                background: var(--nav-bg);
-                flex-direction: column;
-                padding: 1rem;
-                gap: 1rem;
-                border-bottom: 1px solid var(--border-color);
-            }
-            
-            .nav-links.active {
-                display: flex;
-            }
-            
-            .mobile-menu-btn {
-                display: block;
-            }
-            
-            .page-hero h1 {
-                font-size: 2rem;
-            }
-            
-            .container {
-                padding: 1rem;
-            }
-            
-            .quick-links-banner {
-                flex-direction: column;
-                padding: 1rem;
-            }
-            
-            .quick-link {
-                justify-content: center;
-            }
-            
-            .sitemap-grid {
-                grid-template-columns: 1fr;
-            }
-        }
-        
-        /* Chatbot Adjustment */
-        #userway-side {
-            top: 80px !important;
-        }
-    
-/* V3 Paper Plane & Decoration */
-.v3-decoration-container { position: fixed; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; z-index: 0; overflow: hidden; }
-.v3-paper-plane { position: fixed; top: 15%; right: 8%; width: 140px; height: 140px; opacity: 0.25; z-index: 0; pointer-events: none; animation: v3-float-plane 25s ease-in-out infinite; }
-@keyframes v3-float-plane { 0% { transform: translate(0, 0) rotate(0deg); } 20% { transform: translate(-60px, 40px) rotate(10deg); } 40% { transform: translate(120px, 30px) rotate(-8deg); } 60% { transform: translate(40px, 60px) rotate(15deg); } 80% { transform: translate(-30px, 20px) rotate(-5deg); } 100% { transform: translate(0, 0) rotate(0deg); } }
-@media (max-width: 768px) { .v3-paper-plane { width: 100px; height: 100px; top: 10%; right: 5%; opacity: 0.15; } }
-@media (prefers-reduced-motion: reduce) { .v3-paper-plane { animation: none !important; } }
-.v3-blob { position: absolute; border-radius: 50%; filter: blur(80px); opacity: 0.15; animation: pulseBlob 15s ease-in-out infinite; }
-.v3-blob-1 { top: 10%; right: 10%; width: 400px; height: 400px; background: var(--accent-color); }
-.v3-blob-2 { bottom: 20%; left: 5%; width: 300px; height: 300px; background: var(--secondary-accent); animation-delay: -5s; }
-@keyframes pulseBlob { 0%, 100% { transform: scale(1); opacity: 0.15; } 50% { transform: scale(1.1); opacity: 0.2; } }
-</style>
-<style>
-/* ===== ImpactMojo Design System ===== */
-:root {
-    --im-primary-bg: #0F172A;
-    --im-secondary-bg: #1E293B;
-    --im-accent: #0EA5E9;
-    --im-accent-hover: #0284C7;
-    --im-secondary-accent: #6366F1;
-    --im-success: #10B981;
-    --im-text-primary: #F1F5F9;
-    --im-text-secondary: #94A3B8;
-    --im-text-muted: #64748B;
-    --im-card-bg: #1E293B;
-    --im-hover-bg: #334155;
-    --im-border: #334155;
-    --im-nav-bg: rgba(15, 23, 42, 0.95);
-    --im-gradient: linear-gradient(135deg, #0EA5E9 0%, #6366F1 100%);
-}
-[data-theme="light"] {
-    --im-primary-bg: #F8FAFC;
-    --im-secondary-bg: #FFFFFF;
-    --im-accent: #0284C7;
-    --im-accent-hover: #0369A1;
-    --im-text-primary: #0F172A;
-    --im-text-secondary: #475569;
-    --im-text-muted: #64748B;
-    --im-card-bg: #FFFFFF;
-    --im-hover-bg: #F1F5F9;
-    --im-border: #E2E8F0;
-    --im-nav-bg: rgba(248, 250, 252, 0.95);
-}
-
-/* ImpactMojo Top Bar */
-.im-topbar {
-    position: fixed; top: 0; left: 0; right: 0; z-index: 9999;
-    background: var(--im-nav-bg, rgba(15, 23, 42, 0.95));
-    backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px);
-    border-bottom: 1px solid var(--im-border, #334155);
-    padding: 0.5rem 1rem;
-    display: flex; align-items: center; justify-content: space-between;
-    gap: 0.75rem; flex-wrap: wrap;
-    font-family: 'Inter', sans-serif;
-}
-.im-topbar a { text-decoration: none; }
-.im-topbar-left {
-    display: flex; align-items: center; gap: 0.75rem;
-}
-.im-topbar-home {
-    display: flex; align-items: center; gap: 0.5rem;
-    color: var(--im-text-primary, #F1F5F9);
-    font-weight: 700; font-size: 1rem;
-    background: var(--im-gradient);
-    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
-    background-clip: text;
-}
-.im-topbar-home svg { width: 24px; height: 24px; flex-shrink: 0; }
-.im-topbar-right {
-    display: flex; align-items: center; gap: 0.5rem;
-}
-.im-premium-btn {
-    background: var(--im-gradient);
-    color: #fff !important;
-    padding: 0.35rem 0.85rem;
-    border-radius: 6px;
-    font-size: 0.8rem;
-    font-weight: 600;
-    display: flex; align-items: center; gap: 0.35rem;
-    transition: opacity 0.2s;
-    -webkit-text-fill-color: #fff;
-}
-.im-browse-btn { display: inline-flex; align-items: center; gap: 0.4rem; font-family: 'Inter', sans-serif; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: var(--im-text, #1C1917); background: var(--im-surface, #FFFFFF); border: 1.5px solid var(--im-border, #E2E8F0); padding: 0.5rem 1rem; border-radius: 0.5rem; text-decoration: none; transition: background 0.18s ease, border-color 0.18s ease, transform 0.15s ease, box-shadow 0.18s ease; }
-.im-browse-btn:hover { background: var(--im-accent, #0EA5E9); color: #FFFFFF; border-color: var(--im-accent, #0EA5E9); transform: translateY(-1px); box-shadow: 0 4px 12px rgba(14, 165, 233, 0.25); }
-.im-browse-btn svg { width: 14px; height: 14px; }
-@media (prefers-color-scheme: dark) { .im-browse-btn { color: rgba(255,255,255,0.9); background: rgba(255,255,255,0.05); border-color: rgba(255,255,255,0.18); } .im-browse-btn:hover { background: var(--im-accent, #0EA5E9); border-color: var(--im-accent, #0EA5E9); color: #FFFFFF; } }
-.im-premium-btn:hover { opacity: 0.9; }
-.im-premium-btn svg { width: 14px; height: 14px; }
-
-/* Theme Selector - 3 mode */
-.im-theme-selector {
-    display: flex; gap: 2px;
-    background: var(--im-card-bg, #1E293B);
-    border: 1px solid var(--im-border, #334155);
-    border-radius: 8px; padding: 2px;
-}
-.im-theme-btn {
-    background: transparent; border: none;
-    color: var(--im-text-secondary, #94A3B8);
-    padding: 6px; border-radius: 5px; cursor: pointer;
-    transition: all 0.2s; display: flex; align-items: center;
-    justify-content: center; width: 30px; height: 30px;
-}
-.im-theme-btn:hover {
-    background: var(--im-hover-bg, #334155);
-    color: var(--im-text-primary, #F1F5F9);
-}
-.im-theme-btn.active {
-    background: var(--im-accent, #0EA5E9);
-    color: #fff;
-}
-.im-theme-btn svg { width: 16px; height: 16px; }
-
-/* Paper Plane */
-.im-paper-plane {
-    position: fixed; top: 15%; right: 8%;
-    width: 120px; height: 120px;
-    opacity: 0.15; z-index: 0;
-    pointer-events: none;
-    animation: im-fly 25s ease-in-out infinite;
-}
-[data-theme="light"] .im-paper-plane { opacity: 0.2; }
-@keyframes im-fly {
-    0%, 100% { transform: translate(0, 0) rotate(0deg); }
-    20% { transform: translate(60px, -40px) rotate(12deg); }
-    40% { transform: translate(120px, 30px) rotate(-8deg); }
-    60% { transform: translate(40px, 60px) rotate(15deg); }
-    80% { transform: translate(-30px, 20px) rotate(-5deg); }
-}
-
-/* ImpactMojo Footer */
-.im-footer {
-    background: var(--im-secondary-bg, #1E293B);
-    border-top: 1px solid var(--im-border, #334155);
-    padding: 2rem 1rem; margin-top: auto;
-    font-family: 'Inter', sans-serif;
-    color: var(--im-text-secondary, #94A3B8);
-}
-.im-footer-content {
-    max-width: 1100px; margin: 0 auto;
-}
-.im-footer-made {
-    text-align: center; margin-bottom: 1.5rem;
-    font-size: 0.9rem; color: var(--im-text-muted, #64748B);
-}
-.im-footer-made a { color: var(--im-accent, #0EA5E9); }
-.im-footer-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1.5rem; margin-bottom: 1.5rem;
-}
-.im-footer-section h4 {
-    font-family: 'Inter', sans-serif;
-    color: var(--im-text-primary, #F1F5F9);
-    font-size: 0.9rem; margin-bottom: 0.75rem;
-    font-weight: 600;
-}
-.im-footer-section ul { list-style: none; padding: 0; margin: 0; }
-.im-footer-section li { margin-bottom: 0.4rem; }
-.im-footer-section a {
-    color: var(--im-text-secondary, #94A3B8);
-    text-decoration: none; font-size: 0.85rem;
-    transition: color 0.2s;
-}
-.im-footer-section a:hover { color: var(--im-accent, #0EA5E9); }
-.im-footer-bottom {
-    text-align: center; padding-top: 1rem;
-    border-top: 1px solid var(--im-border, #334155);
-    font-size: 0.8rem; color: var(--im-text-muted, #64748B);
-}
-.im-footer-bottom p { margin: 0.25rem 0; }
-.im-footer-bottom a { color: var(--im-accent, #0EA5E9); text-decoration: none; }
-
-/* Mobile Responsive */
-@media (max-width: 768px) {
-    .im-topbar { padding: 0.4rem 0.75rem; gap: 0.5rem; }
-    .im-topbar-home { font-size: 0.85rem; }
-    .im-topbar-home svg { width: 20px; height: 20px; }
-    .im-premium-btn { padding: 0.3rem 0.6rem; font-size: 0.75rem; }
-    .im-theme-btn { width: 26px; height: 26px; padding: 4px; }
-    .im-theme-btn svg { width: 14px; height: 14px; }
-    .im-paper-plane { width: 80px; height: 80px; top: 10%; right: 5%; }
-    .im-footer-grid { grid-template-columns: repeat(2, 1fr); gap: 1rem; }
-}
-@media (max-width: 480px) {
-    .im-footer-grid { grid-template-columns: 1fr; }
-    .im-topbar-home span { display: none; }
-}
-
-/* ImpactMojo Global Font Overrides */
-body { font-family: 'Amaranth', sans-serif !important; }
-h1, h2, h3, h4, h5, h6 { font-family: 'Inter', sans-serif !important; }
-code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !important; }
-
-/* WCAG 2.1 AA (1.4.1 Use of Color): inline anchors in content paragraphs must be distinguishable without relying on color alone. Scoped to <main> so nav/footer button-links are unaffected. */
-main p a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]),
-main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) {
-    text-decoration: underline;
-    text-underline-offset: 0.15em;
-}
-</style>
-<!-- SEO meta (autogenerated) -->
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Site Map &mdash; ImpactMojo</title>
+<meta name="description" content="Every page on ImpactMojo in one filterable map &mdash; flagship courses, 101 decks, labs, games, deep dives, practice packs, premium tools, credentials and more.">
+<meta name="im-page" content="Sitemap">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://www.impactmojo.in/sitemap.html">
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Sitemap - All Pages">
-<meta name="twitter:description" content="Sitemap - All Pages — free development education from ImpactMojo. Browse courses, games, labs, and resources for practitioners across South Asia.">
-<meta name="twitter:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<meta property="og:title" content="Site Map &mdash; ImpactMojo">
+<meta property="og:description" content="Every page on ImpactMojo in one filterable map.">
+<meta property="og:url" content="https://www.impactmojo.in/sitemap.html">
+<meta property="og:type" content="website">
+<meta name="twitter:card" content="summary">
+<link href="/assets/images/favicon.png" rel="icon" type="image/png">
+<link href="/assets/images/apple-touch-icon.png" rel="apple-touch-icon">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
 <style>
-/* Body clears fixed im-topbar (added by site-wide audit fix) */
-body { padding-top: 56px; }
-@media (max-width: 768px) { body { padding-top: 52px; } }
+:root{
+ --bg:#F5F7FA;--surface:#FFFFFF;--surface-2:#FBFCFE;--ink:#0F172A;--mut:#5B677A;--faint:#8996A8;
+ --bd:#E6EBF1;--bd-2:#EEF2F7;--acc:#0EA5E9;--acc2:#6366F1;--acc-soft:rgba(14,165,233,.10);
+ --grad:linear-gradient(135deg,#0EA5E9,#6366F1);--shadow:0 1px 2px rgba(15,23,42,.05),0 8px 24px -12px rgba(15,23,42,.12);
+}
+@media (prefers-color-scheme:dark){:root{
+ --bg:#0A0F1C;--surface:#111A2E;--surface-2:#0E1526;--ink:#F1F5F9;--mut:#96A3B8;--faint:#6B7A93;
+ --bd:#212E48;--bd-2:#1A2338;--acc:#38BDF8;--acc2:#818CF8;--acc-soft:rgba(56,189,248,.12);
+ --shadow:0 1px 2px rgba(0,0,0,.3),0 10px 30px -14px rgba(0,0,0,.6);
+}}
+:root[data-theme="dark"]{
+ --bg:#0A0F1C;--surface:#111A2E;--surface-2:#0E1526;--ink:#F1F5F9;--mut:#96A3B8;--faint:#6B7A93;
+ --bd:#212E48;--bd-2:#1A2338;--acc:#38BDF8;--acc2:#818CF8;--acc-soft:rgba(56,189,248,.12);
+ --shadow:0 1px 2px rgba(0,0,0,.3),0 10px 30px -14px rgba(0,0,0,.6);
+}
+:root[data-theme="light"]{
+ --bg:#F5F7FA;--surface:#FFFFFF;--surface-2:#FBFCFE;--ink:#0F172A;--mut:#5B677A;--faint:#8996A8;
+ --bd:#E6EBF1;--bd-2:#EEF2F7;--acc:#0EA5E9;--acc2:#6366F1;--acc-soft:rgba(14,165,233,.10);
+ --shadow:0 1px 2px rgba(15,23,42,.05),0 8px 24px -12px rgba(15,23,42,.12);
+}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);
+ font-family:"Inter",system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+ line-height:1.5;-webkit-font-smoothing:antialiased;font-size:15px}
+.mono{font-family:ui-monospace,"JetBrains Mono","SFMono-Regular",Menlo,monospace;font-variant-numeric:tabular-nums}
+.wrap{max-width:1120px;margin:0 auto;padding:0 clamp(16px,4vw,32px)}
+
+header.top{position:sticky;top:0;z-index:10;background:color-mix(in srgb,var(--bg) 82%,transparent);
+ backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);border-bottom:1px solid var(--bd)}
+.top-in{display:flex;align-items:center;gap:12px;height:54px}
+.brand{display:flex;align-items:center;gap:9px;font-weight:800;letter-spacing:-.3px;text-decoration:none;color:var(--ink)}
+.brand .dot{width:22px;height:22px;border-radius:6px;background:var(--grad);flex:none;
+ display:flex;align-items:center;justify-content:center;color:#fff;font-size:12px;font-weight:800}
+.brand .site{background:var(--grad);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+.brand .pth{color:var(--faint);font-weight:600}
+.spacer{flex:1}
+.tbtn{width:34px;height:34px;border:1px solid var(--bd);border-radius:9px;background:var(--surface);
+ color:var(--mut);cursor:pointer;display:inline-flex;align-items:center;justify-content:center}
+.tbtn:hover{color:var(--acc);border-color:var(--acc)}
+.tbtn svg{width:16px;height:16px}
+
+.hero{padding:44px 0 8px}
+.eyebrow{font-size:11px;font-weight:700;letter-spacing:.16em;text-transform:uppercase;color:var(--acc)}
+h1,h2,.grp-h h2,.stat .n{font-family:'Amaranth',system-ui,sans-serif}
+h1{font-size:clamp(1.9rem,4.6vw,2.9rem);line-height:1.05;letter-spacing:-1px;margin:.5rem 0 .4rem;
+ font-weight:800;text-wrap:balance}
+.lede{color:var(--mut);max-width:60ch;font-size:1.02rem;margin:0}
+
+.stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(112px,1fr));gap:1px;
+ background:var(--bd);border:1px solid var(--bd);border-radius:14px;overflow:hidden;margin:26px 0 8px;box-shadow:var(--shadow)}
+.stat{background:var(--surface);padding:14px 16px;display:flex;flex-direction:column;gap:2px}
+.stat .n{font-family:ui-monospace,"JetBrains Mono",monospace;font-size:1.4rem;font-weight:800;letter-spacing:-.5px;
+ background:var(--grad);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+.stat .l{font-size:11.5px;color:var(--mut);font-weight:500}
+
+.tools{position:sticky;top:46px;z-index:9;background:color-mix(in srgb,var(--bg) 82%,transparent);
+ backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);padding:14px 0 12px;margin-top:14px}
+.search{position:relative;max-width:420px}
+.search input{width:100%;height:42px;padding:0 14px 0 40px;border:1px solid var(--bd);border-radius:11px;
+ background:var(--surface);color:var(--ink);font:inherit;font-size:14px;box-shadow:var(--shadow)}
+.search input:focus{outline:2px solid var(--acc);outline-offset:1px;border-color:var(--acc)}
+.search svg{position:absolute;left:13px;top:50%;transform:translateY(-50%);width:16px;height:16px;color:var(--faint)}
+.jump{display:flex;flex-wrap:wrap;gap:6px;margin-top:12px}
+.jump a{font-size:12px;font-weight:600;color:var(--mut);text-decoration:none;padding:5px 10px;border-radius:999px;
+ border:1px solid var(--bd);background:var(--surface)}
+.jump a:hover{color:var(--acc);border-color:var(--acc);background:var(--acc-soft)}
+
+main{padding:8px 0 64px}
+.grp{margin-top:34px;scroll-margin-top:120px}
+.grp-h{display:flex;align-items:baseline;gap:10px;margin-bottom:14px;padding-bottom:10px;border-bottom:1px solid var(--bd)}
+.grp-h h2{font-size:1.18rem;font-weight:800;letter-spacing:-.3px;margin:0}
+.cnt{font-family:ui-monospace,"JetBrains Mono",monospace;font-size:12px;font-weight:700;color:var(--acc);
+ background:var(--acc-soft);padding:2px 9px;border-radius:999px}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(230px,1fr));gap:8px}
+.lk{display:flex;flex-direction:column;gap:2px;text-decoration:none;color:var(--ink);
+ background:var(--surface);border:1px solid var(--bd);border-radius:11px;padding:11px 13px;
+ transition:border-color .14s,transform .14s,box-shadow .14s}
+.lk:hover{border-color:var(--acc);transform:translateY(-1px);box-shadow:var(--shadow)}
+.lk-t{font-weight:600;font-size:13.5px;line-height:1.3}
+.lk-u{font-family:ui-monospace,"JetBrains Mono",monospace;font-size:10.5px;color:var(--faint);
+ white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.grp.hide,.lk.hide{display:none}
+.empty{color:var(--mut);font-size:14px;padding:30px 0;display:none}
+.empty.show{display:block}
+footer{border-top:1px solid var(--bd);padding:22px 0 40px;color:var(--faint);font-size:12.5px}
+footer a{color:var(--acc);text-decoration:none}
+@media (prefers-reduced-motion:reduce){*{transition:none!important}}
 </style>
 </head>
-<body class="ib">
-<a href="#main-content" class="im-skip-link">Skip to content</a><style>.im-skip-link{position:absolute;left:-9999px;top:0;background:#0EA5E9;color:#fff;padding:8px 16px;z-index:100000;border-radius:0 0 6px 0;font:600 .85rem/1.2 Inter,system-ui,sans-serif;text-decoration:none}.im-skip-link:focus{left:0}</style>
-<!-- ImpactMojo Top Bar -->
-<div class="im-topbar" id="imTopbar">
-    <div class="im-topbar-left">
-        <a href="/index.html" class="im-topbar-home">
-            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
-            <span>ImpactMojo</span>
-        </a>
-    </div>
-    <div class="im-topbar-right">
-        <a href="/catalog.html" class="im-browse-btn" title="Browse all content"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>Browse</a>
-    
-        <a href="/premium.html" class="im-premium-btn">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
-            Premium
-        </a>
-        <div class="im-theme-selector" aria-label="Theme selection">
-            <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="Use system theme">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
-            </button>
-            <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Use light theme">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
-            </button>
-            <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Use dark theme">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
-            </button>
-        </div>
-    </div>
+<body>
+<div class="wrap">
+ <div class="hero">
+   <div class="eyebrow">Navigation reference</div>
+   <h1>Everything on ImpactMojo, in one map</h1>
+   <p class="lede">Every navigable page grouped by section — courses, labs, games, credentials, tools and the pages that hold the platform together. Search to filter; click any card to open it in a new tab.</p>
+   <div class="stats"><div class="stat"><span class="n">17</span><span class="l">Flagship courses</span></div><div class="stat"><span class="n">55</span><span class="l">Foundational 101s</span></div><div class="stat"><span class="n">29</span><span class="l">Labs</span></div><div class="stat"><span class="n">19</span><span class="l">Games</span></div><div class="stat"><span class="n">22</span><span class="l">Deep dives</span></div><div class="stat"><span class="n">18</span><span class="l">Practice packs</span></div><div class="stat"><span class="n">16</span><span class="l">Premium tools</span></div><div class="stat"><span class="n">105</span><span class="l">Book companions</span></div><div class="stat"><span class="n">5</span><span class="l">Assessed credentials</span></div></div>
+ </div>
 </div>
 
-    <!-- Navigation -->
-    <nav class="navbar">
-        <a href="index.html" class="logo">ImpactMojo</a>
-        <button class="mobile-menu-btn" onclick="toggleMobileMenu()" aria-label="Toggle menu">
-            <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M3 12h18M3 6h18M3 18h18"></path>
-            </svg>
-        </button>
-        <ul class="nav-links">
-            <li><a href="index.html">Home</a></li>
-            <li><a href="/catalog">Courses</a></li>
-            <li><a href="/handouts">Resources</a></li>
-            <li><a href="/blog">Blog</a></li>
-            <li><a href="/about">About</a></li>
-            <li><a href="/contact">Contact</a></li>
-            <li>
-                <div class="theme-selector" aria-label="Theme selection">
-                    <button class="theme-btn" data-theme="system" title="System theme" aria-label="Use system theme">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect><line x1="8" y1="21" x2="16" y2="21"></line><line x1="12" y1="17" x2="12" y2="21"></line></svg>
-                    </button>
-                    <button class="theme-btn" data-theme="light" title="Light theme" aria-label="Use light theme">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
-                    </button>
-                    <button class="theme-btn" data-theme="dark" title="Dark theme" aria-label="Use dark theme">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
-                    </button>
-                </div>
-            </li>
-        </ul>
-    </nav>
-<a id="main-content" tabindex="-1"></a>
-    
-    <!-- Main Content -->
-    <main class="main-content">
-        <div class="container">
-            <!-- Hero Section -->
-            <section class="ib-hero"><div class="ib-hero-in">
-                <span class="ib-eyebrow">All pages</span>
-                <h1>Sitemap</h1>
-                <p class="ib-tagline">Navigate all pages on ImpactMojo. Find courses, tools, resources, and everything else in one place.</p>
-            </div></section>
-            
-            <!-- Quick Links Banner -->
-            <div class="quick-links-banner">
-                <a href="catalog.html" class="quick-link">
-                    <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M4 19.5A2.5 2.5 0 016.5 17H20"></path>
-                        <path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z"></path>
-                    </svg>
-                    All Courses
-                    <span class="badge">Popular</span>
-                </a>
-                <a href="workshops.html" class="quick-link">
-                    <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"></path>
-                        <circle cx="9" cy="7" r="4"></circle>
-                        <path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"></path>
-                    </svg>
-                    Workshops
-                </a>
-                <a href="/handouts" class="quick-link">
-                    <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"></path>
-                    </svg>
-                    Resources
-                </a>
-                <a href="about.html" class="quick-link">
-                    <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
-                        <circle cx="10" cy="10" r="9"></circle>
-                        <path d="M10 14v-4M10 6h.01"></path>
-                    </svg>
-                    About Us
-                </a>
-            </div>
-            
-            <!-- Sitemap Grid -->
-            <div class="sitemap-grid">
-                
-                <!-- Main Pages -->
-                <div class="sitemap-section">
-                    <div class="section-header">
-                        <div class="section-icon">
-                            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
-                                <path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"></path>
-                                <path d="M9 22V12h6v10"></path>
-                            </svg>
-                        </div>
-                        <h2 class="section-title">Main Pages</h2>
-                    </div>
-                    <ul class="sitemap-links">
-                        <li>
-                            <a href="index.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Home
-                            </a>
-                        </li>
-                        <li>
-                            <a href="about.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                About Us
-                            </a>
-                        </li>
-                        <li>
-                            <a href="faq.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                FAQ
-                                <span class="link-badge badge-new">New</span>
-                            </a>
-                        </li>
-                        <li>
-                            <a href="contact.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Contact
-                            </a>
-                        </li>
-                        <li>
-                            <a href="testimonials.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Testimonials
-                            </a>
-                        </li>
-                        <li>
-                            <a href="updates.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Roadmap & What's New
-                            </a>
-                        </li>
-                        <li>
-                            <a href="/community">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Community
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-                
-                <!-- Learning -->
-                <div class="sitemap-section">
-                    <div class="section-header">
-                        <div class="section-icon">
-                            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
-                                <path d="M22 10v6M2 10l10-5 10 5-10 5z"></path>
-                                <path d="M6 12v5c3 3 9 3 12 0v-5"></path>
-                            </svg>
-                        </div>
-                        <h2 class="section-title">Learning</h2>
-                    </div>
-                    <ul class="sitemap-links">
-                        <li>
-                            <a href="catalog.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Course Catalog
-                                <span class="link-badge badge-popular">Popular</span>
-                            </a>
-                        </li>
-                        <li>
-                            <a href="/#labs">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Interactive Labs
-                            </a>
-                        </li>
-                        <li>
-                            <a href="/#games">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Learning Games
-                            </a>
-                        </li>
-                        <li>
-                            <a href="workshops.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Workshops
-                            </a>
-                        </li>
-                        <li>
-                            <a href="handouts.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Handouts & Downloads
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-                
-                <!-- Courses -->
-                <div class="sitemap-section">
-                    <div class="section-header">
-                        <div class="section-icon">
-                            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
-                                <path d="M4 19.5A2.5 2.5 0 016.5 17H20"></path>
-                                <path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z"></path>
-                            </svg>
-                        </div>
-                        <h2 class="section-title">Flagship Courses</h2>
-                    </div>
-                    <ul class="sitemap-links">
-                        <li>
-                            <a href="/courses/gandhi/">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Gandhi & Political Philosophy
-                            </a>
-                        </li>
-                        <li>
-                            <a href="/courses/devecon/">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Development Economics
-                            </a>
-                        </li>
-                        <li>
-                            <a href="/courses/dataviz/">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Data Visualization
-                            </a>
-                        </li>
-                        <li>
-                            <a href="/courses/devai/">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                AI for Development
-                            </a>
-                        </li>
-                        <li>
-                            <a href="/courses/mel/">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Monitoring, Evaluation & Learning
-                            </a>
-                        </li>
-                        <li>
-                            <a href="/courses/poa/">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Policy & Advocacy
-                            </a>
-                        </li>
-                        <li>
-                            <a href="/courses/media/">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Media & Communication
-                            </a>
-                        </li>
-                        <li>
-                            <a href="/courses/law/">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Law & Governance
-                            </a>
-                        </li>
-                        <li>
-                            <a href="/courses/sel/">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Social-Emotional Learning
-                            </a>
-                        </li>
-                                            <li>
-                            <a href="/courses/intervention/">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Designing What Works: Interventions
-                            </a>
-                        </li>
-                    </ul>
-                </div>
+<div class="tools"><div class="wrap">
+ <div class="search">
+   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>
+   <input id="q" type="search" placeholder="Filter 249+ pages…" autocomplete="off" aria-label="Filter pages">
+ </div>
+ <nav class="jump" id="jump"></nav>
+</div></div>
 
-                <!-- Services -->
-                <div class="sitemap-section">
-                    <div class="section-header">
-                        <div class="section-icon">
-                            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
-                                <path d="M20 7h-3a2 2 0 01-2-2V2"></path>
-                                <path d="M9 18a2 2 0 01-2-2V4a2 2 0 012-2h5l4 4v10a2 2 0 01-2 2H9z"></path>
-                            </svg>
-                        </div>
-                        <h2 class="section-title">Services</h2>
-                    </div>
-                    <ul class="sitemap-links">
-                        <li>
-                            <a href="coaching.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Coaching
-                            </a>
-                        </li>
-                        <li>
-                            <a href="workshops.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Workshops
-                            </a>
-                        </li>
-                        <li>
-                            <a href="dojos.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Dojos
-                                <span class="link-badge badge-new">New</span>
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-
-                <!-- Tools & Resources -->
-                <div class="sitemap-section">
-                    <div class="section-header">
-                        <div class="section-icon">
-                            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
-                                <path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"></path>
-                            </svg>
-                        </div>
-                        <h2 class="section-title">Tools & Resources</h2>
-                    </div>
-                    <ul class="sitemap-links">
-                        <li>
-                            <a href="premium.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Premium Tools
-                                <span class="link-badge badge-coming">Coming</span>
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-                
-                <!-- Content -->
-                <div class="sitemap-section">
-                    <div class="section-header">
-                        <div class="section-icon">
-                            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
-                                <path d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2"></path>
-                            </svg>
-                        </div>
-                        <h2 class="section-title">Content</h2>
-                    </div>
-                    <ul class="sitemap-links">
-                        <li>
-                            <a href="blog.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Learning Loops Blog
-                                <span class="link-badge badge-new">New</span>
-                            </a>
-                        </li>
-                        <li>
-                            <a href="podcast.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Between the Logframes Podcast
-                                <span class="link-badge badge-new">New</span>
-                            </a>
-                        </li>
-                        <li>
-                            <a href="https://varna.substack.com" target="_blank" rel="noopener">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Newsletter (Substack)
-                                <svg class="external-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6M15 3h6v6M10 14L21 3"></path></svg>
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-                
-                <!-- Account & Membership -->
-                <div class="sitemap-section">
-                    <div class="section-header">
-                        <div class="section-icon">
-                            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
-                                <path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"></path>
-                                <circle cx="12" cy="7" r="4"></circle>
-                            </svg>
-                        </div>
-                        <h2 class="section-title">Account & Membership</h2>
-                    </div>
-                    <ul class="sitemap-links">
-                        <li>
-                            <a href="login.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Login
-                                <span class="link-badge badge-coming">Coming</span>
-                            </a>
-                        </li>
-                        <li>
-                            <a href="signup.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Sign Up
-                                <span class="link-badge badge-coming">Coming</span>
-                            </a>
-                        </li>
-                        <li>
-                            <a href="premium.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Premium Membership
-                                <span class="link-badge badge-coming">Coming</span>
-                            </a>
-                        </li>
-                        <li>
-                            <a href="coaching.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Coaching Services
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-                
-                <!-- Legal & Policies -->
-                <div class="sitemap-section">
-                    <div class="section-header">
-                        <div class="section-icon">
-                            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
-                                <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"></path>
-                                <path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"></path>
-                            </svg>
-                        </div>
-                        <h2 class="section-title">Legal & Policies</h2>
-                    </div>
-                    <ul class="sitemap-links">
-                        <li>
-                            <a href="privacy-policy.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Privacy Policy
-                            </a>
-                        </li>
-                        <li>
-                            <a href="terms-of-service.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Terms of Service
-                            </a>
-                        </li>
-                        <li>
-                            <a href="refund-policy.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Refund Policy
-                            </a>
-                        </li>
-                        <li>
-                            <a href="disclaimer.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Disclaimer
-                            </a>
-                        </li>
-                        <li>
-                            <a href="data-protection.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Data Protection
-                            </a>
-                        </li>
-                        <li>
-                            <a href="grievance.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                Grievance Redressal
-                            </a>
-                        </li>
-                        <li>
-                            <a href="ai-policy.html">
-                                <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"></path></svg>
-                                AI Policy
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-                
-            </div>
-            
-            <!-- XML Sitemap Notice -->
-            <div class="xml-notice">
-                <h3>For Search Engines</h3>
-                <p>Looking for our XML sitemap? Visit <a href="sitemap.xml">sitemap.xml</a> for the machine-readable version used by search engines.</p>
-            </div>
-        </div>
-    </main>
-    
-    <!-- Footer -->
-    <footer class="footer">
-        <div class="footer-content">
-            <div class="footer-section">
-                <h4>Learn</h4>
-                <a href="catalog.html">All Courses</a>
-                <a href="/#labs">Interactive Labs</a>
-                <a href="/#games">Learning Games</a>
-                <a href="workshops.html">Workshops</a>
-            </div>
-            <div class="footer-section">
-                <h4>Resources</h4>
-                <a href="/handouts">Tools</a>
-                <a href="blog.html">Blog</a>
-                <a href="podcast.html">Podcast</a>
-                <a href="handouts.html">Handouts</a>
-            </div>
-            <div class="footer-section">
-                <h4>Company</h4>
-                <a href="about.html">About Us</a>
-                <a href="contact.html">Contact</a>
-                <a href="faq.html">FAQ</a>
-                <a href="sitemap.html">Sitemap</a>
-            </div>
-            <div class="footer-section">
-                <h4>Legal</h4>
-                <a href="privacy-policy.html">Privacy Policy</a>
-                <a href="terms-of-service.html">Terms of Service</a>
-                <a href="refund-policy.html">Refund Policy</a>
-                <a href="data-protection.html">Data Protection</a>
-            </div>
-        </div>
-        <div class="footer-bottom">
-            <p>Made with &#10084;&#65039; by <a href="https://pinpoint.ventures" target="_blank" rel="noopener">PinPoint Ventures</a></p>
-            <p style="margin-top: 0.5rem;">&copy; 2025 ImpactMojo. All rights reserved.</p>
-        </div>
-        <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Documentation</a></p>
-</footer>
-    
-    <!-- Mojini Chatbot -->
-    <script src="https://www.chatbase.co/embed.min.js" chatbotId="xOgmXEVPn8H3G3mVHFh_0" domain="www.chatbase.co" defer></script>
-    <script>
-    window.chatbaseSettings = {
-        chatbotId: "xOgmXEVPn8H3G3mVHFh_0",
-        domain: "www.chatbase.co",
-        title: "Mojini",
-        welcomeMessage: "Hi! I'm Mojini, your ImpactMojo assistant. Need help finding something on our site?",
-        quickPrompts: [
-            "Show me courses",
-            "Find tools",
-            "I need help"
-        ]
-    };
-    </script>
-    
-    <!-- UserWay Accessibility Widget -->
-    <script>
-    (function(d){
-        var s = d.createElement("script");
-        s.setAttribute("data-account", "EksmhlPg9k");
-        s.setAttribute("src", "https://cdn.userway.org/widget.js");
-        (d.body || d.head).appendChild(s);
-    })(document);
-    </script>
-    <noscript>Please ensure Javascript is enabled for purposes of <a href="https://userway.org">website accessibility</a></noscript>
-    
-    <script>
-        // Theme Toggle
-        // Theme Management
-        
-
-        // Mobile Menu Toggle
-        function toggleMobileMenu() {
-            document.querySelector('.nav-links').classList.toggle('active');
-        }
-    </script>
-
-<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
-<script src="/js/search.js" defer></script>
-<script defer src="js/auto-refresh.js"></script>
-<!-- ImpactMojo Theme Toggle JS -->
+<main><div class="wrap">
+ <section class="grp" data-grp="credential"><div class="grp-h"><h2>Programs &amp; Credentials</h2><span class="cnt">10</span></div><div class="grid"><a class="lk" href="https://www.impactmojo.in/ai-for-me-certificate.html" target="_blank" rel="noopener" data-t="ai for m&amp;e — assessed track"><span class="lk-t">AI for M&amp;E — Assessed Track</span><span class="lk-u">/ai-for-me-certificate.html</span></a><a class="lk" href="https://www.impactmojo.in/mel-assessed-certificate.html" target="_blank" rel="noopener" data-t="mel — assessed track"><span class="lk-t">MEL — Assessed Track</span><span class="lk-u">/mel-assessed-certificate.html</span></a><a class="lk" href="https://www.impactmojo.in/data-tech-assessed-certificate.html" target="_blank" rel="noopener" data-t="data &amp; technology — assessed track"><span class="lk-t">Data &amp; Technology — Assessed Track</span><span class="lk-u">/data-tech-assessed-certificate.html</span></a><a class="lk" href="https://www.impactmojo.in/policy-economics-assessed-certificate.html" target="_blank" rel="noopener" data-t="policy &amp; economics — assessed track"><span class="lk-t">Policy &amp; Economics — Assessed Track</span><span class="lk-u">/policy-economics-assessed-certificate.html</span></a><a class="lk" href="https://www.impactmojo.in/credential-upgrade.html" target="_blank" rel="noopener" data-t="verified credential upgrade"><span class="lk-t">Verified Credential Upgrade</span><span class="lk-u">/credential-upgrade.html</span></a><a class="lk" href="https://www.impactmojo.in/ai-agents-for-evaluators.html" target="_blank" rel="noopener" data-t="ai agents for evaluators (free)"><span class="lk-t">AI Agents for Evaluators (free)</span><span class="lk-u">/ai-agents-for-evaluators.html</span></a><a class="lk" href="https://www.impactmojo.in/build-circles.html" target="_blank" rel="noopener" data-t="build circles (cohorts)"><span class="lk-t">Build Circles (cohorts)</span><span class="lk-u">/build-circles.html</span></a><a class="lk" href="https://www.impactmojo.in/verify-certificate.html" target="_blank" rel="noopener" data-t="verify a certificate"><span class="lk-t">Verify a Certificate</span><span class="lk-u">/verify-certificate.html</span></a><a class="lk" href="https://www.impactmojo.in/verify.html" target="_blank" rel="noopener" data-t="employer verification portal"><span class="lk-t">Employer Verification Portal</span><span class="lk-u">/verify.html</span></a><a class="lk" href="https://www.impactmojo.in/peer-review.html" target="_blank" rel="noopener" data-t="peer review"><span class="lk-t">Peer Review</span><span class="lk-u">/peer-review.html</span></a></div></section><section class="grp" data-grp="flagship"><div class="grp-h"><h2>Flagship Courses</h2><span class="cnt">17</span></div><div class="grid"><a class="lk" href="https://www.impactmojo.in/courses/mel/" target="_blank" rel="noopener" data-t="monitoring, evaluation &amp; learning"><span class="lk-t">Monitoring, Evaluation &amp; Learning</span><span class="lk-u">/courses/mel/</span></a><a class="lk" href="https://www.impactmojo.in/courses/devecon/" target="_blank" rel="noopener" data-t="development economics"><span class="lk-t">Development Economics</span><span class="lk-u">/courses/devecon/</span></a><a class="lk" href="https://www.impactmojo.in/courses/devai/" target="_blank" rel="noopener" data-t="ai for impact"><span class="lk-t">AI for Impact</span><span class="lk-u">/courses/devai/</span></a><a class="lk" href="https://www.impactmojo.in/courses/dataviz/" target="_blank" rel="noopener" data-t="seeing data — visualization"><span class="lk-t">Seeing Data — Visualization</span><span class="lk-u">/courses/dataviz/</span></a><a class="lk" href="https://www.impactmojo.in/courses/causal/" target="_blank" rel="noopener" data-t="causal inference"><span class="lk-t">Causal Inference</span><span class="lk-u">/courses/causal/</span></a><a class="lk" href="https://www.impactmojo.in/courses/intervention/" target="_blank" rel="noopener" data-t="designing what works"><span class="lk-t">Designing What Works</span><span class="lk-u">/courses/intervention/</span></a><a class="lk" href="https://www.impactmojo.in/courses/poa/" target="_blank" rel="noopener" data-t="politics of aspiration"><span class="lk-t">Politics of Aspiration</span><span class="lk-u">/courses/poa/</span></a><a class="lk" href="https://www.impactmojo.in/courses/gender/" target="_blank" rel="noopener" data-t="gender studies"><span class="lk-t">Gender Studies</span><span class="lk-u">/courses/gender/</span></a><a class="lk" href="https://www.impactmojo.in/courses/law/" target="_blank" rel="noopener" data-t="constitution &amp; law"><span class="lk-t">Constitution &amp; Law</span><span class="lk-u">/courses/law/</span></a><a class="lk" href="https://www.impactmojo.in/courses/pubpol/" target="_blank" rel="noopener" data-t="public policy"><span class="lk-t">Public Policy</span><span class="lk-u">/courses/pubpol/</span></a><a class="lk" href="https://www.impactmojo.in/courses/pubchoice/" target="_blank" rel="noopener" data-t="public choice"><span class="lk-t">Public Choice</span><span class="lk-u">/courses/pubchoice/</span></a><a class="lk" href="https://www.impactmojo.in/courses/livelihoods/" target="_blank" rel="noopener" data-t="livelihoods in india"><span class="lk-t">Livelihoods in India</span><span class="lk-u">/courses/livelihoods/</span></a><a class="lk" href="https://www.impactmojo.in/courses/media/" target="_blank" rel="noopener" data-t="media for development"><span class="lk-t">Media for Development</span><span class="lk-u">/courses/media/</span></a><a class="lk" href="https://www.impactmojo.in/courses/sel/" target="_blank" rel="noopener" data-t="social-emotional learning"><span class="lk-t">Social-Emotional Learning</span><span class="lk-u">/courses/sel/</span></a><a class="lk" href="https://www.impactmojo.in/courses/nvc-rj/" target="_blank" rel="noopener" data-t="nonviolence in practice"><span class="lk-t">Nonviolence in Practice</span><span class="lk-u">/courses/nvc-rj/</span></a><a class="lk" href="https://www.impactmojo.in/courses/gandhi/" target="_blank" rel="noopener" data-t="gandhi&#x27;s political thought"><span class="lk-t">Gandhi&#x27;s Political Thought</span><span class="lk-u">/courses/gandhi/</span></a><a class="lk" href="https://www.impactmojo.in/courses/powerBI/" target="_blank" rel="noopener" data-t="power bi for development"><span class="lk-t">Power BI for Development</span><span class="lk-u">/courses/powerBI/</span></a></div></section><section class="grp" data-grp="c101"><div class="grp-h"><h2>Foundational 101 Courses</h2><span class="cnt">51</span></div><div class="grid"><a class="lk" href="https://www.impactmojo.in/101-courses/advocacy-basics.html" target="_blank" rel="noopener" data-t="advocacy basics"><span class="lk-t">Advocacy Basics</span><span class="lk-u">/101-courses/advocacy-basics.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/bcc-comms.html" target="_blank" rel="noopener" data-t="bcc &amp; communications"><span class="lk-t">BCC &amp; Communications</span><span class="lk-u">/101-courses/bcc-comms.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/bi-analysis.html" target="_blank" rel="noopener" data-t="bi &amp; analysis"><span class="lk-t">BI &amp; Analysis</span><span class="lk-u">/101-courses/bi-analysis.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/care-economy-101.html" target="_blank" rel="noopener" data-t="care economy"><span class="lk-t">Care Economy</span><span class="lk-u">/101-courses/care-economy-101.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/child-development.html" target="_blank" rel="noopener" data-t="child development"><span class="lk-t">Child Development</span><span class="lk-u">/101-courses/child-development.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/climate-essentials.html" target="_blank" rel="noopener" data-t="climate essentials"><span class="lk-t">Climate Essentials</span><span class="lk-u">/101-courses/climate-essentials.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/community-dev.html" target="_blank" rel="noopener" data-t="community dev"><span class="lk-t">Community Dev</span><span class="lk-u">/101-courses/community-dev.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/cost-effectiveness.html" target="_blank" rel="noopener" data-t="cost effectiveness"><span class="lk-t">Cost Effectiveness</span><span class="lk-u">/101-courses/cost-effectiveness.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/data-feminism.html" target="_blank" rel="noopener" data-t="data feminism"><span class="lk-t">Data Feminism</span><span class="lk-u">/101-courses/data-feminism.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/data-lit.html" target="_blank" rel="noopener" data-t="data literacy"><span class="lk-t">Data Literacy</span><span class="lk-u">/101-courses/data-lit.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/data-protection-dpdp.html" target="_blank" rel="noopener" data-t="data protection &amp; dpdp act"><span class="lk-t">Data Protection &amp; DPDP Act</span><span class="lk-u">/101-courses/data-protection-dpdp.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/data-viz.html" target="_blank" rel="noopener" data-t="data visualization"><span class="lk-t">Data Visualization</span><span class="lk-u">/101-courses/data-viz.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/decolonize-dev.html" target="_blank" rel="noopener" data-t="decolonising development"><span class="lk-t">Decolonising Development</span><span class="lk-u">/101-courses/decolonize-dev.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/dev-architecture.html" target="_blank" rel="noopener" data-t="development architecture"><span class="lk-t">Development Architecture</span><span class="lk-u">/101-courses/dev-architecture.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/dev-economics.html" target="_blank" rel="noopener" data-t="development economics"><span class="lk-t">Development Economics</span><span class="lk-u">/101-courses/dev-economics.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/digital-ethics.html" target="_blank" rel="noopener" data-t="digital ethics"><span class="lk-t">Digital Ethics</span><span class="lk-u">/101-courses/digital-ethics.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/disability-inclusion.html" target="_blank" rel="noopener" data-t="disability inclusion"><span class="lk-t">Disability Inclusion</span><span class="lk-u">/101-courses/disability-inclusion.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/econometrics-101.html" target="_blank" rel="noopener" data-t="econometrics"><span class="lk-t">Econometrics</span><span class="lk-u">/101-courses/econometrics-101.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/eda-hhs.html" target="_blank" rel="noopener" data-t="eda — household surveys"><span class="lk-t">EDA — Household Surveys</span><span class="lk-u">/101-courses/eda-hhs.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/edu-pedagogy.html" target="_blank" rel="noopener" data-t="education &amp; pedagogy"><span class="lk-t">Education &amp; Pedagogy</span><span class="lk-u">/101-courses/edu-pedagogy.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/eng-dev.html" target="_blank" rel="noopener" data-t="english for development"><span class="lk-t">English for Development</span><span class="lk-u">/101-courses/eng-dev.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/env-justice.html" target="_blank" rel="noopener" data-t="environmental justice"><span class="lk-t">Environmental Justice</span><span class="lk-u">/101-courses/env-justice.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/feminist-research.html" target="_blank" rel="noopener" data-t="feminist research"><span class="lk-t">Feminist Research</span><span class="lk-u">/101-courses/feminist-research.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/fundraising-basics.html" target="_blank" rel="noopener" data-t="fundraising basics"><span class="lk-t">Fundraising Basics</span><span class="lk-u">/101-courses/fundraising-basics.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/genai-practitioners.html" target="_blank" rel="noopener" data-t="genai for practitioners"><span class="lk-t">GenAI for Practitioners</span><span class="lk-u">/101-courses/genai-practitioners.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/gender-mainstreaming.html" target="_blank" rel="noopener" data-t="gender mainstreaming"><span class="lk-t">Gender Mainstreaming</span><span class="lk-u">/101-courses/gender-mainstreaming.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/impact-eval.html" target="_blank" rel="noopener" data-t="impact evaluation"><span class="lk-t">Impact Evaluation</span><span class="lk-u">/101-courses/impact-eval.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/ind-constitution.html" target="_blank" rel="noopener" data-t="indian constitution"><span class="lk-t">Indian Constitution</span><span class="lk-u">/101-courses/ind-constitution.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/inequality-basics.html" target="_blank" rel="noopener" data-t="inequality basics"><span class="lk-t">Inequality Basics</span><span class="lk-u">/101-courses/inequality-basics.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/irt-basics.html" target="_blank" rel="noopener" data-t="irt basics"><span class="lk-t">IRT Basics</span><span class="lk-u">/101-courses/irt-basics.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/logframe-101.html" target="_blank" rel="noopener" data-t="logframe"><span class="lk-t">Logframe</span><span class="lk-u">/101-courses/logframe-101.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/maternal-health.html" target="_blank" rel="noopener" data-t="maternal health"><span class="lk-t">Maternal Health</span><span class="lk-u">/101-courses/maternal-health.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/mel-basics.html" target="_blank" rel="noopener" data-t="mel basics"><span class="lk-t">MEL Basics</span><span class="lk-u">/101-courses/mel-basics.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/mixed-methods.html" target="_blank" rel="noopener" data-t="mixed methods"><span class="lk-t">Mixed Methods</span><span class="lk-u">/101-courses/mixed-methods.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/multivariate-basics.html" target="_blank" rel="noopener" data-t="multivariate basics"><span class="lk-t">Multivariate Basics</span><span class="lk-u">/101-courses/multivariate-basics.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/obs2insight.html" target="_blank" rel="noopener" data-t="observation to insight"><span class="lk-t">Observation to Insight</span><span class="lk-u">/101-courses/obs2insight.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/pol-economy.html" target="_blank" rel="noopener" data-t="political economy"><span class="lk-t">Political Economy</span><span class="lk-u">/101-courses/pol-economy.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/post-truth-101.html" target="_blank" rel="noopener" data-t="post-truth politics"><span class="lk-t">Post-Truth Politics</span><span class="lk-u">/101-courses/post-truth-101.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/public-finance-budgeting.html" target="_blank" rel="noopener" data-t="public finance &amp; budgeting"><span class="lk-t">Public Finance &amp; Budgeting</span><span class="lk-u">/101-courses/public-finance-budgeting.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/pub-health-basics.html" target="_blank" rel="noopener" data-t="public health basics"><span class="lk-t">Public Health Basics</span><span class="lk-u">/101-courses/pub-health-basics.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/qual-methods.html" target="_blank" rel="noopener" data-t="qualitative methods"><span class="lk-t">Qualitative Methods</span><span class="lk-u">/101-courses/qual-methods.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/research-ethics.html" target="_blank" rel="noopener" data-t="research ethics"><span class="lk-t">Research Ethics</span><span class="lk-u">/101-courses/research-ethics.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/safeguarding-psea.html" target="_blank" rel="noopener" data-t="safeguarding &amp; psea"><span class="lk-t">Safeguarding &amp; PSEA</span><span class="lk-u">/101-courses/safeguarding-psea.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/sel-basics.html" target="_blank" rel="noopener" data-t="sel basics"><span class="lk-t">SEL Basics</span><span class="lk-u">/101-courses/sel-basics.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/social-margins.html" target="_blank" rel="noopener" data-t="social margins"><span class="lk-t">Social Margins</span><span class="lk-u">/101-courses/social-margins.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/SRHR-basics.html" target="_blank" rel="noopener" data-t="srhr basics"><span class="lk-t">SRHR Basics</span><span class="lk-u">/101-courses/SRHR-basics.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/survey-design.html" target="_blank" rel="noopener" data-t="survey design"><span class="lk-t">Survey Design</span><span class="lk-u">/101-courses/survey-design.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/toc-workbench.html" target="_blank" rel="noopener" data-t="toc workbench"><span class="lk-t">ToC Workbench</span><span class="lk-u">/101-courses/toc-workbench.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/visual-eth.html" target="_blank" rel="noopener" data-t="visual ethnography"><span class="lk-t">Visual Ethnography</span><span class="lk-u">/101-courses/visual-eth.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/wee-studies.html" target="_blank" rel="noopener" data-t="women&#x27;s economic empowerment"><span class="lk-t">Women&#x27;s Economic Empowerment</span><span class="lk-u">/101-courses/wee-studies.html</span></a><a class="lk" href="https://www.impactmojo.in/101-courses/work-labour-livelihoods.html" target="_blank" rel="noopener" data-t="work, labour &amp; livelihoods"><span class="lk-t">Work, Labour &amp; Livelihoods</span><span class="lk-u">/101-courses/work-labour-livelihoods.html</span></a></div></section><section class="grp" data-grp="lab"><div class="grp-h"><h2>Interactive Labs</h2><span class="cnt">29</span></div><div class="grid"><a class="lk" href="https://www.impactmojo.in/Labs/toc-lab.html" target="_blank" rel="noopener" data-t="theory of change"><span class="lk-t">Theory of Change</span><span class="lk-u">/Labs/toc-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/mel-design-lab.html" target="_blank" rel="noopener" data-t="mel design"><span class="lk-t">MEL Design</span><span class="lk-u">/Labs/mel-design-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/mel-plan-lab.html" target="_blank" rel="noopener" data-t="mel planning"><span class="lk-t">MEL Planning</span><span class="lk-u">/Labs/mel-plan-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/survey-design-lab.html" target="_blank" rel="noopener" data-t="survey design"><span class="lk-t">Survey Design</span><span class="lk-u">/Labs/survey-design-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/sampling-design-lab.html" target="_blank" rel="noopener" data-t="sampling design"><span class="lk-t">Sampling Design</span><span class="lk-u">/Labs/sampling-design-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/sampling-basics-lab.html" target="_blank" rel="noopener" data-t="sampling basics"><span class="lk-t">Sampling Basics</span><span class="lk-u">/Labs/sampling-basics-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/sampling-toolkit.html" target="_blank" rel="noopener" data-t="sampling toolkit"><span class="lk-t">Sampling Toolkit</span><span class="lk-u">/Labs/sampling-toolkit.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/policy-analysis-lab.html" target="_blank" rel="noopener" data-t="policy analysis"><span class="lk-t">Policy Analysis</span><span class="lk-u">/Labs/policy-analysis-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/policy-brief-lab.html" target="_blank" rel="noopener" data-t="policy brief"><span class="lk-t">Policy Brief</span><span class="lk-u">/Labs/policy-brief-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/policy-advocacy-lab.html" target="_blank" rel="noopener" data-t="policy &amp; advocacy"><span class="lk-t">Policy &amp; Advocacy</span><span class="lk-u">/Labs/policy-advocacy-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/stakeholder-mapping-lab.html" target="_blank" rel="noopener" data-t="stakeholder mapping"><span class="lk-t">Stakeholder Mapping</span><span class="lk-u">/Labs/stakeholder-mapping-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/systems-thinking-lab.html" target="_blank" rel="noopener" data-t="systems thinking"><span class="lk-t">Systems Thinking</span><span class="lk-u">/Labs/systems-thinking-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/design-thinking-lab.html" target="_blank" rel="noopener" data-t="design thinking"><span class="lk-t">Design Thinking</span><span class="lk-u">/Labs/design-thinking-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/participatory-methods-lab.html" target="_blank" rel="noopener" data-t="participatory methods"><span class="lk-t">Participatory Methods</span><span class="lk-u">/Labs/participatory-methods-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/storytelling-lab.html" target="_blank" rel="noopener" data-t="storytelling"><span class="lk-t">Storytelling</span><span class="lk-u">/Labs/storytelling-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/grant-writing-lab.html" target="_blank" rel="noopener" data-t="grant writing"><span class="lk-t">Grant Writing</span><span class="lk-u">/Labs/grant-writing-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/budget-fiscal-lab.html" target="_blank" rel="noopener" data-t="budget &amp; fiscal"><span class="lk-t">Budget &amp; Fiscal</span><span class="lk-u">/Labs/budget-fiscal-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/climate-adaptation-lab.html" target="_blank" rel="noopener" data-t="climate adaptation"><span class="lk-t">Climate Adaptation</span><span class="lk-u">/Labs/climate-adaptation-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/conflict-sensitive-lab.html" target="_blank" rel="noopener" data-t="conflict-sensitive programming"><span class="lk-t">Conflict-Sensitive Programming</span><span class="lk-u">/Labs/conflict-sensitive-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/data-feminism-lab.html" target="_blank" rel="noopener" data-t="data feminism"><span class="lk-t">Data Feminism</span><span class="lk-u">/Labs/data-feminism-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/dpi-lab.html" target="_blank" rel="noopener" data-t="digital public infrastructure"><span class="lk-t">Digital Public Infrastructure</span><span class="lk-u">/Labs/dpi-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/ethics-research-lab.html" target="_blank" rel="noopener" data-t="ethics &amp; research integrity"><span class="lk-t">Ethics &amp; Research Integrity</span><span class="lk-u">/Labs/ethics-research-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/gender-studies-lab.html" target="_blank" rel="noopener" data-t="gender studies"><span class="lk-t">Gender Studies</span><span class="lk-u">/Labs/gender-studies-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/impact-partnerships-lab.html" target="_blank" rel="noopener" data-t="impact partnerships"><span class="lk-t">Impact Partnerships</span><span class="lk-u">/Labs/impact-partnerships-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/resource-sustainability-lab.html" target="_blank" rel="noopener" data-t="resource sustainability"><span class="lk-t">Resource Sustainability</span><span class="lk-u">/Labs/resource-sustainability-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/risk-mitigation-lab.html" target="_blank" rel="noopener" data-t="risk mitigation"><span class="lk-t">Risk Mitigation</span><span class="lk-u">/Labs/risk-mitigation-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/teacher-evidence-lab.html" target="_blank" rel="noopener" data-t="teacher evidence"><span class="lk-t">Teacher Evidence</span><span class="lk-u">/Labs/teacher-evidence-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/community-lab.html" target="_blank" rel="noopener" data-t="community engagement"><span class="lk-t">Community Engagement</span><span class="lk-u">/Labs/community-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/Labs/r-python-dev.html" target="_blank" rel="noopener" data-t="r &amp; python for development"><span class="lk-t">R &amp; Python for Development</span><span class="lk-u">/Labs/r-python-dev.html</span></a></div></section><section class="grp" data-grp="game"><div class="grp-h"><h2>Games</h2><span class="cnt">18</span></div><div class="grid"><a class="lk" href="https://www.impactmojo.in/Games/counterfactual-game.html" target="_blank" rel="noopener" data-t="counterfactual game"><span class="lk-t">Counterfactual Game</span><span class="lk-u">/Games/counterfactual-game.html</span></a><a class="lk" href="https://www.impactmojo.in/Games/econ-concepts-game.html" target="_blank" rel="noopener" data-t="econ concepts game"><span class="lk-t">Econ Concepts Game</span><span class="lk-u">/Games/econ-concepts-game.html</span></a><a class="lk" href="https://www.impactmojo.in/Games/opportunity-cost-game.html" target="_blank" rel="noopener" data-t="opportunity cost game"><span class="lk-t">Opportunity Cost Game</span><span class="lk-u">/Games/opportunity-cost-game.html</span></a><a class="lk" href="https://www.impactmojo.in/Games/prisoners-dilemma-game.html" target="_blank" rel="noopener" data-t="prisoners dilemma game"><span class="lk-t">Prisoners Dilemma Game</span><span class="lk-u">/Games/prisoners-dilemma-game.html</span></a><a class="lk" href="https://www.impactmojo.in/Games/cooperation-paradox-game.html" target="_blank" rel="noopener" data-t="cooperation paradox game"><span class="lk-t">Cooperation Paradox Game</span><span class="lk-u">/Games/cooperation-paradox-game.html</span></a><a class="lk" href="https://www.impactmojo.in/Games/commons-crisis-game.html" target="_blank" rel="noopener" data-t="commons crisis game"><span class="lk-t">Commons Crisis Game</span><span class="lk-u">/Games/commons-crisis-game.html</span></a><a class="lk" href="https://www.impactmojo.in/Games/public-good-game.html" target="_blank" rel="noopener" data-t="public good game"><span class="lk-t">Public Good Game</span><span class="lk-u">/Games/public-good-game.html</span></a><a class="lk" href="https://www.impactmojo.in/Games/externality-game.html" target="_blank" rel="noopener" data-t="externality game"><span class="lk-t">Externality Game</span><span class="lk-u">/Games/externality-game.html</span></a><a class="lk" href="https://www.impactmojo.in/Games/info-asymmetry-game.html" target="_blank" rel="noopener" data-t="info asymmetry game"><span class="lk-t">Info Asymmetry Game</span><span class="lk-u">/Games/info-asymmetry-game.html</span></a><a class="lk" href="https://www.impactmojo.in/Games/network-effects-game.html" target="_blank" rel="noopener" data-t="network effects game"><span class="lk-t">Network Effects Game</span><span class="lk-u">/Games/network-effects-game.html</span></a><a class="lk" href="https://www.impactmojo.in/Games/bidding-wars-game.html" target="_blank" rel="noopener" data-t="bidding wars game"><span class="lk-t">Bidding Wars Game</span><span class="lk-u">/Games/bidding-wars-game.html</span></a><a class="lk" href="https://www.impactmojo.in/Games/risk-reward-game.html" target="_blank" rel="noopener" data-t="risk reward game"><span class="lk-t">Risk Reward Game</span><span class="lk-u">/Games/risk-reward-game.html</span></a><a class="lk" href="https://www.impactmojo.in/Games/real-middle-india.html" target="_blank" rel="noopener" data-t="real middle india"><span class="lk-t">Real Middle India</span><span class="lk-u">/Games/real-middle-india.html</span></a><a class="lk" href="https://www.impactmojo.in/Games/climate-action-game.html" target="_blank" rel="noopener" data-t="climate action game"><span class="lk-t">Climate Action Game</span><span class="lk-u">/Games/climate-action-game.html</span></a><a class="lk" href="https://www.impactmojo.in/Games/gender-equity-game.html" target="_blank" rel="noopener" data-t="gender equity game"><span class="lk-t">Gender Equity Game</span><span class="lk-u">/Games/gender-equity-game.html</span></a><a class="lk" href="https://www.impactmojo.in/Games/public-health-game.html" target="_blank" rel="noopener" data-t="public health game"><span class="lk-t">Public Health Game</span><span class="lk-u">/Games/public-health-game.html</span></a><a class="lk" href="https://www.impactmojo.in/Games/digital-ethics-game.html" target="_blank" rel="noopener" data-t="digital ethics game"><span class="lk-t">Digital Ethics Game</span><span class="lk-u">/Games/digital-ethics-game.html</span></a><a class="lk" href="https://www.impactmojo.in/Games/sel-simulation-game.html" target="_blank" rel="noopener" data-t="sel simulation game"><span class="lk-t">SEL Simulation Game</span><span class="lk-u">/Games/sel-simulation-game.html</span></a></div></section><section class="grp" data-grp="deep"><div class="grp-h"><h2>Deep Dives</h2><span class="cnt">21</span></div><div class="grid"><a class="lk" href="https://www.impactmojo.in/DeepDives/impact-measurement-foundations.html" target="_blank" rel="noopener" data-t="impact measurement foundations"><span class="lk-t">Impact Measurement Foundations</span><span class="lk-u">/DeepDives/impact-measurement-foundations.html</span></a><a class="lk" href="https://www.impactmojo.in/DeepDives/randomista-economics.html" target="_blank" rel="noopener" data-t="randomista economics"><span class="lk-t">Randomista Economics</span><span class="lk-u">/DeepDives/randomista-economics.html</span></a><a class="lk" href="https://www.impactmojo.in/DeepDives/cash-transfers-evidence.html" target="_blank" rel="noopener" data-t="cash transfers evidence"><span class="lk-t">Cash Transfers Evidence</span><span class="lk-u">/DeepDives/cash-transfers-evidence.html</span></a><a class="lk" href="https://www.impactmojo.in/DeepDives/politics-of-targeting.html" target="_blank" rel="noopener" data-t="politics of targeting"><span class="lk-t">Politics Of Targeting</span><span class="lk-u">/DeepDives/politics-of-targeting.html</span></a><a class="lk" href="https://www.impactmojo.in/DeepDives/measuring-empowerment.html" target="_blank" rel="noopener" data-t="measuring empowerment"><span class="lk-t">Measuring Empowerment</span><span class="lk-u">/DeepDives/measuring-empowerment.html</span></a><a class="lk" href="https://www.impactmojo.in/DeepDives/the-learning-crisis.html" target="_blank" rel="noopener" data-t="the learning crisis"><span class="lk-t">The Learning Crisis</span><span class="lk-u">/DeepDives/the-learning-crisis.html</span></a><a class="lk" href="https://www.impactmojo.in/DeepDives/the-stunting-puzzle.html" target="_blank" rel="noopener" data-t="the stunting puzzle"><span class="lk-t">The Stunting Puzzle</span><span class="lk-u">/DeepDives/the-stunting-puzzle.html</span></a><a class="lk" href="https://www.impactmojo.in/DeepDives/informality-and-social-protection.html" target="_blank" rel="noopener" data-t="informality and social protection"><span class="lk-t">Informality And Social Protection</span><span class="lk-u">/DeepDives/informality-and-social-protection.html</span></a><a class="lk" href="https://www.impactmojo.in/DeepDives/india-female-labour-force-participation.html" target="_blank" rel="noopener" data-t="india&#x27;s female labour force participation"><span class="lk-t">India&#x27;s Female Labour Force Participation</span><span class="lk-u">/DeepDives/india-female-labour-force-participation.html</span></a><a class="lk" href="https://www.impactmojo.in/DeepDives/indian-political-economy.html" target="_blank" rel="noopener" data-t="indian political economy"><span class="lk-t">Indian Political Economy</span><span class="lk-u">/DeepDives/indian-political-economy.html</span></a><a class="lk" href="https://www.impactmojo.in/DeepDives/caste-identity-development.html" target="_blank" rel="noopener" data-t="caste identity development"><span class="lk-t">Caste Identity Development</span><span class="lk-u">/DeepDives/caste-identity-development.html</span></a><a class="lk" href="https://www.impactmojo.in/DeepDives/the-care-economy.html" target="_blank" rel="noopener" data-t="the care economy"><span class="lk-t">The Care Economy</span><span class="lk-u">/DeepDives/the-care-economy.html</span></a><a class="lk" href="https://www.impactmojo.in/DeepDives/platform-gig-work-india.html" target="_blank" rel="noopener" data-t="platform gig work india"><span class="lk-t">Platform Gig Work India</span><span class="lk-u">/DeepDives/platform-gig-work-india.html</span></a><a class="lk" href="https://www.impactmojo.in/DeepDives/health-systems-uhc-south-asia.html" target="_blank" rel="noopener" data-t="health systems &amp; uhc"><span class="lk-t">Health Systems &amp; UHC</span><span class="lk-u">/DeepDives/health-systems-uhc-south-asia.html</span></a><a class="lk" href="https://www.impactmojo.in/DeepDives/climate-adaptation-finance.html" target="_blank" rel="noopener" data-t="climate adaptation finance"><span class="lk-t">Climate Adaptation Finance</span><span class="lk-u">/DeepDives/climate-adaptation-finance.html</span></a><a class="lk" href="https://www.impactmojo.in/DeepDives/climate-just-transitions-south-asia.html" target="_blank" rel="noopener" data-t="climate just transitions"><span class="lk-t">Climate Just Transitions</span><span class="lk-u">/DeepDives/climate-just-transitions-south-asia.html</span></a><a class="lk" href="https://www.impactmojo.in/DeepDives/climate-migration-south-asia.html" target="_blank" rel="noopener" data-t="climate migration"><span class="lk-t">Climate Migration</span><span class="lk-u">/DeepDives/climate-migration-south-asia.html</span></a><a class="lk" href="https://www.impactmojo.in/DeepDives/ai-and-development.html" target="_blank" rel="noopener" data-t="ai and development"><span class="lk-t">AI And Development</span><span class="lk-u">/DeepDives/ai-and-development.html</span></a><a class="lk" href="https://www.impactmojo.in/DeepDives/data-power-global-south.html" target="_blank" rel="noopener" data-t="data power &amp; the global south"><span class="lk-t">Data Power &amp; the Global South</span><span class="lk-u">/DeepDives/data-power-global-south.html</span></a><a class="lk" href="https://www.impactmojo.in/DeepDives/decolonising-development-knowledge.html" target="_blank" rel="noopener" data-t="decolonising development knowledge"><span class="lk-t">Decolonising Development Knowledge</span><span class="lk-u">/DeepDives/decolonising-development-knowledge.html</span></a><a class="lk" href="https://www.impactmojo.in/DeepDives/sel-evaluation-india.html" target="_blank" rel="noopener" data-t="sel evaluation in india"><span class="lk-t">SEL Evaluation in India</span><span class="lk-u">/DeepDives/sel-evaluation-india.html</span></a></div></section><section class="grp" data-grp="pack"><div class="grp-h"><h2>Practice Packs</h2><span class="cnt">18</span></div><div class="grid"><a class="lk" href="https://www.impactmojo.in/practice-packs/mel-from-scratch/" target="_blank" rel="noopener" data-t="mel from scratch"><span class="lk-t">MEL from Scratch</span><span class="lk-u">/practice-packs/mel-from-scratch/</span></a><a class="lk" href="https://www.impactmojo.in/practice-packs/logframe-building/" target="_blank" rel="noopener" data-t="logframe building"><span class="lk-t">Logframe Building</span><span class="lk-u">/practice-packs/logframe-building/</span></a><a class="lk" href="https://www.impactmojo.in/practice-packs/tor-writing/" target="_blank" rel="noopener" data-t="tor writing"><span class="lk-t">ToR Writing</span><span class="lk-u">/practice-packs/tor-writing/</span></a><a class="lk" href="https://www.impactmojo.in/practice-packs/survey-instrument/" target="_blank" rel="noopener" data-t="survey instrument"><span class="lk-t">Survey Instrument</span><span class="lk-u">/practice-packs/survey-instrument/</span></a><a class="lk" href="https://www.impactmojo.in/practice-packs/programme-costing/" target="_blank" rel="noopener" data-t="programme costing"><span class="lk-t">Programme Costing</span><span class="lk-u">/practice-packs/programme-costing/</span></a><a class="lk" href="https://www.impactmojo.in/practice-packs/donor-reporting/" target="_blank" rel="noopener" data-t="donor reporting"><span class="lk-t">Donor Reporting</span><span class="lk-u">/practice-packs/donor-reporting/</span></a><a class="lk" href="https://www.impactmojo.in/practice-packs/stakeholder-mapping/" target="_blank" rel="noopener" data-t="stakeholder mapping"><span class="lk-t">Stakeholder Mapping</span><span class="lk-u">/practice-packs/stakeholder-mapping/</span></a><a class="lk" href="https://www.impactmojo.in/practice-packs/critiquing-evidence/" target="_blank" rel="noopener" data-t="critiquing evidence"><span class="lk-t">Critiquing Evidence</span><span class="lk-u">/practice-packs/critiquing-evidence/</span></a><a class="lk" href="https://www.impactmojo.in/practice-packs/focus-group-discussion/" target="_blank" rel="noopener" data-t="focus group discussion"><span class="lk-t">Focus Group Discussion</span><span class="lk-u">/practice-packs/focus-group-discussion/</span></a><a class="lk" href="https://www.impactmojo.in/practice-packs/education-evaluation/" target="_blank" rel="noopener" data-t="education evaluation"><span class="lk-t">Education Evaluation</span><span class="lk-u">/practice-packs/education-evaluation/</span></a><a class="lk" href="https://www.impactmojo.in/practice-packs/health-evaluation/" target="_blank" rel="noopener" data-t="health evaluation"><span class="lk-t">Health Evaluation</span><span class="lk-u">/practice-packs/health-evaluation/</span></a><a class="lk" href="https://www.impactmojo.in/practice-packs/gender-impact/" target="_blank" rel="noopener" data-t="gender impact"><span class="lk-t">Gender Impact</span><span class="lk-u">/practice-packs/gender-impact/</span></a><a class="lk" href="https://www.impactmojo.in/practice-packs/climate-evaluation/" target="_blank" rel="noopener" data-t="climate evaluation"><span class="lk-t">Climate Evaluation</span><span class="lk-u">/practice-packs/climate-evaluation/</span></a><a class="lk" href="https://www.impactmojo.in/practice-packs/governance-evaluation/" target="_blank" rel="noopener" data-t="governance evaluation"><span class="lk-t">Governance Evaluation</span><span class="lk-u">/practice-packs/governance-evaluation/</span></a><a class="lk" href="https://www.impactmojo.in/practice-packs/livelihoods-evaluation/" target="_blank" rel="noopener" data-t="livelihoods evaluation"><span class="lk-t">Livelihoods Evaluation</span><span class="lk-u">/practice-packs/livelihoods-evaluation/</span></a><a class="lk" href="https://www.impactmojo.in/practice-packs/media-evaluation/" target="_blank" rel="noopener" data-t="media evaluation"><span class="lk-t">Media Evaluation</span><span class="lk-u">/practice-packs/media-evaluation/</span></a><a class="lk" href="https://www.impactmojo.in/practice-packs/policy-evaluation/" target="_blank" rel="noopener" data-t="policy evaluation"><span class="lk-t">Policy Evaluation</span><span class="lk-u">/practice-packs/policy-evaluation/</span></a><a class="lk" href="https://www.impactmojo.in/practice-packs/sel-evaluation/" target="_blank" rel="noopener" data-t="sel evaluation"><span class="lk-t">SEL Evaluation</span><span class="lk-u">/practice-packs/sel-evaluation/</span></a></div></section><section class="grp" data-grp="tool"><div class="grp-h"><h2>Premium Tools</h2><span class="cnt">16</span></div><div class="grid"><a class="lk" href="https://www.impactmojo.in/premium-tools/rq-builder.html" target="_blank" rel="noopener" data-t="research question builder"><span class="lk-t">Research Question Builder</span><span class="lk-u">/premium-tools/rq-builder.html</span></a><a class="lk" href="https://www.impactmojo.in/premium-tools/tor-builder.html" target="_blank" rel="noopener" data-t="tor builder"><span class="lk-t">ToR Builder</span><span class="lk-u">/premium-tools/tor-builder.html</span></a><a class="lk" href="https://www.impactmojo.in/premium-tools/toc-pro.html" target="_blank" rel="noopener" data-t="theory of change pro"><span class="lk-t">Theory of Change Pro</span><span class="lk-u">/premium-tools/toc-pro.html</span></a><a class="lk" href="https://www.impactmojo.in/premium-tools/logframe-pro.html" target="_blank" rel="noopener" data-t="logframe pro"><span class="lk-t">Logframe Pro</span><span class="lk-u">/premium-tools/logframe-pro.html</span></a><a class="lk" href="https://www.impactmojo.in/premium-tools/chart-selector-pro.html" target="_blank" rel="noopener" data-t="chart selector pro"><span class="lk-t">Chart Selector Pro</span><span class="lk-u">/premium-tools/chart-selector-pro.html</span></a><a class="lk" href="https://www.impactmojo.in/premium-tools/viz-cookbook.html" target="_blank" rel="noopener" data-t="viz cookbook"><span class="lk-t">Viz Cookbook</span><span class="lk-u">/premium-tools/viz-cookbook.html</span></a><a class="lk" href="https://www.impactmojo.in/premium-tools/qual-insights-lab.html" target="_blank" rel="noopener" data-t="qualitative insights lab"><span class="lk-t">Qualitative Insights Lab</span><span class="lk-u">/premium-tools/qual-insights-lab.html</span></a><a class="lk" href="https://www.impactmojo.in/premium-tools/code-converter-pro.html" target="_blank" rel="noopener" data-t="code converter pro"><span class="lk-t">Code Converter Pro</span><span class="lk-u">/premium-tools/code-converter-pro.html</span></a><a class="lk" href="https://www.impactmojo.in/premium-tools/stakeholder-pro.html" target="_blank" rel="noopener" data-t="stakeholder pro"><span class="lk-t">Stakeholder Pro</span><span class="lk-u">/premium-tools/stakeholder-pro.html</span></a><a class="lk" href="https://www.impactmojo.in/premium-tools/policy-canvas-pro.html" target="_blank" rel="noopener" data-t="policy canvas pro"><span class="lk-t">Policy Canvas Pro</span><span class="lk-u">/premium-tools/policy-canvas-pro.html</span></a><a class="lk" href="https://www.impactmojo.in/premium-tools/ai-canvas-pro.html" target="_blank" rel="noopener" data-t="ai canvas pro"><span class="lk-t">AI Canvas Pro</span><span class="lk-u">/premium-tools/ai-canvas-pro.html</span></a><a class="lk" href="https://www.impactmojo.in/premium-tools/empathy-pro.html" target="_blank" rel="noopener" data-t="empathy canvas pro"><span class="lk-t">Empathy Canvas Pro</span><span class="lk-u">/premium-tools/empathy-pro.html</span></a><a class="lk" href="https://www.impactmojo.in/premium-tools/advisory-board-pro.html" target="_blank" rel="noopener" data-t="advisory board pro"><span class="lk-t">Advisory Board Pro</span><span class="lk-u">/premium-tools/advisory-board-pro.html</span></a><a class="lk" href="https://www.impactmojo.in/premium-tools/field-notes.html" target="_blank" rel="noopener" data-t="field notes pro"><span class="lk-t">Field Notes Pro</span><span class="lk-u">/premium-tools/field-notes.html</span></a><a class="lk" href="https://www.impactmojo.in/premium-tools/devdata-practice.html" target="_blank" rel="noopener" data-t="devdata practice"><span class="lk-t">DevData Practice</span><span class="lk-u">/premium-tools/devdata-practice.html</span></a><a class="lk" href="https://www.impactmojo.in/premium-tools/vaniscribe.html" target="_blank" rel="noopener" data-t="vaniscribe"><span class="lk-t">VaniScribe</span><span class="lk-u">/premium-tools/vaniscribe.html</span></a></div></section><section class="grp" data-grp="timeline"><div class="grp-h"><h2>Timelines</h2><span class="cnt">6</span></div><div class="grid"><a class="lk" href="https://www.impactmojo.in/timelines/development-thinking.html" target="_blank" rel="noopener" data-t="development thinking"><span class="lk-t">Development Thinking</span><span class="lk-u">/timelines/development-thinking.html</span></a><a class="lk" href="https://www.impactmojo.in/timelines/indian-policy.html" target="_blank" rel="noopener" data-t="indian policy"><span class="lk-t">Indian Policy</span><span class="lk-u">/timelines/indian-policy.html</span></a><a class="lk" href="https://www.impactmojo.in/timelines/indian-rights.html" target="_blank" rel="noopener" data-t="indian rights"><span class="lk-t">Indian Rights</span><span class="lk-u">/timelines/indian-rights.html</span></a><a class="lk" href="https://www.impactmojo.in/timelines/mel-methods.html" target="_blank" rel="noopener" data-t="mel methods"><span class="lk-t">MEL Methods</span><span class="lk-u">/timelines/mel-methods.html</span></a><a class="lk" href="https://www.impactmojo.in/timelines/gender-work-india.html" target="_blank" rel="noopener" data-t="gender &amp; work in india"><span class="lk-t">Gender &amp; Work in India</span><span class="lk-u">/timelines/gender-work-india.html</span></a><a class="lk" href="https://www.impactmojo.in/timelines/climate-policy.html" target="_blank" rel="noopener" data-t="climate policy"><span class="lk-t">Climate Policy</span><span class="lk-u">/timelines/climate-policy.html</span></a></div></section><section class="grp" data-grp="explore"><div class="grp-h"><h2>Explore &amp; Community</h2><span class="cnt">23</span></div><div class="grid"><a class="lk" href="https://www.impactmojo.in/index.html" target="_blank" rel="noopener" data-t="home"><span class="lk-t">Home</span><span class="lk-u">/index.html</span></a><a class="lk" href="https://www.impactmojo.in/catalog.html" target="_blank" rel="noopener" data-t="catalog"><span class="lk-t">Catalog</span><span class="lk-u">/catalog.html</span></a><a class="lk" href="https://www.impactmojo.in/premium.html" target="_blank" rel="noopener" data-t="premium"><span class="lk-t">Premium</span><span class="lk-u">/premium.html</span></a><a class="lk" href="https://www.impactmojo.in/products.html" target="_blank" rel="noopener" data-t="products &amp; notes"><span class="lk-t">Products &amp; Notes</span><span class="lk-u">/products.html</span></a><a class="lk" href="https://www.impactmojo.in/game-library.html" target="_blank" rel="noopener" data-t="game library"><span class="lk-t">Game Library</span><span class="lk-u">/game-library.html</span></a><a class="lk" href="https://www.impactmojo.in/handouts.html" target="_blank" rel="noopener" data-t="handouts"><span class="lk-t">Handouts</span><span class="lk-u">/handouts.html</span></a><a class="lk" href="https://www.impactmojo.in/dataverse.html" target="_blank" rel="noopener" data-t="dataverse"><span class="lk-t">Dataverse</span><span class="lk-u">/dataverse.html</span></a><a class="lk" href="https://www.impactmojo.in/bct-repository.html" target="_blank" rel="noopener" data-t="bct repository"><span class="lk-t">BCT Repository</span><span class="lk-u">/bct-repository.html</span></a><a class="lk" href="https://www.impactmojo.in/blog.html" target="_blank" rel="noopener" data-t="blog"><span class="lk-t">Blog</span><span class="lk-u">/blog.html</span></a><a class="lk" href="https://www.impactmojo.in/podcast.html" target="_blank" rel="noopener" data-t="podcast"><span class="lk-t">Podcast</span><span class="lk-u">/podcast.html</span></a><a class="lk" href="https://www.impactmojo.in/dojos.html" target="_blank" rel="noopener" data-t="dojos"><span class="lk-t">Dojos</span><span class="lk-u">/dojos.html</span></a><a class="lk" href="https://www.impactmojo.in/challenges.html" target="_blank" rel="noopener" data-t="live case challenges"><span class="lk-t">Live Case Challenges</span><span class="lk-u">/challenges.html</span></a><a class="lk" href="https://www.impactmojo.in/live-projects.html" target="_blank" rel="noopener" data-t="live projects"><span class="lk-t">Live Projects</span><span class="lk-u">/live-projects.html</span></a><a class="lk" href="https://www.impactmojo.in/workshops.html" target="_blank" rel="noopener" data-t="workshops"><span class="lk-t">Workshops</span><span class="lk-u">/workshops.html</span></a><a class="lk" href="https://www.impactmojo.in/events.html" target="_blank" rel="noopener" data-t="events"><span class="lk-t">Events</span><span class="lk-u">/events.html</span></a><a class="lk" href="https://www.impactmojo.in/coaching.html" target="_blank" rel="noopener" data-t="coaching"><span class="lk-t">Coaching</span><span class="lk-u">/coaching.html</span></a><a class="lk" href="https://www.impactmojo.in/testimonials.html" target="_blank" rel="noopener" data-t="testimonials"><span class="lk-t">Testimonials</span><span class="lk-u">/testimonials.html</span></a><a class="lk" href="https://www.impactmojo.in/the-long-view.html" target="_blank" rel="noopener" data-t="the long view"><span class="lk-t">The Long View</span><span class="lk-u">/the-long-view.html</span></a><a class="lk" href="https://www.impactmojo.in/portfolio.html" target="_blank" rel="noopener" data-t="portfolio"><span class="lk-t">Portfolio</span><span class="lk-u">/portfolio.html</span></a><a class="lk" href="https://www.impactmojo.in/toc-builder.html" target="_blank" rel="noopener" data-t="toc builder"><span class="lk-t">ToC Builder</span><span class="lk-u">/toc-builder.html</span></a><a class="lk" href="https://www.impactmojo.in/toc-workbench.html" target="_blank" rel="noopener" data-t="toc workbench"><span class="lk-t">ToC Workbench</span><span class="lk-u">/toc-workbench.html</span></a><a class="lk" href="https://www.impactmojo.in/impact-dashboard.html" target="_blank" rel="noopener" data-t="impact dashboard"><span class="lk-t">Impact Dashboard</span><span class="lk-u">/impact-dashboard.html</span></a><a class="lk" href="https://www.impactmojo.in/climate-trace-india.html" target="_blank" rel="noopener" data-t="climate trace india"><span class="lk-t">Climate TRACE India</span><span class="lk-u">/climate-trace-india.html</span></a></div></section><section class="grp" data-grp="lib"><div class="grp-h"><h2>Content Libraries</h2><span class="cnt">7</span></div><div class="grid"><a class="lk" href="https://www.impactmojo.in/BookSummaries/" target="_blank" rel="noopener" data-t="book summaries — 105 companions"><span class="lk-t">Book Summaries — 105 companions</span><span class="lk-u">/BookSummaries/</span></a><a class="lk" href="https://www.impactmojo.in/DeepDives/" target="_blank" rel="noopener" data-t="deep dives — 22 reading lists"><span class="lk-t">Deep Dives — 22 reading lists</span><span class="lk-u">/DeepDives/</span></a><a class="lk" href="https://www.impactmojo.in/practice-packs/" target="_blank" rel="noopener" data-t="practice packs — 18 packs"><span class="lk-t">Practice Packs — 18 packs</span><span class="lk-u">/practice-packs/</span></a><a class="lk" href="https://www.impactmojo.in/handouts.html" target="_blank" rel="noopener" data-t="handouts — 84 across 7 tracks"><span class="lk-t">Handouts — 84 across 7 tracks</span><span class="lk-u">/handouts.html</span></a><a class="lk" href="https://www.impactmojo.in/blog.html" target="_blank" rel="noopener" data-t="blog — 33 posts"><span class="lk-t">Blog — 33 posts</span><span class="lk-u">/blog.html</span></a><a class="lk" href="https://www.impactmojo.in/products.html#course-notes" target="_blank" rel="noopener" data-t="course notes — 17 printable pdfs"><span class="lk-t">Course Notes — 17 printable PDFs</span><span class="lk-u">/products.html#course-notes</span></a><a class="lk" href="https://www.impactmojo.in/timelines/development-thinking.html" target="_blank" rel="noopener" data-t="timelines — 6 interactive"><span class="lk-t">Timelines — 6 interactive</span><span class="lk-u">/timelines/development-thinking.html</span></a></div></section><section class="grp" data-grp="account"><div class="grp-h"><h2>Account &amp; Access</h2><span class="cnt">6</span></div><div class="grid"><a class="lk" href="https://www.impactmojo.in/login.html" target="_blank" rel="noopener" data-t="log in"><span class="lk-t">Log in</span><span class="lk-u">/login.html</span></a><a class="lk" href="https://www.impactmojo.in/signup.html" target="_blank" rel="noopener" data-t="sign up"><span class="lk-t">Sign up</span><span class="lk-u">/signup.html</span></a><a class="lk" href="https://www.impactmojo.in/forgot-password.html" target="_blank" rel="noopener" data-t="forgot password"><span class="lk-t">Forgot password</span><span class="lk-u">/forgot-password.html</span></a><a class="lk" href="https://www.impactmojo.in/account.html" target="_blank" rel="noopener" data-t="my account"><span class="lk-t">My Account</span><span class="lk-u">/account.html</span></a><a class="lk" href="https://www.impactmojo.in/upgrade.html" target="_blank" rel="noopener" data-t="upgrade"><span class="lk-t">Upgrade</span><span class="lk-u">/upgrade.html</span></a><a class="lk" href="https://www.impactmojo.in/org-dashboard.html" target="_blank" rel="noopener" data-t="organisation dashboard"><span class="lk-t">Organisation Dashboard</span><span class="lk-u">/org-dashboard.html</span></a></div></section><section class="grp" data-grp="company"><div class="grp-h"><h2>Company &amp; Meta</h2><span class="cnt">12</span></div><div class="grid"><a class="lk" href="https://www.impactmojo.in/about.html" target="_blank" rel="noopener" data-t="about"><span class="lk-t">About</span><span class="lk-u">/about.html</span></a><a class="lk" href="https://www.impactmojo.in/contact.html" target="_blank" rel="noopener" data-t="contact"><span class="lk-t">Contact</span><span class="lk-u">/contact.html</span></a><a class="lk" href="https://www.impactmojo.in/faq.html" target="_blank" rel="noopener" data-t="faq"><span class="lk-t">FAQ</span><span class="lk-u">/faq.html</span></a><a class="lk" href="https://www.impactmojo.in/transparency.html" target="_blank" rel="noopener" data-t="transparency"><span class="lk-t">Transparency</span><span class="lk-u">/transparency.html</span></a><a class="lk" href="https://www.impactmojo.in/updates.html" target="_blank" rel="noopener" data-t="updates &amp; roadmap"><span class="lk-t">Updates &amp; Roadmap</span><span class="lk-u">/updates.html</span></a><a class="lk" href="https://www.impactmojo.in/contribute.html" target="_blank" rel="noopener" data-t="contribute / teach with us"><span class="lk-t">Contribute / Teach with Us</span><span class="lk-u">/contribute.html</span></a><a class="lk" href="https://www.impactmojo.in/ImpactMojo_PressKit.html" target="_blank" rel="noopener" data-t="press kit"><span class="lk-t">Press Kit</span><span class="lk-u">/ImpactMojo_PressKit.html</span></a><a class="lk" href="https://www.impactmojo.in/starter-kit.html" target="_blank" rel="noopener" data-t="starter kit"><span class="lk-t">Starter Kit</span><span class="lk-u">/starter-kit.html</span></a><a class="lk" href="https://www.impactmojo.in/content-marketing-kit.html" target="_blank" rel="noopener" data-t="content marketing kit"><span class="lk-t">Content Marketing Kit</span><span class="lk-u">/content-marketing-kit.html</span></a><a class="lk" href="https://www.impactmojo.in/status.html" target="_blank" rel="noopener" data-t="status"><span class="lk-t">Status</span><span class="lk-u">/status.html</span></a><a class="lk" href="https://www.impactmojo.in/api-docs.html" target="_blank" rel="noopener" data-t="api for partners"><span class="lk-t">API for Partners</span><span class="lk-u">/api-docs.html</span></a><a class="lk" href="https://www.impactmojo.in/sitemap.html" target="_blank" rel="noopener" data-t="sitemap"><span class="lk-t">Sitemap</span><span class="lk-u">/sitemap.html</span></a></div></section><section class="grp" data-grp="legal"><div class="grp-h"><h2>Legal &amp; Policy</h2><span class="cnt">8</span></div><div class="grid"><a class="lk" href="https://www.impactmojo.in/privacy-policy.html" target="_blank" rel="noopener" data-t="privacy policy"><span class="lk-t">Privacy Policy</span><span class="lk-u">/privacy-policy.html</span></a><a class="lk" href="https://www.impactmojo.in/terms-of-service.html" target="_blank" rel="noopener" data-t="terms of service"><span class="lk-t">Terms of Service</span><span class="lk-u">/terms-of-service.html</span></a><a class="lk" href="https://www.impactmojo.in/refund-policy.html" target="_blank" rel="noopener" data-t="refund policy"><span class="lk-t">Refund Policy</span><span class="lk-u">/refund-policy.html</span></a><a class="lk" href="https://www.impactmojo.in/disclaimer.html" target="_blank" rel="noopener" data-t="disclaimer"><span class="lk-t">Disclaimer</span><span class="lk-u">/disclaimer.html</span></a><a class="lk" href="https://www.impactmojo.in/data-protection.html" target="_blank" rel="noopener" data-t="data protection"><span class="lk-t">Data Protection</span><span class="lk-u">/data-protection.html</span></a><a class="lk" href="https://www.impactmojo.in/ai-policy.html" target="_blank" rel="noopener" data-t="ai policy"><span class="lk-t">AI Policy</span><span class="lk-u">/ai-policy.html</span></a><a class="lk" href="https://www.impactmojo.in/accessibility.html" target="_blank" rel="noopener" data-t="accessibility"><span class="lk-t">Accessibility</span><span class="lk-u">/accessibility.html</span></a><a class="lk" href="https://www.impactmojo.in/grievance.html" target="_blank" rel="noopener" data-t="grievance"><span class="lk-t">Grievance</span><span class="lk-u">/grievance.html</span></a></div></section><section class="grp" data-grp="admin"><div class="grp-h"><h2>Admin &amp; System</h2><span class="cnt">7</span></div><div class="grid"><a class="lk" href="https://www.impactmojo.in/admin/index.html" target="_blank" rel="noopener" data-t="admin home"><span class="lk-t">Admin Home</span><span class="lk-u">/admin/index.html</span></a><a class="lk" href="https://www.impactmojo.in/admin/cms.html" target="_blank" rel="noopener" data-t="cms"><span class="lk-t">CMS</span><span class="lk-u">/admin/cms.html</span></a><a class="lk" href="https://www.impactmojo.in/admin/analytics.html" target="_blank" rel="noopener" data-t="analytics"><span class="lk-t">Analytics</span><span class="lk-u">/admin/analytics.html</span></a><a class="lk" href="https://www.impactmojo.in/admin/learner-analytics.html" target="_blank" rel="noopener" data-t="learner analytics"><span class="lk-t">Learner Analytics</span><span class="lk-u">/admin/learner-analytics.html</span></a><a class="lk" href="https://www.impactmojo.in/admin/bugs.html" target="_blank" rel="noopener" data-t="bug tracker"><span class="lk-t">Bug Tracker</span><span class="lk-u">/admin/bugs.html</span></a><a class="lk" href="https://www.impactmojo.in/offline.html" target="_blank" rel="noopener" data-t="offline page"><span class="lk-t">Offline page</span><span class="lk-u">/offline.html</span></a><a class="lk" href="https://www.impactmojo.in/404.html" target="_blank" rel="noopener" data-t="404 page"><span class="lk-t">404 page</span><span class="lk-u">/404.html</span></a></div></section>
+ <p class="empty" id="empty">No pages match that filter.</p>
+</div></main>
+<script>
+(function(){
+ // jump chips from section headings
+ var jump=document.getElementById('jump');
+ [].forEach.call(document.querySelectorAll('.grp'),function(g,i){
+   var h=g.querySelector('h2').textContent, id='g'+i; g.id=id;
+   var a=document.createElement('a'); a.href='#'+id; a.textContent=h; jump.appendChild(a);
+ });
+ // live filter
+ var q=document.getElementById('q'), empty=document.getElementById('empty');
+ q.addEventListener('input',function(){
+   var v=q.value.trim().toLowerCase(), any=false;
+   [].forEach.call(document.querySelectorAll('.grp'),function(g){
+     var shown=0;
+     [].forEach.call(g.querySelectorAll('.lk'),function(l){
+       var m=!v || l.getAttribute('data-t').indexOf(v)>-1 || l.querySelector('.lk-u').textContent.toLowerCase().indexOf(v)>-1;
+       l.classList.toggle('hide',!m); if(m) shown++;
+     });
+     g.classList.toggle('hide',shown===0); if(shown) any=true;
+   });
+   empty.classList.toggle('show',!any);
+ });
+})();
+</script>
 <script src="/js/theme.js"></script>
-<!-- ImpactMojo Paper Plane -->
-<svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-    <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M80,130 L150,50" stroke="#10B981" stroke-width="2" stroke-dasharray="4,4"/>
-    <circle cx="150" cy="50" r="4" fill="#6366F1"/>
-    <circle cx="40" cy="155" r="2" fill="#0EA5E9" opacity="0.6"/>
-    <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
-    <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
-</svg>
-
-<!-- Supabase Auth -->
-<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
-<script src="/js/state-manager.js"></script>
-<script src="/js/config.js"></script>
-<script src="/js/auth.js"></script>
-<script src="/js/translate-sarvam.js" defer></script>
-  <script src="/js/site-chrome.js" defer></script>
+<script src="/js/site-chrome.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## What

Replaces the old static `sitemap.html` (84 links) with a **searchable, theme-aware map of 249 destinations across 15 sections** — Programs & Credentials, Flagship Courses, Foundational 101s, Labs, Games, Deep Dives, Practice Packs, Premium Tools, Timelines, Explore & Community, Content Libraries, Account, Company, Legal, Admin.

## Details

- Uses the standard **site-chrome** bar + footer and brand fonts (Amaranth/Inter), so it's consistent with the rest of the site and theme-aware.
- **Live filter box** (type to filter all 249 links) + **section jump-nav** chips + a stats row.
- Every internal link was verified against a real file (0 broken).
- The machine-readable **`sitemap.xml`** (for search engines) is unchanged — this is only the human-facing page.
- Verified rendering in a headless browser: site-chrome bar + footer inject, 15 sections, 249 cards, filter works.

Changelog: v10.89.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZJVUELWTXytJLQvurs8CJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZJVUELWTXytJLQvurs8CJ)_