### PR TITLE
Add Data Dives — independent data investigations (first piece: state welfare budgeting)

### DIFF
--- a/DataDives/_template.html
+++ b/DataDives/_template.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<!--
+    ImpactMojo Data Dive — Template
+    ================================
+    A Data Dive is an INDEPENDENT DATA INVESTIGATION (not a reading list — those are Deep Dives).
+    Structure: hero → "the finding" → stat tiles → 2-4 chart-led sections → a mandatory
+    "What this data can and can't tell you" methodology block → sources → related → cite.
+
+    To author a new one:
+    1. Copy this file to /DataDives/<slug>.html and replace every [BRACKET] token.
+    2. Keep the <style> block and the chart renderer <script> verbatim — they are self-contained,
+       theme-aware, and accessible. Only edit the data arrays at the bottom of the script.
+    3. EVERY chart must ship: a <figure> with title + sub, the <div class="dv-chart" id="...">,
+       a <details> data table, and a figcaption naming the source.
+    4. Charts are honest by construction: single-hue magnitude bars, reference lines for averages,
+       direct value labels, associational-not-causal language on any scatter.
+    5. Add an entry to /data/data-dives.json and wire cross-refs (see docs/data-dives-guide.md).
+
+    This template is a documentation stub. The canonical, fully worked reference implementation
+    is /DataDives/state-welfare-budgets.html — copy THAT file to start a real investigation,
+    then strip its content down to these placeholders.
+-->
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>[TITLE] | ImpactMojo Data Dive</title>
+<meta name="description" content="[STANDFIRST]">
+<link rel="canonical" href="https://www.impactmojo.in/DataDives/[SLUG].html">
+<meta name="robots" content="index, follow">
+<!--
+  Head, topbar, footer, design tokens, and the chart renderer are identical to
+  /DataDives/state-welfare-budgets.html. Start from that file rather than this stub.
+
+  Required page skeleton inside <main class="dv-wrap">:
+
+    <a class="dv-back" href="/DataDives/">← All Data Dives</a>
+    <div class="dv-eyebrow">Data Dive · [TOPIC]</div>
+    <h1 class="dv-title">[TITLE]</h1>
+    <p class="dv-standfirst">[STANDFIRST]</p>
+    <div class="dv-byline">… Investigation · ImpactMojo Data · [DATE] · [READ TIME] · Source: [DATASET] …</div>
+
+    <div class="dv-finding"> … the one-sentence headline finding … </div>
+    <div class="dv-stats"> … 3-4 dv-stat tiles … </div>
+
+    <div class="dv-section-kicker">01 — [SECTION]</div>
+    <h2>[SECTION HEADING]</h2>
+    <p> … narrative … </p>
+    <figure class="dv-fig">
+      <div class="dv-fig-title">[CHART TITLE]</div>
+      <div class="dv-fig-sub">[what higher/lower means]</div>
+      <div class="dv-chart" id="chart-[key]" role="img" aria-label="[full text description of the chart]"></div>
+      <details class="dv-data-toggle"><summary>View data table</summary> … <table class="dv-table"> … </details>
+      <figcaption><strong>Source:</strong> [citation].</figcaption>
+    </figure>
+
+    … repeat sections …
+
+    <div class="dv-method"> "How to read this responsibly" — stocks vs flows, association≠causation, coverage caveats </div>
+    <div class="dv-method"> "Sources & data" — <ul class="dv-sources"> linked </ul> </div>
+    <div class="dv-related"> "Go deeper on ImpactMojo" — link to matching Deep Dives / courses </div>
+    <div class="dv-cite-block"> suggested citation </div>
+    <div class="dv-cta"> "Have a dataset worth digging into?" → /contact.html?topic=DataDive </div>
+
+  Chart API (see the reference file's <script>):
+    barChart(mountId, { data:[{label,value,hl?}], max, ticks:[…], avg:{value,label}, suffix?, tipLabel? })
+    scatterChart(mountId, { data:[{label,x,y}], xMin, xMax, yMax, xTicks:[…], yTicks:[…] })
+-->
+</head>
+<body>
+<p>This is an authoring stub. Copy <code>/DataDives/state-welfare-budgets.html</code> to begin a real Data Dive.</p>
+</body>
+</html>

--- a/DataDives/index.html
+++ b/DataDives/index.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Data Dives — Independent Data Investigations | ImpactMojo</title>
+<meta name="description" content="Independent data investigations built from public data — original charts, a clear argument, and an honest account of what the numbers can and can't show. Free, browser-based, no login.">
+<link rel="canonical" href="https://www.impactmojo.in/DataDives/index.html">
+<meta name="robots" content="index, follow">
+
+<meta property="og:type" content="website">
+<meta property="og:title" content="Data Dives — Independent Data Investigations | ImpactMojo">
+<meta property="og:description" content="Independent data investigations built from public data — original charts, a clear argument, and an honest account of the numbers.">
+<meta property="og:url" content="https://impactmojo.in/DataDives/">
+<meta property="og:image" content="https://impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<meta property="og:site_name" content="ImpactMojo">
+<meta name="twitter:card" content="summary_large_image">
+
+<link rel="icon" href="/assets/images/ImpactMojo%20Logo.png" type="image/png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-JRCMEB9TBW');
+</script>
+
+<style>
+:root {
+    --im-gradient: linear-gradient(135deg, #2563EB 0%, #4338CA 100%);
+    --im-accent: #2563EB;
+    --im-nav-bg: rgba(15, 23, 42, 0.95);
+    --im-border: #334155;
+    --im-text-primary: #F1F5F9;
+    --im-text-secondary: #94A3B8;
+    --im-text-muted: #64748B;
+    --im-card-bg: #1E293B;
+    --im-hover-bg: #334155;
+    --im-secondary-bg: #1E293B;
+    --dv-bg: #FAF7F2;
+    --dv-surface: #FFFFFF;
+    --dv-border: #E5DDD0;
+    --dv-text: #1A1A1A;
+    --dv-text-soft: #3F3F46;
+    --dv-muted: #6B6560;
+    --dv-accent: #2563EB;
+    --dv-accent-soft: #EAF1FE;
+    --dv-teal: #0F766E;
+    --dv-teal-soft: #E7F3F1;
+}
+html.dark {
+    --dv-bg: #0F172A;
+    --dv-surface: #1E293B;
+    --dv-border: #334155;
+    --dv-text: #F1F5F9;
+    --dv-text-soft: #CBD5E1;
+    --dv-muted: #94A3B8;
+    --dv-accent: #60A5FA;
+    --dv-accent-soft: rgba(96, 165, 250, 0.12);
+    --dv-teal: #2DD4BF;
+    --dv-teal-soft: rgba(45, 212, 191, 0.10);
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { padding-top: 56px; background: var(--dv-bg); color: var(--dv-text); font-family: 'Amaranth', Arial, sans-serif; line-height: 1.7; }
+
+.im-topbar { position: fixed; top: 0; left: 0; right: 0; z-index: 9999; background: var(--im-nav-bg); backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px); border-bottom: 1px solid var(--im-border); padding: 0.5rem 1rem; display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; flex-wrap: wrap; font-family: 'Inter', sans-serif; }
+.im-topbar a { text-decoration: none; }
+.im-topbar-left { display: flex; align-items: center; gap: 0.75rem; }
+.im-topbar-home { display: flex; align-items: center; gap: 0.5rem; font-weight: 700; font-size: 1rem; color: #2563EB; }
+.im-topbar-home img { width: 24px; height: 24px; border-radius: 4px; }
+.im-topbar-right { display: flex; align-items: center; gap: 0.5rem; }
+.im-premium-btn { background: var(--im-gradient); color: #fff; padding: 0.35rem 0.85rem; border-radius: 6px; font-size: 0.8rem; font-weight: 600; display: flex; align-items: center; gap: 0.35rem; }
+.im-browse-btn { display: inline-flex; align-items: center; gap: 0.4rem; font-family: 'Inter', sans-serif; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: #1C1917; background: #FFFFFF; border: 1.5px solid #E2E8F0; padding: 0.5rem 1rem; border-radius: 0.5rem; text-decoration: none; transition: all 0.18s ease; }
+.im-browse-btn:hover { background: var(--im-accent); color: #FFFFFF; border-color: var(--im-accent); transform: translateY(-1px); }
+.im-browse-btn svg { width: 14px; height: 14px; }
+@media (prefers-color-scheme: dark) { .im-browse-btn { color: rgba(255,255,255,0.9); background: rgba(255,255,255,0.05); border-color: rgba(255,255,255,0.18); } }
+.im-premium-btn svg { width: 14px; height: 14px; }
+.im-theme-selector { display: flex; gap: 2px; background: var(--im-card-bg); border: 1px solid var(--im-border); border-radius: 8px; padding: 2px; }
+.im-theme-btn { background: transparent; border: none; color: var(--im-text-secondary); padding: 6px; border-radius: 5px; cursor: pointer; transition: all 0.2s; display: flex; align-items: center; justify-content: center; width: 30px; height: 30px; }
+.im-theme-btn:hover { background: var(--im-hover-bg); color: var(--im-text-primary); }
+.im-theme-btn.active { background: var(--im-accent); color: #fff; }
+.im-theme-btn svg { width: 16px; height: 16px; }
+.im-skip-link { position: absolute; top: -40px; left: 0; background: var(--im-accent); color: #fff; padding: 8px 16px; z-index: 10000; text-decoration: none; font-family: 'Inter', sans-serif; font-size: 0.85rem; font-weight: 600; }
+.im-skip-link:focus { top: 0; }
+
+.dv-wrap { max-width: 1100px; margin: 0 auto; padding: 3rem 1.25rem 4rem; }
+.dv-eyebrow { display: inline-flex; align-items: center; gap: .5rem; font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; color: var(--dv-accent); margin-bottom: 1rem; }
+.dv-eyebrow::before { content: ""; width: 26px; height: 2px; background: var(--dv-accent); border-radius: 2px; }
+.dv-page-title { font-family: 'Inter', sans-serif; font-size: clamp(2rem, 5vw, 3rem); font-weight: 800; letter-spacing: -0.02em; line-height: 1.12; margin-bottom: 1rem; color: var(--dv-text); }
+.dv-page-lede { font-size: 1.2rem; color: var(--dv-text-soft); max-width: 720px; line-height: 1.6; margin-bottom: 1rem; }
+.dv-intro { font-family: 'Inter', sans-serif; font-size: .9rem; color: var(--dv-muted); margin-bottom: 2.5rem; max-width: 720px; line-height: 1.6; }
+.dv-intro strong { color: var(--dv-text-soft); }
+.dv-intro a { color: var(--dv-accent); text-decoration: none; border-bottom: 1px dotted var(--dv-accent); }
+
+.dv-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 1.25rem; }
+.dv-card { background: var(--dv-surface); border: 1px solid var(--dv-border); border-radius: 14px; padding: 1.6rem; display: flex; flex-direction: column; transition: transform .2s, border-color .2s, box-shadow .2s; text-decoration: none; color: inherit; }
+.dv-card:hover { transform: translateY(-3px); border-color: var(--dv-accent); box-shadow: 0 10px 28px rgba(37,99,235,.10); }
+.dv-card-top { display: flex; align-items: center; gap: .5rem; margin-bottom: .85rem; }
+.dv-card-topic { font-family: 'Inter', sans-serif; font-size: 10px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; color: var(--dv-accent); background: var(--dv-accent-soft); padding: .25rem .6rem; border-radius: 5px; }
+.dv-card-charts { margin-left: auto; font-family: 'Inter', sans-serif; font-size: .72rem; font-weight: 600; color: var(--dv-teal); display: inline-flex; align-items: center; gap: .3rem; }
+.dv-card-title { font-family: 'Inter', sans-serif; font-size: 1.4rem; font-weight: 800; line-height: 1.2; margin-bottom: .55rem; color: var(--dv-text); letter-spacing: -0.01em; }
+.dv-card-tagline { font-size: .98rem; color: var(--dv-muted); line-height: 1.55; margin-bottom: 1.15rem; flex: 1; }
+.dv-card-meta { display: flex; align-items: center; gap: .6rem; padding-top: .85rem; border-top: 1px solid var(--dv-border); font-family: 'Inter', sans-serif; font-size: .78rem; color: var(--dv-muted); flex-wrap: wrap; }
+.dv-card-author { font-weight: 600; color: var(--dv-text-soft); }
+.dv-card-dataset { margin-left: auto; padding: .15rem .5rem; border-radius: 4px; background: var(--dv-teal-soft); color: var(--dv-teal); font-weight: 600; font-size: .72rem; }
+
+.dv-empty { text-align: center; padding: 3rem 1rem; color: var(--dv-muted); font-family: 'Inter', sans-serif; grid-column: 1 / -1; }
+
+.dv-pitch { margin: 4rem 0 0; padding: 2.5rem; background: var(--dv-accent-soft); border-radius: 14px; text-align: center; }
+.dv-pitch h2 { font-family: 'Inter', sans-serif; font-size: 1.5rem; margin-bottom: .75rem; color: var(--dv-accent); }
+.dv-pitch p { font-size: 1rem; color: var(--dv-text-soft); max-width: 600px; margin: 0 auto 1.5rem; line-height: 1.6; }
+.dv-pitch a { display: inline-block; background: var(--dv-accent); color: #fff !important; font-family: 'Inter', sans-serif; font-weight: 600; padding: .75rem 1.75rem; border-radius: 8px; text-decoration: none; }
+
+.im-footer { background: var(--im-secondary-bg); border-top: 1px solid var(--im-border); padding: 2rem 1rem; margin-top: 4rem; font-family: 'Inter', sans-serif; color: var(--im-text-secondary); }
+.im-footer-content { max-width: 1100px; margin: 0 auto; }
+.im-footer-made { text-align: center; margin-bottom: 1.5rem; font-size: 0.9rem; color: var(--im-text-muted); }
+.im-footer-made a { color: var(--im-accent); text-decoration: none; }
+.im-footer-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1.5rem; margin-bottom: 1.5rem; }
+.im-footer-section h4 { color: var(--im-text-primary); font-size: 0.9rem; margin-bottom: 0.75rem; font-weight: 600; }
+.im-footer-section ul { list-style: none; padding: 0; margin: 0; }
+.im-footer-section li { margin-bottom: 0.4rem; }
+.im-footer-section a { color: var(--im-text-secondary); font-size: 0.85rem; text-decoration: none; transition: color 0.2s; }
+.im-footer-section a:hover { color: var(--im-accent); }
+.im-footer-bottom { text-align: center; padding-top: 1rem; border-top: 1px solid var(--im-border); font-size: 0.8rem; color: var(--im-text-muted); }
+.im-footer-bottom a { color: var(--im-accent); text-decoration: none; }
+
+@media (max-width: 640px) {
+    .dv-wrap { padding: 2rem 1rem 3rem; }
+    .dv-grid { grid-template-columns: 1fr; }
+}
+</style>
+<link href="/assets/images/favicon.png" rel="icon" type="image/png">
+</head>
+<body>
+<a href="#main-content" class="im-skip-link">Skip to content</a>
+
+<header class="im-topbar" role="banner">
+  <div class="im-topbar-left">
+    <a class="im-topbar-home" href="/" aria-label="ImpactMojo home">
+      <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo">
+      <span>ImpactMojo</span>
+    </a>
+  </div>
+  <div class="im-topbar-right">
+    <a href="/catalog.html" class="im-browse-btn" title="Browse all content"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>Browse</a>
+    <a class="im-premium-btn" href="/premium.html">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+      Premium
+    </a>
+    <div class="im-theme-selector" role="group" aria-label="Theme">
+      <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="System theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Light theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Dark theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+    </div>
+  </div>
+</header>
+
+<main id="main-content" class="dv-wrap">
+  <div class="dv-eyebrow">ImpactMojo</div>
+  <h1 class="dv-page-title">Data Dives</h1>
+  <p class="dv-page-lede">Independent data investigations — where we take one public dataset, dig in, and show you what it really says.</p>
+  <p class="dv-intro">Each Data Dive starts from a number that deserves a second look. We chart it ourselves, make an argument, and — just as importantly — spell out what the data <strong>can't</strong> tell you. Every source is linked; every chart has a data table behind it. Free, browser-based, no login. New investigations as the data lands. Looking for annotated reading lists instead? Those are our <a href="/DeepDives/">Deep Dives</a>.</p>
+
+  <div class="dv-grid" id="dvGrid"></div>
+
+  <section class="dv-pitch">
+    <h2>Have a dataset worth digging into?</h2>
+    <p>If you know a number — a budget line, a survey result, an administrative figure — that deserves a closer, honest look, pitch us. We build the charts and show our working.</p>
+    <a href="/contact.html?topic=DataDive">Pitch a Data Dive →</a>
+  </section>
+</main>
+
+<footer class="im-footer" role="contentinfo">
+  <div class="im-footer-content">
+    <p class="im-footer-made">Made with ♥ by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+    <div class="im-footer-grid">
+      <div class="im-footer-section"><h4>About ImpactMojo</h4><ul>
+        <li><a href="/about.html">About Us</a></li>
+        <li><a href="/contact.html">Contact</a></li>
+        <li><a href="https://github.com/ImpactMojo/ImpactMojo" rel="noopener noreferrer" target="_blank">GitHub</a></li>
+        <li><a href="/transparency.html">Transparency</a></li>
+      </ul></div>
+      <div class="im-footer-section"><h4>Legal</h4><ul>
+        <li><a href="/privacy-policy.html">Privacy Policy</a></li>
+        <li><a href="/terms-of-service.html">Terms of Service</a></li>
+        <li><a href="/disclaimer.html">Disclaimer</a></li>
+        <li><a href="/data-protection.html">Data Protection</a></li>
+      </ul></div>
+      <div class="im-footer-section"><h4>Quick Links</h4><ul>
+        <li><a href="/catalog.html">All Courses</a></li>
+        <li><a href="/DataDives/">Data Dives</a></li>
+        <li><a href="/DeepDives/">Deep Dives</a></li>
+        <li><a href="/premium.html">Premium</a></li>
+      </ul></div>
+      <div class="im-footer-section"><h4>Resources</h4><ul>
+        <li><a href="/handouts.html">Handouts</a></li>
+        <li><a href="/blog.html">Blog</a></li>
+        <li><a href="/faq.html">FAQ</a></li>
+        <li><a href="/sitemap.html">Sitemap</a></li>
+      </ul></div>
+    </div>
+    <div class="im-footer-bottom">
+      <p>&copy; 2026 ImpactMojo. All content for educational purposes only.</p>
+      <p>Released under <strong>MIT License</strong> | Supported by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+    </div>
+  </div>
+</footer>
+
+<script src="/js/theme.js"></script>
+
+<script>
+// Render the Data Dives grid from registry
+(async function() {
+    const grid = document.getElementById('dvGrid');
+    let dives = [];
+    try {
+        const res = await fetch('/data/data-dives.json');
+        const json = await res.json();
+        dives = json.data_dives || [];
+    } catch (e) {
+        grid.innerHTML = '<p class="dv-empty">Could not load Data Dives. Please try again.</p>';
+        return;
+    }
+    if (!dives.length) {
+        grid.innerHTML = '<p class="dv-empty">The first Data Dive is on its way.</p>';
+        return;
+    }
+    grid.innerHTML = dives.map(d => `
+        <a class="dv-card" href="${d.url}">
+            <div class="dv-card-top">
+                <span class="dv-card-topic">${d.topic}</span>
+                <span class="dv-card-charts">${d.chart_count} charts · ${d.read_time}</span>
+            </div>
+            <div class="dv-card-title">${d.title}</div>
+            <p class="dv-card-tagline">${d.tagline}</p>
+            <div class="dv-card-meta">
+                <span class="dv-card-author">${d.author}</span>
+                <span class="dv-card-dataset">${d.dataset}</span>
+            </div>
+        </a>
+    `).join('');
+})();
+</script>
+
+<!-- Supabase Auth (deferred, non-blocking) -->
+<script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script defer src="/js/state-manager.js"></script>
+<script defer src="/js/config.js"></script>
+<script defer src="/js/auth.js"></script>
+<script src="/js/translate-sarvam.js" defer></script>
+<script src="/js/site-chrome.js" defer></script>
+</body>
+</html>

--- a/DataDives/state-welfare-budgets.html
+++ b/DataDives/state-welfare-budgets.html
@@ -1,0 +1,747 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>The Welfare Spending Paradox — Why India's Biggest Social Spenders Have the Worst Outcomes | ImpactMojo Data Dive</title>
+<meta name="description" content="An independent data investigation into how Indian states budget for welfare. Jharkhand and Bihar spend the largest share on social sectors and still record the worst maternal and nutrition outcomes; Kerala and Tamil Nadu spend less and lead. What the RBI's 2025-26 state-budget data really shows.">
+<link rel="canonical" href="https://www.impactmojo.in/DataDives/state-welfare-budgets.html">
+<meta name="robots" content="index, follow">
+
+<meta property="og:type" content="article">
+<meta property="og:title" content="The Welfare Spending Paradox — A Data Dive on State Budgets">
+<meta property="og:description" content="India's biggest social-sector spenders record its worst welfare outcomes, while the states that spend the least pull ahead. An independent look at the RBI's 2025-26 state-budget numbers.">
+<meta property="og:url" content="https://www.impactmojo.in/DataDives/state-welfare-budgets.html">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<meta property="og:site_name" content="ImpactMojo">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="The Welfare Spending Paradox — A Data Dive on State Budgets">
+<meta name="twitter:description" content="India's biggest social-sector spenders record its worst welfare outcomes. What the RBI's 2025-26 state-budget data really shows.">
+
+<link rel="icon" href="/assets/images/favicon.png" type="image/png">
+<link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+
+<!-- Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-JRCMEB9TBW');
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "The Welfare Spending Paradox — Why India's Biggest Social Spenders Have the Worst Outcomes",
+  "description": "An independent data investigation into how Indian states budget for welfare, using the RBI's State Finances: A Study of Budgets 2025-26.",
+  "image": "https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png",
+  "author": { "@type": "Organization", "name": "ImpactMojo Data" },
+  "publisher": {
+    "@type": "Organization",
+    "name": "ImpactMojo",
+    "logo": { "@type": "ImageObject", "url": "https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" }
+  },
+  "datePublished": "2026-07-11",
+  "mainEntityOfPage": "https://www.impactmojo.in/DataDives/state-welfare-budgets.html",
+  "isAccessibleForFree": true
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "ImpactMojo", "item": "https://www.impactmojo.in/" },
+    { "@type": "ListItem", "position": 2, "name": "Data Dives", "item": "https://www.impactmojo.in/DataDives/" },
+    { "@type": "ListItem", "position": 3, "name": "The Welfare Spending Paradox" }
+  ]
+}
+</script>
+
+<style>
+/* === ImpactMojo Brand Topbar / Footer === */
+:root {
+    --im-gradient: linear-gradient(135deg, #2563EB 0%, #4338CA 100%);
+    --im-accent: #2563EB;
+    --im-nav-bg: rgba(15, 23, 42, 0.95);
+    --im-border: #334155;
+    --im-text-primary: #F1F5F9;
+    --im-text-secondary: #94A3B8;
+    --im-text-muted: #64748B;
+    --im-card-bg: #1E293B;
+    --im-hover-bg: #334155;
+    --im-secondary-bg: #1E293B;
+}
+body { padding-top: 56px !important; margin: 0; }
+.im-topbar { position: fixed; top: 0; left: 0; right: 0; z-index: 9999; background: var(--im-nav-bg); backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px); border-bottom: 1px solid var(--im-border); padding: 0.5rem 1rem; display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; flex-wrap: wrap; font-family: 'Inter', 'Amaranth', sans-serif; }
+.im-topbar a { text-decoration: none; }
+.im-topbar-left { display: flex; align-items: center; gap: 0.75rem; }
+.im-topbar-home { display: flex; align-items: center; gap: 0.5rem; font-weight: 700; font-size: 1rem; color: #2563EB; }
+.im-topbar-home img { width: 24px; height: 24px; border-radius: 4px; }
+.im-topbar-right { display: flex; align-items: center; gap: 0.5rem; }
+.im-premium-btn { background: var(--im-gradient); color: #fff; padding: 0.35rem 0.85rem; border-radius: 6px; font-size: 0.8rem; font-weight: 600; display: flex; align-items: center; gap: 0.35rem; }
+.im-browse-btn { display: inline-flex; align-items: center; gap: 0.4rem; font-family: 'Inter', sans-serif; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: var(--im-text, #1C1917); background: var(--im-surface, #FFFFFF); border: 1.5px solid var(--im-border, #E2E8F0); padding: 0.5rem 1rem; border-radius: 0.5rem; text-decoration: none; transition: background 0.18s ease, border-color 0.18s ease, transform 0.15s ease, box-shadow 0.18s ease; }
+.im-browse-btn:hover { background: var(--im-accent, #2563EB); color: #FFFFFF; border-color: var(--im-accent, #2563EB); transform: translateY(-1px); box-shadow: 0 4px 12px rgba(37, 99, 235, 0.25); }
+.im-browse-btn svg { width: 14px; height: 14px; }
+@media (prefers-color-scheme: dark) { .im-browse-btn { color: rgba(255,255,255,0.9); background: rgba(255,255,255,0.05); border-color: rgba(255,255,255,0.18); } .im-browse-btn:hover { background: var(--im-accent, #2563EB); border-color: var(--im-accent, #2563EB); color: #FFFFFF; } }
+.im-premium-btn svg { width: 14px; height: 14px; }
+.im-theme-selector { display: flex; gap: 2px; background: var(--im-card-bg); border: 1px solid var(--im-border); border-radius: 8px; padding: 2px; }
+.im-theme-btn { background: transparent; border: none; color: var(--im-text-secondary); padding: 6px; border-radius: 5px; cursor: pointer; transition: all 0.2s; display: flex; align-items: center; justify-content: center; width: 30px; height: 30px; }
+.im-theme-btn:hover { background: var(--im-hover-bg); color: var(--im-text-primary); }
+.im-theme-btn.active { background: var(--im-accent); color: #fff; }
+.im-theme-btn svg { width: 16px; height: 16px; }
+.im-skip-link { position: absolute; left: -999px; top: 0; background: var(--im-accent); color: #fff; padding: .5rem 1rem; z-index: 10000; border-radius: 0 0 6px 0; }
+.im-skip-link:focus { left: 0; }
+
+.im-footer { background: var(--im-secondary-bg); border-top: 1px solid var(--im-border); padding: 2rem 1rem; margin-top: 4rem; font-family: 'Inter', 'Amaranth', sans-serif; color: var(--im-text-secondary); }
+.im-footer-content { max-width: 1100px; margin: 0 auto; }
+.im-footer-made { text-align: center; margin-bottom: 1.5rem; font-size: 0.9rem; color: var(--im-text-muted); }
+.im-footer-made a { color: var(--im-accent); }
+.im-footer-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1.5rem; margin-bottom: 1.5rem; }
+.im-footer-section h4 { color: var(--im-text-primary); font-size: 0.9rem; margin-bottom: 0.75rem; font-weight: 600; }
+.im-footer-section ul { list-style: none; padding: 0; margin: 0; }
+.im-footer-section li { margin-bottom: 0.4rem; }
+.im-footer-section a { color: var(--im-text-secondary); font-size: 0.85rem; transition: color 0.2s; }
+.im-footer-section a:hover { color: var(--im-accent); }
+.im-footer-bottom { text-align: center; padding-top: 1rem; border-top: 1px solid var(--im-border); font-size: 0.8rem; color: var(--im-text-muted); }
+.im-footer-bottom a { color: var(--im-accent); }
+
+/* === Data Dive design tokens === */
+:root {
+    --dv-bg: #FAF7F2;
+    --dv-surface: #FFFFFF;
+    --dv-surface-2: #F4EFE7;
+    --dv-border: #E5DDD0;
+    --dv-text: #1A1A1A;
+    --dv-text-soft: #3F3F46;
+    --dv-muted: #6B6560;
+    --dv-accent: #2563EB;
+    --dv-accent-soft: #EAF1FE;
+    --dv-teal: #0F766E;
+    --dv-teal-soft: #E7F3F1;
+    --dv-radius: 12px;
+    /* chart roles */
+    --dv-series: #2563EB;
+    --dv-series-soft: #BFD4FB;
+    --dv-avg: #B45309;
+    --dv-good: #15803D;
+    --dv-bad: #B91C1C;
+    --dv-grid: #E7DFD2;
+    --dv-axis: #C9BFAE;
+    --dv-ink: #1A1A1A;
+    --dv-ink-soft: #6B6560;
+    --dv-chart-surface: #FFFFFF;
+}
+html.dark {
+    --dv-bg: #0F172A;
+    --dv-surface: #1E293B;
+    --dv-surface-2: #172033;
+    --dv-border: #334155;
+    --dv-text: #F1F5F9;
+    --dv-text-soft: #CBD5E1;
+    --dv-muted: #94A3B8;
+    --dv-accent: #60A5FA;
+    --dv-accent-soft: rgba(96, 165, 250, 0.12);
+    --dv-teal: #2DD4BF;
+    --dv-teal-soft: rgba(45, 212, 191, 0.10);
+    --dv-series: #60A5FA;
+    --dv-series-soft: rgba(96, 165, 250, 0.30);
+    --dv-avg: #FBBF24;
+    --dv-good: #4ADE80;
+    --dv-bad: #F87171;
+    --dv-grid: #2A3852;
+    --dv-axis: #475569;
+    --dv-ink: #F1F5F9;
+    --dv-ink-soft: #94A3B8;
+    --dv-chart-surface: #1E293B;
+}
+* { box-sizing: border-box; }
+html, body { background: var(--dv-bg); color: var(--dv-text); font-family: 'Amaranth', Arial, sans-serif; line-height: 1.7; }
+.dv-wrap { max-width: 800px; margin: 0 auto; padding: 2.25rem 1.25rem 4rem; }
+
+.dv-back { display: inline-block; margin-bottom: 1.5rem; font-family: 'Inter', sans-serif; font-size: .85rem; color: var(--dv-muted); text-decoration: none; }
+.dv-back:hover { color: var(--dv-accent); }
+
+/* Hero */
+.dv-eyebrow { display: inline-flex; align-items: center; gap: .5rem; font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; color: var(--dv-accent); margin-bottom: 1rem; }
+.dv-eyebrow::before { content: ""; width: 26px; height: 2px; background: var(--dv-accent); border-radius: 2px; }
+.dv-title { font-family: 'Inter', sans-serif; font-size: clamp(1.9rem, 4.5vw, 2.9rem); font-weight: 800; letter-spacing: -0.02em; line-height: 1.12; margin: 0 0 .9rem; color: var(--dv-text); }
+.dv-standfirst { font-size: 1.2rem; color: var(--dv-text-soft); line-height: 1.6; margin-bottom: 1.5rem; }
+.dv-byline { display: flex; flex-wrap: wrap; align-items: center; gap: .5rem .9rem; font-family: 'Inter', sans-serif; font-size: .82rem; color: var(--dv-muted); padding-bottom: 1.5rem; margin-bottom: 2.25rem; border-bottom: 1px solid var(--dv-border); }
+.dv-byline strong { color: var(--dv-text-soft); font-weight: 600; }
+.dv-byline .dv-dot { color: var(--dv-border); }
+.dv-tag { font-family: 'Inter', sans-serif; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; padding: .2rem .55rem; border-radius: 4px; background: var(--dv-accent-soft); color: var(--dv-accent); }
+
+/* Body prose */
+.dv-prose p { font-size: 1.08rem; line-height: 1.8; color: var(--dv-text-soft); margin: 0 0 1.25rem; }
+.dv-prose h2 { font-family: 'Inter', sans-serif; font-size: 1.55rem; font-weight: 700; letter-spacing: -0.01em; color: var(--dv-text); margin: 2.75rem 0 1rem; line-height: 1.25; }
+.dv-prose h3 { font-family: 'Inter', sans-serif; font-size: 1.15rem; font-weight: 700; color: var(--dv-text); margin: 2rem 0 .5rem; }
+.dv-prose a { color: var(--dv-accent); text-decoration: none; border-bottom: 1px solid rgba(37,99,235,.3); }
+.dv-prose a:hover { border-bottom-color: var(--dv-accent); }
+.dv-prose strong { color: var(--dv-text); font-weight: 700; }
+.dv-section-kicker { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; color: var(--dv-accent); margin: 2.75rem 0 .35rem; }
+.dv-section-kicker + h2 { margin-top: .15rem; }
+
+/* Pull finding */
+.dv-finding { margin: 2rem 0; padding: 1.5rem 1.75rem; background: var(--dv-surface); border: 1px solid var(--dv-border); border-left: 4px solid var(--dv-accent); border-radius: 0 var(--dv-radius) var(--dv-radius) 0; }
+.dv-finding-label { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; color: var(--dv-accent); margin-bottom: .6rem; }
+.dv-finding p { font-size: 1.12rem; line-height: 1.65; color: var(--dv-text); margin: 0; font-family: 'Inter', sans-serif; font-weight: 500; }
+
+/* Stat tiles */
+.dv-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: .85rem; margin: 2rem 0 2.5rem; }
+.dv-stat { background: var(--dv-surface); border: 1px solid var(--dv-border); border-radius: var(--dv-radius); padding: 1.15rem 1.15rem 1rem; }
+.dv-stat-num { font-family: 'Inter', sans-serif; font-size: 2rem; font-weight: 800; letter-spacing: -0.02em; color: var(--dv-accent); line-height: 1; margin-bottom: .35rem; font-variant-numeric: tabular-nums; }
+.dv-stat-label { font-family: 'Inter', sans-serif; font-size: .82rem; line-height: 1.4; color: var(--dv-muted); }
+.dv-stat-label strong { color: var(--dv-text-soft); font-weight: 600; }
+
+/* Figure / chart */
+figure.dv-fig { margin: 2.25rem 0; padding: 1.5rem 1.25rem 1.1rem; background: var(--dv-chart-surface); border: 1px solid var(--dv-border); border-radius: var(--dv-radius); }
+.dv-fig-title { font-family: 'Inter', sans-serif; font-size: 1.08rem; font-weight: 700; color: var(--dv-text); margin: 0 0 .2rem; }
+.dv-fig-sub { font-family: 'Inter', sans-serif; font-size: .85rem; color: var(--dv-muted); margin: 0 0 1rem; line-height: 1.5; }
+.dv-chart svg { width: 100%; height: auto; display: block; overflow: visible; font-family: 'Inter', sans-serif; }
+.dv-fig figcaption { font-family: 'Inter', sans-serif; font-size: .78rem; color: var(--dv-muted); margin-top: 1rem; line-height: 1.5; }
+.dv-fig figcaption strong { color: var(--dv-text-soft); font-weight: 600; }
+
+/* Chart primitives */
+.dv-bar { fill: var(--dv-series); }
+.dv-bar.hl { fill: var(--dv-accent); }
+.dv-bar-track { fill: var(--dv-series-soft); opacity: .28; }
+.dv-bar-lbl { fill: var(--dv-ink); font-size: 13px; font-weight: 600; }
+.dv-bar-val { fill: var(--dv-ink); font-size: 13px; font-weight: 700; font-variant-numeric: tabular-nums; }
+.dv-grid-line { stroke: var(--dv-grid); stroke-width: 1; }
+.dv-axis-line { stroke: var(--dv-axis); stroke-width: 1; }
+.dv-tick { fill: var(--dv-muted); font-size: 11px; font-variant-numeric: tabular-nums; }
+.dv-ref-line { stroke: var(--dv-avg); stroke-width: 1.5; stroke-dasharray: 5 4; }
+.dv-ref-lbl { fill: var(--dv-avg); font-size: 11px; font-weight: 700; }
+.dv-dot { fill: var(--dv-series); stroke: var(--dv-chart-surface); stroke-width: 2; }
+.dv-dot-lbl { fill: var(--dv-ink); font-size: 12px; font-weight: 700; }
+.dv-dot-sub { fill: var(--dv-muted); font-size: 10.5px; font-variant-numeric: tabular-nums; }
+.dv-axis-title { fill: var(--dv-muted); font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .06em; }
+.dv-bargroup { cursor: default; }
+.dv-bargroup:hover .dv-bar { fill: var(--dv-accent); }
+
+/* Table fallback */
+.dv-data-toggle { margin-top: .85rem; }
+.dv-data-toggle summary { font-family: 'Inter', sans-serif; font-size: .8rem; font-weight: 600; color: var(--dv-accent); cursor: pointer; list-style: none; display: inline-flex; align-items: center; gap: .35rem; }
+.dv-data-toggle summary::-webkit-details-marker { display: none; }
+.dv-data-toggle summary::before { content: "▸"; font-size: .7rem; }
+.dv-data-toggle[open] summary::before { content: "▾"; }
+.dv-table { width: 100%; border-collapse: collapse; margin-top: .85rem; font-family: 'Inter', sans-serif; font-size: .85rem; }
+.dv-table th, .dv-table td { text-align: left; padding: .45rem .6rem; border-bottom: 1px solid var(--dv-border); }
+.dv-table th { color: var(--dv-muted); font-weight: 600; font-size: .75rem; text-transform: uppercase; letter-spacing: .05em; }
+.dv-table td { color: var(--dv-text-soft); }
+.dv-table td.num { text-align: right; font-variant-numeric: tabular-nums; font-weight: 600; color: var(--dv-text); }
+
+/* Tooltip */
+.dv-tip { position: fixed; z-index: 10001; pointer-events: none; background: var(--dv-text); color: var(--dv-bg); font-family: 'Inter', sans-serif; font-size: .78rem; line-height: 1.35; padding: .4rem .6rem; border-radius: 6px; box-shadow: 0 6px 18px rgba(0,0,0,.25); opacity: 0; transform: translateY(4px); transition: opacity .12s; max-width: 220px; }
+.dv-tip.show { opacity: 1; transform: translateY(0); }
+.dv-tip b { color: #fff; }
+html.dark .dv-tip { background: #F1F5F9; color: #0F172A; }
+html.dark .dv-tip b { color: #0F172A; }
+
+/* Methodology / sources */
+.dv-method { margin: 2.75rem 0; padding: 1.5rem 1.75rem; background: var(--dv-surface-2); border: 1px solid var(--dv-border); border-radius: var(--dv-radius); }
+.dv-method-label { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; color: var(--dv-muted); margin-bottom: .85rem; }
+.dv-method p, .dv-method li { font-family: 'Inter', sans-serif; font-size: .9rem; line-height: 1.65; color: var(--dv-text-soft); }
+.dv-method p { margin: 0 0 .85rem; }
+.dv-method ul { margin: 0; padding-left: 1.15rem; }
+.dv-method li { margin-bottom: .45rem; }
+.dv-sources { list-style: none; padding: 0; margin: .5rem 0 0; }
+.dv-sources li { font-family: 'Inter', sans-serif; font-size: .88rem; line-height: 1.55; color: var(--dv-text-soft); padding: .4rem 0; border-top: 1px solid var(--dv-border); }
+.dv-sources li:first-child { border-top: none; }
+.dv-sources a { color: var(--dv-accent); text-decoration: none; border-bottom: 1px dotted var(--dv-accent); }
+
+/* Related + cite + CTA */
+.dv-related { padding: 1.5rem 1.75rem; background: var(--dv-teal-soft); border-radius: var(--dv-radius); margin: 2.5rem 0; }
+.dv-related-label { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; color: var(--dv-teal); margin-bottom: .85rem; }
+.dv-related ul { list-style: none; padding: 0; margin: 0; display: grid; gap: .55rem; }
+.dv-related li { font-family: 'Inter', sans-serif; font-size: .95rem; }
+.dv-related a { color: var(--dv-text); text-decoration: none; border-bottom: 1px dotted var(--dv-teal); }
+.dv-related a:hover { color: var(--dv-teal); }
+.dv-cite-block { padding: 1.25rem 1.5rem; background: var(--dv-surface); border: 1px dashed var(--dv-border); border-radius: var(--dv-radius); margin: 2rem 0; }
+.dv-cite-label { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; color: var(--dv-muted); margin-bottom: .5rem; }
+.dv-cite-text { font-family: 'Inter', sans-serif; font-size: .88rem; color: var(--dv-text-soft); line-height: 1.6; }
+.dv-cta { padding: 1.75rem; background: var(--dv-accent-soft); border-radius: var(--dv-radius); text-align: center; margin-top: 2.5rem; }
+.dv-cta h3 { font-family: 'Inter', sans-serif; font-size: 1.2rem; margin: 0 0 .5rem; color: var(--dv-accent); }
+.dv-cta p { font-size: .95rem; color: var(--dv-text-soft); margin: 0 0 1rem; }
+.dv-cta a { display: inline-block; background: var(--dv-accent); color: #fff !important; font-family: 'Inter', sans-serif; font-weight: 600; padding: .65rem 1.5rem; border-radius: 8px; text-decoration: none; }
+
+@media (max-width: 640px) {
+    .dv-wrap { padding: 1.5rem 1rem 3rem; }
+    .dv-method, .dv-related, .dv-cta, .dv-finding { padding: 1.25rem; }
+    figure.dv-fig { padding: 1.1rem .75rem 1rem; }
+    .dv-bar-lbl { font-size: 12px; }
+}
+</style>
+</head>
+<body>
+<a href="#main-content" class="im-skip-link">Skip to content</a>
+
+<!-- ImpactMojo Topbar -->
+<header class="im-topbar" role="banner">
+  <div class="im-topbar-left">
+    <a class="im-topbar-home" href="/" aria-label="ImpactMojo home">
+      <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo">
+      <span>ImpactMojo</span>
+    </a>
+  </div>
+  <div class="im-topbar-right">
+    <a href="/catalog.html" class="im-browse-btn" title="Browse all content"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>Browse</a>
+    <a class="im-premium-btn" href="/premium.html">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+      Premium
+    </a>
+    <div class="im-theme-selector" role="group" aria-label="Theme">
+      <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="System theme">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+      </button>
+      <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Light theme">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+      </button>
+      <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Dark theme">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+      </button>
+    </div>
+  </div>
+</header>
+
+<main id="main-content" class="dv-wrap">
+  <a class="dv-back" href="/DataDives/">← All Data Dives</a>
+
+  <!-- HERO -->
+  <div class="dv-eyebrow">Data Dive · Public Finance</div>
+  <h1 class="dv-title">The Welfare Spending Paradox</h1>
+  <p class="dv-standfirst">India's biggest social-sector spenders record some of its worst welfare outcomes — while the states that spend the least on welfare, as a share of their budgets, are the ones pulling ahead. A look at what the numbers behind state budgets actually say, and what they can't.</p>
+  <div class="dv-byline">
+    <span class="dv-tag">Investigation</span>
+    <span><strong>ImpactMojo Data</strong></span>
+    <span class="dv-dot">·</span>
+    <span>11 July 2026</span>
+    <span class="dv-dot">·</span>
+    <span>8 min read</span>
+    <span class="dv-dot">·</span>
+    <span>Source: RBI State Finances 2025-26</span>
+  </div>
+
+  <div class="dv-prose">
+
+    <p>Few budget lines say more about a government's priorities than what it spends on schools, hospitals, nutrition, and welfare. Across the last decade, the "social sector" has become the single largest component of state spending in India. But averages hide a striking divergence: some states devote more than half of their budgets to social sectors, while others allocate barely a fifth — and the two groups are not who you would guess.</p>
+
+    <div class="dv-finding">
+      <div class="dv-finding-label">The finding</div>
+      <p>The states that budget the <em>largest</em> share for welfare — Jharkhand, West Bengal, Bihar, Chhattisgarh — also carry the country's worst maternal mortality, anaemia, and multidimensional-poverty numbers. The states near the <em>bottom</em> of the spending table — Kerala, Tamil Nadu — post the best outcomes in the country. High spending is tracking poor outcomes, not curing them.</p>
+    </div>
+
+    <div class="dv-stats">
+      <div class="dv-stat">
+        <div class="dv-stat-num">42.2%</div>
+        <div class="dv-stat-label">of the average state budget goes to <strong>social sectors</strong> (2025-26)</div>
+      </div>
+      <div class="dv-stat">
+        <div class="dv-stat-num">54.8%</div>
+        <div class="dv-stat-label"><strong>Jharkhand</strong> — the highest social-sector share of any state</div>
+      </div>
+      <div class="dv-stat">
+        <div class="dv-stat-num">21.3%</div>
+        <div class="dv-stat-label"><strong>Punjab</strong> — the lowest share among the states analysed</div>
+      </div>
+      <div class="dv-stat">
+        <div class="dv-stat-num">4.9×</div>
+        <div class="dv-stat-label">gap in maternal deaths between top-spender <strong>Chhattisgarh</strong> and low-spender <strong>Kerala</strong></div>
+      </div>
+    </div>
+
+    <div class="dv-section-kicker">01 — The spending spectrum</div>
+    <h2>Who spends the most on welfare?</h2>
+
+    <p>In 2025-26, Jharkhand, West Bengal, Delhi, Chhattisgarh, and Bihar top the table, each directing roughly half of total budgetary spending to the social sector. Jharkhand leads at 54.8% — up from 49.9% a decade earlier. West Bengal's share climbed even faster, from 47.4% to 54.2%. At the other end, Punjab commits just 21.3%, with Kerala and Tamil Nadu also in the bottom five despite their long-standing reputation for strong human development.</p>
+
+    <figure class="dv-fig">
+      <div class="dv-fig-title">Social-sector spending as a share of total budget, 2025-26</div>
+      <div class="dv-fig-sub">Higher bars = a larger share of the state's own budget spent on education, health, nutrition, and welfare. The dashed line is the all-state average.</div>
+      <div class="dv-chart" id="chart-spend" role="img" aria-label="Horizontal bar chart of social-sector spending as a share of total budget for nine states in 2025-26. Jharkhand leads at 54.8 percent, West Bengal 54.2, Delhi 54.1, Chhattisgarh 50.3, Bihar 49.8, all above the 42.2 percent national average; Tamil Nadu 33.6, Kerala 32.2, and Punjab 21.3 fall well below it."></div>
+      <details class="dv-data-toggle"><summary>View data table</summary>
+        <table class="dv-table">
+          <thead><tr><th>State</th><th>Social-sector share (2025-26)</th></tr></thead>
+          <tbody>
+            <tr><td>Jharkhand</td><td class="num">54.8%</td></tr>
+            <tr><td>West Bengal</td><td class="num">54.2%</td></tr>
+            <tr><td>Delhi</td><td class="num">54.1%</td></tr>
+            <tr><td>Chhattisgarh</td><td class="num">50.3%</td></tr>
+            <tr><td>Bihar</td><td class="num">49.8%</td></tr>
+            <tr><td>All-state average</td><td class="num">42.2%</td></tr>
+            <tr><td>Tamil Nadu</td><td class="num">33.6%</td></tr>
+            <tr><td>Kerala</td><td class="num">32.2%</td></tr>
+            <tr><td>Punjab</td><td class="num">21.3%</td></tr>
+          </tbody>
+        </table>
+      </details>
+      <figcaption><strong>Source:</strong> RBI, <em>State Finances: A Study of Budgets of 2025-26</em>. Figures are budget estimates (BE) and exclude north-eastern states and union territories other than Delhi.</figcaption>
+    </figure>
+
+    <p>Read on its own, this table looks like a straightforward story of generosity: poorer, more deprived states spending hard to catch up. And in part it is. Jharkhand, Bihar, and Chhattisgarh are among India's poorest and most populous states; they carry enormous unmet needs in health, education, and nutrition, so a large social-sector share is exactly what you would expect. The puzzle appears only when you put spending next to results.</p>
+
+    <div class="dv-section-kicker">02 — Spending vs outcomes</div>
+    <h2>More money, worse results</h2>
+
+    <p>Take maternal mortality — one of the sharpest tests of whether a health system reaches poor women. Chhattisgarh, which spends 50.3% of its budget on social sectors, records 146 maternal deaths per 100,000 live births — the highest among the states analysed. West Bengal, another heavy spender at 54.2%, records 104, more than triple Kerala's rate. Kerala and Tamil Nadu, both in the <em>bottom</em> five for social-sector share, record 30 and 35 respectively.</p>
+
+    <figure class="dv-fig">
+      <div class="dv-fig-title">Spend more, lose more mothers?</div>
+      <div class="dv-fig-sub">Each dot is a state: its social-sector spending share (left–right) against its maternal mortality ratio (bottom–top). If money bought outcomes on its own, the dots would fall to the lower right. They rise to the upper right instead.</div>
+      <div class="dv-chart" id="chart-scatter" role="img" aria-label="Scatter plot of social-sector spending share against maternal mortality ratio for four states. Kerala (32.2 percent spend, 30 deaths) and Tamil Nadu (33.6 percent, 35) sit in the low-spend, low-mortality corner; West Bengal (54.2 percent, 104) and Chhattisgarh (50.3 percent, 146) sit in the high-spend, high-mortality corner. Higher spending is associated with higher maternal mortality across these four states."></div>
+      <details class="dv-data-toggle"><summary>View data table</summary>
+        <table class="dv-table">
+          <thead><tr><th>State</th><th>Social-sector share</th><th>Maternal deaths / 100k</th></tr></thead>
+          <tbody>
+            <tr><td>Kerala</td><td class="num">32.2%</td><td class="num">30</td></tr>
+            <tr><td>Tamil Nadu</td><td class="num">33.6%</td><td class="num">35</td></tr>
+            <tr><td>West Bengal</td><td class="num">54.2%</td><td class="num">104</td></tr>
+            <tr><td>Chhattisgarh</td><td class="num">50.3%</td><td class="num">146</td></tr>
+          </tbody>
+        </table>
+      </details>
+      <figcaption><strong>Source:</strong> RBI <em>State Finances 2025-26</em> (spending); maternal mortality figures as cited in the RBI analysis. The relationship is <strong>associational, not causal</strong> — see the note on reading this chart below.</figcaption>
+    </figure>
+
+    <p>The same pattern repeats across other measures. Bihar, a big spender, has the highest poverty headcount ratio (33.8%) and the highest multidimensional-poverty index of the group; nearly two-thirds of its pregnant women are anaemic. In Jharkhand, 28.8% of the population remains multidimensionally poor and anaemia affects more than half of expectant mothers. Kerala, by contrast, has almost eliminated multidimensional poverty, and its anaemia rate among pregnant women (31.4%) is less than half the national average.</p>
+
+    <div class="dv-finding">
+      <div class="dv-finding-label">Why this is not a case against spending</div>
+      <p>The states doing well today are not spending less because welfare doesn't work. They are spending a smaller <em>share</em> because decades of earlier investment already built the schools, clinics, and public systems that hold their outcomes up. Kerala and Tamil Nadu are living off a stock of past spending; Bihar and Jharkhand are still paying to build the stock. Cross-sectional budget shares capture the flow, not the accumulated stock — which is exactly why the snapshot inverts.</p>
+    </div>
+
+    <div class="dv-section-kicker">03 — Budgeting for women</div>
+    <h2>Where the gender rupee goes</h2>
+
+    <p>A second layer of the story is how much of the budget is directed at women specifically. Here the ranking scrambles again. Jharkhand earmarks 35.5% of its budget for women-focused schemes — the highest of any state — but so does Tamil Nadu, at 29.8%, second only to Jharkhand and far above its overall social-sector rank would suggest. Both sit well above the national average of 9.4%. Delhi, a top-five social-sector spender overall, directs just 9.5% to women — and records the lowest female labour-force participation in the country, at 10.4%.</p>
+
+    <figure class="dv-fig">
+      <div class="dv-fig-title">Share of the budget directed at women-focused schemes</div>
+      <div class="dv-fig-sub">Gender budgeting as a percentage of total expenditure. The dashed line is the national average of 9.4%.</div>
+      <div class="dv-chart" id="chart-gender" role="img" aria-label="Horizontal bar chart of gender budgeting as a share of total expenditure. Jharkhand 35.5 percent, Tamil Nadu 29.8, West Bengal 26.3, Kerala 21.4, all far above the 9.4 percent national average; Delhi at 9.5 percent sits essentially on the average line."></div>
+      <details class="dv-data-toggle"><summary>View data table</summary>
+        <table class="dv-table">
+          <thead><tr><th>State</th><th>Women-focused share of budget</th></tr></thead>
+          <tbody>
+            <tr><td>Jharkhand</td><td class="num">35.5%</td></tr>
+            <tr><td>Tamil Nadu</td><td class="num">29.8%</td></tr>
+            <tr><td>West Bengal</td><td class="num">26.3%</td></tr>
+            <tr><td>Kerala</td><td class="num">21.4%</td></tr>
+            <tr><td>Delhi</td><td class="num">9.5%</td></tr>
+            <tr><td>National average</td><td class="num">9.4%</td></tr>
+          </tbody>
+        </table>
+      </details>
+      <figcaption><strong>Source:</strong> RBI, <em>State Finances: A Study of Budgets of 2025-26</em>, gender-budget statements. High gender budgeting is not confined to the biggest overall spenders.</figcaption>
+    </figure>
+
+    <p>That Tamil Nadu can post both a low overall social-sector share <em>and</em> one of the highest gender-budget shares is a useful reminder that these numbers measure allocation, not effort or effectiveness. A state that has already achieved near-universal schooling can shift its marginal rupee toward targeted women's schemes; a state still building basic coverage cannot.</p>
+
+    <div class="dv-section-kicker">04 — Reading the numbers honestly</div>
+    <h2>What this data can and can't tell you</h2>
+
+    <p>It is tempting to turn a chart like the maternal-mortality scatter into a slogan — "welfare spending doesn't work." That would be a misreading, and the reason it would be a misreading is worth stating plainly, because it is the whole point of a data dive.</p>
+
+    <div class="dv-method">
+      <div class="dv-method-label">How to read this responsibly</div>
+      <ul>
+        <li><strong>Budget shares are not spending levels.</strong> A "share of total budget" says nothing about rupees per person. A poor state spending 54% of a small budget may still spend less per capita than a rich state spending 32% of a large one.</li>
+        <li><strong>Allocation is not delivery.</strong> Money budgeted is not money spent well. Leakage, absorption capacity, and administrative quality sit between the budget line and the clinic — and they vary enormously across states.</li>
+        <li><strong>Stocks vs flows.</strong> Today's outcomes reflect decades of past investment (the stock), while budget shares capture this year's spending (the flow). Kerala's advantage was bought in the 1970s–90s; it shows up now as a licence to spend a smaller share.</li>
+        <li><strong>Association is not causation.</strong> The spend-vs-mortality pattern is a correlation across a handful of states, driven by the underlying fact that poor states have both high need and high spending. It does not mean spending <em>causes</em> worse outcomes.</li>
+        <li><strong>Coverage is partial.</strong> The RBI analysis excludes north-eastern states and union territories other than Delhi, and works from budget estimates (BE), which are intentions, not audited actuals.</li>
+      </ul>
+      <p>Read this way, the data delivers a sharper and more useful message than the slogan: <strong>where a state is on its development journey shapes how much it needs to spend — and spending share is a poor scoreboard for judging whether that money is working.</strong> To judge that, you need per-capita spending, outcome trends over time, and delivery data — the natural subjects of the next data dives.</p>
+    </div>
+
+    <div class="dv-method">
+      <div class="dv-method-label">Sources &amp; data</div>
+      <ul class="dv-sources">
+        <li>Reserve Bank of India, <a href="https://www.rbi.org.in/Scripts/AnnualPublications.aspx?head=State+Finances+%3A+A+Study+of+Budgets" target="_blank" rel="noopener">State Finances: A Study of Budgets of 2025-26</a> — social-sector expenditure shares, gender-budget statements, and outcome indicators.</li>
+        <li>Shikha Chaturvedi, "<a href="https://www.business-standard.com/economy/news/from-bihar-to-kerala-state-budgets-chart-divergent-paths-in-social-welfare-126062500724_1.html" target="_blank" rel="noopener">From Bihar to Kerala, state Budgets chart divergent paths in social welfare</a>," <em>Business Standard</em>, 2026 — reporting and analysis that surfaced these figures.</li>
+        <li>PRS Legislative Research, <a href="https://prsindia.org/budgets/states" target="_blank" rel="noopener">State Budget analyses</a> — for readers who want to trace individual state budgets.</li>
+      </ul>
+    </div>
+
+    <div class="dv-related">
+      <div class="dv-related-label">Go deeper on ImpactMojo</div>
+      <ul>
+        <li><a href="/DeepDives/politics-of-targeting.html">Deep Dive — The Politics of Targeting</a>: universal vs targeted welfare, and who gets left out.</li>
+        <li><a href="/DeepDives/health-systems-uhc-south-asia.html">Deep Dive — Health Systems and UHC in South Asia</a>: why the money, not just the medicine, is the hard part.</li>
+        <li><a href="/DeepDives/the-stunting-puzzle.html">Deep Dive — The Stunting Puzzle</a>: why South Asia's children are stunted, and what brings it down.</li>
+        <li><a href="/DeepDives/cash-transfers-evidence.html">Deep Dive — Cash Transfers and the Evidence</a>: what two decades of trials taught us about giving money to the poor.</li>
+      </ul>
+    </div>
+
+    <div class="dv-cite-block">
+      <div class="dv-cite-label">Suggested citation</div>
+      <p class="dv-cite-text">ImpactMojo Data (2026). "The Welfare Spending Paradox: Why India's Biggest Social Spenders Have the Worst Outcomes." <em>ImpactMojo Data Dives</em>. Retrieved from https://impactmojo.in/DataDives/state-welfare-budgets.html</p>
+    </div>
+
+    <div class="dv-cta">
+      <h3>Have a dataset worth digging into?</h3>
+      <p>Data Dives are independent investigations built from public data. If you know a number that deserves a closer look, tell us.</p>
+      <a href="/contact.html?topic=DataDive">Pitch a Data Dive →</a>
+    </div>
+
+  </div>
+</main>
+
+<!-- ImpactMojo Footer -->
+<footer class="im-footer" role="contentinfo">
+  <div class="im-footer-content">
+    <p class="im-footer-made">Made with ♥ by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+    <div class="im-footer-grid">
+      <div class="im-footer-section">
+        <h4>About ImpactMojo</h4>
+        <ul>
+          <li><a href="/about.html">About Us</a></li>
+          <li><a href="/contact.html">Contact</a></li>
+          <li><a href="https://github.com/ImpactMojo/ImpactMojo" rel="noopener noreferrer" target="_blank">GitHub</a></li>
+          <li><a href="/transparency.html">Transparency</a></li>
+        </ul>
+      </div>
+      <div class="im-footer-section">
+        <h4>Legal</h4>
+        <ul>
+          <li><a href="/privacy-policy.html">Privacy Policy</a></li>
+          <li><a href="/terms-of-service.html">Terms of Service</a></li>
+          <li><a href="/disclaimer.html">Disclaimer</a></li>
+          <li><a href="/data-protection.html">Data Protection</a></li>
+        </ul>
+      </div>
+      <div class="im-footer-section">
+        <h4>Quick Links</h4>
+        <ul>
+          <li><a href="/catalog.html">All Courses</a></li>
+          <li><a href="/DataDives/">Data Dives</a></li>
+          <li><a href="/DeepDives/">Deep Dives</a></li>
+          <li><a href="/premium.html">Premium</a></li>
+        </ul>
+      </div>
+      <div class="im-footer-section">
+        <h4>Resources</h4>
+        <ul>
+          <li><a href="/handouts.html">Handouts</a></li>
+          <li><a href="/blog.html">Blog</a></li>
+          <li><a href="/faq.html">FAQ</a></li>
+          <li><a href="/sitemap.html">Sitemap</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="im-footer-bottom">
+      <p>&copy; 2026 ImpactMojo. All content for educational purposes only.</p>
+      <p>Released under <strong>MIT License</strong> | Supported by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+    </div>
+  </div>
+</footer>
+
+<div class="dv-tip" id="dv-tip" role="status" aria-live="polite"></div>
+
+<script src="/js/theme.js"></script>
+
+<script>
+/* ImpactMojo Data Dive — inline chart renderer (self-contained, theme-aware) */
+(function () {
+  var SVGNS = "http://www.w3.org/2000/svg";
+  var tip = document.getElementById('dv-tip');
+
+  function el(tag, attrs, text) {
+    var n = document.createElementNS(SVGNS, tag);
+    if (attrs) for (var k in attrs) n.setAttribute(k, attrs[k]);
+    if (text != null) n.textContent = text;
+    return n;
+  }
+  function showTip(html, evt) {
+    tip.innerHTML = html;
+    tip.classList.add('show');
+    moveTip(evt);
+  }
+  function moveTip(evt) {
+    var x = evt.clientX, y = evt.clientY;
+    var w = tip.offsetWidth, h = tip.offsetHeight;
+    var nx = x + 14, ny = y + 14;
+    if (nx + w > window.innerWidth - 8) nx = x - w - 14;
+    if (ny + h > window.innerHeight - 8) ny = y - h - 14;
+    tip.style.left = nx + 'px';
+    tip.style.top = ny + 'px';
+  }
+  function hideTip() { tip.classList.remove('show'); }
+
+  /* ---- Horizontal bar chart ---- */
+  function barChart(mountId, opts) {
+    var mount = document.getElementById(mountId);
+    if (!mount) return;
+    var data = opts.data;            // [{label, value}]
+    var max = opts.max;              // axis max
+    var ticks = opts.ticks;          // [numbers]
+    var avg = opts.avg;              // {value, label}
+    var suffix = opts.suffix || '%';
+    var W = 680, rowH = 40, padTop = 26, padBottom = 34;
+    var labelW = 118, rightPad = 46;
+    var H = padTop + data.length * rowH + padBottom;
+    var x0 = labelW, x1 = W - rightPad;
+    var scale = function (v) { return x0 + (v / max) * (x1 - x0); };
+    var svg = el('svg', { viewBox: '0 0 ' + W + ' ' + H, preserveAspectRatio: 'xMidYMid meet' });
+
+    // gridlines + ticks
+    ticks.forEach(function (t) {
+      var x = scale(t);
+      svg.appendChild(el('line', { x1: x, y1: padTop - 8, x2: x, y2: padTop + data.length * rowH, class: 'dv-grid-line' }));
+      var tk = el('text', { x: x, y: padTop + data.length * rowH + 18, 'text-anchor': 'middle', class: 'dv-tick' }, t + suffix);
+      svg.appendChild(tk);
+    });
+    // baseline
+    svg.appendChild(el('line', { x1: x0, y1: padTop - 8, x2: x0, y2: padTop + data.length * rowH, class: 'dv-axis-line' }));
+
+    // bars
+    data.forEach(function (d, i) {
+      var y = padTop + i * rowH;
+      var by = y + (rowH - 22) / 2;
+      var bw = Math.max(0, scale(d.value) - x0);
+      var g = el('g', { class: 'dv-bargroup' });
+      // track
+      g.appendChild(el('rect', { x: x0, y: by, width: x1 - x0, height: 22, rx: 4, class: 'dv-bar-track' }));
+      // bar
+      var bar = el('rect', { x: x0, y: by, width: bw, height: 22, rx: 4, class: 'dv-bar' + (d.hl ? ' hl' : '') });
+      g.appendChild(bar);
+      // state label
+      g.appendChild(el('text', { x: x0 - 10, y: by + 15, 'text-anchor': 'end', class: 'dv-bar-lbl' }, d.label));
+      // value label
+      g.appendChild(el('text', { x: scale(d.value) + 8, y: by + 15, 'text-anchor': 'start', class: 'dv-bar-val' }, d.value + suffix));
+      // interaction
+      (function (dd) {
+        g.addEventListener('mousemove', function (e) {
+          showTip('<b>' + dd.label + '</b><br>' + (opts.tipLabel || 'Value') + ': ' + dd.value + suffix, e);
+        });
+        g.addEventListener('mouseleave', hideTip);
+      })(d);
+      svg.appendChild(g);
+    });
+
+    // average reference line
+    if (avg) {
+      var ax = scale(avg.value);
+      svg.appendChild(el('line', { x1: ax, y1: padTop - 14, x2: ax, y2: padTop + data.length * rowH + 2, class: 'dv-ref-line' }));
+      svg.appendChild(el('text', { x: ax, y: padTop - 18, 'text-anchor': 'middle', class: 'dv-ref-lbl' }, avg.label));
+    }
+    mount.appendChild(svg);
+  }
+
+  /* ---- Scatter plot ---- */
+  function scatterChart(mountId, opts) {
+    var mount = document.getElementById(mountId);
+    if (!mount) return;
+    var data = opts.data;   // [{label, x, y}]
+    var W = 680, H = 460, padL = 62, padR = 28, padT = 24, padB = 58;
+    var xMin = opts.xMin, xMax = opts.xMax, yMin = 0, yMax = opts.yMax;
+    var px = function (v) { return padL + (v - xMin) / (xMax - xMin) * (W - padL - padR); };
+    var py = function (v) { return H - padB - (v - yMin) / (yMax - yMin) * (H - padT - padB); };
+    var svg = el('svg', { viewBox: '0 0 ' + W + ' ' + H, preserveAspectRatio: 'xMidYMid meet' });
+
+    // y gridlines + ticks
+    opts.yTicks.forEach(function (t) {
+      var y = py(t);
+      svg.appendChild(el('line', { x1: padL, y1: y, x2: W - padR, y2: y, class: 'dv-grid-line' }));
+      svg.appendChild(el('text', { x: padL - 10, y: y + 4, 'text-anchor': 'end', class: 'dv-tick' }, t));
+    });
+    // x ticks
+    opts.xTicks.forEach(function (t) {
+      var x = px(t);
+      svg.appendChild(el('text', { x: x, y: H - padB + 20, 'text-anchor': 'middle', class: 'dv-tick' }, t + '%'));
+    });
+    // axes
+    svg.appendChild(el('line', { x1: padL, y1: padT, x2: padL, y2: H - padB, class: 'dv-axis-line' }));
+    svg.appendChild(el('line', { x1: padL, y1: H - padB, x2: W - padR, y2: H - padB, class: 'dv-axis-line' }));
+    // axis titles
+    svg.appendChild(el('text', { x: (padL + W - padR) / 2, y: H - 12, 'text-anchor': 'middle', class: 'dv-axis-title' }, 'Social-sector spending share →'));
+    var yt = el('text', { x: 16, y: (padT + H - padB) / 2, 'text-anchor': 'middle', class: 'dv-axis-title', transform: 'rotate(-90 16 ' + ((padT + H - padB) / 2) + ')' }, 'Maternal deaths / 100k →');
+    svg.appendChild(yt);
+
+    // points
+    data.forEach(function (d) {
+      var cx = px(d.x), cy = py(d.y);
+      var g = el('g');
+      g.appendChild(el('circle', { cx: cx, cy: cy, r: 9, class: 'dv-dot' }));
+      // label placement: per-point overrides avoid collisions on near-coincident dots
+      var anchor = d.anchor || (d.x > (xMin + xMax) / 2 ? 'end' : 'start');
+      var lx = anchor === 'end' ? cx - 14 : cx + 14;
+      var nameY, subY;
+      if (d.vpos === 'down') { nameY = cy + 20; subY = cy + 34; }
+      else { nameY = cy - 20; subY = cy - 6; }
+      g.appendChild(el('text', { x: lx, y: nameY, 'text-anchor': anchor, class: 'dv-dot-lbl' }, d.label));
+      g.appendChild(el('text', { x: lx, y: subY, 'text-anchor': anchor, class: 'dv-dot-sub' }, d.x + '% spend · ' + d.y + ' deaths'));
+      (function (dd) {
+        g.addEventListener('mousemove', function (e) {
+          showTip('<b>' + dd.label + '</b><br>Spend: ' + dd.x + '%<br>Maternal deaths: ' + dd.y + ' / 100k', e);
+        });
+        g.addEventListener('mouseleave', hideTip);
+      })(d);
+      svg.appendChild(g);
+    });
+    mount.appendChild(svg);
+  }
+
+  window.addEventListener('mousemove', function (e) { if (tip.classList.contains('show')) moveTip(e); });
+
+  // Chart 1 — social-sector spending share
+  barChart('chart-spend', {
+    data: [
+      { label: 'Jharkhand', value: 54.8 },
+      { label: 'West Bengal', value: 54.2 },
+      { label: 'Delhi', value: 54.1 },
+      { label: 'Chhattisgarh', value: 50.3 },
+      { label: 'Bihar', value: 49.8 },
+      { label: 'Tamil Nadu', value: 33.6 },
+      { label: 'Kerala', value: 32.2 },
+      { label: 'Punjab', value: 21.3 }
+    ],
+    max: 60, ticks: [0, 20, 40, 60],
+    avg: { value: 42.2, label: 'All-state avg 42.2%' },
+    tipLabel: 'Social-sector share'
+  });
+
+  // Chart 2 — spend vs maternal mortality
+  scatterChart('chart-scatter', {
+    data: [
+      { label: 'Kerala', x: 32.2, y: 30, anchor: 'start', vpos: 'down' },
+      { label: 'Tamil Nadu', x: 33.6, y: 35, anchor: 'start', vpos: 'up' },
+      { label: 'West Bengal', x: 54.2, y: 104, anchor: 'end', vpos: 'up' },
+      { label: 'Chhattisgarh', x: 50.3, y: 146, anchor: 'end', vpos: 'up' }
+    ],
+    xMin: 25, xMax: 60, yMax: 160,
+    xTicks: [30, 40, 50, 60],
+    yTicks: [0, 40, 80, 120, 160]
+  });
+
+  // Chart 3 — gender budgeting
+  barChart('chart-gender', {
+    data: [
+      { label: 'Jharkhand', value: 35.5 },
+      { label: 'Tamil Nadu', value: 29.8 },
+      { label: 'West Bengal', value: 26.3 },
+      { label: 'Kerala', value: 21.4 },
+      { label: 'Delhi', value: 9.5 }
+    ],
+    max: 40, ticks: [0, 10, 20, 30, 40],
+    avg: { value: 9.4, label: 'National avg 9.4%' },
+    tipLabel: 'Women-focused share'
+  });
+})();
+</script>
+
+<!-- Supabase Auth (deferred, non-blocking) -->
+<script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script defer src="/js/state-manager.js"></script>
+<script defer src="/js/config.js"></script>
+<script defer src="/js/auth.js"></script>
+<script src="/js/translate-sarvam.js" defer></script>
+<script src="/js/site-chrome.js" defer></script>
+</body>
+</html>

--- a/DataDives/state-welfare-budgets.html
+++ b/DataDives/state-welfare-budgets.html
@@ -3,19 +3,19 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>The Welfare Spending Paradox — Why India's Biggest Social Spenders Have the Worst Outcomes | ImpactMojo Data Dive</title>
+<title>The states that spend most on welfare have the least to show for it | ImpactMojo Data Dive</title>
 <meta name="description" content="An independent data investigation into how Indian states budget for welfare. Jharkhand and Bihar spend the largest share on social sectors and still record the worst maternal and nutrition outcomes; Kerala and Tamil Nadu spend less and lead. What the RBI's 2025-26 state-budget data really shows.">
 <link rel="canonical" href="https://www.impactmojo.in/DataDives/state-welfare-budgets.html">
 <meta name="robots" content="index, follow">
 
 <meta property="og:type" content="article">
-<meta property="og:title" content="The Welfare Spending Paradox — A Data Dive on State Budgets">
+<meta property="og:title" content="The states that spend most on welfare have the least to show for it — ImpactMojo Data Dive">
 <meta property="og:description" content="India's biggest social-sector spenders record its worst welfare outcomes, while the states that spend the least pull ahead. An independent look at the RBI's 2025-26 state-budget numbers.">
 <meta property="og:url" content="https://www.impactmojo.in/DataDives/state-welfare-budgets.html">
 <meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
 <meta property="og:site_name" content="ImpactMojo">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="The Welfare Spending Paradox — A Data Dive on State Budgets">
+<meta name="twitter:title" content="The states that spend most on welfare have the least to show for it — ImpactMojo Data Dive">
 <meta name="twitter:description" content="India's biggest social-sector spenders record its worst welfare outcomes. What the RBI's 2025-26 state-budget data really shows.">
 
 <link rel="icon" href="/assets/images/favicon.png" type="image/png">
@@ -37,7 +37,7 @@
 {
   "@context": "https://schema.org",
   "@type": "Article",
-  "headline": "The Welfare Spending Paradox — Why India's Biggest Social Spenders Have the Worst Outcomes",
+  "headline": "The states that spend most on welfare have the least to show for it",
   "description": "An independent data investigation into how Indian states budget for welfare, using the RBI's State Finances: A Study of Budgets 2025-26.",
   "image": "https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png",
   "author": { "@type": "Organization", "name": "ImpactMojo Data" },
@@ -58,7 +58,7 @@
   "itemListElement": [
     { "@type": "ListItem", "position": 1, "name": "ImpactMojo", "item": "https://www.impactmojo.in/" },
     { "@type": "ListItem", "position": 2, "name": "Data Dives", "item": "https://www.impactmojo.in/DataDives/" },
-    { "@type": "ListItem", "position": 3, "name": "The Welfare Spending Paradox" }
+    { "@type": "ListItem", "position": 3, "name": "The states that spend most on welfare have the least to show for it" }
   ]
 }
 </script>
@@ -315,7 +315,7 @@ html.dark .dv-tip b { color: #0F172A; }
 
   <!-- HERO -->
   <div class="dv-eyebrow">Data Dive · Public Finance</div>
-  <h1 class="dv-title">The Welfare Spending Paradox</h1>
+  <h1 class="dv-title">The states that spend most on welfare have the least to show for it</h1>
   <p class="dv-standfirst">India's biggest social-sector spenders record some of its worst welfare outcomes — while the states that spend the least on welfare, as a share of their budgets, are the ones pulling ahead. A look at what the numbers behind state budgets actually say, and what they can't.</p>
   <div class="dv-byline">
     <span class="dv-tag">Investigation</span>
@@ -481,7 +481,7 @@ html.dark .dv-tip b { color: #0F172A; }
 
     <div class="dv-cite-block">
       <div class="dv-cite-label">Suggested citation</div>
-      <p class="dv-cite-text">ImpactMojo Data (2026). "The Welfare Spending Paradox: Why India's Biggest Social Spenders Have the Worst Outcomes." <em>ImpactMojo Data Dives</em>. Retrieved from https://impactmojo.in/DataDives/state-welfare-budgets.html</p>
+      <p class="dv-cite-text">ImpactMojo Data (2026). "The states that spend most on welfare have the least to show for it." <em>ImpactMojo Data Dives</em>. Retrieved from https://impactmojo.in/DataDives/state-welfare-budgets.html</p>
     </div>
 
     <div class="dv-cta">

--- a/contribute.html
+++ b/contribute.html
@@ -338,6 +338,7 @@ body {
                 <div class="way-card"><h3>Flagship course</h3><p>A deep, modular course (10–15 modules) on a subject you know cold — the platform's most substantial format.</p><span class="way-effort">Biggest lift · highest impact</span></div>
                 <div class="way-card"><h3>101 course</h3><p>A self-paced, ~100-slide interactive deck that introduces one topic or method clearly and from scratch.</p><span class="way-effort">Focused · self-contained</span></div>
                 <div class="way-card"><h3>Deep Dive</h3><p>A curated, fully-cited reading path on a live development question — the best sources, annotated, in order.</p><span class="way-effort">Research &amp; synthesis</span></div>
+                <div class="way-card"><h3>Data Dive</h3><p>An independent data investigation — take one public dataset, chart it, and show what the numbers do (and don't) prove.</p><span class="way-effort">Analysis &amp; charts</span></div>
                 <div class="way-card"><h3>Interactive lab</h3><p>A hands-on, browser-based tool that lets practitioners <em>do</em> something — we help with the build.</p><span class="way-effort">Design the logic, we build</span></div>
                 <div class="way-card"><h3>Reading companion</h3><p>An interactive companion to a key development text — the ideas, the arguments, and how to interrogate them.</p><span class="way-effort">One book, done well</span></div>
                 <div class="way-card"><h3>Handout</h3><p>A printable one-pager or quick-reference card on a concept, method or checklist practitioners reach for.</p><span class="way-effort">Smallest lift · quick win</span></div>
@@ -399,6 +400,7 @@ body {
                         <option>Flagship course</option>
                         <option>101 course</option>
                         <option>Deep Dive</option>
+                        <option>Data Dive</option>
                         <option>Interactive lab</option>
                         <option>Reading companion</option>
                         <option>Handout</option>

--- a/data/data-dives.json
+++ b/data/data-dives.json
@@ -1,0 +1,34 @@
+{
+  "version": "1.0.0",
+  "updated": "2026-07-11",
+  "description": "Independent data investigations built from public data. Each Data Dive interrogates one dataset — with original charts, a clear argument, and an honest account of what the numbers can and can't show.",
+  "data_dives": [
+    {
+      "id": "state-welfare-budgets",
+      "title": "The Welfare Spending Paradox",
+      "tagline": "India's biggest social-sector spenders record its worst welfare outcomes, while the states that spend the least pull ahead. What the RBI's 2025-26 state-budget data really shows — and what it can't.",
+      "topic": "Public Finance",
+      "url": "/DataDives/state-welfare-budgets.html",
+      "author": "ImpactMojo Data",
+      "dataset": "RBI State Finances 2025-26",
+      "read_time": "8 min",
+      "chart_count": 3,
+      "sections": [
+        "The spending spectrum",
+        "Spending vs outcomes",
+        "Budgeting for women",
+        "Reading the numbers honestly"
+      ],
+      "tags": [
+        "public-finance",
+        "welfare",
+        "state-budgets",
+        "india",
+        "health",
+        "gender-budgeting",
+        "social-policy"
+      ],
+      "published": "2026-07-11"
+    }
+  ]
+}

--- a/data/data-dives.json
+++ b/data/data-dives.json
@@ -5,7 +5,7 @@
   "data_dives": [
     {
       "id": "state-welfare-budgets",
-      "title": "The Welfare Spending Paradox",
+      "title": "The states that spend most on welfare have the least to show for it",
       "tagline": "India's biggest social-sector spenders record its worst welfare outcomes, while the states that spend the least pull ahead. What the RBI's 2025-26 state-budget data really shows — and what it can't.",
       "topic": "Public Finance",
       "url": "/DataDives/state-welfare-budgets.html",

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -6758,7 +6758,7 @@
   },
   {
     "id": "DV001",
-    "title": "The Welfare Spending Paradox",
+    "title": "The states that spend most on welfare have the least to show for it",
     "description": "An independent data investigation: India's biggest social-sector spenders record its worst welfare outcomes, while low-spending Kerala and Tamil Nadu lead. Built from the RBI State Finances 2025-26 data, with original charts and an honest account of what the numbers can't show.",
     "type": "data-dive",
     "category": "Data Dives",

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -6757,6 +6757,25 @@
     ]
   },
   {
+    "id": "DV001",
+    "title": "The Welfare Spending Paradox",
+    "description": "An independent data investigation: India's biggest social-sector spenders record its worst welfare outcomes, while low-spending Kerala and Tamil Nadu lead. Built from the RBI State Finances 2025-26 data, with original charts and an honest account of what the numbers can't show.",
+    "type": "data-dive",
+    "category": "Data Dives",
+    "url": "/DataDives/state-welfare-budgets.html",
+    "tags": [
+      "public finance",
+      "welfare",
+      "state budgets",
+      "india",
+      "health",
+      "gender budgeting",
+      "social policy",
+      "data investigation",
+      "rbi"
+    ]
+  },
+  {
     "id": "DD001",
     "title": "Reading Indian Political Economy",
     "description": "From colonial legacies to coalition capitalism — a curated reading list on how power, markets, and the state co-evolve in India. Curated by Sukhmeet Bedi.",

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -18,6 +18,7 @@
 * [Research to Action Guide](research-to-action-guide.md)
 * [Practice Packs Guide](practice-packs-guide.md)
 * [Deep Dives Guide](deep-dives-guide.md)
+* [Data Dives Guide](data-dives-guide.md)
 * [Dojos Guide](dojos-guide.md)
 * [Reading Companions Guide](book-summaries-guide.md)
 * [101 Course Decks Guide](101-decks-guide.md)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -15,6 +15,7 @@
   - [Research to Action Guide](research-to-action-guide.md)
   - [Practice Packs Guide](practice-packs-guide.md)
   - [Deep Dives Guide](deep-dives-guide.md)
+  - [Data Dives Guide](data-dives-guide.md)
   - [Dojos Guide](dojos-guide.md)
   - [Reading Companions Guide](book-summaries-guide.md)
   - [101 Course Decks](101-decks-guide.md)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,7 @@ What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](h
 
 ### For Learners
 
-- **Data Dives** — a new kind of content: independent data investigations that take one public dataset, chart it, make an argument, and spell out what the numbers can't show. Browse them at [/DataDives/](https://www.impactmojo.in/DataDives/). The first, [**The Welfare Spending Paradox**](https://www.impactmojo.in/DataDives/state-welfare-budgets.html), digs into the RBI's 2025-26 state budgets: India's biggest social-sector spenders record its worst welfare outcomes, while low-spending Kerala and Tamil Nadu lead — with three interactive charts and a plain-English guide to reading the data honestly. Distinct from our reading-list Deep Dives.
+- **Data Dives** — a new kind of content: independent data investigations that take one public dataset, chart it, make an argument, and spell out what the numbers can't show. Browse them at [/DataDives/](https://www.impactmojo.in/DataDives/). The first, [**The states that spend most on welfare have the least to show for it**](https://www.impactmojo.in/DataDives/state-welfare-budgets.html), digs into the RBI's 2025-26 state budgets: India's biggest social-sector spenders record its worst welfare outcomes, while low-spending Kerala and Tamil Nadu lead — with three interactive charts and a plain-English guide to reading the data honestly. Distinct from our reading-list Deep Dives.
 
 ## v10.103.0 — July 11, 2026 (One comprehensive MEL Lab)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.104.0 — July 11, 2026 (Data Dives — independent data investigations)
+
+### For Learners
+
+- **Data Dives** — a new kind of content: independent data investigations that take one public dataset, chart it, make an argument, and spell out what the numbers can't show. Browse them at [/DataDives/](https://www.impactmojo.in/DataDives/). The first, [**The Welfare Spending Paradox**](https://www.impactmojo.in/DataDives/state-welfare-budgets.html), digs into the RBI's 2025-26 state budgets: India's biggest social-sector spenders record its worst welfare outcomes, while low-spending Kerala and Tamil Nadu lead — with three interactive charts and a plain-English guide to reading the data honestly. Distinct from our reading-list Deep Dives.
+
 ## v10.103.0 — July 11, 2026 (One comprehensive MEL Lab)
 
 ### For Learners

--- a/docs/data-dives-guide.md
+++ b/docs/data-dives-guide.md
@@ -19,7 +19,7 @@ If you want to know *what to read* on a topic, use a [Deep Dive](deep-dives-guid
 
 | Data Dive | Topic | Dataset | Charts | Link |
 |-----------|-------|---------|--------|------|
-| **The Welfare Spending Paradox** | Public Finance | RBI State Finances 2025-26 | 3 | [Open](/DataDives/state-welfare-budgets.html) |
+| **The states that spend most on welfare have the least to show for it** | Public Finance | RBI State Finances 2025-26 | 3 | [Open](/DataDives/state-welfare-budgets.html) |
 
 Browse all Data Dives at [/DataDives/](/DataDives/).
 
@@ -48,7 +48,7 @@ Each Data Dive follows the same honest structure:
 ## For Educators
 
 - **As a data-literacy teaching case.** Walk students through the "What this data can and can't tell you" block — stocks vs flows, allocation vs delivery — as a live lesson in reading official statistics critically.
-- **To pair with courses and Deep Dives.** The Welfare Spending Paradox pairs with the [Politics of Targeting](/DeepDives/politics-of-targeting.html) and [Health Systems and UHC in South Asia](/DeepDives/health-systems-uhc-south-asia.html) Deep Dives, and with development-economics and MEL courses.
+- **To pair with courses and Deep Dives.** The state welfare-spending investigation pairs with the [Politics of Targeting](/DeepDives/politics-of-targeting.html) and [Health Systems and UHC in South Asia](/DeepDives/health-systems-uhc-south-asia.html) Deep Dives, and with development-economics and MEL courses.
 - **As a prompt for replication.** Point research assistants at the source dataset and ask them to reproduce a chart, then extend it (per-capita spending, trends over time) — the natural next questions each dive leaves open.
 
 ---

--- a/docs/data-dives-guide.md
+++ b/docs/data-dives-guide.md
@@ -1,0 +1,74 @@
+# Data Dives Guide
+
+## What Are Data Dives?
+
+Data Dives are **independent data investigations**. Each one takes a single public dataset, interrogates it with original charts, builds a clear argument — and, just as importantly, spells out what the numbers *can't* show. They are ImpactMojo's data-journalism format: closer to an investigative brief than a lesson or a reading list.
+
+All Data Dives are **free, browser-based, and require no login**. Every chart is drawn on the page (no external services), carries a data table behind it, and names its source.
+
+### How a Data Dive Differs from a Deep Dive
+
+- **A Deep Dive** curates the *literature* on a question — an annotated reading list with a point of view. Many authors, sequenced and annotated.
+- **A Data Dive** interrogates the *data* on a question — original analysis of one dataset, with charts we build and an argument we make. One dataset, dug into.
+
+If you want to know *what to read* on a topic, use a [Deep Dive](deep-dives-guide.md). If you want to know *what the numbers say*, use a Data Dive.
+
+---
+
+## The Data Dives
+
+| Data Dive | Topic | Dataset | Charts | Link |
+|-----------|-------|---------|--------|------|
+| **The Welfare Spending Paradox** | Public Finance | RBI State Finances 2025-26 | 3 | [Open](/DataDives/state-welfare-budgets.html) |
+
+Browse all Data Dives at [/DataDives/](/DataDives/).
+
+---
+
+## How a Data Dive Is Built
+
+Each Data Dive follows the same honest structure:
+
+1. **The finding** — a one-sentence headline of what the data shows, stated up front.
+2. **Stat tiles** — the three or four numbers that anchor the story.
+3. **Chart-led sections** — two to four sections, each pairing narrative with a chart we drew ourselves. Every chart has a title, a plain-English note on what higher/lower means, a data table, and a source line.
+4. **"What this data can and can't tell you"** — a mandatory methodology block. Stocks vs flows, allocation vs delivery, association vs causation, coverage caveats. This is the part that separates a data dive from a hot take.
+5. **Sources & data** — every source linked so readers can check our working.
+6. **Go deeper** — links to the matching Deep Dives and courses.
+
+### Editorial principles
+
+- **Charts are honest by construction.** Single-hue magnitude bars, reference lines for averages, direct value labels, and explicit "associational, not causal" language on any scatter. No dual axes, no truncated baselines that exaggerate a gap, no chartjunk.
+- **Show the working.** Every chart ships a data table; every number is sourced.
+- **State the limits.** A Data Dive that doesn't tell you what it *can't* prove isn't finished.
+- **Accessible and theme-aware.** Charts render in light and dark, carry an `aria-label` description, and degrade to a table.
+
+---
+
+## For Educators
+
+- **As a data-literacy teaching case.** Walk students through the "What this data can and can't tell you" block — stocks vs flows, allocation vs delivery — as a live lesson in reading official statistics critically.
+- **To pair with courses and Deep Dives.** The Welfare Spending Paradox pairs with the [Politics of Targeting](/DeepDives/politics-of-targeting.html) and [Health Systems and UHC in South Asia](/DeepDives/health-systems-uhc-south-asia.html) Deep Dives, and with development-economics and MEL courses.
+- **As a prompt for replication.** Point research assistants at the source dataset and ask them to reproduce a chart, then extend it (per-capita spending, trends over time) — the natural next questions each dive leaves open.
+
+---
+
+## Authoring a New Data Dive
+
+1. Copy `/DataDives/state-welfare-budgets.html` (the reference implementation) to `/DataDives/<slug>.html` and rewrite the content. Keep the `<style>` block and the chart-renderer `<script>` — they are self-contained, theme-aware, and accessible.
+2. Edit only the data arrays at the bottom of the chart script. The chart API is:
+   - `barChart(mountId, { data:[{label,value,hl?}], max, ticks, avg:{value,label}, suffix?, tipLabel? })`
+   - `scatterChart(mountId, { data:[{label,x,y}], xMin, xMax, yMax, xTicks, yTicks })`
+3. Add an entry to `data/data-dives.json`.
+4. Wire cross-references: `index.html` (Data Dives section + footer explore list), `data/search-index.json`, `sitemap.xml`, this guide's table, and a `### For Learners` bullet in `docs/changelog.md`.
+5. Validate: `python3 -m json.tool data/data-dives.json` and `python3 -m json.tool data/search-index.json`, plus `python3 scripts/check-mojibake.py`.
+
+See `/DataDives/_template.html` for the annotated skeleton.
+
+---
+
+## Related
+
+- [Deep Dives Guide](deep-dives-guide.md) — the reading-list companion format
+- Skill `tufte-viz` and `dataviz` — the visualization principles behind the charts
+- Skill `deep-research` — for sourcing and verifying the underlying data

--- a/index.html
+++ b/index.html
@@ -2693,7 +2693,7 @@ window.addEventListener('authStateChanged', function(e) {
 <span class="card-number"><svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Activity"/></svg> DV1</span>
 <span class="learner-badge">3 charts</span>
 </div>
-<h3 class="card-title">The Welfare Spending Paradox</h3>
+<h3 class="card-title">The states that spend most on welfare have the least to show for it</h3>
 <p class="card-description">India's biggest social-sector spenders record its worst welfare outcomes, while the states that spend the least pull ahead. What the RBI's 2025-26 state-budget data really shows — and what it can't.</p>
 </a>
 </div>

--- a/index.html
+++ b/index.html
@@ -2682,6 +2682,29 @@ window.addEventListener('authStateChanged', function(e) {
                 </a>
 </div>
 </section>
+<!-- Data Dives Section -->
+<section class="section" id="data-dives">
+<h2 class="section-title">Data Dives</h2>
+<p class="section-subtitle">Independent data investigations — we take one public dataset, chart it ourselves, make an argument, and show you what the numbers can (and can't) say.</p>
+<div class="cards-grid">
+<div class="card">
+<a href="/DataDives/state-welfare-budgets.html">
+<div class="card-header">
+<span class="card-number"><svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Activity"/></svg> DV1</span>
+<span class="learner-badge">3 charts</span>
+</div>
+<h3 class="card-title">The Welfare Spending Paradox</h3>
+<p class="card-description">India's biggest social-sector spenders record its worst welfare outcomes, while the states that spend the least pull ahead. What the RBI's 2025-26 state-budget data really shows — and what it can't.</p>
+</a>
+</div>
+</div>
+<div class="action-buttons">
+<a class="btn btn-primary" href="/DataDives/">
+<svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Activity"/></svg>
+                    View All Data Dives
+                </a>
+</div>
+</section>
 <!-- Deep Dives Section -->
 <section class="section" id="deep-dives">
 <h2 class="section-title">Deep Dives</h2>
@@ -4508,6 +4531,7 @@ window.addEventListener('authStateChanged', function(e) {
 <li><a href="/labs/">All Labs</a></li>
 <li><a href="/game-library.html">All Games</a></li>
 <li><a href="/BookSummaries/">Reading Companions</a></li>
+<li><a href="/DataDives/">Data Dives</a></li>
 <li><a href="/DeepDives/">Deep Dives</a></li>
 <li><a href='/premium'>Premium Content</a></li>
 <li><a href="/build-circles.html">Build Circles</a></li>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1511,6 +1511,20 @@
         <priority>0.6</priority>
     </url>
 
+    <!-- Data Dives -->
+    <url>
+        <loc>https://www.impactmojo.in/DataDives/</loc>
+        <lastmod>2026-07-11</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://www.impactmojo.in/DataDives/state-welfare-budgets.html</loc>
+        <lastmod>2026-07-11</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.7</priority>
+    </url>
+
     <!-- Deep Dives -->
     <url>
         <loc>https://www.impactmojo.in/DeepDives/</loc>


### PR DESCRIPTION
## What this adds

A new standalone content type — **Data Dives** — distinct from the reading-list Deep Dives. A Data Dive takes one public dataset, charts it, makes an argument, and states plainly what the numbers can't show.

### New
- **`/DataDives/`** — registry-driven collection page (blue identity, separate from the gold Deep Dives).
- **First investigation** — *The states that spend most on welfare have the least to show for it* (`/DataDives/state-welfare-budgets.html`), built on **RBI State Finances: A Study of Budgets 2025-26**. Three accessible, theme-aware SVG charts (social-sector spend share, spend-vs-maternal-mortality scatter, gender budgeting), each with a data-table fallback and sourced figures, plus a mandatory "what this data can and can't tell you" methodology block.
- **`data/data-dives.json`** registry + **`DataDives/_template.html`** authoring stub.
- **`docs/data-dives-guide.md`** guide.

### Wired in
- Homepage: new Data Dives section + footer explore link.
- `data/search-index.json`, `sitemap.xml`.
- Docs sidebar + SUMMARY; changelog `### For Learners` entry.
- **Teach with Us** (`contribute.html`): added Data Dive as a seventh contribution route (way-card + form dropdown).

### Verified
- JSON validity (`data-dives.json`, `search-index.json`) and `check-mojibake.py` pass.
- All three charts rendered in headless Chromium (light mode) — labels, reference lines, and the scatter's collision-free point labels confirmed.

Data figures verified against the RBI 2025-26 report as surfaced in Shikha Chaturvedi's *Business Standard* analysis; the piece is explicit that the spend-vs-outcome relationship is associational, not causal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QoV2865kws9MaCYD6DcKM

---
_Generated by [Claude Code](https://claude.ai/code/session_011QoV2865kws9MaCYD6DcKM)_