### PR TITLE
Field Radio: remove "PLC" from the search-index entry

### DIFF
--- a/data/search-index.json
+++ b/data/search-index.json
@@ -12221,7 +12221,7 @@
   {
     "id": "FIELD-RADIO",
     "title": "Field Radio",
-    "description": "A community station of voice notes and shorts from the ImpactMojo Practitioner Learning Community. Press play and listen in — clips play back-to-back, filterable by learning track, each with a transcript.",
+    "description": "A community station of voice notes and short videos from practitioners across South Asia. Press play and listen in — clips play back-to-back, filterable by learning track, each with a transcript.",
     "type": "page",
     "category": "Explore",
     "url": "/field-radio.html",
@@ -12232,7 +12232,6 @@
       "shorts",
       "audio",
       "video",
-      "PLC",
       "community",
       "station",
       "listen"


### PR DESCRIPTION
Consistency follow-up to #742: the `FIELD-RADIO` search-index entry still referenced the internal "PLC" shorthand in its description and tags. Updated the description to "voice notes and short videos from practitioners across South Asia" and dropped the `PLC` tag. Data-only; JSON re-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZJVUELWTXytJLQvurs8CJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZJVUELWTXytJLQvurs8CJ)_