### PR TITLE
Surface the Libraries hub in the footer nav

### DIFF
--- a/js/site-chrome.js
+++ b/js/site-chrome.js
@@ -179,8 +179,9 @@
           '<a href="' + SITE + '/courses/">Flagship Courses</a><a href="' + SITE + '/101-courses/">101 Series</a>' +
           '<a href="' + SITE + '/Labs/">Labs</a><a href="' + SITE + '/catalog.html">Full Catalog</a></div>' +
         '<div class="im-sc-foot-col"><h4>Explore</h4>' +
-          '<a href="' + SITE + '/dataverse.html">Dataverse</a><a href="' + SITE + '/dojos.html">Dojos &amp; Practice</a>' +
-          '<a href="' + SITE + '/BookSummaries/">Reading Companions</a><a href="' + SITE + '/blog.html">Blog</a></div>' +
+          '<a href="' + SITE + '/libraries.html"><b>All Libraries</b></a><a href="' + SITE + '/dataverse.html">Dataverse</a>' +
+          '<a href="' + SITE + '/BookSummaries/">Reading Companions</a><a href="' + SITE + '/dojos.html">Dojos &amp; Practice</a>' +
+          '<a href="' + SITE + '/blog.html">Blog</a></div>' +
         '<div class="im-sc-foot-col"><h4>ImpactMojo</h4>' +
           '<a href="' + SITE + '/about.html">About</a><a href="' + SITE + '/premium.html">Premium</a>' +
           '<a href="' + SITE + '/community.html">Community</a><a href="https://github.com/ImpactMojo/ImpactMojo">GitHub</a></div>' +


### PR DESCRIPTION
## What

Adds **"All Libraries" → `/libraries.html`** as the lead link in the site-chrome footer's **Explore** column, so the new hub is reachable from every page — closing the loop on the IA discoverability problem.

Deliberately **not** added to the top bar: the bar hides the wordmark under 600px and has no spare width (the recent mobile-overflow fix), so another item would re-crowd it. The footer Explore column is the right home.

## Verification

`node --check` passes on `js/site-chrome.js`; single additive link, no structural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZJVUELWTXytJLQvurs8CJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZJVUELWTXytJLQvurs8CJ)_