### PR TITLE
Mobile fix: wide tables in two new handouts scroll instead of overflowing

### DIFF
--- a/Handouts/Education and Pedagogy/Measuring SEL/measuring_sel_handout.html
+++ b/Handouts/Education and Pedagogy/Measuring SEL/measuring_sel_handout.html
@@ -409,6 +409,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 /* Body clears fixed im-topbar (added by site-wide audit fix) */
 body { padding-top: 56px; }
 @media (max-width: 768px) { body { padding-top: 52px; } }
+
+/* Mobile: wide tables scroll within their own container instead of overflowing the page */
+@media (max-width: 640px) {
+  table { display: block; max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+}
 </style>
 <link rel="icon" type="image/png" href="/assets/images/favicon.png">
 <link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">

--- a/Handouts/Philosophy Law and Governance Track/Rights-Based Approach/rights_based_approach_handout.html
+++ b/Handouts/Philosophy Law and Governance Track/Rights-Based Approach/rights_based_approach_handout.html
@@ -409,6 +409,11 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 /* Body clears fixed im-topbar (added by site-wide audit fix) */
 body { padding-top: 56px; }
 @media (max-width: 768px) { body { padding-top: 52px; } }
+
+/* Mobile: wide tables scroll within their own container instead of overflowing the page */
+@media (max-width: 640px) {
+  table { display: block; max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+}
 </style>
 <link rel="icon" type="image/png" href="/assets/images/favicon.png">
 <link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">


### PR DESCRIPTION
## What does this PR do?

Follow-up to #752. A 390px headless check found two of the new handouts had comparison tables wider than the viewport — **Rights-Based Approach (15px overflow)** and **Measuring SEL (221px overflow)** — causing horizontal page scroll on phones. Adds a mobile rule so tables scroll inside their own container instead of pushing the page.

Verified: **0px horizontal overflow at 390px on all five new handouts** after the fix (the other three were already clean, as are the three new labs).

## Type of change
- [x] Bug fix (mobile layout)

## Checklist
- [x] Tested on desktop / headless 390px (0px overflow confirmed on all 5 handouts)
- [x] No console errors
- [x] Links working; `check-mojibake.py` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZJVUELWTXytJLQvurs8CJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZJVUELWTXytJLQvurs8CJ)_