### PR TITLE
Data Dives: five more investigations + responsive, fancy chart engine

### DIFF
--- a/DataDives/datadive.css
+++ b/DataDives/datadive.css
@@ -1,0 +1,291 @@
+/* ImpactMojo Data Dives — shared styles (chrome + article + collection + charts).
+   Charts render at real pixel width via datadive.js, so this file only handles
+   layout/colour; text size on charts is controlled by the .dv-* chart classes
+   below and stays constant (real px) across screen sizes. */
+
+/* ===== Brand chrome tokens ===== */
+:root {
+  --im-gradient: linear-gradient(135deg, #2563EB 0%, #4338CA 100%);
+  --im-accent: #2563EB;
+  --im-nav-bg: rgba(15, 23, 42, 0.95);
+  --im-border: #334155;
+  --im-text-primary: #F1F5F9;
+  --im-text-secondary: #94A3B8;
+  --im-text-muted: #64748B;
+  --im-card-bg: #1E293B;
+  --im-hover-bg: #334155;
+  --im-secondary-bg: #1E293B;
+  /* Data Dive design tokens */
+  --dv-bg: #FAF7F2;
+  --dv-surface: #FFFFFF;
+  --dv-surface-2: #F4EFE7;
+  --dv-border: #E5DDD0;
+  --dv-text: #1A1A1A;
+  --dv-text-soft: #3F3F46;
+  --dv-muted: #6B6560;
+  --dv-accent: #2563EB;
+  --dv-accent-soft: #EAF1FE;
+  --dv-teal: #0F766E;
+  --dv-teal-soft: #E7F3F1;
+  --dv-radius: 12px;
+  /* chart roles */
+  --dv-series: #2563EB;
+  --dv-series-2: #60A5FA;
+  --dv-series-soft: #BFD4FB;
+  --dv-avg: #B45309;
+  --dv-avg-2: #F59E0B;
+  --dv-b-2: #FBBF24;
+  --dv-good: #15803D;
+  --dv-bad: #B91C1C;
+  --dv-grid: #E7DFD2;
+  --dv-axis: #C9BFAE;
+  --dv-ink: #1A1A1A;
+  --dv-a: #2563EB;
+  --dv-b: #D97706;
+  --dv-chart-surface: #FFFFFF;
+}
+html.dark {
+  --dv-bg: #0F172A;
+  --dv-surface: #1E293B;
+  --dv-surface-2: #172033;
+  --dv-border: #334155;
+  --dv-text: #F1F5F9;
+  --dv-text-soft: #CBD5E1;
+  --dv-muted: #94A3B8;
+  --dv-accent: #60A5FA;
+  --dv-accent-soft: rgba(96, 165, 250, 0.12);
+  --dv-teal: #2DD4BF;
+  --dv-teal-soft: rgba(45, 212, 191, 0.10);
+  --dv-series: #60A5FA;
+  --dv-series-2: #A5C9FB;
+  --dv-series-soft: rgba(96, 165, 250, 0.30);
+  --dv-avg: #FBBF24;
+  --dv-avg-2: #FCD34D;
+  --dv-b-2: #FCD34D;
+  --dv-good: #4ADE80;
+  --dv-bad: #F87171;
+  --dv-grid: #2A3852;
+  --dv-axis: #475569;
+  --dv-ink: #F1F5F9;
+  --dv-a: #60A5FA;
+  --dv-b: #FBBF24;
+  --dv-chart-surface: #1E293B;
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; background: var(--dv-bg); color: var(--dv-text); font-family: 'Amaranth', Arial, sans-serif; line-height: 1.7; }
+body { padding-top: 56px; }
+
+/* ===== Topbar ===== */
+.im-topbar { position: fixed; top: 0; left: 0; right: 0; z-index: 9999; background: var(--im-nav-bg); backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px); border-bottom: 1px solid var(--im-border); padding: 0.5rem 1rem; display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; flex-wrap: wrap; font-family: 'Inter', sans-serif; }
+.im-topbar a { text-decoration: none; }
+.im-topbar-left { display: flex; align-items: center; gap: 0.75rem; }
+.im-topbar-home { display: flex; align-items: center; gap: 0.5rem; font-weight: 700; font-size: 1rem; color: #2563EB; }
+.im-topbar-home img { width: 24px; height: 24px; border-radius: 4px; }
+.im-topbar-right { display: flex; align-items: center; gap: 0.5rem; }
+.im-premium-btn { background: var(--im-gradient); color: #fff; padding: 0.35rem 0.85rem; border-radius: 6px; font-size: 0.8rem; font-weight: 600; display: flex; align-items: center; gap: 0.35rem; }
+.im-browse-btn { display: inline-flex; align-items: center; gap: 0.4rem; font-family: 'Inter', sans-serif; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: #1C1917; background: #FFFFFF; border: 1.5px solid #E2E8F0; padding: 0.5rem 1rem; border-radius: 0.5rem; text-decoration: none; transition: all 0.18s ease; }
+.im-browse-btn:hover { background: var(--im-accent); color: #FFFFFF; border-color: var(--im-accent); transform: translateY(-1px); }
+.im-browse-btn svg { width: 14px; height: 14px; }
+@media (prefers-color-scheme: dark) { .im-browse-btn { color: rgba(255,255,255,0.9); background: rgba(255,255,255,0.05); border-color: rgba(255,255,255,0.18); } }
+.im-premium-btn svg { width: 14px; height: 14px; }
+.im-theme-selector { display: flex; gap: 2px; background: var(--im-card-bg); border: 1px solid var(--im-border); border-radius: 8px; padding: 2px; }
+.im-theme-btn { background: transparent; border: none; color: var(--im-text-secondary); padding: 6px; border-radius: 5px; cursor: pointer; transition: all 0.2s; display: flex; align-items: center; justify-content: center; width: 30px; height: 30px; }
+.im-theme-btn:hover { background: var(--im-hover-bg); color: var(--im-text-primary); }
+.im-theme-btn.active { background: var(--im-accent); color: #fff; }
+.im-theme-btn svg { width: 16px; height: 16px; }
+.im-skip-link { position: absolute; top: -40px; left: 0; background: var(--im-accent); color: #fff; padding: 8px 16px; z-index: 10000; text-decoration: none; font-family: 'Inter', sans-serif; font-size: 0.85rem; font-weight: 600; }
+.im-skip-link:focus { top: 0; }
+
+/* ===== Footer ===== */
+.im-footer { background: var(--im-secondary-bg); border-top: 1px solid var(--im-border); padding: 2rem 1rem; margin-top: 4rem; font-family: 'Inter', sans-serif; color: var(--im-text-secondary); }
+.im-footer-content { max-width: 1100px; margin: 0 auto; }
+.im-footer-made { text-align: center; margin-bottom: 1.5rem; font-size: 0.9rem; color: var(--im-text-muted); }
+.im-footer-made a { color: var(--im-accent); text-decoration: none; }
+.im-footer-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1.5rem; margin-bottom: 1.5rem; }
+.im-footer-section h4 { color: var(--im-text-primary); font-size: 0.9rem; margin-bottom: 0.75rem; font-weight: 600; }
+.im-footer-section ul { list-style: none; padding: 0; margin: 0; }
+.im-footer-section li { margin-bottom: 0.4rem; }
+.im-footer-section a { color: var(--im-text-secondary); font-size: 0.85rem; text-decoration: none; transition: color 0.2s; }
+.im-footer-section a:hover { color: var(--im-accent); }
+.im-footer-bottom { text-align: center; padding-top: 1rem; border-top: 1px solid var(--im-border); font-size: 0.8rem; color: var(--im-text-muted); }
+.im-footer-bottom a { color: var(--im-accent); text-decoration: none; }
+
+/* ===== Collection (index) ===== */
+.dv-wrap { max-width: 800px; margin: 0 auto; padding: 2.25rem 1.25rem 4rem; }
+.dv-wrap.wide { max-width: 1100px; }
+.dv-eyebrow { display: inline-flex; align-items: center; gap: .5rem; font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; color: var(--dv-accent); margin-bottom: 1rem; }
+.dv-eyebrow::before { content: ""; width: 26px; height: 2px; background: var(--dv-accent); border-radius: 2px; }
+.dv-page-title { font-family: 'Inter', sans-serif; font-size: clamp(2rem, 5vw, 3rem); font-weight: 800; letter-spacing: -0.02em; line-height: 1.12; margin-bottom: 1rem; color: var(--dv-text); }
+.dv-page-lede { font-size: 1.2rem; color: var(--dv-text-soft); max-width: 720px; line-height: 1.6; margin-bottom: 1rem; }
+.dv-intro { font-family: 'Inter', sans-serif; font-size: .9rem; color: var(--dv-muted); margin-bottom: 2.5rem; max-width: 720px; line-height: 1.6; }
+.dv-intro strong { color: var(--dv-text-soft); }
+.dv-intro a { color: var(--dv-accent); text-decoration: none; border-bottom: 1px dotted var(--dv-accent); }
+.dv-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.25rem; }
+.dv-card { background: var(--dv-surface); border: 1px solid var(--dv-border); border-radius: 14px; padding: 1.6rem; display: flex; flex-direction: column; transition: transform .2s, border-color .2s, box-shadow .2s; text-decoration: none; color: inherit; }
+.dv-card:hover { transform: translateY(-3px); border-color: var(--dv-accent); box-shadow: 0 10px 28px rgba(37,99,235,.10); }
+.dv-card-top { display: flex; align-items: center; gap: .5rem; margin-bottom: .85rem; }
+.dv-card-topic { font-family: 'Inter', sans-serif; font-size: 10px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; color: var(--dv-accent); background: var(--dv-accent-soft); padding: .25rem .6rem; border-radius: 5px; }
+.dv-card-charts { margin-left: auto; font-family: 'Inter', sans-serif; font-size: .72rem; font-weight: 600; color: var(--dv-teal); }
+.dv-card-title { font-family: 'Inter', sans-serif; font-size: 1.3rem; font-weight: 800; line-height: 1.22; margin-bottom: .55rem; color: var(--dv-text); letter-spacing: -0.01em; }
+.dv-card-tagline { font-size: .96rem; color: var(--dv-muted); line-height: 1.55; margin-bottom: 1.15rem; flex: 1; }
+.dv-card-meta { display: flex; align-items: center; gap: .6rem; padding-top: .85rem; border-top: 1px solid var(--dv-border); font-family: 'Inter', sans-serif; font-size: .78rem; color: var(--dv-muted); flex-wrap: wrap; }
+.dv-card-author { font-weight: 600; color: var(--dv-text-soft); }
+.dv-card-dataset { margin-left: auto; padding: .15rem .5rem; border-radius: 4px; background: var(--dv-teal-soft); color: var(--dv-teal); font-weight: 600; font-size: .72rem; }
+.dv-empty { text-align: center; padding: 3rem 1rem; color: var(--dv-muted); font-family: 'Inter', sans-serif; grid-column: 1 / -1; }
+.dv-pitch { margin: 4rem 0 0; padding: 2.5rem; background: var(--dv-accent-soft); border-radius: 14px; text-align: center; }
+.dv-pitch h2 { font-family: 'Inter', sans-serif; font-size: 1.5rem; margin-bottom: .75rem; color: var(--dv-accent); }
+.dv-pitch p { font-size: 1rem; color: var(--dv-text-soft); max-width: 600px; margin: 0 auto 1.5rem; line-height: 1.6; }
+.dv-pitch a { display: inline-block; background: var(--dv-accent); color: #fff !important; font-family: 'Inter', sans-serif; font-weight: 600; padding: .75rem 1.75rem; border-radius: 8px; text-decoration: none; }
+
+/* ===== Article ===== */
+.dv-back { display: inline-block; margin-bottom: 1.5rem; font-family: 'Inter', sans-serif; font-size: .85rem; color: var(--dv-muted); text-decoration: none; }
+.dv-back:hover { color: var(--dv-accent); }
+.dv-title { font-family: 'Inter', sans-serif; font-size: clamp(1.8rem, 4.5vw, 2.9rem); font-weight: 800; letter-spacing: -0.02em; line-height: 1.14; margin: 0 0 .9rem; color: var(--dv-text); }
+.dv-standfirst { font-size: 1.18rem; color: var(--dv-text-soft); line-height: 1.6; margin-bottom: 1.5rem; }
+.dv-byline { display: flex; flex-wrap: wrap; align-items: center; gap: .45rem .8rem; font-family: 'Inter', sans-serif; font-size: .82rem; color: var(--dv-muted); padding-bottom: 1.5rem; margin-bottom: 2.25rem; border-bottom: 1px solid var(--dv-border); }
+.dv-byline strong { color: var(--dv-text-soft); font-weight: 600; }
+.dv-byline .dv-dot { color: var(--dv-border); }
+.dv-tag { font-family: 'Inter', sans-serif; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; padding: .2rem .55rem; border-radius: 4px; background: var(--dv-accent-soft); color: var(--dv-accent); }
+.dv-prose p { font-size: 1.06rem; line-height: 1.8; color: var(--dv-text-soft); margin: 0 0 1.25rem; }
+.dv-prose h2 { font-family: 'Inter', sans-serif; font-size: 1.5rem; font-weight: 700; letter-spacing: -0.01em; color: var(--dv-text); margin: 2.75rem 0 1rem; line-height: 1.25; }
+.dv-prose h3 { font-family: 'Inter', sans-serif; font-size: 1.15rem; font-weight: 700; color: var(--dv-text); margin: 2rem 0 .5rem; }
+.dv-prose a { color: var(--dv-accent); text-decoration: none; border-bottom: 1px solid rgba(37,99,235,.3); }
+.dv-prose a:hover { border-bottom-color: var(--dv-accent); }
+.dv-prose strong { color: var(--dv-text); font-weight: 700; }
+.dv-section-kicker { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; color: var(--dv-accent); margin: 2.75rem 0 .35rem; }
+.dv-section-kicker + h2 { margin-top: .15rem; }
+
+.dv-finding { margin: 2rem 0; padding: 1.5rem 1.75rem; background: var(--dv-surface); border: 1px solid var(--dv-border); border-left: 4px solid var(--dv-accent); border-radius: 0 var(--dv-radius) var(--dv-radius) 0; }
+.dv-finding-label { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; color: var(--dv-accent); margin-bottom: .6rem; }
+.dv-finding p { font-size: 1.1rem; line-height: 1.65; color: var(--dv-text); margin: 0; font-family: 'Inter', sans-serif; font-weight: 500; }
+
+.dv-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: .85rem; margin: 2rem 0 2.5rem; }
+.dv-stat { background: var(--dv-surface); border: 1px solid var(--dv-border); border-radius: var(--dv-radius); padding: 1.15rem 1.15rem 1rem; }
+.dv-stat-num { font-family: 'Inter', sans-serif; font-size: 2rem; font-weight: 800; letter-spacing: -0.02em; color: var(--dv-accent); line-height: 1; margin-bottom: .35rem; font-variant-numeric: tabular-nums; }
+.dv-stat-label { font-family: 'Inter', sans-serif; font-size: .82rem; line-height: 1.4; color: var(--dv-muted); }
+.dv-stat-label strong { color: var(--dv-text-soft); font-weight: 600; }
+
+figure.dv-fig { margin: 2.25rem 0; padding: 1.5rem 1.25rem 1.1rem; background: var(--dv-chart-surface); border: 1px solid var(--dv-border); border-radius: var(--dv-radius); }
+.dv-fig-title { font-family: 'Inter', sans-serif; font-size: 1.06rem; font-weight: 700; color: var(--dv-text); margin: 0 0 .2rem; }
+.dv-fig-sub { font-family: 'Inter', sans-serif; font-size: .85rem; color: var(--dv-muted); margin: 0 0 1rem; line-height: 1.5; }
+.dv-chart svg { width: 100%; height: auto; display: block; overflow: visible; font-family: 'Inter', sans-serif; }
+.dv-fig figcaption { font-family: 'Inter', sans-serif; font-size: .78rem; color: var(--dv-muted); margin-top: 1rem; line-height: 1.5; }
+.dv-fig figcaption strong { color: var(--dv-text-soft); font-weight: 600; }
+
+/* Chart primitives (font-size here is REAL px thanks to datadive.js) */
+.dv-bar { fill: var(--dv-series); }
+.dv-bar.hl { fill: var(--dv-avg); }
+.dv-bar-track { fill: var(--dv-series-soft); opacity: .28; }
+.dv-bar-lbl { fill: var(--dv-ink); font-size: 13px; font-weight: 600; }
+.dv-bar-val { fill: var(--dv-ink); font-size: 13px; font-weight: 700; font-variant-numeric: tabular-nums; }
+.dv-bar-val.inside { fill: #fff; }
+.dv-grid-line { stroke: var(--dv-grid); stroke-width: 1; }
+.dv-axis-line { stroke: var(--dv-axis); stroke-width: 1; }
+.dv-tick { fill: var(--dv-muted); font-size: 11px; font-variant-numeric: tabular-nums; }
+.dv-ref-line { stroke: var(--dv-avg); stroke-width: 1.5; stroke-dasharray: 5 4; }
+.dv-ref-lbl { fill: var(--dv-avg); font-size: 11px; font-weight: 700; }
+.dv-dot { fill: var(--dv-series); stroke: var(--dv-chart-surface); stroke-width: 2; }
+.dv-dot-lbl { fill: var(--dv-ink); font-size: 12px; font-weight: 700; }
+.dv-dot-sub { fill: var(--dv-muted); font-size: 10.5px; font-variant-numeric: tabular-nums; }
+.dv-axis-title { fill: var(--dv-muted); font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; }
+.dv-bargroup:hover .dv-bar { fill: var(--dv-avg); }
+.dv-legend { fill: var(--dv-text-soft); font-size: 11.5px; font-weight: 600; }
+/* dumbbell */
+.dv-dumb-line { stroke: var(--dv-axis); stroke-width: 2.5; }
+.dv-dumb-a { fill: var(--dv-a); }
+.dv-dumb-b { fill: var(--dv-b); }
+.dv-dumb-val { fill: var(--dv-ink); font-size: 12px; font-weight: 700; font-variant-numeric: tabular-nums; }
+/* line */
+.dv-line-a { stroke: var(--dv-a); stroke-width: 2.5; }
+.dv-line-a-dot { fill: var(--dv-a); stroke: var(--dv-chart-surface); stroke-width: 1.5; }
+.dv-line-a-lbl { fill: var(--dv-a); font-size: 12px; font-weight: 700; }
+.dv-line-b { stroke: var(--dv-b); stroke-width: 2.5; stroke-dasharray: 6 4; }
+.dv-line-b-dot { fill: var(--dv-b); stroke: var(--dv-chart-surface); stroke-width: 1.5; }
+.dv-line-b-lbl { fill: var(--dv-b); font-size: 12px; font-weight: 700; }
+
+/* Table fallback */
+.dv-data-toggle { margin-top: .85rem; }
+.dv-data-toggle summary { font-family: 'Inter', sans-serif; font-size: .8rem; font-weight: 600; color: var(--dv-accent); cursor: pointer; list-style: none; display: inline-flex; align-items: center; gap: .35rem; }
+.dv-data-toggle summary::-webkit-details-marker { display: none; }
+.dv-data-toggle summary::before { content: "▸"; font-size: .7rem; }
+.dv-data-toggle[open] summary::before { content: "▾"; }
+.dv-table-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+.dv-table { width: 100%; border-collapse: collapse; margin-top: .85rem; font-family: 'Inter', sans-serif; font-size: .85rem; }
+.dv-table th, .dv-table td { text-align: left; padding: .45rem .6rem; border-bottom: 1px solid var(--dv-border); white-space: nowrap; }
+.dv-table th { color: var(--dv-muted); font-weight: 600; font-size: .75rem; text-transform: uppercase; letter-spacing: .05em; }
+.dv-table td { color: var(--dv-text-soft); }
+.dv-table td.num { text-align: right; font-variant-numeric: tabular-nums; font-weight: 600; color: var(--dv-text); }
+
+/* Tooltip */
+.dv-tip { position: fixed; z-index: 10001; pointer-events: none; background: var(--dv-text); color: var(--dv-bg); font-family: 'Inter', sans-serif; font-size: .78rem; line-height: 1.35; padding: .4rem .6rem; border-radius: 6px; box-shadow: 0 6px 18px rgba(0,0,0,.25); opacity: 0; transform: translateY(4px); transition: opacity .12s; max-width: 240px; }
+.dv-tip.show { opacity: 1; transform: translateY(0); }
+.dv-tip b { color: #fff; }
+html.dark .dv-tip { background: #F1F5F9; color: #0F172A; }
+html.dark .dv-tip b { color: #0F172A; }
+
+/* Method / sources / related / cite / cta */
+.dv-method { margin: 2.75rem 0; padding: 1.5rem 1.75rem; background: var(--dv-surface-2); border: 1px solid var(--dv-border); border-radius: var(--dv-radius); }
+.dv-method-label { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; color: var(--dv-muted); margin-bottom: .85rem; }
+.dv-method p, .dv-method li { font-family: 'Inter', sans-serif; font-size: .9rem; line-height: 1.65; color: var(--dv-text-soft); }
+.dv-method p { margin: 0 0 .85rem; }
+.dv-method ul { margin: 0; padding-left: 1.15rem; }
+.dv-method li { margin-bottom: .45rem; }
+.dv-method a { color: var(--dv-accent); text-decoration: none; border-bottom: 1px dotted var(--dv-accent); }
+.dv-sources { list-style: none; padding: 0; margin: .5rem 0 0; }
+.dv-sources li { font-family: 'Inter', sans-serif; font-size: .88rem; line-height: 1.55; color: var(--dv-text-soft); padding: .4rem 0; border-top: 1px solid var(--dv-border); }
+.dv-sources li:first-child { border-top: none; }
+.dv-sources a { color: var(--dv-accent); text-decoration: none; border-bottom: 1px dotted var(--dv-accent); }
+.dv-related { padding: 1.5rem 1.75rem; background: var(--dv-teal-soft); border-radius: var(--dv-radius); margin: 2.5rem 0; }
+.dv-related-label { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; color: var(--dv-teal); margin-bottom: .85rem; }
+.dv-related ul { list-style: none; padding: 0; margin: 0; display: grid; gap: .55rem; }
+.dv-related li { font-family: 'Inter', sans-serif; font-size: .95rem; }
+.dv-related a { color: var(--dv-text); text-decoration: none; border-bottom: 1px dotted var(--dv-teal); }
+.dv-related a:hover { color: var(--dv-teal); }
+.dv-cite-block { padding: 1.25rem 1.5rem; background: var(--dv-surface); border: 1px dashed var(--dv-border); border-radius: var(--dv-radius); margin: 2rem 0; }
+.dv-cite-label { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; color: var(--dv-muted); margin-bottom: .5rem; }
+.dv-cite-text { font-family: 'Inter', sans-serif; font-size: .88rem; color: var(--dv-text-soft); line-height: 1.6; }
+.dv-cta { padding: 1.75rem; background: var(--dv-accent-soft); border-radius: var(--dv-radius); text-align: center; margin-top: 2.5rem; }
+.dv-cta h3 { font-family: 'Inter', sans-serif; font-size: 1.2rem; margin: 0 0 .5rem; color: var(--dv-accent); }
+.dv-cta p { font-size: .95rem; color: var(--dv-text-soft); margin: 0 0 1rem; }
+.dv-cta a { display: inline-block; background: var(--dv-accent); color: #fff !important; font-family: 'Inter', sans-serif; font-weight: 600; padding: .65rem 1.5rem; border-radius: 8px; text-decoration: none; }
+
+/* ===== Fancy chart polish: gradients, shadows, entrance animation ===== */
+.dv-stop-a0 { stop-color: var(--dv-series); }
+.dv-stop-a1 { stop-color: var(--dv-series-2); }
+.dv-stop-hl0 { stop-color: var(--dv-avg); }
+.dv-stop-hl1 { stop-color: var(--dv-avg-2); }
+.dv-stop-area0 { stop-color: var(--dv-series); stop-opacity: .30; }
+.dv-stop-area1 { stop-color: var(--dv-series); stop-opacity: 0; }
+.dv-stop-areaB0 { stop-color: var(--dv-b); stop-opacity: .32; }
+.dv-stop-areaB1 { stop-color: var(--dv-b); stop-opacity: 0; }
+.dv-stop-dotA0 { stop-color: var(--dv-series-2); }
+.dv-stop-dotA1 { stop-color: var(--dv-series); }
+.dv-stop-dotB0 { stop-color: var(--dv-b-2); }
+.dv-stop-dotB1 { stop-color: var(--dv-b); }
+
+.dv-bar { filter: drop-shadow(0 2px 3px rgba(37,99,235,.22)); }
+.dv-bar.hl { filter: drop-shadow(0 2px 3px rgba(180,83,9,.22)); }
+.dv-dot, .dv-dumb-a, .dv-dumb-b, .dv-line-a-dot, .dv-line-b-dot { filter: drop-shadow(0 1px 2px rgba(0,0,0,.20)); }
+html.dark .dv-bar { filter: drop-shadow(0 2px 4px rgba(0,0,0,.45)); }
+
+@keyframes dvGrow { from { transform: scaleX(0); } to { transform: scaleX(1); } }
+@keyframes dvPop { from { transform: scale(0); opacity: 0; } to { transform: scale(1); opacity: 1; } }
+@keyframes dvDraw { from { stroke-dashoffset: 1; } to { stroke-dashoffset: 0; } }
+@keyframes dvFade { from { opacity: 0; } to { opacity: 1; } }
+@media (prefers-reduced-motion: no-preference) {
+  .dv-anim-bar { transform-box: fill-box; transform-origin: left center; animation: dvGrow .7s cubic-bezier(.22,.61,.36,1) both; }
+  .dv-anim-dot { transform-box: fill-box; transform-origin: center; animation: dvPop .5s cubic-bezier(.34,1.3,.64,1) both; animation-delay: .28s; }
+  .dv-anim-line { stroke-dasharray: 1; stroke-dashoffset: 1; animation: dvDraw .9s ease .1s forwards; }
+  .dv-anim-area { opacity: 0; animation: dvFade .8s ease .5s forwards; }
+}
+
+/* ===== Mobile ===== */
+@media (max-width: 640px) {
+  .dv-wrap { padding: 1.5rem 1rem 3rem; }
+  .dv-grid { grid-template-columns: 1fr; }
+  .dv-method, .dv-related, .dv-cta, .dv-finding { padding: 1.25rem; }
+  figure.dv-fig { padding: 1.1rem .75rem 1rem; }
+  .dv-standfirst { font-size: 1.08rem; }
+  .dv-prose p { font-size: 1.02rem; }
+  .dv-stat-num { font-size: 1.7rem; }
+}

--- a/DataDives/datadive.js
+++ b/DataDives/datadive.js
@@ -1,0 +1,321 @@
+/* ImpactMojo Data Dives — shared, responsive chart engine.
+   Charts are drawn at the container's REAL pixel width (viewBox = clientWidth),
+   so 1 SVG unit = 1 CSS px and text stays readable at any screen size instead of
+   shrinking. Every chart re-renders on resize and switches to a compact layout on
+   narrow screens. All charts ship a hover tooltip; the page supplies a <details>
+   data table for the non-visual fallback. */
+(function () {
+  var SVGNS = "http://www.w3.org/2000/svg";
+
+  // --- shared tooltip ---
+  var tip;
+  function ensureTip() {
+    if (tip) return tip;
+    tip = document.createElement('div');
+    tip.className = 'dv-tip';
+    tip.setAttribute('role', 'status');
+    tip.setAttribute('aria-live', 'polite');
+    document.body.appendChild(tip);
+    window.addEventListener('mousemove', function (e) { if (tip.classList.contains('show')) moveTip(e); });
+    return tip;
+  }
+  function showTip(html, e) { ensureTip(); tip.innerHTML = html; tip.classList.add('show'); moveTip(e); }
+  function moveTip(e) {
+    var w = tip.offsetWidth, h = tip.offsetHeight;
+    var nx = e.clientX + 14, ny = e.clientY + 14;
+    if (nx + w > window.innerWidth - 8) nx = e.clientX - w - 14;
+    if (ny + h > window.innerHeight - 8) ny = e.clientY - h - 14;
+    tip.style.left = nx + 'px'; tip.style.top = ny + 'px';
+  }
+  function hideTip() { if (tip) tip.classList.remove('show'); }
+
+  function el(tag, attrs, text) {
+    var n = document.createElementNS(SVGNS, tag);
+    if (attrs) for (var k in attrs) n.setAttribute(k, attrs[k]);
+    if (text != null) n.textContent = text;
+    return n;
+  }
+  function svgRoot(W, H) {
+    // Inline style beats any global `svg{}` rule from injected site chrome, so the
+    // SVG always fills its mount exactly; viewBox = measured px means 1 unit = 1 CSS px.
+    return el('svg', { viewBox: '0 0 ' + W + ' ' + H, preserveAspectRatio: 'xMinYMin meet',
+      role: 'presentation', style: 'display:block;width:100%;height:auto;overflow:visible' });
+  }
+
+  // Gradient + shadow defs, unique per SVG. Stop colours are set in CSS (theme-aware).
+  var _uid = 0;
+  function addDefs(svg) {
+    var id = 'dvg' + (_uid++);
+    var defs = el('defs');
+    function grad(sfx, x2, y2, stops) {
+      var g = el('linearGradient', { id: id + sfx, x1: '0', y1: '0', x2: x2, y2: y2 });
+      stops.forEach(function (c) { g.appendChild(el('stop', { offset: c[0], 'class': c[1] })); });
+      defs.appendChild(g);
+    }
+    grad('-a', '1', '0', [['0', 'dv-stop-a0'], ['1', 'dv-stop-a1']]);
+    grad('-hl', '1', '0', [['0', 'dv-stop-hl0'], ['1', 'dv-stop-hl1']]);
+    grad('-area', '0', '1', [['0', 'dv-stop-area0'], ['1', 'dv-stop-area1']]);
+    grad('-areaB', '0', '1', [['0', 'dv-stop-areaB0'], ['1', 'dv-stop-areaB1']]);
+    var rgA = el('radialGradient', { id: id + '-dotA', cx: '0.35', cy: '0.3', r: '0.85' });
+    rgA.appendChild(el('stop', { offset: '0', 'class': 'dv-stop-dotA0' }));
+    rgA.appendChild(el('stop', { offset: '1', 'class': 'dv-stop-dotA1' }));
+    defs.appendChild(rgA);
+    var rgB = el('radialGradient', { id: id + '-dotB', cx: '0.35', cy: '0.3', r: '0.85' });
+    rgB.appendChild(el('stop', { offset: '0', 'class': 'dv-stop-dotB0' }));
+    rgB.appendChild(el('stop', { offset: '1', 'class': 'dv-stop-dotB1' }));
+    defs.appendChild(rgB);
+    svg.appendChild(defs);
+    return id;
+  }
+  function fmt(n) { return (Math.round(n * 100) / 100).toLocaleString('en-IN'); }
+
+  // Re-render on width change (debounced). drawFn(W) returns an <svg>.
+  function responsive(mount, drawFn) {
+    var last = -1, raf;
+    function paint() {
+      var W = Math.max(260, Math.floor(mount.getBoundingClientRect().width || mount.clientWidth || 320));
+      if (W === last) return;
+      last = W;
+      mount.textContent = '';
+      mount.appendChild(drawFn(W));
+    }
+    paint();
+    if ('ResizeObserver' in window) {
+      var ro = new ResizeObserver(function () { cancelAnimationFrame(raf); raf = requestAnimationFrame(paint); });
+      ro.observe(mount);
+    } else {
+      window.addEventListener('resize', function () { cancelAnimationFrame(raf); raf = requestAnimationFrame(paint); });
+    }
+  }
+
+  function attachTip(node, html) {
+    node.style.cursor = 'default';
+    node.addEventListener('mousemove', function (e) { showTip(html, e); });
+    node.addEventListener('mouseleave', hideTip);
+  }
+
+  /* ============ HORIZONTAL BAR CHART ============
+     opts: { data:[{label,value,hl?}], max, ticks:[…], avg:{value,label},
+             suffix?, tipLabel?, valueFmt?(v) } */
+  function barChart(mount, opts) {
+    responsive(mount, function (W) {
+      var data = opts.data, max = opts.max, suffix = opts.suffix != null ? opts.suffix : '%';
+      var vfmt = opts.valueFmt || function (v) { return fmt(v) + suffix; };
+      var compact = W < 520;
+      var padR = compact ? 14 : 16, padL = compact ? 14 : 16;
+      var rowH = compact ? 50 : 40, padTop = 30, padBottom = 30;
+      var labelW = compact ? 0 : Math.min(150, Math.max(96, W * 0.22));
+      var H = padTop + data.length * rowH + padBottom;
+      var x0 = padL + labelW, x1 = W - padR;
+      var barH = compact ? 20 : 22;
+      var scale = function (v) { return x0 + (v / max) * (x1 - x0); };
+      var svg = svgRoot(W, H);
+      var gid = addDefs(svg);
+
+      // gridlines + ticks (skip on very narrow compact to reduce clutter)
+      (opts.ticks || []).forEach(function (t) {
+        var x = scale(t);
+        svg.appendChild(el('line', { x1: x, y1: padTop - 6, x2: x, y2: padTop + data.length * rowH, class: 'dv-grid-line' }));
+        svg.appendChild(el('text', { x: x, y: padTop + data.length * rowH + 18, 'text-anchor': 'middle', class: 'dv-tick' }, t + suffix));
+      });
+      svg.appendChild(el('line', { x1: x0, y1: padTop - 6, x2: x0, y2: padTop + data.length * rowH, class: 'dv-axis-line' }));
+
+      data.forEach(function (d, i) {
+        var y = padTop + i * rowH;
+        var g = el('g', { class: 'dv-bargroup' });
+        var by, bw = Math.max(0, scale(d.value) - x0);
+        if (compact) {
+          // name (left) + value (right) on one line, full-width track below
+          by = y + 22;
+          g.appendChild(el('text', { x: x0, y: y + 14, 'text-anchor': 'start', class: 'dv-bar-lbl' }, d.label));
+          g.appendChild(el('text', { x: x1, y: y + 14, 'text-anchor': 'end', class: 'dv-bar-val' }, vfmt(d.value)));
+        } else {
+          by = y + (rowH - barH) / 2;
+          g.appendChild(el('text', { x: x0 - 10, y: by + 15, 'text-anchor': 'end', class: 'dv-bar-lbl' }, d.label));
+        }
+        g.appendChild(el('rect', { x: x0, y: by, width: x1 - x0, height: barH, rx: 5, class: 'dv-bar-track' }));
+        var bar = el('rect', { x: x0, y: by, width: bw, height: barH, rx: 5, class: 'dv-bar dv-anim-bar' + (d.hl ? ' hl' : '') });
+        bar.style.fill = 'url(#' + gid + (d.hl ? '-hl' : '-a') + ')';
+        bar.style.animationDelay = (i * 0.06) + 's';
+        g.appendChild(bar);
+        if (!compact) {
+          // value label at bar end — inside (white) if it would overflow the canvas
+          var vx = scale(d.value) + 8, anchor = 'start';
+          if (vx > x1 - 30) { vx = scale(d.value) - 8; anchor = 'end'; }
+          g.appendChild(el('text', { x: vx, y: by + 15, 'text-anchor': anchor, class: 'dv-bar-val' + (vx < scale(d.value) ? ' inside' : '') }, vfmt(d.value)));
+        }
+        attachTip(g, '<b>' + d.label + '</b><br>' + (opts.tipLabel || 'Value') + ': ' + vfmt(d.value));
+        svg.appendChild(g);
+      });
+
+      if (opts.avg) {
+        var ax = scale(opts.avg.value);
+        svg.appendChild(el('line', { x1: ax, y1: padTop - 12, x2: ax, y2: padTop + data.length * rowH + 2, class: 'dv-ref-line' }));
+        svg.appendChild(el('text', { x: Math.min(ax, W - 6), y: padTop - 16, 'text-anchor': ax > W * 0.6 ? 'end' : 'middle', class: 'dv-ref-lbl' }, opts.avg.label));
+      }
+      return svg;
+    });
+  }
+
+  /* ============ SCATTER ============
+     opts: { data:[{label,x,y,anchor?,vpos?}], xMin,xMax,yMax, xTicks,yTicks,
+             xTitle, yTitle, xSuffix?, tipX?, tipY? } */
+  function scatterChart(mount, opts) {
+    responsive(mount, function (W) {
+      var compact = W < 520;
+      var data = opts.data;
+      var H = Math.round(Math.max(300, Math.min(460, W * (compact ? 0.95 : 0.66))));
+      var padL = compact ? 44 : 60, padR = 20, padT = 22, padB = 54;
+      var xMin = opts.xMin, xMax = opts.xMax, yMin = 0, yMax = opts.yMax;
+      var xs = opts.xSuffix != null ? opts.xSuffix : '%';
+      var px = function (v) { return padL + (v - xMin) / (xMax - xMin) * (W - padL - padR); };
+      var py = function (v) { return H - padB - (v - yMin) / (yMax - yMin) * (H - padT - padB); };
+      var svg = svgRoot(W, H);
+      var gid = addDefs(svg);
+
+      (opts.yTicks || []).forEach(function (t) {
+        var y = py(t);
+        svg.appendChild(el('line', { x1: padL, y1: y, x2: W - padR, y2: y, class: 'dv-grid-line' }));
+        svg.appendChild(el('text', { x: padL - 8, y: y + 4, 'text-anchor': 'end', class: 'dv-tick' }, t));
+      });
+      (opts.xTicks || []).forEach(function (t) {
+        svg.appendChild(el('text', { x: px(t), y: H - padB + 18, 'text-anchor': 'middle', class: 'dv-tick' }, t + xs));
+      });
+      svg.appendChild(el('line', { x1: padL, y1: padT, x2: padL, y2: H - padB, class: 'dv-axis-line' }));
+      svg.appendChild(el('line', { x1: padL, y1: H - padB, x2: W - padR, y2: H - padB, class: 'dv-axis-line' }));
+      if (opts.xTitle) svg.appendChild(el('text', { x: (padL + W - padR) / 2, y: H - 10, 'text-anchor': 'middle', class: 'dv-axis-title' }, opts.xTitle));
+      if (opts.yTitle) {
+        var cy = (padT + H - padB) / 2;
+        svg.appendChild(el('text', { x: 14, y: cy, 'text-anchor': 'middle', class: 'dv-axis-title', transform: 'rotate(-90 14 ' + cy + ')' }, opts.yTitle));
+      }
+
+      data.forEach(function (d) {
+        var cx = px(d.x), cy = py(d.y);
+        var g = el('g');
+        var dot = el('circle', { cx: cx, cy: cy, r: 9, class: 'dv-dot dv-anim-dot' });
+        dot.style.fill = 'url(#' + gid + '-dotA)';
+        g.appendChild(dot);
+        var anchor = d.anchor || (d.x > (xMin + xMax) / 2 ? 'end' : 'start');
+        var lx = anchor === 'end' ? cx - 13 : cx + 13;
+        var nameY = d.vpos === 'down' ? cy + 19 : cy - 19;
+        var subY = d.vpos === 'down' ? cy + 33 : cy - 5;
+        g.appendChild(el('text', { x: lx, y: nameY, 'text-anchor': anchor, class: 'dv-dot-lbl' }, d.label));
+        if (!compact || d.sub !== false)
+          g.appendChild(el('text', { x: lx, y: subY, 'text-anchor': anchor, class: 'dv-dot-sub' }, fmt(d.x) + xs + ' · ' + fmt(d.y)));
+        attachTip(g, '<b>' + d.label + '</b><br>' + (opts.tipX || 'x') + ': ' + fmt(d.x) + xs + '<br>' + (opts.tipY || 'y') + ': ' + fmt(d.y));
+        svg.appendChild(g);
+      });
+      return svg;
+    });
+  }
+
+  /* ============ DUMBBELL (two values per row, connected) ============
+     opts: { data:[{label, a, b}], max, aLabel, bLabel, suffix?, ticks?, valueFmt? } */
+  function dumbbellChart(mount, opts) {
+    responsive(mount, function (W) {
+      var data = opts.data, max = opts.max, suffix = opts.suffix != null ? opts.suffix : '';
+      var vfmt = opts.valueFmt || function (v) { return fmt(v) + suffix; };
+      var compact = W < 520;
+      var padR = 16, padL = 16, rowH = compact ? 56 : 44, padTop = 34, padBottom = 30;
+      var labelW = compact ? 0 : Math.min(150, Math.max(96, W * 0.22));
+      var H = padTop + data.length * rowH + padBottom;
+      var x0 = padL + labelW, x1 = W - padR;
+      var scale = function (v) { return x0 + (v / max) * (x1 - x0); };
+      var svg = svgRoot(W, H);
+
+      (opts.ticks || []).forEach(function (t) {
+        var x = scale(t);
+        svg.appendChild(el('line', { x1: x, y1: padTop - 6, x2: x, y2: padTop + data.length * rowH, class: 'dv-grid-line' }));
+        svg.appendChild(el('text', { x: x, y: padTop + data.length * rowH + 18, 'text-anchor': 'middle', class: 'dv-tick' }, vfmt(t)));
+      });
+
+      var gid = addDefs(svg);
+      // legend
+      var lg = el('g');
+      lg.appendChild(el('circle', { cx: x0 + 6, cy: padTop - 18, r: 6, class: 'dv-dumb-a' }));
+      lg.appendChild(el('text', { x: x0 + 18, y: padTop - 14, 'text-anchor': 'start', class: 'dv-legend' }, opts.aLabel));
+      var bx = x0 + 26 + (opts.aLabel.length * 7);
+      lg.appendChild(el('circle', { cx: bx, cy: padTop - 18, r: 6, class: 'dv-dumb-b' }));
+      lg.appendChild(el('text', { x: bx + 12, y: padTop - 14, 'text-anchor': 'start', class: 'dv-legend' }, opts.bLabel));
+      svg.appendChild(lg);
+
+      data.forEach(function (d, i) {
+        var y = padTop + i * rowH, g = el('g');
+        var cy;
+        if (compact) { cy = y + 30; svg.appendChild(el('text', { x: x0, y: y + 14, 'text-anchor': 'start', class: 'dv-bar-lbl' }, d.label)); }
+        else { cy = y + rowH / 2; g.appendChild(el('text', { x: x0 - 10, y: cy + 4, 'text-anchor': 'end', class: 'dv-bar-lbl' }, d.label)); }
+        var ax = scale(d.a), bx2 = scale(d.b);
+        g.appendChild(el('line', { x1: ax, y1: cy, x2: bx2, y2: cy, pathLength: '1', class: 'dv-dumb-line dv-anim-line' }));
+        var da = el('circle', { cx: ax, cy: cy, r: 8, class: 'dv-dumb-a dv-anim-dot' });
+        da.style.fill = 'url(#' + gid + '-dotA)';
+        var db = el('circle', { cx: bx2, cy: cy, r: 8, class: 'dv-dumb-b dv-anim-dot' });
+        db.style.fill = 'url(#' + gid + '-dotB)';
+        g.appendChild(da); g.appendChild(db);
+        // value labels at the outer ends
+        var lo = Math.min(ax, bx2), hi = Math.max(ax, bx2);
+        g.appendChild(el('text', { x: lo - 9, y: cy + 4, 'text-anchor': 'end', class: 'dv-dumb-val' }, vfmt(Math.min(d.a, d.b))));
+        g.appendChild(el('text', { x: hi + 9, y: cy + 4, 'text-anchor': 'start', class: 'dv-dumb-val' }, vfmt(Math.max(d.a, d.b))));
+        attachTip(g, '<b>' + d.label + '</b><br>' + opts.aLabel + ': ' + vfmt(d.a) + '<br>' + opts.bLabel + ': ' + vfmt(d.b));
+        svg.appendChild(g);
+      });
+      return svg;
+    });
+  }
+
+  /* ============ LINE CHART (1-2 series over an ordered x) ============
+     opts: { series:[{name, color?('a'|'b'), points:[{x,y}]}], xLabels:[…],
+             yMax, yMin?, yTicks, yFmt?, xTitle?, yTitle? }  (x is category index) */
+  function lineChart(mount, opts) {
+    responsive(mount, function (W) {
+      var compact = W < 520;
+      var H = Math.round(Math.max(280, Math.min(420, W * (compact ? 0.8 : 0.56))));
+      var padL = compact ? 44 : 56, padR = 18, padT = 24, padB = 46;
+      var labels = opts.xLabels, n = labels.length;
+      var yMin = opts.yMin || 0, yMax = opts.yMax;
+      var yFmt = opts.yFmt || function (v) { return fmt(v); };
+      var xAt = function (i) { return padL + (n === 1 ? 0.5 : i / (n - 1)) * (W - padL - padR); };
+      var yAt = function (v) { return H - padB - (v - yMin) / (yMax - yMin) * (H - padT - padB); };
+      var svg = svgRoot(W, H);
+      var gid = addDefs(svg);
+
+      (opts.yTicks || []).forEach(function (t) {
+        var y = yAt(t);
+        svg.appendChild(el('line', { x1: padL, y1: y, x2: W - padR, y2: y, class: 'dv-grid-line' }));
+        svg.appendChild(el('text', { x: padL - 8, y: y + 4, 'text-anchor': 'end', class: 'dv-tick' }, yFmt(t)));
+      });
+      // x labels (thin on compact)
+      var step = compact && n > 5 ? Math.ceil(n / 5) : 1;
+      labels.forEach(function (lb, i) {
+        if (i % step !== 0 && i !== n - 1) return;
+        svg.appendChild(el('text', { x: xAt(i), y: H - padB + 18, 'text-anchor': i === 0 ? 'start' : (i === n - 1 ? 'end' : 'middle'), class: 'dv-tick' }, lb));
+      });
+      svg.appendChild(el('line', { x1: padL, y1: padT, x2: padL, y2: H - padB, class: 'dv-axis-line' }));
+      svg.appendChild(el('line', { x1: padL, y1: H - padB, x2: W - padR, y2: H - padB, class: 'dv-axis-line' }));
+      if (opts.yTitle) { var cy = (padT + H - padB) / 2; svg.appendChild(el('text', { x: 13, y: cy, 'text-anchor': 'middle', class: 'dv-axis-title', transform: 'rotate(-90 13 ' + cy + ')' }, opts.yTitle)); }
+
+      opts.series.forEach(function (s, si) {
+        var cls = s.color === 'b' ? 'dv-line-b' : 'dv-line-a';
+        var lineD = s.points.map(function (p, i) { return (i ? 'L' : 'M') + xAt(p.x) + ' ' + yAt(p.y); }).join(' ');
+        if (s.area) {
+          var first = s.points[0], last = s.points[s.points.length - 1];
+          var areaD = lineD + ' L' + xAt(last.x) + ' ' + yAt(yMin) + ' L' + xAt(first.x) + ' ' + yAt(yMin) + ' Z';
+          var ar = el('path', { d: areaD, class: 'dv-area dv-anim-area' });
+          ar.style.fill = 'url(#' + gid + (s.color === 'b' ? '-areaB' : '-area') + ')';
+          svg.appendChild(ar);
+        }
+        svg.appendChild(el('path', { d: lineD, fill: 'none', pathLength: '1', class: cls + ' dv-anim-line' }));
+        s.points.forEach(function (p) {
+          var mk = el('circle', { cx: xAt(p.x), cy: yAt(p.y), r: 5, class: cls + '-dot dv-anim-dot' });
+          attachTip(mk, '<b>' + s.name + '</b><br>' + labels[p.x] + ': ' + yFmt(p.y));
+          svg.appendChild(mk);
+        });
+        // direct end-label
+        var last = s.points[s.points.length - 1];
+        svg.appendChild(el('text', { x: xAt(last.x) - 2, y: yAt(last.y) - 8, 'text-anchor': 'end', class: cls + '-lbl' }, s.name));
+      });
+      return svg;
+    });
+  }
+
+  window.DataDive = { barChart: barChart, scatterChart: scatterChart, dumbbellChart: dumbbellChart, lineChart: lineChart };
+})();

--- a/DataDives/honorarium-not-a-wage.html
+++ b/DataDives/honorarium-not-a-wage.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Paid an honorarium, not a wage | ImpactMojo Data Dive</title>
+<meta name="description" content="India runs its child-nutrition and rural-health systems on the labour of some 34 lakh women paid a central 'honorarium' of ₹4,500 a month or less — below the national floor wage, and roughly a fifth of the minimum wage for unskilled work. An independent data investigation.">
+<link rel="canonical" href="https://www.impactmojo.in/DataDives/honorarium-not-a-wage.html">
+<meta name="robots" content="index, follow">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Paid an honorarium, not a wage — ImpactMojo Data Dive">
+<meta property="og:description" content="India runs its nutrition and rural-health systems on ~34 lakh women paid a central 'honorarium' of ₹4,500/month or less — below the wage floor. What the numbers show.">
+<meta property="og:url" content="https://www.impactmojo.in/DataDives/honorarium-not-a-wage.html">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<meta property="og:site_name" content="ImpactMojo">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Paid an honorarium, not a wage — ImpactMojo Data Dive">
+<meta name="twitter:description" content="India runs its nutrition and rural-health systems on ~34 lakh women paid below the wage floor. What the numbers show.">
+<link rel="icon" href="/assets/images/favicon.png" type="image/png">
+<link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-JRCMEB9TBW');
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org", "@type": "Article",
+  "headline": "Paid an honorarium, not a wage",
+  "description": "An independent data investigation into the pay of India's Anganwadi and ASHA workers, paid an honorarium below the minimum wage.",
+  "image": "https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png",
+  "author": { "@type": "Organization", "name": "ImpactMojo Data" },
+  "publisher": { "@type": "Organization", "name": "ImpactMojo", "logo": { "@type": "ImageObject", "url": "https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" } },
+  "datePublished": "2026-07-11",
+  "mainEntityOfPage": "https://www.impactmojo.in/DataDives/honorarium-not-a-wage.html",
+  "isAccessibleForFree": true
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org", "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "ImpactMojo", "item": "https://www.impactmojo.in/" },
+    { "@type": "ListItem", "position": 2, "name": "Data Dives", "item": "https://www.impactmojo.in/DataDives/" },
+    { "@type": "ListItem", "position": 3, "name": "Paid an honorarium, not a wage" }
+  ]
+}
+</script>
+<link rel="stylesheet" href="/DataDives/datadive.css">
+</head>
+<body>
+<a href="#main-content" class="im-skip-link">Skip to content</a>
+<header class="im-topbar" role="banner">
+  <div class="im-topbar-left">
+    <a class="im-topbar-home" href="/" aria-label="ImpactMojo home">
+      <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo"><span>ImpactMojo</span>
+    </a>
+  </div>
+  <div class="im-topbar-right">
+    <a href="/catalog.html" class="im-browse-btn" title="Browse all content"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>Browse</a>
+    <a class="im-premium-btn" href="/premium.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>Premium</a>
+    <div class="im-theme-selector" role="group" aria-label="Theme">
+      <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="System theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Light theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Dark theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+    </div>
+  </div>
+</header>
+
+<main id="main-content" class="dv-wrap">
+  <a class="dv-back" href="/DataDives/">← All Data Dives</a>
+  <div class="dv-eyebrow">Data Dive · Care &amp; Work</div>
+  <h1 class="dv-title">Paid an honorarium, not a wage</h1>
+  <p class="dv-standfirst">India's child-nutrition and rural-health systems run on the labour of roughly 34 lakh women. The central government pays them an "honorarium" — not a salary — of ₹4,500 a month or less, below the national floor wage. Calling the work voluntary is what keeps it that cheap.</p>
+  <div class="dv-byline">
+    <span class="dv-tag">Investigation</span>
+    <span><strong>ImpactMojo Data</strong></span>
+    <span class="dv-dot">·</span><span>11 July 2026</span>
+    <span class="dv-dot">·</span><span>6 min read</span>
+    <span class="dv-dot">·</span><span>Source: MWCD · NHM · Supreme Court</span>
+  </div>
+
+  <div class="dv-prose">
+    <p>Every Anganwadi centre that weighs a baby, feeds a toddler, or counsels a pregnant woman is staffed by an Anganwadi worker and a helper. Every village that gets a community health visit has an ASHA. Together these two cadres — roughly 23.7 lakh Anganwadi workers and helpers, and around 10 lakh ASHAs — are the human infrastructure of India's nutrition and primary-health systems. Almost all of them are women.</p>
+
+    <p>They are not, in the government's accounting, employees. They are "honorary workers" who "voluntarily come forward," and what they receive is an honorarium. That single word does a lot of work: it is the reason the pay can sit below the minimum wage.</p>
+
+    <div class="dv-finding">
+      <div class="dv-finding-label">The finding</div>
+      <p>An Anganwadi worker's central honorarium is <strong>₹4,500 a month</strong> — below the national floor wage, and about <strong>a fifth of the ₹20,000-odd</strong> a month that the central minimum wage implies for unskilled work. A helper gets ₹2,250. ASHAs have no fixed salary at all. The central amounts have not moved since 2018 — even after the Supreme Court held, in 2022, that this "honorarium" is in fact <em>wages</em>.</p>
+    </div>
+
+    <div class="dv-stats">
+      <div class="dv-stat"><div class="dv-stat-num">~34L</div><div class="dv-stat-label">frontline <strong>women</strong> — Anganwadi workers, helpers, and ASHAs</div></div>
+      <div class="dv-stat"><div class="dv-stat-num">₹4,500</div><div class="dv-stat-label">central monthly <strong>honorarium</strong> for an Anganwadi worker</div></div>
+      <div class="dv-stat"><div class="dv-stat-num">~22%</div><div class="dv-stat-label">of the central <strong>unskilled minimum wage</strong> that ₹4,500 represents</div></div>
+      <div class="dv-stat"><div class="dv-stat-num">2018</div><div class="dv-stat-label">the last time the central honorarium was <strong>raised</strong></div></div>
+    </div>
+
+    <div class="dv-section-kicker">01 — Below the floor</div>
+    <h2>An honorarium under the minimum wage</h2>
+    <p>Set the honorarium against the wage benchmarks and the framing does its job in plain sight. The national floor-level minimum wage — an advisory level states are not supposed to undercut — works out to roughly ₹4,600 a month for full-time work. An Anganwadi worker's ₹4,500 sits just under it; a helper's ₹2,250 is about half. Against the central government's own minimum wage for unskilled work — around ₹20,000 a month with allowances — the worker's honorarium is barely a fifth.</p>
+
+    <figure class="dv-fig">
+      <div class="dv-fig-title">The honorarium against the wage floor</div>
+      <div class="dv-fig-sub">Monthly amounts. The two left bars are what the Centre pays; the two right bars are wage benchmarks for comparison.</div>
+      <div class="dv-chart" id="c-wage" role="img" aria-label="Bar chart of monthly amounts in rupees: Anganwadi helper honorarium 2,250; Anganwadi worker honorarium 4,500; national floor wage about 4,628; central unskilled minimum wage about 20,358. The honorarium sits below the wage floor."></div>
+      <details class="dv-data-toggle"><summary>View data table</summary>
+        <div class="dv-table-scroll"><table class="dv-table"><thead><tr><th>Monthly amount</th><th>Rupees</th></tr></thead>
+        <tbody>
+          <tr><td>Anganwadi helper (honorarium)</td><td class="num">2,250</td></tr>
+          <tr><td>Anganwadi worker (honorarium)</td><td class="num">4,500</td></tr>
+          <tr><td>National floor wage (≈26 days)</td><td class="num">4,628</td></tr>
+          <tr><td>Central unskilled minimum wage (with VDA)</td><td class="num">20,358</td></tr>
+        </tbody></table></div>
+      </details>
+      <figcaption><strong>Source:</strong> Central honoraria — Ministry of Women &amp; Child Development (revised 2018, unchanged since). Wage benchmarks — Ministry of Labour &amp; Employment; the minimum-wage figure is revised twice a year, so treat it as approximate.</figcaption>
+    </figure>
+
+    <p>ASHAs are paid differently and, in a sense, worse: they have no fixed salary at all. They receive a small fixed monthly incentive (₹2,000) plus piece-rate payments for specific tasks — an institutional delivery here, an immunisation session there — so a month's earnings swing with the work available and the state they are in. In 2022 the World Health Organization gave India's ASHAs a Global Health Leaders Award; workers noted that an award does not pay a wage.</p>
+
+    <div class="dv-section-kicker">02 — The geography lottery</div>
+    <h2>Same job, very different pay</h2>
+    <p>The central honorarium is a floor, and states top it up — by wildly different amounts. Where the Centre pays ₹4,500 to an Anganwadi worker, a handful of states lift the total to three or four times that. The result is that what the identical job pays depends mostly on which state you do it in.</p>
+
+    <figure class="dv-fig">
+      <div class="dv-fig-title">Anganwadi worker's total monthly pay, by state</div>
+      <div class="dv-fig-sub">Reported total in-hand pay (central honorarium plus state top-up) for selected states. The dashed line is the ₹4,500 central amount everyone starts from.</div>
+      <div class="dv-chart" id="c-state" role="img" aria-label="Bar chart of Anganwadi worker total monthly pay by state, reported: Tamil Nadu about 18,000 rupees, Kerala 17,000, Telangana 13,000, Karnataka 12,000, Andhra Pradesh 12,000, against a central floor of 4,500 rupees."></div>
+      <details class="dv-data-toggle"><summary>View data table</summary>
+        <div class="dv-table-scroll"><table class="dv-table"><thead><tr><th>State (reported total)</th><th>Rupees / month</th></tr></thead>
+        <tbody>
+          <tr><td>Tamil Nadu</td><td class="num">~18,000</td></tr>
+          <tr><td>Kerala</td><td class="num">~17,000</td></tr>
+          <tr><td>Telangana</td><td class="num">~13,000</td></tr>
+          <tr><td>Karnataka</td><td class="num">~12,000</td></tr>
+          <tr><td>Andhra Pradesh</td><td class="num">~12,000</td></tr>
+          <tr><td>Central honorarium (everywhere)</td><td class="num">4,500</td></tr>
+        </tbody></table></div>
+      </details>
+      <figcaption><strong>Source:</strong> Reported state totals (aggregated from public compilations); the ₹4,500 central floor is from MWCD. State amounts change with state budgets — treat them as indicative, not audited.</figcaption>
+    </figure>
+
+    <div class="dv-section-kicker">03 — Reading the numbers honestly</div>
+    <h2>What this data can and can't tell you</h2>
+    <div class="dv-method">
+      <div class="dv-method-label">How to read this responsibly</div>
+      <ul>
+        <li><strong>"Voluntary" is a legal device, not a description.</strong> These schemes run on executive orders, not labour statutes, which is what lets the state pay an honorarium instead of a wage. In 2022 the Supreme Court held that Anganwadi workers are employees and their honorarium is wages, entitling them to gratuity — the label and the law already disagree.</li>
+        <li><strong>Hours are contested, so hourly rates are estimates.</strong> The roles are officially "part-time," but unions and field studies document full days. Any implied hourly figure depends on the hours you assume — state the assumption rather than quoting a single number.</li>
+        <li><strong>The minimum-wage benchmark moves.</strong> The ~₹20,000 central unskilled wage is revised twice a year with dearness allowance; the ~22% ratio is a snapshot, not a fixed fact.</li>
+        <li><strong>State top-ups are reported, not audited here.</strong> The state totals come from public compilations and shift with state budgets; the one hard number is the ₹4,500 central floor that is identical everywhere.</li>
+        <li><strong>Don't confuse this with the value of unpaid care.</strong> Wide estimates that care work is worth 15–40% of GDP describe <em>unpaid domestic</em> work, not this paid-but-underpaid cadre. They frame the undervaluation; they don't price these workers.</li>
+      </ul>
+      <p>The claim the data supports: <strong>India delivers nutrition and primary health to hundreds of millions through ~34 lakh women it pays below its own wage floor, on amounts frozen since 2018 — a cost structure that depends on calling the work "voluntary" even after the courts called it employment.</strong></p>
+    </div>
+
+    <div class="dv-method">
+      <div class="dv-method-label">Sources &amp; data</div>
+      <ul class="dv-sources">
+        <li>Ministry of Women &amp; Child Development — <a href="https://www.pib.gov.in/PressReleaseIframePage.aspx?PRID=2003433" target="_blank" rel="noopener">worker counts and honorarium amounts</a> (2024); <a href="https://www.pib.gov.in/Pressreleaseshare.aspx?PRID=1546623" target="_blank" rel="noopener">2018 revision</a>.</li>
+        <li>Supreme Court of India, <em>Maniben Maganbhai Bhariya v. District Development Officer</em> (2022) — honorarium as wages, gratuity for Anganwadi workers (via <a href="https://scroll.in/latest/1022741/anganwadi-workers-helpers-are-entitled-to-gratuity-says-supreme-court" target="_blank" rel="noopener">Scroll</a>).</li>
+        <li>World Health Organization — <a href="https://www.who.int/india/india-asha-workers" target="_blank" rel="noopener">ASHA cadre size and recognition</a> (2022); Ministry of Labour &amp; Employment — minimum-wage benchmarks.</li>
+      </ul>
+    </div>
+
+    <div class="dv-related">
+      <div class="dv-related-label">Go deeper on ImpactMojo</div>
+      <ul>
+        <li><a href="/DeepDives/the-care-economy.html">Deep Dive — The Care Economy</a>: recognising, reducing, and redistributing care work.</li>
+        <li><a href="/DeepDives/informality-and-social-protection.html">Deep Dive — Informality and Social Protection</a>: the workers who hold systems up, and the benefits that miss them.</li>
+        <li><a href="/DeepDives/measuring-empowerment.html">Deep Dive — Measuring Empowerment</a>: valuing work that resists valuation.</li>
+        <li><a href="/DataDives/whose-name-on-the-house.html">Data Dive — Whose name is on the house?</a>: another gap between the paperwork and the reality.</li>
+      </ul>
+    </div>
+
+    <div class="dv-cite-block">
+      <div class="dv-cite-label">Suggested citation</div>
+      <p class="dv-cite-text">ImpactMojo Data (2026). "Paid an honorarium, not a wage." <em>ImpactMojo Data Dives</em>. Retrieved from https://impactmojo.in/DataDives/honorarium-not-a-wage.html</p>
+    </div>
+
+    <div class="dv-cta">
+      <h3>Have a dataset worth digging into?</h3>
+      <p>Data Dives are independent investigations built from public data. If you know a number that deserves a closer look, tell us.</p>
+      <a href="/contact.html?topic=DataDive">Pitch a Data Dive →</a>
+    </div>
+  </div>
+</main>
+
+<footer class="im-footer" role="contentinfo">
+  <div class="im-footer-content">
+    <p class="im-footer-made">Made with ♥ by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+    <div class="im-footer-grid">
+      <div class="im-footer-section"><h4>About ImpactMojo</h4><ul><li><a href="/about.html">About Us</a></li><li><a href="/contact.html">Contact</a></li><li><a href="https://github.com/ImpactMojo/ImpactMojo" rel="noopener noreferrer" target="_blank">GitHub</a></li><li><a href="/transparency.html">Transparency</a></li></ul></div>
+      <div class="im-footer-section"><h4>Legal</h4><ul><li><a href="/privacy-policy.html">Privacy Policy</a></li><li><a href="/terms-of-service.html">Terms of Service</a></li><li><a href="/disclaimer.html">Disclaimer</a></li><li><a href="/data-protection.html">Data Protection</a></li></ul></div>
+      <div class="im-footer-section"><h4>Quick Links</h4><ul><li><a href="/catalog.html">All Courses</a></li><li><a href="/DataDives/">Data Dives</a></li><li><a href="/DeepDives/">Deep Dives</a></li><li><a href="/premium.html">Premium</a></li></ul></div>
+      <div class="im-footer-section"><h4>Resources</h4><ul><li><a href="/handouts.html">Handouts</a></li><li><a href="/blog.html">Blog</a></li><li><a href="/faq.html">FAQ</a></li><li><a href="/sitemap.html">Sitemap</a></li></ul></div>
+    </div>
+    <div class="im-footer-bottom">
+      <p>&copy; 2026 ImpactMojo. All content for educational purposes only.</p>
+      <p>Released under <strong>MIT License</strong> | Supported by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+    </div>
+  </div>
+</footer>
+
+<script src="/js/theme.js"></script>
+<script src="/DataDives/datadive.js"></script>
+<script>
+var rupee = function (v) { return '₹' + Math.round(v).toLocaleString('en-IN'); };
+DataDive.barChart(document.getElementById('c-wage'), {
+  data: [
+    { label: 'AWH honorarium', value: 2250, hl: true },
+    { label: 'AWW honorarium', value: 4500, hl: true },
+    { label: 'National floor wage', value: 4628 },
+    { label: 'Unskilled min wage', value: 20358 }
+  ],
+  max: 22000, ticks: [0, 5000, 10000, 15000, 20000], suffix: '',
+  tipLabel: 'Monthly', valueFmt: rupee
+});
+DataDive.barChart(document.getElementById('c-state'), {
+  data: [
+    { label: 'Tamil Nadu', value: 18000 }, { label: 'Kerala', value: 17000 },
+    { label: 'Telangana', value: 13000 }, { label: 'Karnataka', value: 12000 },
+    { label: 'Andhra Pradesh', value: 12000 }
+  ],
+  max: 20000, ticks: [0, 5000, 10000, 15000, 20000], suffix: '',
+  avg: { value: 4500, label: 'Central ₹4,500' }, tipLabel: 'Total pay', valueFmt: rupee
+});
+</script>
+
+<script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script defer src="/js/state-manager.js"></script>
+<script defer src="/js/config.js"></script>
+<script defer src="/js/auth.js"></script>
+<script src="/js/translate-sarvam.js" defer></script>
+<script src="/js/site-chrome.js" defer></script>
+</body>
+</html>

--- a/DataDives/state-welfare-budgets.html
+++ b/DataDives/state-welfare-budgets.html
@@ -22,9 +22,8 @@
 <link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 
-<!-- Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
@@ -63,226 +62,11 @@
 }
 </script>
 
-<style>
-/* === ImpactMojo Brand Topbar / Footer === */
-:root {
-    --im-gradient: linear-gradient(135deg, #2563EB 0%, #4338CA 100%);
-    --im-accent: #2563EB;
-    --im-nav-bg: rgba(15, 23, 42, 0.95);
-    --im-border: #334155;
-    --im-text-primary: #F1F5F9;
-    --im-text-secondary: #94A3B8;
-    --im-text-muted: #64748B;
-    --im-card-bg: #1E293B;
-    --im-hover-bg: #334155;
-    --im-secondary-bg: #1E293B;
-}
-body { padding-top: 56px !important; margin: 0; }
-.im-topbar { position: fixed; top: 0; left: 0; right: 0; z-index: 9999; background: var(--im-nav-bg); backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px); border-bottom: 1px solid var(--im-border); padding: 0.5rem 1rem; display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; flex-wrap: wrap; font-family: 'Inter', 'Amaranth', sans-serif; }
-.im-topbar a { text-decoration: none; }
-.im-topbar-left { display: flex; align-items: center; gap: 0.75rem; }
-.im-topbar-home { display: flex; align-items: center; gap: 0.5rem; font-weight: 700; font-size: 1rem; color: #2563EB; }
-.im-topbar-home img { width: 24px; height: 24px; border-radius: 4px; }
-.im-topbar-right { display: flex; align-items: center; gap: 0.5rem; }
-.im-premium-btn { background: var(--im-gradient); color: #fff; padding: 0.35rem 0.85rem; border-radius: 6px; font-size: 0.8rem; font-weight: 600; display: flex; align-items: center; gap: 0.35rem; }
-.im-browse-btn { display: inline-flex; align-items: center; gap: 0.4rem; font-family: 'Inter', sans-serif; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: var(--im-text, #1C1917); background: var(--im-surface, #FFFFFF); border: 1.5px solid var(--im-border, #E2E8F0); padding: 0.5rem 1rem; border-radius: 0.5rem; text-decoration: none; transition: background 0.18s ease, border-color 0.18s ease, transform 0.15s ease, box-shadow 0.18s ease; }
-.im-browse-btn:hover { background: var(--im-accent, #2563EB); color: #FFFFFF; border-color: var(--im-accent, #2563EB); transform: translateY(-1px); box-shadow: 0 4px 12px rgba(37, 99, 235, 0.25); }
-.im-browse-btn svg { width: 14px; height: 14px; }
-@media (prefers-color-scheme: dark) { .im-browse-btn { color: rgba(255,255,255,0.9); background: rgba(255,255,255,0.05); border-color: rgba(255,255,255,0.18); } .im-browse-btn:hover { background: var(--im-accent, #2563EB); border-color: var(--im-accent, #2563EB); color: #FFFFFF; } }
-.im-premium-btn svg { width: 14px; height: 14px; }
-.im-theme-selector { display: flex; gap: 2px; background: var(--im-card-bg); border: 1px solid var(--im-border); border-radius: 8px; padding: 2px; }
-.im-theme-btn { background: transparent; border: none; color: var(--im-text-secondary); padding: 6px; border-radius: 5px; cursor: pointer; transition: all 0.2s; display: flex; align-items: center; justify-content: center; width: 30px; height: 30px; }
-.im-theme-btn:hover { background: var(--im-hover-bg); color: var(--im-text-primary); }
-.im-theme-btn.active { background: var(--im-accent); color: #fff; }
-.im-theme-btn svg { width: 16px; height: 16px; }
-.im-skip-link { position: absolute; left: -999px; top: 0; background: var(--im-accent); color: #fff; padding: .5rem 1rem; z-index: 10000; border-radius: 0 0 6px 0; }
-.im-skip-link:focus { left: 0; }
-
-.im-footer { background: var(--im-secondary-bg); border-top: 1px solid var(--im-border); padding: 2rem 1rem; margin-top: 4rem; font-family: 'Inter', 'Amaranth', sans-serif; color: var(--im-text-secondary); }
-.im-footer-content { max-width: 1100px; margin: 0 auto; }
-.im-footer-made { text-align: center; margin-bottom: 1.5rem; font-size: 0.9rem; color: var(--im-text-muted); }
-.im-footer-made a { color: var(--im-accent); }
-.im-footer-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1.5rem; margin-bottom: 1.5rem; }
-.im-footer-section h4 { color: var(--im-text-primary); font-size: 0.9rem; margin-bottom: 0.75rem; font-weight: 600; }
-.im-footer-section ul { list-style: none; padding: 0; margin: 0; }
-.im-footer-section li { margin-bottom: 0.4rem; }
-.im-footer-section a { color: var(--im-text-secondary); font-size: 0.85rem; transition: color 0.2s; }
-.im-footer-section a:hover { color: var(--im-accent); }
-.im-footer-bottom { text-align: center; padding-top: 1rem; border-top: 1px solid var(--im-border); font-size: 0.8rem; color: var(--im-text-muted); }
-.im-footer-bottom a { color: var(--im-accent); }
-
-/* === Data Dive design tokens === */
-:root {
-    --dv-bg: #FAF7F2;
-    --dv-surface: #FFFFFF;
-    --dv-surface-2: #F4EFE7;
-    --dv-border: #E5DDD0;
-    --dv-text: #1A1A1A;
-    --dv-text-soft: #3F3F46;
-    --dv-muted: #6B6560;
-    --dv-accent: #2563EB;
-    --dv-accent-soft: #EAF1FE;
-    --dv-teal: #0F766E;
-    --dv-teal-soft: #E7F3F1;
-    --dv-radius: 12px;
-    /* chart roles */
-    --dv-series: #2563EB;
-    --dv-series-soft: #BFD4FB;
-    --dv-avg: #B45309;
-    --dv-good: #15803D;
-    --dv-bad: #B91C1C;
-    --dv-grid: #E7DFD2;
-    --dv-axis: #C9BFAE;
-    --dv-ink: #1A1A1A;
-    --dv-ink-soft: #6B6560;
-    --dv-chart-surface: #FFFFFF;
-}
-html.dark {
-    --dv-bg: #0F172A;
-    --dv-surface: #1E293B;
-    --dv-surface-2: #172033;
-    --dv-border: #334155;
-    --dv-text: #F1F5F9;
-    --dv-text-soft: #CBD5E1;
-    --dv-muted: #94A3B8;
-    --dv-accent: #60A5FA;
-    --dv-accent-soft: rgba(96, 165, 250, 0.12);
-    --dv-teal: #2DD4BF;
-    --dv-teal-soft: rgba(45, 212, 191, 0.10);
-    --dv-series: #60A5FA;
-    --dv-series-soft: rgba(96, 165, 250, 0.30);
-    --dv-avg: #FBBF24;
-    --dv-good: #4ADE80;
-    --dv-bad: #F87171;
-    --dv-grid: #2A3852;
-    --dv-axis: #475569;
-    --dv-ink: #F1F5F9;
-    --dv-ink-soft: #94A3B8;
-    --dv-chart-surface: #1E293B;
-}
-* { box-sizing: border-box; }
-html, body { background: var(--dv-bg); color: var(--dv-text); font-family: 'Amaranth', Arial, sans-serif; line-height: 1.7; }
-.dv-wrap { max-width: 800px; margin: 0 auto; padding: 2.25rem 1.25rem 4rem; }
-
-.dv-back { display: inline-block; margin-bottom: 1.5rem; font-family: 'Inter', sans-serif; font-size: .85rem; color: var(--dv-muted); text-decoration: none; }
-.dv-back:hover { color: var(--dv-accent); }
-
-/* Hero */
-.dv-eyebrow { display: inline-flex; align-items: center; gap: .5rem; font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; color: var(--dv-accent); margin-bottom: 1rem; }
-.dv-eyebrow::before { content: ""; width: 26px; height: 2px; background: var(--dv-accent); border-radius: 2px; }
-.dv-title { font-family: 'Inter', sans-serif; font-size: clamp(1.9rem, 4.5vw, 2.9rem); font-weight: 800; letter-spacing: -0.02em; line-height: 1.12; margin: 0 0 .9rem; color: var(--dv-text); }
-.dv-standfirst { font-size: 1.2rem; color: var(--dv-text-soft); line-height: 1.6; margin-bottom: 1.5rem; }
-.dv-byline { display: flex; flex-wrap: wrap; align-items: center; gap: .5rem .9rem; font-family: 'Inter', sans-serif; font-size: .82rem; color: var(--dv-muted); padding-bottom: 1.5rem; margin-bottom: 2.25rem; border-bottom: 1px solid var(--dv-border); }
-.dv-byline strong { color: var(--dv-text-soft); font-weight: 600; }
-.dv-byline .dv-dot { color: var(--dv-border); }
-.dv-tag { font-family: 'Inter', sans-serif; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; padding: .2rem .55rem; border-radius: 4px; background: var(--dv-accent-soft); color: var(--dv-accent); }
-
-/* Body prose */
-.dv-prose p { font-size: 1.08rem; line-height: 1.8; color: var(--dv-text-soft); margin: 0 0 1.25rem; }
-.dv-prose h2 { font-family: 'Inter', sans-serif; font-size: 1.55rem; font-weight: 700; letter-spacing: -0.01em; color: var(--dv-text); margin: 2.75rem 0 1rem; line-height: 1.25; }
-.dv-prose h3 { font-family: 'Inter', sans-serif; font-size: 1.15rem; font-weight: 700; color: var(--dv-text); margin: 2rem 0 .5rem; }
-.dv-prose a { color: var(--dv-accent); text-decoration: none; border-bottom: 1px solid rgba(37,99,235,.3); }
-.dv-prose a:hover { border-bottom-color: var(--dv-accent); }
-.dv-prose strong { color: var(--dv-text); font-weight: 700; }
-.dv-section-kicker { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; color: var(--dv-accent); margin: 2.75rem 0 .35rem; }
-.dv-section-kicker + h2 { margin-top: .15rem; }
-
-/* Pull finding */
-.dv-finding { margin: 2rem 0; padding: 1.5rem 1.75rem; background: var(--dv-surface); border: 1px solid var(--dv-border); border-left: 4px solid var(--dv-accent); border-radius: 0 var(--dv-radius) var(--dv-radius) 0; }
-.dv-finding-label { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; color: var(--dv-accent); margin-bottom: .6rem; }
-.dv-finding p { font-size: 1.12rem; line-height: 1.65; color: var(--dv-text); margin: 0; font-family: 'Inter', sans-serif; font-weight: 500; }
-
-/* Stat tiles */
-.dv-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: .85rem; margin: 2rem 0 2.5rem; }
-.dv-stat { background: var(--dv-surface); border: 1px solid var(--dv-border); border-radius: var(--dv-radius); padding: 1.15rem 1.15rem 1rem; }
-.dv-stat-num { font-family: 'Inter', sans-serif; font-size: 2rem; font-weight: 800; letter-spacing: -0.02em; color: var(--dv-accent); line-height: 1; margin-bottom: .35rem; font-variant-numeric: tabular-nums; }
-.dv-stat-label { font-family: 'Inter', sans-serif; font-size: .82rem; line-height: 1.4; color: var(--dv-muted); }
-.dv-stat-label strong { color: var(--dv-text-soft); font-weight: 600; }
-
-/* Figure / chart */
-figure.dv-fig { margin: 2.25rem 0; padding: 1.5rem 1.25rem 1.1rem; background: var(--dv-chart-surface); border: 1px solid var(--dv-border); border-radius: var(--dv-radius); }
-.dv-fig-title { font-family: 'Inter', sans-serif; font-size: 1.08rem; font-weight: 700; color: var(--dv-text); margin: 0 0 .2rem; }
-.dv-fig-sub { font-family: 'Inter', sans-serif; font-size: .85rem; color: var(--dv-muted); margin: 0 0 1rem; line-height: 1.5; }
-.dv-chart svg { width: 100%; height: auto; display: block; overflow: visible; font-family: 'Inter', sans-serif; }
-.dv-fig figcaption { font-family: 'Inter', sans-serif; font-size: .78rem; color: var(--dv-muted); margin-top: 1rem; line-height: 1.5; }
-.dv-fig figcaption strong { color: var(--dv-text-soft); font-weight: 600; }
-
-/* Chart primitives */
-.dv-bar { fill: var(--dv-series); }
-.dv-bar.hl { fill: var(--dv-accent); }
-.dv-bar-track { fill: var(--dv-series-soft); opacity: .28; }
-.dv-bar-lbl { fill: var(--dv-ink); font-size: 13px; font-weight: 600; }
-.dv-bar-val { fill: var(--dv-ink); font-size: 13px; font-weight: 700; font-variant-numeric: tabular-nums; }
-.dv-grid-line { stroke: var(--dv-grid); stroke-width: 1; }
-.dv-axis-line { stroke: var(--dv-axis); stroke-width: 1; }
-.dv-tick { fill: var(--dv-muted); font-size: 11px; font-variant-numeric: tabular-nums; }
-.dv-ref-line { stroke: var(--dv-avg); stroke-width: 1.5; stroke-dasharray: 5 4; }
-.dv-ref-lbl { fill: var(--dv-avg); font-size: 11px; font-weight: 700; }
-.dv-dot { fill: var(--dv-series); stroke: var(--dv-chart-surface); stroke-width: 2; }
-.dv-dot-lbl { fill: var(--dv-ink); font-size: 12px; font-weight: 700; }
-.dv-dot-sub { fill: var(--dv-muted); font-size: 10.5px; font-variant-numeric: tabular-nums; }
-.dv-axis-title { fill: var(--dv-muted); font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .06em; }
-.dv-bargroup { cursor: default; }
-.dv-bargroup:hover .dv-bar { fill: var(--dv-accent); }
-
-/* Table fallback */
-.dv-data-toggle { margin-top: .85rem; }
-.dv-data-toggle summary { font-family: 'Inter', sans-serif; font-size: .8rem; font-weight: 600; color: var(--dv-accent); cursor: pointer; list-style: none; display: inline-flex; align-items: center; gap: .35rem; }
-.dv-data-toggle summary::-webkit-details-marker { display: none; }
-.dv-data-toggle summary::before { content: "▸"; font-size: .7rem; }
-.dv-data-toggle[open] summary::before { content: "▾"; }
-.dv-table { width: 100%; border-collapse: collapse; margin-top: .85rem; font-family: 'Inter', sans-serif; font-size: .85rem; }
-.dv-table th, .dv-table td { text-align: left; padding: .45rem .6rem; border-bottom: 1px solid var(--dv-border); }
-.dv-table th { color: var(--dv-muted); font-weight: 600; font-size: .75rem; text-transform: uppercase; letter-spacing: .05em; }
-.dv-table td { color: var(--dv-text-soft); }
-.dv-table td.num { text-align: right; font-variant-numeric: tabular-nums; font-weight: 600; color: var(--dv-text); }
-
-/* Tooltip */
-.dv-tip { position: fixed; z-index: 10001; pointer-events: none; background: var(--dv-text); color: var(--dv-bg); font-family: 'Inter', sans-serif; font-size: .78rem; line-height: 1.35; padding: .4rem .6rem; border-radius: 6px; box-shadow: 0 6px 18px rgba(0,0,0,.25); opacity: 0; transform: translateY(4px); transition: opacity .12s; max-width: 220px; }
-.dv-tip.show { opacity: 1; transform: translateY(0); }
-.dv-tip b { color: #fff; }
-html.dark .dv-tip { background: #F1F5F9; color: #0F172A; }
-html.dark .dv-tip b { color: #0F172A; }
-
-/* Methodology / sources */
-.dv-method { margin: 2.75rem 0; padding: 1.5rem 1.75rem; background: var(--dv-surface-2); border: 1px solid var(--dv-border); border-radius: var(--dv-radius); }
-.dv-method-label { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; color: var(--dv-muted); margin-bottom: .85rem; }
-.dv-method p, .dv-method li { font-family: 'Inter', sans-serif; font-size: .9rem; line-height: 1.65; color: var(--dv-text-soft); }
-.dv-method p { margin: 0 0 .85rem; }
-.dv-method ul { margin: 0; padding-left: 1.15rem; }
-.dv-method li { margin-bottom: .45rem; }
-.dv-sources { list-style: none; padding: 0; margin: .5rem 0 0; }
-.dv-sources li { font-family: 'Inter', sans-serif; font-size: .88rem; line-height: 1.55; color: var(--dv-text-soft); padding: .4rem 0; border-top: 1px solid var(--dv-border); }
-.dv-sources li:first-child { border-top: none; }
-.dv-sources a { color: var(--dv-accent); text-decoration: none; border-bottom: 1px dotted var(--dv-accent); }
-
-/* Related + cite + CTA */
-.dv-related { padding: 1.5rem 1.75rem; background: var(--dv-teal-soft); border-radius: var(--dv-radius); margin: 2.5rem 0; }
-.dv-related-label { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; color: var(--dv-teal); margin-bottom: .85rem; }
-.dv-related ul { list-style: none; padding: 0; margin: 0; display: grid; gap: .55rem; }
-.dv-related li { font-family: 'Inter', sans-serif; font-size: .95rem; }
-.dv-related a { color: var(--dv-text); text-decoration: none; border-bottom: 1px dotted var(--dv-teal); }
-.dv-related a:hover { color: var(--dv-teal); }
-.dv-cite-block { padding: 1.25rem 1.5rem; background: var(--dv-surface); border: 1px dashed var(--dv-border); border-radius: var(--dv-radius); margin: 2rem 0; }
-.dv-cite-label { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; color: var(--dv-muted); margin-bottom: .5rem; }
-.dv-cite-text { font-family: 'Inter', sans-serif; font-size: .88rem; color: var(--dv-text-soft); line-height: 1.6; }
-.dv-cta { padding: 1.75rem; background: var(--dv-accent-soft); border-radius: var(--dv-radius); text-align: center; margin-top: 2.5rem; }
-.dv-cta h3 { font-family: 'Inter', sans-serif; font-size: 1.2rem; margin: 0 0 .5rem; color: var(--dv-accent); }
-.dv-cta p { font-size: .95rem; color: var(--dv-text-soft); margin: 0 0 1rem; }
-.dv-cta a { display: inline-block; background: var(--dv-accent); color: #fff !important; font-family: 'Inter', sans-serif; font-weight: 600; padding: .65rem 1.5rem; border-radius: 8px; text-decoration: none; }
-
-@media (max-width: 640px) {
-    .dv-wrap { padding: 1.5rem 1rem 3rem; }
-    .dv-method, .dv-related, .dv-cta, .dv-finding { padding: 1.25rem; }
-    figure.dv-fig { padding: 1.1rem .75rem 1rem; }
-    .dv-bar-lbl { font-size: 12px; }
-}
-</style>
+<link rel="stylesheet" href="/DataDives/datadive.css">
 </head>
 <body>
 <a href="#main-content" class="im-skip-link">Skip to content</a>
 
-<!-- ImpactMojo Topbar -->
 <header class="im-topbar" role="banner">
   <div class="im-topbar-left">
     <a class="im-topbar-home" href="/" aria-label="ImpactMojo home">
@@ -297,15 +81,9 @@ html.dark .dv-tip b { color: #0F172A; }
       Premium
     </a>
     <div class="im-theme-selector" role="group" aria-label="Theme">
-      <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="System theme">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
-      </button>
-      <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Light theme">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
-      </button>
-      <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Dark theme">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
-      </button>
+      <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="System theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Light theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Dark theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
     </div>
   </div>
 </header>
@@ -313,7 +91,6 @@ html.dark .dv-tip b { color: #0F172A; }
 <main id="main-content" class="dv-wrap">
   <a class="dv-back" href="/DataDives/">← All Data Dives</a>
 
-  <!-- HERO -->
   <div class="dv-eyebrow">Data Dive · Public Finance</div>
   <h1 class="dv-title">The states that spend most on welfare have the least to show for it</h1>
   <p class="dv-standfirst">India's biggest social-sector spenders record some of its worst welfare outcomes — while the states that spend the least on welfare, as a share of their budgets, are the ones pulling ahead. A look at what the numbers behind state budgets actually say, and what they can't.</p>
@@ -366,7 +143,7 @@ html.dark .dv-tip b { color: #0F172A; }
       <div class="dv-fig-sub">Higher bars = a larger share of the state's own budget spent on education, health, nutrition, and welfare. The dashed line is the all-state average.</div>
       <div class="dv-chart" id="chart-spend" role="img" aria-label="Horizontal bar chart of social-sector spending as a share of total budget for nine states in 2025-26. Jharkhand leads at 54.8 percent, West Bengal 54.2, Delhi 54.1, Chhattisgarh 50.3, Bihar 49.8, all above the 42.2 percent national average; Tamil Nadu 33.6, Kerala 32.2, and Punjab 21.3 fall well below it."></div>
       <details class="dv-data-toggle"><summary>View data table</summary>
-        <table class="dv-table">
+        <div class="dv-table-scroll"><table class="dv-table">
           <thead><tr><th>State</th><th>Social-sector share (2025-26)</th></tr></thead>
           <tbody>
             <tr><td>Jharkhand</td><td class="num">54.8%</td></tr>
@@ -379,7 +156,7 @@ html.dark .dv-tip b { color: #0F172A; }
             <tr><td>Kerala</td><td class="num">32.2%</td></tr>
             <tr><td>Punjab</td><td class="num">21.3%</td></tr>
           </tbody>
-        </table>
+        </table></div>
       </details>
       <figcaption><strong>Source:</strong> RBI, <em>State Finances: A Study of Budgets of 2025-26</em>. Figures are budget estimates (BE) and exclude north-eastern states and union territories other than Delhi.</figcaption>
     </figure>
@@ -396,7 +173,7 @@ html.dark .dv-tip b { color: #0F172A; }
       <div class="dv-fig-sub">Each dot is a state: its social-sector spending share (left–right) against its maternal mortality ratio (bottom–top). If money bought outcomes on its own, the dots would fall to the lower right. They rise to the upper right instead.</div>
       <div class="dv-chart" id="chart-scatter" role="img" aria-label="Scatter plot of social-sector spending share against maternal mortality ratio for four states. Kerala (32.2 percent spend, 30 deaths) and Tamil Nadu (33.6 percent, 35) sit in the low-spend, low-mortality corner; West Bengal (54.2 percent, 104) and Chhattisgarh (50.3 percent, 146) sit in the high-spend, high-mortality corner. Higher spending is associated with higher maternal mortality across these four states."></div>
       <details class="dv-data-toggle"><summary>View data table</summary>
-        <table class="dv-table">
+        <div class="dv-table-scroll"><table class="dv-table">
           <thead><tr><th>State</th><th>Social-sector share</th><th>Maternal deaths / 100k</th></tr></thead>
           <tbody>
             <tr><td>Kerala</td><td class="num">32.2%</td><td class="num">30</td></tr>
@@ -404,7 +181,7 @@ html.dark .dv-tip b { color: #0F172A; }
             <tr><td>West Bengal</td><td class="num">54.2%</td><td class="num">104</td></tr>
             <tr><td>Chhattisgarh</td><td class="num">50.3%</td><td class="num">146</td></tr>
           </tbody>
-        </table>
+        </table></div>
       </details>
       <figcaption><strong>Source:</strong> RBI <em>State Finances 2025-26</em> (spending); maternal mortality figures as cited in the RBI analysis. The relationship is <strong>associational, not causal</strong> — see the note on reading this chart below.</figcaption>
     </figure>
@@ -426,7 +203,7 @@ html.dark .dv-tip b { color: #0F172A; }
       <div class="dv-fig-sub">Gender budgeting as a percentage of total expenditure. The dashed line is the national average of 9.4%.</div>
       <div class="dv-chart" id="chart-gender" role="img" aria-label="Horizontal bar chart of gender budgeting as a share of total expenditure. Jharkhand 35.5 percent, Tamil Nadu 29.8, West Bengal 26.3, Kerala 21.4, all far above the 9.4 percent national average; Delhi at 9.5 percent sits essentially on the average line."></div>
       <details class="dv-data-toggle"><summary>View data table</summary>
-        <table class="dv-table">
+        <div class="dv-table-scroll"><table class="dv-table">
           <thead><tr><th>State</th><th>Women-focused share of budget</th></tr></thead>
           <tbody>
             <tr><td>Jharkhand</td><td class="num">35.5%</td></tr>
@@ -436,7 +213,7 @@ html.dark .dv-tip b { color: #0F172A; }
             <tr><td>Delhi</td><td class="num">9.5%</td></tr>
             <tr><td>National average</td><td class="num">9.4%</td></tr>
           </tbody>
-        </table>
+        </table></div>
       </details>
       <figcaption><strong>Source:</strong> RBI, <em>State Finances: A Study of Budgets of 2025-26</em>, gender-budget statements. High gender budgeting is not confined to the biggest overall spenders.</figcaption>
     </figure>
@@ -493,47 +270,34 @@ html.dark .dv-tip b { color: #0F172A; }
   </div>
 </main>
 
-<!-- ImpactMojo Footer -->
 <footer class="im-footer" role="contentinfo">
   <div class="im-footer-content">
     <p class="im-footer-made">Made with ♥ by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
     <div class="im-footer-grid">
-      <div class="im-footer-section">
-        <h4>About ImpactMojo</h4>
-        <ul>
-          <li><a href="/about.html">About Us</a></li>
-          <li><a href="/contact.html">Contact</a></li>
-          <li><a href="https://github.com/ImpactMojo/ImpactMojo" rel="noopener noreferrer" target="_blank">GitHub</a></li>
-          <li><a href="/transparency.html">Transparency</a></li>
-        </ul>
-      </div>
-      <div class="im-footer-section">
-        <h4>Legal</h4>
-        <ul>
-          <li><a href="/privacy-policy.html">Privacy Policy</a></li>
-          <li><a href="/terms-of-service.html">Terms of Service</a></li>
-          <li><a href="/disclaimer.html">Disclaimer</a></li>
-          <li><a href="/data-protection.html">Data Protection</a></li>
-        </ul>
-      </div>
-      <div class="im-footer-section">
-        <h4>Quick Links</h4>
-        <ul>
-          <li><a href="/catalog.html">All Courses</a></li>
-          <li><a href="/DataDives/">Data Dives</a></li>
-          <li><a href="/DeepDives/">Deep Dives</a></li>
-          <li><a href="/premium.html">Premium</a></li>
-        </ul>
-      </div>
-      <div class="im-footer-section">
-        <h4>Resources</h4>
-        <ul>
-          <li><a href="/handouts.html">Handouts</a></li>
-          <li><a href="/blog.html">Blog</a></li>
-          <li><a href="/faq.html">FAQ</a></li>
-          <li><a href="/sitemap.html">Sitemap</a></li>
-        </ul>
-      </div>
+      <div class="im-footer-section"><h4>About ImpactMojo</h4><ul>
+        <li><a href="/about.html">About Us</a></li>
+        <li><a href="/contact.html">Contact</a></li>
+        <li><a href="https://github.com/ImpactMojo/ImpactMojo" rel="noopener noreferrer" target="_blank">GitHub</a></li>
+        <li><a href="/transparency.html">Transparency</a></li>
+      </ul></div>
+      <div class="im-footer-section"><h4>Legal</h4><ul>
+        <li><a href="/privacy-policy.html">Privacy Policy</a></li>
+        <li><a href="/terms-of-service.html">Terms of Service</a></li>
+        <li><a href="/disclaimer.html">Disclaimer</a></li>
+        <li><a href="/data-protection.html">Data Protection</a></li>
+      </ul></div>
+      <div class="im-footer-section"><h4>Quick Links</h4><ul>
+        <li><a href="/catalog.html">All Courses</a></li>
+        <li><a href="/DataDives/">Data Dives</a></li>
+        <li><a href="/DeepDives/">Deep Dives</a></li>
+        <li><a href="/premium.html">Premium</a></li>
+      </ul></div>
+      <div class="im-footer-section"><h4>Resources</h4><ul>
+        <li><a href="/handouts.html">Handouts</a></li>
+        <li><a href="/blog.html">Blog</a></li>
+        <li><a href="/faq.html">FAQ</a></li>
+        <li><a href="/sitemap.html">Sitemap</a></li>
+      </ul></div>
     </div>
     <div class="im-footer-bottom">
       <p>&copy; 2026 ImpactMojo. All content for educational purposes only.</p>
@@ -542,201 +306,45 @@ html.dark .dv-tip b { color: #0F172A; }
   </div>
 </footer>
 
-<div class="dv-tip" id="dv-tip" role="status" aria-live="polite"></div>
-
 <script src="/js/theme.js"></script>
-
+<script src="/DataDives/datadive.js"></script>
 <script>
-/* ImpactMojo Data Dive — inline chart renderer (self-contained, theme-aware) */
-(function () {
-  var SVGNS = "http://www.w3.org/2000/svg";
-  var tip = document.getElementById('dv-tip');
+DataDive.barChart(document.getElementById('chart-spend'), {
+  data: [
+    { label: 'Jharkhand', value: 54.8 }, { label: 'West Bengal', value: 54.2 },
+    { label: 'Delhi', value: 54.1 }, { label: 'Chhattisgarh', value: 50.3 },
+    { label: 'Bihar', value: 49.8 }, { label: 'Tamil Nadu', value: 33.6 },
+    { label: 'Kerala', value: 32.2 }, { label: 'Punjab', value: 21.3 }
+  ],
+  max: 60, ticks: [0, 20, 40, 60],
+  avg: { value: 42.2, label: 'All-state avg 42.2%' },
+  tipLabel: 'Social-sector share'
+});
 
-  function el(tag, attrs, text) {
-    var n = document.createElementNS(SVGNS, tag);
-    if (attrs) for (var k in attrs) n.setAttribute(k, attrs[k]);
-    if (text != null) n.textContent = text;
-    return n;
-  }
-  function showTip(html, evt) {
-    tip.innerHTML = html;
-    tip.classList.add('show');
-    moveTip(evt);
-  }
-  function moveTip(evt) {
-    var x = evt.clientX, y = evt.clientY;
-    var w = tip.offsetWidth, h = tip.offsetHeight;
-    var nx = x + 14, ny = y + 14;
-    if (nx + w > window.innerWidth - 8) nx = x - w - 14;
-    if (ny + h > window.innerHeight - 8) ny = y - h - 14;
-    tip.style.left = nx + 'px';
-    tip.style.top = ny + 'px';
-  }
-  function hideTip() { tip.classList.remove('show'); }
+DataDive.scatterChart(document.getElementById('chart-scatter'), {
+  data: [
+    { label: 'Kerala', x: 32.2, y: 30, anchor: 'start', vpos: 'down' },
+    { label: 'Tamil Nadu', x: 33.6, y: 35, anchor: 'start', vpos: 'up' },
+    { label: 'West Bengal', x: 54.2, y: 104, anchor: 'end', vpos: 'up' },
+    { label: 'Chhattisgarh', x: 50.3, y: 146, anchor: 'end', vpos: 'up' }
+  ],
+  xMin: 25, xMax: 60, yMax: 160, xTicks: [30, 40, 50, 60], yTicks: [0, 40, 80, 120, 160],
+  xTitle: 'Social-sector spending share →', yTitle: 'Maternal deaths / 100k →',
+  tipX: 'Spend', tipY: 'Maternal deaths'
+});
 
-  /* ---- Horizontal bar chart ---- */
-  function barChart(mountId, opts) {
-    var mount = document.getElementById(mountId);
-    if (!mount) return;
-    var data = opts.data;            // [{label, value}]
-    var max = opts.max;              // axis max
-    var ticks = opts.ticks;          // [numbers]
-    var avg = opts.avg;              // {value, label}
-    var suffix = opts.suffix || '%';
-    var W = 680, rowH = 40, padTop = 26, padBottom = 34;
-    var labelW = 118, rightPad = 46;
-    var H = padTop + data.length * rowH + padBottom;
-    var x0 = labelW, x1 = W - rightPad;
-    var scale = function (v) { return x0 + (v / max) * (x1 - x0); };
-    var svg = el('svg', { viewBox: '0 0 ' + W + ' ' + H, preserveAspectRatio: 'xMidYMid meet' });
-
-    // gridlines + ticks
-    ticks.forEach(function (t) {
-      var x = scale(t);
-      svg.appendChild(el('line', { x1: x, y1: padTop - 8, x2: x, y2: padTop + data.length * rowH, class: 'dv-grid-line' }));
-      var tk = el('text', { x: x, y: padTop + data.length * rowH + 18, 'text-anchor': 'middle', class: 'dv-tick' }, t + suffix);
-      svg.appendChild(tk);
-    });
-    // baseline
-    svg.appendChild(el('line', { x1: x0, y1: padTop - 8, x2: x0, y2: padTop + data.length * rowH, class: 'dv-axis-line' }));
-
-    // bars
-    data.forEach(function (d, i) {
-      var y = padTop + i * rowH;
-      var by = y + (rowH - 22) / 2;
-      var bw = Math.max(0, scale(d.value) - x0);
-      var g = el('g', { class: 'dv-bargroup' });
-      // track
-      g.appendChild(el('rect', { x: x0, y: by, width: x1 - x0, height: 22, rx: 4, class: 'dv-bar-track' }));
-      // bar
-      var bar = el('rect', { x: x0, y: by, width: bw, height: 22, rx: 4, class: 'dv-bar' + (d.hl ? ' hl' : '') });
-      g.appendChild(bar);
-      // state label
-      g.appendChild(el('text', { x: x0 - 10, y: by + 15, 'text-anchor': 'end', class: 'dv-bar-lbl' }, d.label));
-      // value label
-      g.appendChild(el('text', { x: scale(d.value) + 8, y: by + 15, 'text-anchor': 'start', class: 'dv-bar-val' }, d.value + suffix));
-      // interaction
-      (function (dd) {
-        g.addEventListener('mousemove', function (e) {
-          showTip('<b>' + dd.label + '</b><br>' + (opts.tipLabel || 'Value') + ': ' + dd.value + suffix, e);
-        });
-        g.addEventListener('mouseleave', hideTip);
-      })(d);
-      svg.appendChild(g);
-    });
-
-    // average reference line
-    if (avg) {
-      var ax = scale(avg.value);
-      svg.appendChild(el('line', { x1: ax, y1: padTop - 14, x2: ax, y2: padTop + data.length * rowH + 2, class: 'dv-ref-line' }));
-      svg.appendChild(el('text', { x: ax, y: padTop - 18, 'text-anchor': 'middle', class: 'dv-ref-lbl' }, avg.label));
-    }
-    mount.appendChild(svg);
-  }
-
-  /* ---- Scatter plot ---- */
-  function scatterChart(mountId, opts) {
-    var mount = document.getElementById(mountId);
-    if (!mount) return;
-    var data = opts.data;   // [{label, x, y}]
-    var W = 680, H = 460, padL = 62, padR = 28, padT = 24, padB = 58;
-    var xMin = opts.xMin, xMax = opts.xMax, yMin = 0, yMax = opts.yMax;
-    var px = function (v) { return padL + (v - xMin) / (xMax - xMin) * (W - padL - padR); };
-    var py = function (v) { return H - padB - (v - yMin) / (yMax - yMin) * (H - padT - padB); };
-    var svg = el('svg', { viewBox: '0 0 ' + W + ' ' + H, preserveAspectRatio: 'xMidYMid meet' });
-
-    // y gridlines + ticks
-    opts.yTicks.forEach(function (t) {
-      var y = py(t);
-      svg.appendChild(el('line', { x1: padL, y1: y, x2: W - padR, y2: y, class: 'dv-grid-line' }));
-      svg.appendChild(el('text', { x: padL - 10, y: y + 4, 'text-anchor': 'end', class: 'dv-tick' }, t));
-    });
-    // x ticks
-    opts.xTicks.forEach(function (t) {
-      var x = px(t);
-      svg.appendChild(el('text', { x: x, y: H - padB + 20, 'text-anchor': 'middle', class: 'dv-tick' }, t + '%'));
-    });
-    // axes
-    svg.appendChild(el('line', { x1: padL, y1: padT, x2: padL, y2: H - padB, class: 'dv-axis-line' }));
-    svg.appendChild(el('line', { x1: padL, y1: H - padB, x2: W - padR, y2: H - padB, class: 'dv-axis-line' }));
-    // axis titles
-    svg.appendChild(el('text', { x: (padL + W - padR) / 2, y: H - 12, 'text-anchor': 'middle', class: 'dv-axis-title' }, 'Social-sector spending share →'));
-    var yt = el('text', { x: 16, y: (padT + H - padB) / 2, 'text-anchor': 'middle', class: 'dv-axis-title', transform: 'rotate(-90 16 ' + ((padT + H - padB) / 2) + ')' }, 'Maternal deaths / 100k →');
-    svg.appendChild(yt);
-
-    // points
-    data.forEach(function (d) {
-      var cx = px(d.x), cy = py(d.y);
-      var g = el('g');
-      g.appendChild(el('circle', { cx: cx, cy: cy, r: 9, class: 'dv-dot' }));
-      // label placement: per-point overrides avoid collisions on near-coincident dots
-      var anchor = d.anchor || (d.x > (xMin + xMax) / 2 ? 'end' : 'start');
-      var lx = anchor === 'end' ? cx - 14 : cx + 14;
-      var nameY, subY;
-      if (d.vpos === 'down') { nameY = cy + 20; subY = cy + 34; }
-      else { nameY = cy - 20; subY = cy - 6; }
-      g.appendChild(el('text', { x: lx, y: nameY, 'text-anchor': anchor, class: 'dv-dot-lbl' }, d.label));
-      g.appendChild(el('text', { x: lx, y: subY, 'text-anchor': anchor, class: 'dv-dot-sub' }, d.x + '% spend · ' + d.y + ' deaths'));
-      (function (dd) {
-        g.addEventListener('mousemove', function (e) {
-          showTip('<b>' + dd.label + '</b><br>Spend: ' + dd.x + '%<br>Maternal deaths: ' + dd.y + ' / 100k', e);
-        });
-        g.addEventListener('mouseleave', hideTip);
-      })(d);
-      svg.appendChild(g);
-    });
-    mount.appendChild(svg);
-  }
-
-  window.addEventListener('mousemove', function (e) { if (tip.classList.contains('show')) moveTip(e); });
-
-  // Chart 1 — social-sector spending share
-  barChart('chart-spend', {
-    data: [
-      { label: 'Jharkhand', value: 54.8 },
-      { label: 'West Bengal', value: 54.2 },
-      { label: 'Delhi', value: 54.1 },
-      { label: 'Chhattisgarh', value: 50.3 },
-      { label: 'Bihar', value: 49.8 },
-      { label: 'Tamil Nadu', value: 33.6 },
-      { label: 'Kerala', value: 32.2 },
-      { label: 'Punjab', value: 21.3 }
-    ],
-    max: 60, ticks: [0, 20, 40, 60],
-    avg: { value: 42.2, label: 'All-state avg 42.2%' },
-    tipLabel: 'Social-sector share'
-  });
-
-  // Chart 2 — spend vs maternal mortality
-  scatterChart('chart-scatter', {
-    data: [
-      { label: 'Kerala', x: 32.2, y: 30, anchor: 'start', vpos: 'down' },
-      { label: 'Tamil Nadu', x: 33.6, y: 35, anchor: 'start', vpos: 'up' },
-      { label: 'West Bengal', x: 54.2, y: 104, anchor: 'end', vpos: 'up' },
-      { label: 'Chhattisgarh', x: 50.3, y: 146, anchor: 'end', vpos: 'up' }
-    ],
-    xMin: 25, xMax: 60, yMax: 160,
-    xTicks: [30, 40, 50, 60],
-    yTicks: [0, 40, 80, 120, 160]
-  });
-
-  // Chart 3 — gender budgeting
-  barChart('chart-gender', {
-    data: [
-      { label: 'Jharkhand', value: 35.5 },
-      { label: 'Tamil Nadu', value: 29.8 },
-      { label: 'West Bengal', value: 26.3 },
-      { label: 'Kerala', value: 21.4 },
-      { label: 'Delhi', value: 9.5 }
-    ],
-    max: 40, ticks: [0, 10, 20, 30, 40],
-    avg: { value: 9.4, label: 'National avg 9.4%' },
-    tipLabel: 'Women-focused share'
-  });
-})();
+DataDive.barChart(document.getElementById('chart-gender'), {
+  data: [
+    { label: 'Jharkhand', value: 35.5 }, { label: 'Tamil Nadu', value: 29.8 },
+    { label: 'West Bengal', value: 26.3 }, { label: 'Kerala', value: 21.4 },
+    { label: 'Delhi', value: 9.5 }
+  ],
+  max: 40, ticks: [0, 10, 20, 30, 40],
+  avg: { value: 9.4, label: 'National avg 9.4%' },
+  tipLabel: 'Women-focused share'
+});
 </script>
 
-<!-- Supabase Auth (deferred, non-blocking) -->
 <script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script defer src="/js/state-manager.js"></script>
 <script defer src="/js/config.js"></script>

--- a/DataDives/the-pension-that-never-got-a-raise.html
+++ b/DataDives/the-pension-that-never-got-a-raise.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>The pension that never got a raise | ImpactMojo Data Dive</title>
+<meta name="description" content="India's central old-age pension has been ₹200 a month since 2006. Inflation has cut its real value by roughly two-thirds; to keep pace it would need to be around ₹700. An independent data investigation into a benefit that stood still while prices ran.">
+<link rel="canonical" href="https://www.impactmojo.in/DataDives/the-pension-that-never-got-a-raise.html">
+<meta name="robots" content="index, follow">
+<meta property="og:type" content="article">
+<meta property="og:title" content="The pension that never got a raise — ImpactMojo Data Dive">
+<meta property="og:description" content="India's central old-age pension has been ₹200 a month since 2006. Inflation cut its real value by two-thirds. A benefit that stood still while prices ran.">
+<meta property="og:url" content="https://www.impactmojo.in/DataDives/the-pension-that-never-got-a-raise.html">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<meta property="og:site_name" content="ImpactMojo">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="The pension that never got a raise — ImpactMojo Data Dive">
+<meta name="twitter:description" content="India's central old-age pension has been ₹200/month since 2006. Inflation cut its real value by two-thirds.">
+<link rel="icon" href="/assets/images/favicon.png" type="image/png">
+<link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-JRCMEB9TBW');
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org", "@type": "Article",
+  "headline": "The pension that never got a raise",
+  "description": "An independent data investigation into the frozen ₹200 central old-age pension and the erosion of its real value.",
+  "image": "https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png",
+  "author": { "@type": "Organization", "name": "ImpactMojo Data" },
+  "publisher": { "@type": "Organization", "name": "ImpactMojo", "logo": { "@type": "ImageObject", "url": "https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" } },
+  "datePublished": "2026-07-11",
+  "mainEntityOfPage": "https://www.impactmojo.in/DataDives/the-pension-that-never-got-a-raise.html",
+  "isAccessibleForFree": true
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org", "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "ImpactMojo", "item": "https://www.impactmojo.in/" },
+    { "@type": "ListItem", "position": 2, "name": "Data Dives", "item": "https://www.impactmojo.in/DataDives/" },
+    { "@type": "ListItem", "position": 3, "name": "The pension that never got a raise" }
+  ]
+}
+</script>
+<link rel="stylesheet" href="/DataDives/datadive.css">
+</head>
+<body>
+<a href="#main-content" class="im-skip-link">Skip to content</a>
+<header class="im-topbar" role="banner">
+  <div class="im-topbar-left">
+    <a class="im-topbar-home" href="/" aria-label="ImpactMojo home">
+      <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo"><span>ImpactMojo</span>
+    </a>
+  </div>
+  <div class="im-topbar-right">
+    <a href="/catalog.html" class="im-browse-btn" title="Browse all content"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>Browse</a>
+    <a class="im-premium-btn" href="/premium.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>Premium</a>
+    <div class="im-theme-selector" role="group" aria-label="Theme">
+      <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="System theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Light theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Dark theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+    </div>
+  </div>
+</header>
+
+<main id="main-content" class="dv-wrap">
+  <a class="dv-back" href="/DataDives/">← All Data Dives</a>
+  <div class="dv-eyebrow">Data Dive · Social Security</div>
+  <h1 class="dv-title">The pension that never got a raise</h1>
+  <p class="dv-standfirst">India's central old-age pension has been ₹200 a month since 2006. The rupee amount never changed; prices more than tripled. What an elderly person actually receives now depends less on the Centre than on the accident of which state they live in.</p>
+  <div class="dv-byline">
+    <span class="dv-tag">Investigation</span>
+    <span><strong>ImpactMojo Data</strong></span>
+    <span class="dv-dot">·</span><span>11 July 2026</span>
+    <span class="dv-dot">·</span><span>6 min read</span>
+    <span class="dv-dot">·</span><span>Source: NSAP · Labour Bureau CPI-IW</span>
+  </div>
+
+  <div class="dv-prose">
+    <p>Under the National Social Assistance Programme, the central government pays a pension to poor elderly people, widows, and persons with disabilities. For someone aged 60 to 79, the central share of the old-age pension is ₹200 a month. It has been ₹200 since 2006. In the years since, the price of nearly everything an old person buys — food, fuel, medicine — has more than tripled. The number on the pension order did not move at all.</p>
+
+    <div class="dv-finding">
+      <div class="dv-finding-label">The finding</div>
+      <p>Frozen at ₹200 since 2006, the central old-age pension has lost roughly <strong>two-thirds of its real value</strong> to inflation. To buy what ₹200 bought in 2006, you would need about <strong>₹700</strong> today. The government's own evaluation concedes a ~45% loss just since 2012 — and in 2025 told Parliament there is "no proposal under consideration" to raise it.</p>
+    </div>
+
+    <div class="dv-stats">
+      <div class="dv-stat"><div class="dv-stat-num">₹200</div><div class="dv-stat-label">central monthly <strong>old-age pension</strong> (ages 60-79), unchanged since 2006</div></div>
+      <div class="dv-stat"><div class="dv-stat-num">~₹57</div><div class="dv-stat-label">what that ₹200 is <strong>worth today</strong> in 2006 rupees</div></div>
+      <div class="dv-stat"><div class="dv-stat-num">~₹700</div><div class="dv-stat-label">what it would need to be to <strong>keep pace</strong> with prices</div></div>
+      <div class="dv-stat"><div class="dv-stat-num">3.09 cr</div><div class="dv-stat-label"><strong>beneficiaries</strong> on the central-funded rolls</div></div>
+    </div>
+
+    <div class="dv-section-kicker">01 — The flat line and the falling line</div>
+    <h2>A number that stood still</h2>
+    <p>Plot the pension two ways. The <em>nominal</em> amount — the rupees printed on the order — is a dead-flat line at ₹200 from 2006 to today. The <em>real</em> value — what those rupees actually buy, measured in 2006 prices — slides steadily downward as inflation eats it, to roughly ₹57 now. The distance between the two lines is the quiet cut that no one ever announced.</p>
+
+    <figure class="dv-fig">
+      <div class="dv-fig-title">₹200, nominal vs real value (2006 rupees)</div>
+      <div class="dv-fig-sub">The flat line is the pension as paid. The falling line is what it is worth, deflated to 2006 prices by the CPI for industrial workers. Intermediate points are interpolated.</div>
+      <div class="dv-chart" id="c-real" role="img" aria-label="Line chart. The nominal pension is flat at 200 rupees from 2006 to 2025. Its real value, in 2006 rupees, falls from 200 in 2006 to about 122 in 2012, 77 in 2019, and 57 in 2025."></div>
+      <details class="dv-data-toggle"><summary>View data table</summary>
+        <div class="dv-table-scroll"><table class="dv-table"><thead><tr><th>Year</th><th>Nominal (₹)</th><th>Real value (2006 ₹)</th></tr></thead>
+        <tbody>
+          <tr><td>2006</td><td class="num">200</td><td class="num">200</td></tr>
+          <tr><td>2012</td><td class="num">200</td><td class="num">~122</td></tr>
+          <tr><td>2019</td><td class="num">200</td><td class="num">~77</td></tr>
+          <tr><td>2025</td><td class="num">200</td><td class="num">~57</td></tr>
+        </tbody></table></div>
+      </details>
+      <figcaption><strong>Source:</strong> pension amount — NSAP (Ministry of Rural Development); real value — deflated by CPI-Industrial Workers (Labour Bureau), price level up ~3.5× since 2006. Endpoints are sourced; the intermediate curve is interpolated and illustrative.</figcaption>
+    </figure>
+
+    <p>The government does not entirely dispute this. A ministry-commissioned evaluation found that for the amounts frozen since 2012 — the ₹500 pension for the over-80s, and the ₹300 widow and disability pensions — real value had already fallen about 45%, and recommended an inflation-linked floor. The ₹200 old-age rate has been frozen six years longer than those, so its erosion is larger still. In August 2025 the government told Parliament that no increase was under consideration.</p>
+
+    <div class="dv-section-kicker">02 — The geography of a pension</div>
+    <h2>Same Centre, very different cheque</h2>
+    <p>Because the central amount is so small and so frozen, what an elderly person actually receives is decided mostly by their state. States top up the ₹200 by anything from a few hundred rupees to several thousand. An old person in Andhra Pradesh or Haryana can receive fifteen to twenty times what the Centre pays; one in a low-topping-up state receives a fraction of that. The central slice — ₹200 — is identical in every bar below.</p>
+
+    <figure class="dv-fig">
+      <div class="dv-fig-title">Total monthly old-age pension, by state</div>
+      <div class="dv-fig-sub">Central ₹200 plus the state top-up. The dashed line marks the ₹200 central share that is the same everywhere.</div>
+      <div class="dv-chart" id="c-states" role="img" aria-label="Bar chart of total monthly old-age pension by state: Andhra Pradesh about 3,500 rupees, Haryana 3,200, Delhi 2,500, Goa 2,500, Kerala 1,600, Rajasthan 1,250, Tamil Nadu 1,100, Madhya Pradesh 600, against a central share of 200 rupees."></div>
+      <details class="dv-data-toggle"><summary>View data table</summary>
+        <div class="dv-table-scroll"><table class="dv-table"><thead><tr><th>State (total, approx.)</th><th>Rupees / month</th></tr></thead>
+        <tbody>
+          <tr><td>Andhra Pradesh</td><td class="num">~3,500</td></tr>
+          <tr><td>Haryana</td><td class="num">~3,200</td></tr>
+          <tr><td>Delhi</td><td class="num">~2,500</td></tr>
+          <tr><td>Goa</td><td class="num">~2,500</td></tr>
+          <tr><td>Kerala</td><td class="num">~1,600</td></tr>
+          <tr><td>Rajasthan</td><td class="num">~1,250</td></tr>
+          <tr><td>Tamil Nadu</td><td class="num">~1,100</td></tr>
+          <tr><td>Madhya Pradesh</td><td class="num">~600</td></tr>
+          <tr><td>Central share (everywhere)</td><td class="num">200</td></tr>
+        </tbody></table></div>
+      </details>
+      <figcaption><strong>Source:</strong> state social-security schemes (approximate totals, 2024-26); central share from NSAP. State amounts change with state budgets and elections — treat as indicative.</figcaption>
+    </figure>
+
+    <div class="dv-section-kicker">03 — Reading the numbers honestly</div>
+    <h2>What this data can and can't tell you</h2>
+    <div class="dv-method">
+      <div class="dv-method-label">How to read this responsibly</div>
+      <ul>
+        <li><strong>The two-thirds erosion is a computation — here's the working.</strong> It deflates ₹200 by CPI-Industrial Workers, which rose roughly 3.5× between 2006 and 2025. A different price index (say, for rural labourers) would give a broadly similar but not identical figure. The endpoints are sourced; the year-by-year curve is interpolated for illustration.</li>
+        <li><strong>Two freeze dates, two erosions.</strong> The ₹200 old-age rate has been frozen since 2006; the ₹500/₹300 rates since 2012. The ~45% figure is the government's own and applies to the 2012-frozen amounts — the ₹200's loss is larger. Don't apply one figure to the other.</li>
+        <li><strong>State totals are approximate.</strong> They move with state budgets and are compiled from scheme notifications of different vintages; the one hard, uniform number is the ₹200 central share.</li>
+        <li><strong>Beneficiary counts are contested.</strong> ~3.09 crore are on the central-capped rolls (limited by 2011-census caps); auditors and researchers put the true number of pension recipients much higher once state-funded pensioners are counted.</li>
+        <li><strong>Real value is not the whole welfare story.</strong> A pension's adequacy also depends on what else a household receives; but a benefit losing two-thirds of its purchasing power while unchanged on paper is, by any measure, a cut administered by inaction.</li>
+      </ul>
+      <p>The defensible claim: <strong>India's central old-age pension has not risen since 2006 and has lost most of its real value to inflation; the Centre's contribution is now so small that a pensioner's income is set mainly by their state — and the central government has said it does not plan to change the figure.</strong></p>
+    </div>
+
+    <div class="dv-method">
+      <div class="dv-method-label">Sources &amp; data</div>
+      <ul class="dv-sources">
+        <li>National Social Assistance Programme, Ministry of Rural Development — <a href="https://socialwelfare.vikaspedia.in/viewcontent/social-welfare/social-security/pension-benefits-under-nsap" target="_blank" rel="noopener">pension amounts and revision history</a>; beneficiary counts (2025).</li>
+        <li>Labour Bureau (MoSPI) — <a href="https://labourbureau.gov.in/CPI" target="_blank" rel="noopener">CPI-Industrial Workers</a>, used to deflate the pension to 2006 prices.</li>
+        <li>Ministry-commissioned NSAP evaluation — ~45% real-value loss on 2012-frozen amounts (via <a href="https://www.ensureias.com/blog/current-affairs/old-age-pension-under-nsap-concerns-over-declining-real-value" target="_blank" rel="noopener">summary</a>); <a href="https://www.outlookmoney.com/retirement/invest/life-insurance-pension-plan/oldage-pension-of-rs-200-enough-for-senior-citizens-know-what-the-govt-says-about-the-hike-proposal" target="_blank" rel="noopener">Parliament reply</a> (Aug 2025) — "no proposal under consideration."</li>
+      </ul>
+    </div>
+
+    <div class="dv-related">
+      <div class="dv-related-label">Go deeper on ImpactMojo</div>
+      <ul>
+        <li><a href="/DeepDives/informality-and-social-protection.html">Deep Dive — Informality and Social Protection</a>: designing protection that reaches people.</li>
+        <li><a href="/DeepDives/cash-transfers-evidence.html">Deep Dive — Cash Transfers and the Evidence</a>: what giving money to the poor does, and doesn't, do.</li>
+        <li><a href="/DeepDives/politics-of-targeting.html">Deep Dive — The Politics of Targeting</a>: caps, exclusion, and who a scheme leaves out.</li>
+        <li><a href="/DataDives/the-safety-fund-nobody-spends.html">Data Dive — The safety fund nobody spends</a>: another number the framing decides.</li>
+      </ul>
+    </div>
+
+    <div class="dv-cite-block">
+      <div class="dv-cite-label">Suggested citation</div>
+      <p class="dv-cite-text">ImpactMojo Data (2026). "The pension that never got a raise." <em>ImpactMojo Data Dives</em>. Retrieved from https://impactmojo.in/DataDives/the-pension-that-never-got-a-raise.html</p>
+    </div>
+
+    <div class="dv-cta">
+      <h3>Have a dataset worth digging into?</h3>
+      <p>Data Dives are independent investigations built from public data. If you know a number that deserves a closer look, tell us.</p>
+      <a href="/contact.html?topic=DataDive">Pitch a Data Dive →</a>
+    </div>
+  </div>
+</main>
+
+<footer class="im-footer" role="contentinfo">
+  <div class="im-footer-content">
+    <p class="im-footer-made">Made with ♥ by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+    <div class="im-footer-grid">
+      <div class="im-footer-section"><h4>About ImpactMojo</h4><ul><li><a href="/about.html">About Us</a></li><li><a href="/contact.html">Contact</a></li><li><a href="https://github.com/ImpactMojo/ImpactMojo" rel="noopener noreferrer" target="_blank">GitHub</a></li><li><a href="/transparency.html">Transparency</a></li></ul></div>
+      <div class="im-footer-section"><h4>Legal</h4><ul><li><a href="/privacy-policy.html">Privacy Policy</a></li><li><a href="/terms-of-service.html">Terms of Service</a></li><li><a href="/disclaimer.html">Disclaimer</a></li><li><a href="/data-protection.html">Data Protection</a></li></ul></div>
+      <div class="im-footer-section"><h4>Quick Links</h4><ul><li><a href="/catalog.html">All Courses</a></li><li><a href="/DataDives/">Data Dives</a></li><li><a href="/DeepDives/">Deep Dives</a></li><li><a href="/premium.html">Premium</a></li></ul></div>
+      <div class="im-footer-section"><h4>Resources</h4><ul><li><a href="/handouts.html">Handouts</a></li><li><a href="/blog.html">Blog</a></li><li><a href="/faq.html">FAQ</a></li><li><a href="/sitemap.html">Sitemap</a></li></ul></div>
+    </div>
+    <div class="im-footer-bottom">
+      <p>&copy; 2026 ImpactMojo. All content for educational purposes only.</p>
+      <p>Released under <strong>MIT License</strong> | Supported by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+    </div>
+  </div>
+</footer>
+
+<script src="/js/theme.js"></script>
+<script src="/DataDives/datadive.js"></script>
+<script>
+var rupee = function (v) { return '₹' + Math.round(v); };
+DataDive.lineChart(document.getElementById('c-real'), {
+  xLabels: ['2006', '2012', '2019', '2025'],
+  yMax: 250, yTicks: [0, 50, 100, 150, 200, 250], yFmt: rupee,
+  yTitle: 'Value (₹) →',
+  series: [
+    { name: 'Nominal ₹200', color: 'a', points: [ {x:0,y:200},{x:1,y:200},{x:2,y:200},{x:3,y:200} ] },
+    { name: 'Real value', color: 'b', area: true, points: [ {x:0,y:200},{x:1,y:122},{x:2,y:77},{x:3,y:57} ] }
+  ]
+});
+DataDive.barChart(document.getElementById('c-states'), {
+  data: [
+    { label: 'Andhra Pradesh', value: 3500 }, { label: 'Haryana', value: 3200 },
+    { label: 'Delhi', value: 2500 }, { label: 'Goa', value: 2500 },
+    { label: 'Kerala', value: 1600 }, { label: 'Rajasthan', value: 1250 },
+    { label: 'Tamil Nadu', value: 1100 }, { label: 'Madhya Pradesh', value: 600 }
+  ],
+  max: 4000, ticks: [0, 1000, 2000, 3000, 4000], suffix: '',
+  avg: { value: 200, label: 'Central ₹200' }, tipLabel: 'Total pension', valueFmt: rupee
+});
+</script>
+
+<script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script defer src="/js/state-manager.js"></script>
+<script defer src="/js/config.js"></script>
+<script defer src="/js/auth.js"></script>
+<script src="/js/translate-sarvam.js" defer></script>
+<script src="/js/site-chrome.js" defer></script>
+</body>
+</html>

--- a/DataDives/the-safety-fund-nobody-spends.html
+++ b/DataDives/the-safety-fund-nobody-spends.html
@@ -1,0 +1,233 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>The safety fund nobody spends | ImpactMojo Data Dive</title>
+<meta name="description" content="India's Nirbhaya Fund for women's safety is either 76% spent or barely a fifth spent, depending on what you divide by. An independent data investigation into how one fund produces three official 'utilisation' figures — and where the money actually went.">
+<link rel="canonical" href="https://www.impactmojo.in/DataDives/the-safety-fund-nobody-spends.html">
+<meta name="robots" content="index, follow">
+<meta property="og:type" content="article">
+<meta property="og:title" content="The safety fund nobody spends — ImpactMojo Data Dive">
+<meta property="og:description" content="India's Nirbhaya Fund is either 76% spent or barely a fifth spent, depending what you divide by. One fund, three official truths.">
+<meta property="og:url" content="https://www.impactmojo.in/DataDives/the-safety-fund-nobody-spends.html">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<meta property="og:site_name" content="ImpactMojo">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="The safety fund nobody spends — ImpactMojo Data Dive">
+<meta name="twitter:description" content="India's Nirbhaya Fund is either 76% spent or a fifth spent, depending what you divide by. One fund, three official truths.">
+<link rel="icon" href="/assets/images/favicon.png" type="image/png">
+<link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-JRCMEB9TBW');
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org", "@type": "Article",
+  "headline": "The safety fund nobody spends",
+  "description": "An independent data investigation into the utilisation of India's Nirbhaya Fund for women's safety.",
+  "image": "https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png",
+  "author": { "@type": "Organization", "name": "ImpactMojo Data" },
+  "publisher": { "@type": "Organization", "name": "ImpactMojo", "logo": { "@type": "ImageObject", "url": "https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" } },
+  "datePublished": "2026-07-11",
+  "mainEntityOfPage": "https://www.impactmojo.in/DataDives/the-safety-fund-nobody-spends.html",
+  "isAccessibleForFree": true
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org", "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "ImpactMojo", "item": "https://www.impactmojo.in/" },
+    { "@type": "ListItem", "position": 2, "name": "Data Dives", "item": "https://www.impactmojo.in/DataDives/" },
+    { "@type": "ListItem", "position": 3, "name": "The safety fund nobody spends" }
+  ]
+}
+</script>
+<link rel="stylesheet" href="/DataDives/datadive.css">
+</head>
+<body>
+<a href="#main-content" class="im-skip-link">Skip to content</a>
+<header class="im-topbar" role="banner">
+  <div class="im-topbar-left">
+    <a class="im-topbar-home" href="/" aria-label="ImpactMojo home">
+      <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo"><span>ImpactMojo</span>
+    </a>
+  </div>
+  <div class="im-topbar-right">
+    <a href="/catalog.html" class="im-browse-btn" title="Browse all content"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>Browse</a>
+    <a class="im-premium-btn" href="/premium.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>Premium</a>
+    <div class="im-theme-selector" role="group" aria-label="Theme">
+      <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="System theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Light theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Dark theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+    </div>
+  </div>
+</header>
+
+<main id="main-content" class="dv-wrap">
+  <a class="dv-back" href="/DataDives/">← All Data Dives</a>
+  <div class="dv-eyebrow">Data Dive · Public Money</div>
+  <h1 class="dv-title">The safety fund nobody spends</h1>
+  <p class="dv-standfirst">India created a dedicated fund for women's safety after 2012. Depending on the official source, it is either 76% spent or barely a fifth spent — same fund, same year, different denominators. A look at how one number becomes three, and where the money for women's safety actually sits.</p>
+  <div class="dv-byline">
+    <span class="dv-tag">Investigation</span>
+    <span><strong>ImpactMojo Data</strong></span>
+    <span class="dv-dot">·</span><span>11 July 2026</span>
+    <span class="dv-dot">·</span><span>6 min read</span>
+    <span class="dv-dot">·</span><span>Source: MWCD · Parliament · Standing Committee</span>
+  </div>
+
+  <div class="dv-prose">
+    <p>The Nirbhaya Fund was set up in 2013, in the aftermath of the December 2012 Delhi gang-rape, as a pool of money ring-fenced for women's safety — emergency helplines, one-stop crisis centres, fast-track courts, safe-city projects. More than a decade on, the obvious question is simple: has the money been spent? The answer is where it gets slippery.</p>
+
+    <div class="dv-finding">
+      <div class="dv-finding-label">The finding</div>
+      <p>The same fund is officially "76% utilised," "70% utilised," or "about a fifth utilised" — all true, and all measured against different bases. The government's cheerful figure divides spending by the <em>budget allocated</em>. A parliamentary committee, dividing by the value of <em>approved projects</em>, found under 40% disbursed. The gap between the three numbers is the story.</p>
+    </div>
+
+    <div class="dv-stats">
+      <div class="dv-stat"><div class="dv-stat-num">₹7,713 cr</div><div class="dv-stat-label">cumulatively <strong>allocated</strong> to the Fund (to 2024-25)</div></div>
+      <div class="dv-stat"><div class="dv-stat-num">₹5,846 cr</div><div class="dv-stat-label">reported <strong>utilised</strong> — "about 76% of allocation"</div></div>
+      <div class="dv-stat"><div class="dv-stat-num">38.6%</div><div class="dv-stat-label">disbursed against <strong>approved projects</strong>, a parliamentary panel found (2021)</div></div>
+      <div class="dv-stat"><div class="dv-stat-num">0%</div><div class="dv-stat-label">of one fast-track-courts tranche <strong>spent</strong> across 11 states</div></div>
+    </div>
+
+    <div class="dv-section-kicker">01 — One fund, three truths</div>
+    <h2>It depends what you divide by</h2>
+    <p>Every "utilisation" percentage for the Nirbhaya Fund is a fraction, and everyone reporting it picks a different bottom half. Measure spending against the <em>budget allocated</em> and you get the government's ~76%. Measure it against the money actually <em>released</em> to states and ministries and you land around 70%. Measure it against the far larger value of <em>approved projects</em> and it collapses to roughly 20–31%. None is wrong; each answers a different question.</p>
+
+    <figure class="dv-fig">
+      <div class="dv-fig-title">The same spending, three denominators</div>
+      <div class="dv-fig-sub">Nirbhaya Fund "utilisation," as a share of three different bases. The number you hear depends on which one is used.</div>
+      <div class="dv-chart" id="c-denom" role="img" aria-label="Bar chart of Nirbhaya Fund utilisation against three denominators: as a share of approved project cost about 25 percent, as a share of funds released about 70 percent, as a share of budget allocation about 76 percent."></div>
+      <details class="dv-data-toggle"><summary>View data table</summary>
+        <div class="dv-table-scroll"><table class="dv-table"><thead><tr><th>Utilisation measured against…</th><th>Share</th></tr></thead>
+        <tbody>
+          <tr><td>Approved project cost</td><td class="num">~25%</td></tr>
+          <tr><td>Funds released</td><td class="num">~70%</td></tr>
+          <tr><td>Budget allocation</td><td class="num">~76%</td></tr>
+        </tbody></table></div>
+      </details>
+      <figcaption><strong>Source:</strong> MWCD (2025) for the allocation-based figure; parliamentary replies for the released-funds figure; Parliamentary Standing Committee on Home Affairs (2021) and independent analyses for the approved-cost figure. Different dates and denominators — do not read as a trend.</figcaption>
+    </figure>
+
+    <div class="dv-section-kicker">02 — The widening gap</div>
+    <h2>Allocated, then not spent</h2>
+    <p>Hold the denominator steady — budget allocation — and track it over time, and the shape is a persistent gap between what was set aside and what was used. Cumulative allocation roughly doubled between the early years and 2024-25; utilisation rose too, but always trailing, always leaving a cushion of unspent money for women's safety sitting in the system.</p>
+
+    <figure class="dv-fig">
+      <div class="dv-fig-title">Cumulative allocated vs utilised (₹ crore)</div>
+      <div class="dv-fig-sub">Two snapshots on a consistent basis. The distance between the dots is money allocated but not yet spent.</div>
+      <div class="dv-chart" id="c-gap" role="img" aria-label="Dumbbell chart of cumulative Nirbhaya Fund allocation versus utilisation. Around 2021: about 2,922 crore utilised against 5,713 crore allocated. By 2024-25: about 5,846 crore utilised against 7,713 crore allocated."></div>
+      <details class="dv-data-toggle"><summary>View data table</summary>
+        <div class="dv-table-scroll"><table class="dv-table"><thead><tr><th>As of</th><th>Utilised (₹ cr)</th><th>Allocated (₹ cr)</th></tr></thead>
+        <tbody>
+          <tr><td>~2021</td><td class="num">2,922</td><td class="num">5,713</td></tr>
+          <tr><td>2024-25</td><td class="num">5,846</td><td class="num">7,713</td></tr>
+        </tbody></table></div>
+      </details>
+      <figcaption><strong>Source:</strong> cumulative figures from MWCD / parliamentary replies (2021, 2025). The 2025 release folds "released" and "utilised" together, so the recent gap is a conservative reading.</figcaption>
+    </figure>
+
+    <p>Underneath the totals, specific schemes tell the sharpest version of the story. One tranche of fast-track special courts saw funds released to eleven states and <em>not one rupee</em> spent. A vehicle-tracking safety platform reached 19 states and used about an eighth of the money. Four large states used none of their allotted safe-city funds. The pattern the Standing Committee named was blunt: money parked, coordination poor, "no permanent scheme" built.</p>
+
+    <div class="dv-section-kicker">03 — Reading the numbers honestly</div>
+    <h2>What this data can and can't tell you</h2>
+    <div class="dv-method">
+      <div class="dv-method-label">How to read this responsibly</div>
+      <ul>
+        <li><strong>Never put the three percentages on one line.</strong> ~25%, ~70%, and ~76% are not a trend or a disagreement about facts — they are three different fractions of the same spending, divided by approved cost, released funds, and allocation respectively. Each is honest; mixing them is not.</li>
+        <li><strong>"Allocated" itself is ambiguous.</strong> The budget corpus (~₹7,713 cr) is smaller than the appraised value of approved projects (~₹9,300 cr). The government tends to quote the smaller base (making utilisation look higher); the Standing Committee used the larger one.</li>
+        <li><strong>The 2025 figure blends released and utilised.</strong> The most recent official release does not separate money moved from money spent, so the true "spent" share that year can't be independently checked from it.</li>
+        <li><strong>State and scheme figures come from different vintages.</strong> Utilisation numbers from 2020, 2021, and 2022 use different bases and dates; keep them in separate comparisons rather than one ranking.</li>
+        <li><strong>Low utilisation is not the whole harm.</strong> Money spent is not the same as safety delivered — but unspent money is at least an unambiguous signal that the intended safety infrastructure was not built on time.</li>
+      </ul>
+      <p>The defensible claim: <strong>more than a decade after the fund was created, a large share of the money earmarked for women's safety remains unspent on any honest denominator, and specific safety schemes have gone entirely unused — while the headline "76%" quietly picks the base that flatters it most.</strong></p>
+    </div>
+
+    <div class="dv-method">
+      <div class="dv-method-label">Sources &amp; data</div>
+      <ul class="dv-sources">
+        <li>Ministry of Women &amp; Child Development — <a href="https://www.pib.gov.in/PressReleasePage.aspx?PRID=2110881" target="_blank" rel="noopener">cumulative allocation and utilisation</a> (2025).</li>
+        <li>Parliamentary Standing Committee on Home Affairs (2021) — 38.55% disbursed against approved projects (via <a href="https://sabrangindia.in/only-385-nirbhaya-fund-disbursed-funds-under-utilised-parliament-committee-report/" target="_blank" rel="noopener">SabrangIndia</a>).</li>
+        <li>Lok Sabha replies and <a href="https://www.data.gov.in/resource/year-wise-details-budget-allocation-under-nirbhaya-fund-2013-14-2024-25" target="_blank" rel="noopener">Open Government Data</a> — year-wise allocation; <a href="https://www.downtoearth.org.in/news/governance/10-years-of-delhi-gang-rape-70-of-released-nirbhaya-funds-utilised-lok-sabha-told-86623" target="_blank" rel="noopener">Down To Earth</a> — released-funds utilisation; <a href="https://accountabilityindia.in/blog/nirbhaya-fund-for-women-safety-under-utilised/" target="_blank" rel="noopener">Accountability India</a> — ministry- and scheme-wise underuse.</li>
+      </ul>
+    </div>
+
+    <div class="dv-related">
+      <div class="dv-related-label">Go deeper on ImpactMojo</div>
+      <ul>
+        <li><a href="/DeepDives/politics-of-targeting.html">Deep Dive — The Politics of Targeting</a>: how "programmes for the poor" become poor programmes.</li>
+        <li><a href="/DeepDives/measuring-empowerment.html">Deep Dive — Measuring Empowerment</a>: the difference between inputs and outcomes.</li>
+        <li><a href="/DataDives/state-welfare-budgets.html">Data Dive — The welfare-spending scoreboard</a>: allocation is not delivery.</li>
+        <li><a href="/DataDives/the-pension-that-never-got-a-raise.html">Data Dive — The pension that never got a raise</a>: another number the framing decides.</li>
+      </ul>
+    </div>
+
+    <div class="dv-cite-block">
+      <div class="dv-cite-label">Suggested citation</div>
+      <p class="dv-cite-text">ImpactMojo Data (2026). "The safety fund nobody spends." <em>ImpactMojo Data Dives</em>. Retrieved from https://impactmojo.in/DataDives/the-safety-fund-nobody-spends.html</p>
+    </div>
+
+    <div class="dv-cta">
+      <h3>Have a dataset worth digging into?</h3>
+      <p>Data Dives are independent investigations built from public data. If you know a number that deserves a closer look, tell us.</p>
+      <a href="/contact.html?topic=DataDive">Pitch a Data Dive →</a>
+    </div>
+  </div>
+</main>
+
+<footer class="im-footer" role="contentinfo">
+  <div class="im-footer-content">
+    <p class="im-footer-made">Made with ♥ by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+    <div class="im-footer-grid">
+      <div class="im-footer-section"><h4>About ImpactMojo</h4><ul><li><a href="/about.html">About Us</a></li><li><a href="/contact.html">Contact</a></li><li><a href="https://github.com/ImpactMojo/ImpactMojo" rel="noopener noreferrer" target="_blank">GitHub</a></li><li><a href="/transparency.html">Transparency</a></li></ul></div>
+      <div class="im-footer-section"><h4>Legal</h4><ul><li><a href="/privacy-policy.html">Privacy Policy</a></li><li><a href="/terms-of-service.html">Terms of Service</a></li><li><a href="/disclaimer.html">Disclaimer</a></li><li><a href="/data-protection.html">Data Protection</a></li></ul></div>
+      <div class="im-footer-section"><h4>Quick Links</h4><ul><li><a href="/catalog.html">All Courses</a></li><li><a href="/DataDives/">Data Dives</a></li><li><a href="/DeepDives/">Deep Dives</a></li><li><a href="/premium.html">Premium</a></li></ul></div>
+      <div class="im-footer-section"><h4>Resources</h4><ul><li><a href="/handouts.html">Handouts</a></li><li><a href="/blog.html">Blog</a></li><li><a href="/faq.html">FAQ</a></li><li><a href="/sitemap.html">Sitemap</a></li></ul></div>
+    </div>
+    <div class="im-footer-bottom">
+      <p>&copy; 2026 ImpactMojo. All content for educational purposes only.</p>
+      <p>Released under <strong>MIT License</strong> | Supported by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+    </div>
+  </div>
+</footer>
+
+<script src="/js/theme.js"></script>
+<script src="/DataDives/datadive.js"></script>
+<script>
+DataDive.barChart(document.getElementById('c-denom'), {
+  data: [
+    { label: 'of approved cost', value: 25, hl: true },
+    { label: 'of funds released', value: 70 },
+    { label: 'of allocation', value: 76 }
+  ],
+  max: 100, ticks: [0, 25, 50, 75, 100], tipLabel: 'Utilised'
+});
+DataDive.dumbbellChart(document.getElementById('c-gap'), {
+  data: [
+    { label: '~2021', a: 2922, b: 5713 },
+    { label: '2024-25', a: 5846, b: 7713 }
+  ],
+  max: 8500, ticks: [0, 2000, 4000, 6000, 8000], suffix: '',
+  aLabel: 'Utilised', bLabel: 'Allocated',
+  valueFmt: function (v) { return '₹' + Math.round(v).toLocaleString('en-IN') + ' cr'; }
+});
+</script>
+
+<script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script defer src="/js/state-manager.js"></script>
+<script defer src="/js/config.js"></script>
+<script defer src="/js/auth.js"></script>
+<script src="/js/translate-sarvam.js" defer></script>
+<script src="/js/site-chrome.js" defer></script>
+</body>
+</html>

--- a/DataDives/whose-name-on-the-house.html
+++ b/DataDives/whose-name-on-the-house.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Whose name is on the house? | ImpactMojo Data Dive</title>
+<meta name="description" content="India's flagship housing scheme puts homes in women's names by mandate — up to 97% of them. Yet only 42% of Indian women own a house at all, and just 13% own one in their sole name. An independent data investigation into the gap between the paperwork and the deed.">
+<link rel="canonical" href="https://www.impactmojo.in/DataDives/whose-name-on-the-house.html">
+<meta name="robots" content="index, follow">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Whose name is on the house? — ImpactMojo Data Dive">
+<meta property="og:description" content="India's housing scheme puts homes in women's names by mandate. Most Indian women still don't own the home they live in. The gap between paper and deed.">
+<meta property="og:url" content="https://www.impactmojo.in/DataDives/whose-name-on-the-house.html">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<meta property="og:site_name" content="ImpactMojo">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Whose name is on the house? — ImpactMojo Data Dive">
+<meta name="twitter:description" content="India's housing scheme puts homes in women's names by mandate. Most women still don't own the home they live in.">
+<link rel="icon" href="/assets/images/favicon.png" type="image/png">
+<link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-JRCMEB9TBW');
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org", "@type": "Article",
+  "headline": "Whose name is on the house?",
+  "description": "An independent data investigation into the gap between the PMAY women-ownership mandate and women's actual home and land ownership in India.",
+  "image": "https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png",
+  "author": { "@type": "Organization", "name": "ImpactMojo Data" },
+  "publisher": { "@type": "Organization", "name": "ImpactMojo", "logo": { "@type": "ImageObject", "url": "https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" } },
+  "datePublished": "2026-07-11",
+  "mainEntityOfPage": "https://www.impactmojo.in/DataDives/whose-name-on-the-house.html",
+  "isAccessibleForFree": true
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org", "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "ImpactMojo", "item": "https://www.impactmojo.in/" },
+    { "@type": "ListItem", "position": 2, "name": "Data Dives", "item": "https://www.impactmojo.in/DataDives/" },
+    { "@type": "ListItem", "position": 3, "name": "Whose name is on the house?" }
+  ]
+}
+</script>
+<link rel="stylesheet" href="/DataDives/datadive.css">
+</head>
+<body>
+<a href="#main-content" class="im-skip-link">Skip to content</a>
+<header class="im-topbar" role="banner">
+  <div class="im-topbar-left">
+    <a class="im-topbar-home" href="/" aria-label="ImpactMojo home">
+      <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo"><span>ImpactMojo</span>
+    </a>
+  </div>
+  <div class="im-topbar-right">
+    <a href="/catalog.html" class="im-browse-btn" title="Browse all content"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>Browse</a>
+    <a class="im-premium-btn" href="/premium.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>Premium</a>
+    <div class="im-theme-selector" role="group" aria-label="Theme">
+      <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="System theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Light theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Dark theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+    </div>
+  </div>
+</header>
+
+<main id="main-content" class="dv-wrap">
+  <a class="dv-back" href="/DataDives/">← All Data Dives</a>
+  <div class="dv-eyebrow">Data Dive · Gender &amp; Assets</div>
+  <h1 class="dv-title">Whose name is on the house?</h1>
+  <p class="dv-standfirst">India runs one of the world's largest transfers of housing to women — its flagship scheme puts homes in women's names by mandate. Yet most Indian women still don't own the home they live in. A look at the distance between a name on an allotment letter and a woman who owns her house.</p>
+  <div class="dv-byline">
+    <span class="dv-tag">Investigation</span>
+    <span><strong>ImpactMojo Data</strong></span>
+    <span class="dv-dot">·</span><span>11 July 2026</span>
+    <span class="dv-dot">·</span><span>6 min read</span>
+    <span class="dv-dot">·</span><span>Source: PMAY · NFHS-5</span>
+  </div>
+
+  <div class="dv-prose">
+    <p>The Pradhan Mantri Awas Yojana (PMAY) does something unusual for a government programme: it requires the house it builds to be owned by a woman. Under both the urban and rural arms, a PMAY home must be in the name of the female head of household, or jointly in the names of husband and wife — a male-only title is the narrow exception. It is, on paper, one of the largest deliberate transfers of property to women anywhere.</p>
+
+    <p>And the scheme's own numbers look triumphant. Under the latest urban phase, about 97% of houses were sanctioned to women, sole or joint; under the rural arm, roughly 73% of completed houses have a woman owner. Set those beside what the National Family Health Survey finds about women in general, though, and a gap opens up.</p>
+
+    <div class="dv-finding">
+      <div class="dv-finding-label">The finding</div>
+      <p>The scheme reports up to <strong>97% of its homes in women's names</strong>. But nationally, only <strong>42% of women own a house at all</strong>, and just <strong>13% own one in their sole name</strong> — the rest is joint ownership. The mandate is real, but it leans heavily on <em>joint</em> titles and sits atop a country where sole ownership by women is still rare.</p>
+    </div>
+
+    <div class="dv-stats">
+      <div class="dv-stat"><div class="dv-stat-num">~73%</div><div class="dv-stat-label">of completed <strong>PMAY-Gramin</strong> homes have a woman owner (sole or joint)</div></div>
+      <div class="dv-stat"><div class="dv-stat-num">27%</div><div class="dv-stat-label">of those are in a woman's <strong>sole</strong> name; the rest are joint</div></div>
+      <div class="dv-stat"><div class="dv-stat-num">42.3%</div><div class="dv-stat-label">of all Indian women (15-49) own a house, alone or jointly (NFHS-5)</div></div>
+      <div class="dv-stat"><div class="dv-stat-num">13%</div><div class="dv-stat-label">own a house in their <strong>sole</strong> name</div></div>
+    </div>
+
+    <div class="dv-section-kicker">01 — Paper vs deed</div>
+    <h2>The mandate meets the baseline</h2>
+    <p>Read the scheme numbers and the survey numbers together and the shape of the gap is clear. PMAY can allot almost every one of its houses to a woman; but PMAY reaches only poor, eligible households, and it counts a joint title — the house in the names of husband <em>and</em> wife — as "women's ownership." Across all women, sole ownership is the exception, not the rule.</p>
+
+    <figure class="dv-fig">
+      <div class="dv-fig-title">Homes in women's names: the mandate vs the baseline</div>
+      <div class="dv-fig-sub">Scheme figures count sole and joint ownership together; the survey figures show how rare sole ownership is across all women. Read them side by side, not as one series.</div>
+      <div class="dv-chart" id="c-paper" role="img" aria-label="Bar chart. PMAY-Urban 2.0 houses sanctioned to women (sole or joint) 97 percent; PMAY-Gramin completed houses with a woman owner 73 percent; all Indian women who own a house alone or jointly 42.3 percent; women who own a house in their sole name 13 percent."></div>
+      <details class="dv-data-toggle"><summary>View data table</summary>
+        <div class="dv-table-scroll"><table class="dv-table"><thead><tr><th>Measure</th><th>Share</th></tr></thead>
+        <tbody>
+          <tr><td>PMAY-Urban 2.0 — sanctioned to women (sole/joint)</td><td class="num">97%</td></tr>
+          <tr><td>PMAY-Gramin — completed with a woman owner (sole/joint)</td><td class="num">73%</td></tr>
+          <tr><td>All women — own a house (alone or jointly)</td><td class="num">42.3%</td></tr>
+          <tr><td>All women — own a house in sole name</td><td class="num">13%</td></tr>
+        </tbody></table></div>
+      </details>
+      <figcaption><strong>Source:</strong> PMAY figures — Ministry of Housing &amp; Urban Affairs and Ministry of Rural Development (2024-25); women's ownership — NFHS-5 (2019-21). The scheme and survey measure different populations (beneficiaries vs all women) — see the note below.</figcaption>
+    </figure>
+
+    <div class="dv-section-kicker">02 — The gap between assets</div>
+    <h2>House, land, farmland — the gap widens</h2>
+    <p>Home ownership is where women come closest to men; on land and farmland the distance grows. NFHS-5 finds 42.3% of women own a house against 62.5% of men, and 31.7% own land against 43.9% of men. And when you get to agricultural land specifically, women are under 14% of operational holders — and "operating" a holding overstates owning it.</p>
+
+    <figure class="dv-fig">
+      <div class="dv-fig-title">Women and men, by asset</div>
+      <div class="dv-fig-sub">Share owning each asset, alone or jointly (NFHS-5). The gap is narrowest for the house and widens for land.</div>
+      <div class="dv-chart" id="c-gap" role="img" aria-label="Dumbbell chart comparing women and men: house ownership 42.3 percent women versus 62.5 percent men; land ownership 31.7 percent women versus 43.9 percent men."></div>
+      <details class="dv-data-toggle"><summary>View data table</summary>
+        <div class="dv-table-scroll"><table class="dv-table"><thead><tr><th>Asset (owns, alone or jointly)</th><th>Women</th><th>Men</th></tr></thead>
+        <tbody>
+          <tr><td>A house</td><td class="num">42.3%</td><td class="num">62.5%</td></tr>
+          <tr><td>Land</td><td class="num">31.7%</td><td class="num">43.9%</td></tr>
+        </tbody></table></div>
+      </details>
+      <figcaption><strong>Source:</strong> NFHS-5 (2019-21), women and men aged 15-49. Agricultural land: women were 13.9% of operational holders (Agriculture Census 2015-16), a measure of who operates land, which overstates who owns it.</figcaption>
+    </figure>
+
+    <div class="dv-section-kicker">03 — Where women own most</div>
+    <h2>A wide spread across states</h2>
+    <p>Women's ownership varies enormously by state, and not always in the direction a development map would predict. Karnataka, Telangana, and Punjab record well over 60% of women owning a house or land; Maharashtra and Tripura sit below 25%. Between the two survey rounds, ownership actually <em>fell</em> in roughly half the large states — a pattern analysts treat with caution, since asset questions are notoriously sensitive to how they are asked.</p>
+
+    <figure class="dv-fig">
+      <div class="dv-fig-title">Women who own a house and/or land, by state</div>
+      <div class="dv-fig-sub">Share of women (15-49) owning a house and/or land, alone or jointly (NFHS-5). The dashed line is the national average. A verified selection of states, not the full list.</div>
+      <div class="dv-chart" id="c-states" role="img" aria-label="Bar chart of women who own a house and/or land by state from NFHS-5: Ladakh 72.2 percent, Karnataka 67.6, Telangana 66.6, Punjab 63.5, Uttar Pradesh 51.9, Gujarat 42.6, Maharashtra 22.9, Tripura 17.2, against a national average of 43.3 percent."></div>
+      <details class="dv-data-toggle"><summary>View data table</summary>
+        <div class="dv-table-scroll"><table class="dv-table"><thead><tr><th>State / UT</th><th>Own house and/or land</th></tr></thead>
+        <tbody>
+          <tr><td>Ladakh</td><td class="num">72.2%</td></tr>
+          <tr><td>Karnataka</td><td class="num">67.6%</td></tr>
+          <tr><td>Telangana</td><td class="num">66.6%</td></tr>
+          <tr><td>Punjab</td><td class="num">63.5%</td></tr>
+          <tr><td>Uttar Pradesh</td><td class="num">51.9%</td></tr>
+          <tr><td>National average</td><td class="num">43.3%</td></tr>
+          <tr><td>Gujarat</td><td class="num">42.6%</td></tr>
+          <tr><td>Maharashtra</td><td class="num">22.9%</td></tr>
+          <tr><td>Tripura</td><td class="num">17.2%</td></tr>
+        </tbody></table></div>
+      </details>
+      <figcaption><strong>Source:</strong> NFHS-5 (2019-21) state fact sheets, combined house-and/or-land indicator. A verified subset of states — the full 36-state table lives in the NFHS-5 report.</figcaption>
+    </figure>
+
+    <div class="dv-section-kicker">04 — Reading the numbers honestly</div>
+    <h2>What this data can and can't tell you</h2>
+    <div class="dv-method">
+      <div class="dv-method-label">How to read this responsibly</div>
+      <ul>
+        <li><strong>Sole is not the same as joint.</strong> The scheme's headline "women's ownership" bundles joint titles (husband and wife) with sole female ownership. The sole-female share is far smaller — about 27% of PMAY-Gramin houses, and 13% of all women. Any honest reading keeps the two apart.</li>
+        <li><strong>A title is not control.</strong> A name on an allotment letter or sale deed is not the same as effective say over the asset. The urban scheme even allows the woman's name to be added at a "later stage" — a known compliance gap.</li>
+        <li><strong>The scheme and the survey count different people.</strong> PMAY reaches only poor, eligible households; NFHS samples all women. You cannot subtract one from the other — read them as mandate vs baseline, not as a before-and-after.</li>
+        <li><strong>The state numbers are a verified subset,</strong> and ownership fell in about half the large states between survey rounds — a trend analysts flag as partly a data-comparability artefact, not necessarily real decline.</li>
+        <li><strong>Operating land is not owning it.</strong> The 14% female-holder figure counts who <em>operates</em> agricultural land; titled ownership by women is lower still.</li>
+      </ul>
+      <p>The defensible claim: <strong>a genuine, large-scale mandate to put homes in women's names coexists with a country where most women own no house in their own right.</strong> The scheme is moving the number — but from a very low base, and largely through joint titles. Whether a name on a deed becomes real control is the question the ownership statistics can't answer.</p>
+    </div>
+
+    <div class="dv-method">
+      <div class="dv-method-label">Sources &amp; data</div>
+      <ul class="dv-sources">
+        <li>Ministry of Rural Development &amp; Ministry of Housing &amp; Urban Affairs — <a href="https://www.pib.gov.in/PressReleasePage.aspx?PRID=2074713" target="_blank" rel="noopener">PMAY women-ownership figures</a> (2024).</li>
+        <li>National Family Health Survey-5 (2019-21) — women's house and land ownership; <a href="https://india.unfpa.org/sites/default/files/pub-pdf/analytical_paper_6_-_asset_ownership_among_women_in_india_-_insights_from_nfhs_data_-_final_1.pdf" target="_blank" rel="noopener">UNFPA analysis</a> of the NFHS asset data.</li>
+        <li>Agriculture Census 2015-16, Ministry of Agriculture &amp; Farmers' Welfare — female operational holders.</li>
+      </ul>
+    </div>
+
+    <div class="dv-related">
+      <div class="dv-related-label">Go deeper on ImpactMojo</div>
+      <ul>
+        <li><a href="/DeepDives/measuring-empowerment.html">Deep Dive — Measuring Empowerment</a>: agency, autonomy, and the trouble with proxies.</li>
+        <li><a href="/DeepDives/the-care-economy.html">Deep Dive — The Care Economy</a>: the unpaid work, and unrecognised claims, that hold economies up.</li>
+        <li><a href="/DeepDives/politics-of-targeting.html">Deep Dive — The Politics of Targeting</a>: who a scheme reaches, and who it counts.</li>
+        <li><a href="/DataDives/state-welfare-budgets.html">Data Dive — The welfare-spending scoreboard</a>: allocation vs delivery, again.</li>
+      </ul>
+    </div>
+
+    <div class="dv-cite-block">
+      <div class="dv-cite-label">Suggested citation</div>
+      <p class="dv-cite-text">ImpactMojo Data (2026). "Whose name is on the house?" <em>ImpactMojo Data Dives</em>. Retrieved from https://impactmojo.in/DataDives/whose-name-on-the-house.html</p>
+    </div>
+
+    <div class="dv-cta">
+      <h3>Have a dataset worth digging into?</h3>
+      <p>Data Dives are independent investigations built from public data. If you know a number that deserves a closer look, tell us.</p>
+      <a href="/contact.html?topic=DataDive">Pitch a Data Dive →</a>
+    </div>
+  </div>
+</main>
+
+<footer class="im-footer" role="contentinfo">
+  <div class="im-footer-content">
+    <p class="im-footer-made">Made with ♥ by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+    <div class="im-footer-grid">
+      <div class="im-footer-section"><h4>About ImpactMojo</h4><ul><li><a href="/about.html">About Us</a></li><li><a href="/contact.html">Contact</a></li><li><a href="https://github.com/ImpactMojo/ImpactMojo" rel="noopener noreferrer" target="_blank">GitHub</a></li><li><a href="/transparency.html">Transparency</a></li></ul></div>
+      <div class="im-footer-section"><h4>Legal</h4><ul><li><a href="/privacy-policy.html">Privacy Policy</a></li><li><a href="/terms-of-service.html">Terms of Service</a></li><li><a href="/disclaimer.html">Disclaimer</a></li><li><a href="/data-protection.html">Data Protection</a></li></ul></div>
+      <div class="im-footer-section"><h4>Quick Links</h4><ul><li><a href="/catalog.html">All Courses</a></li><li><a href="/DataDives/">Data Dives</a></li><li><a href="/DeepDives/">Deep Dives</a></li><li><a href="/premium.html">Premium</a></li></ul></div>
+      <div class="im-footer-section"><h4>Resources</h4><ul><li><a href="/handouts.html">Handouts</a></li><li><a href="/blog.html">Blog</a></li><li><a href="/faq.html">FAQ</a></li><li><a href="/sitemap.html">Sitemap</a></li></ul></div>
+    </div>
+    <div class="im-footer-bottom">
+      <p>&copy; 2026 ImpactMojo. All content for educational purposes only.</p>
+      <p>Released under <strong>MIT License</strong> | Supported by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+    </div>
+  </div>
+</footer>
+
+<script src="/js/theme.js"></script>
+<script src="/DataDives/datadive.js"></script>
+<script>
+DataDive.barChart(document.getElementById('c-paper'), {
+  data: [
+    { label: 'PMAY-U 2.0 (to women)', value: 97 },
+    { label: 'PMAY-G (women owner)', value: 73 },
+    { label: 'All women own a house', value: 42.3, hl: true },
+    { label: 'Women sole owner', value: 13, hl: true }
+  ],
+  max: 100, ticks: [0, 25, 50, 75, 100], tipLabel: 'Share'
+});
+DataDive.dumbbellChart(document.getElementById('c-gap'), {
+  data: [ { label: 'Owns a house', a: 42.3, b: 62.5 }, { label: 'Owns land', a: 31.7, b: 43.9 } ],
+  max: 70, ticks: [0, 20, 40, 60], suffix: '%',
+  aLabel: 'Women', bLabel: 'Men', valueFmt: function (v) { return v + '%'; }
+});
+DataDive.barChart(document.getElementById('c-states'), {
+  data: [
+    { label: 'Ladakh', value: 72.2 }, { label: 'Karnataka', value: 67.6 },
+    { label: 'Telangana', value: 66.6 }, { label: 'Punjab', value: 63.5 },
+    { label: 'Uttar Pradesh', value: 51.9 }, { label: 'Gujarat', value: 42.6 },
+    { label: 'Maharashtra', value: 22.9 }, { label: 'Tripura', value: 17.2 }
+  ],
+  max: 80, ticks: [0, 20, 40, 60, 80],
+  avg: { value: 43.3, label: 'National avg 43.3%' }, tipLabel: 'Own house/land'
+});
+</script>
+
+<script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script defer src="/js/state-manager.js"></script>
+<script defer src="/js/config.js"></script>
+<script defer src="/js/auth.js"></script>
+<script src="/js/translate-sarvam.js" defer></script>
+<script src="/js/site-chrome.js" defer></script>
+</body>
+</html>

--- a/DataDives/women-and-the-sir.html
+++ b/DataDives/women-and-the-sir.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>The women dropping off the voter list | ImpactMojo Data Dive</title>
+<meta name="description" content="When India revised its electoral rolls, women were deleted in far greater numbers than men — 22.7 lakh women against 15.6 lakh men in Bihar alone, and 61.8% of deletions in West Bengal. An independent data investigation into the gendered edge of the Special Intensive Revision, and why the documents demanded fall hardest on women.">
+<link rel="canonical" href="https://www.impactmojo.in/DataDives/women-and-the-sir.html">
+<meta name="robots" content="index, follow">
+<meta property="og:type" content="article">
+<meta property="og:title" content="The women dropping off the voter list — ImpactMojo Data Dive">
+<meta property="og:description" content="Women were deleted from India's electoral rolls in far greater numbers than men during the Special Intensive Revision. What the numbers show, and what they can't.">
+<meta property="og:url" content="https://www.impactmojo.in/DataDives/women-and-the-sir.html">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<meta property="og:site_name" content="ImpactMojo">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="The women dropping off the voter list — ImpactMojo Data Dive">
+<meta name="twitter:description" content="Women were deleted from India's electoral rolls in far greater numbers than men. What the SIR numbers show, and what they can't.">
+<link rel="icon" href="/assets/images/favicon.png" type="image/png">
+<link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-JRCMEB9TBW');
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org", "@type": "Article",
+  "headline": "The women dropping off the voter list",
+  "description": "An independent data investigation into the gendered impact of India's Special Intensive Revision of electoral rolls.",
+  "image": "https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png",
+  "author": { "@type": "Organization", "name": "ImpactMojo Data" },
+  "publisher": { "@type": "Organization", "name": "ImpactMojo", "logo": { "@type": "ImageObject", "url": "https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png" } },
+  "datePublished": "2026-07-11",
+  "mainEntityOfPage": "https://www.impactmojo.in/DataDives/women-and-the-sir.html",
+  "isAccessibleForFree": true
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org", "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "ImpactMojo", "item": "https://www.impactmojo.in/" },
+    { "@type": "ListItem", "position": 2, "name": "Data Dives", "item": "https://www.impactmojo.in/DataDives/" },
+    { "@type": "ListItem", "position": 3, "name": "The women dropping off the voter list" }
+  ]
+}
+</script>
+<link rel="stylesheet" href="/DataDives/datadive.css">
+</head>
+<body>
+<a href="#main-content" class="im-skip-link">Skip to content</a>
+<header class="im-topbar" role="banner">
+  <div class="im-topbar-left">
+    <a class="im-topbar-home" href="/" aria-label="ImpactMojo home">
+      <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo"><span>ImpactMojo</span>
+    </a>
+  </div>
+  <div class="im-topbar-right">
+    <a href="/catalog.html" class="im-browse-btn" title="Browse all content"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>Browse</a>
+    <a class="im-premium-btn" href="/premium.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>Premium</a>
+    <div class="im-theme-selector" role="group" aria-label="Theme">
+      <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="System theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Light theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Dark theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+    </div>
+  </div>
+</header>
+
+<main id="main-content" class="dv-wrap">
+  <a class="dv-back" href="/DataDives/">← All Data Dives</a>
+  <div class="dv-eyebrow">Data Dive · Democracy &amp; Data</div>
+  <h1 class="dv-title">The women dropping off the voter list</h1>
+  <p class="dv-standfirst">When India set out to clean up its electoral rolls, more women than men disappeared from them — and the documents the exercise demanded are precisely the ones women are least likely to hold. A look at the gendered edge of the Special Intensive Revision, and at the limits of what the published numbers can prove.</p>
+  <div class="dv-byline">
+    <span class="dv-tag">Investigation</span>
+    <span><strong>ImpactMojo Data</strong></span>
+    <span class="dv-dot">·</span><span>11 July 2026</span>
+    <span class="dv-dot">·</span><span>7 min read</span>
+    <span class="dv-dot">·</span><span>Source: ECI · The Hindu · NFHS-5</span>
+  </div>
+
+  <div class="dv-prose">
+    <p>Between June and September 2025, the Election Commission of India ran a "Special Intensive Revision" (SIR) of Bihar's electoral roll — a door-to-door re-verification of every voter, the first of its kind in decades. The stated aim was housekeeping: remove the dead, the duplicated, and those who had moved away. When the final roll was published, it had shrunk by about 47 lakh names, from 7.89 crore to 7.42 crore. Then a second, larger phase rolled the exercise out across a dozen more states.</p>
+
+    <p>Buried inside the aggregate was a pattern the headline number hid: the people removed were disproportionately women.</p>
+
+    <div class="dv-finding">
+      <div class="dv-finding-label">The finding</div>
+      <p>In Bihar, the Election Commission's own figures record <strong>22.7 lakh women deleted against 15.6 lakh men</strong> — women were about 59% of the attributed deletions, though they are under half the electorate. Bihar's voter sex ratio fell from 914 to 892, dropping in 37 of 38 districts. In the West Bengal phase, women were <strong>61.8% of all deletions</strong>. The documents the SIR accepted as proof lean on exactly the papers women are least likely to have.</p>
+    </div>
+
+    <div class="dv-stats">
+      <div class="dv-stat"><div class="dv-stat-num">22.7L</div><div class="dv-stat-label"><strong>women</strong> deleted in Bihar, vs 15.6 lakh men</div></div>
+      <div class="dv-stat"><div class="dv-stat-num">892</div><div class="dv-stat-label">Bihar's voter <strong>sex ratio</strong> after SIR, down from 914</div></div>
+      <div class="dv-stat"><div class="dv-stat-num">61.8%</div><div class="dv-stat-label">of West Bengal deletions were <strong>women</strong></div></div>
+      <div class="dv-stat"><div class="dv-stat-num">~39%</div><div class="dv-stat-label">of Bihar women <strong>never attended school</strong> — vs 18% of men (NFHS-5)</div></div>
+    </div>
+
+    <div class="dv-section-kicker">01 — Who got deleted</div>
+    <h2>More women than men, in both states measured</h2>
+    <p>The Election Commission attributed 22.74 lakh deletions in Bihar to women and 15.55 lakh to men. That is not a subtle skew: women made up roughly 59% of these deletions while forming under half the roll. When West Bengal's phase produced a frozen list months later, the tilt was sharper still — women were 61.8% of deletions there, and a majority of deletions in 219 of the state's 294 constituencies.</p>
+
+    <figure class="dv-fig">
+      <div class="dv-fig-title">Deletions by sex — Bihar</div>
+      <div class="dv-fig-sub">Voters removed during the SIR, as attributed by the Election Commission. Women are under half the electorate but the larger share of deletions.</div>
+      <div class="dv-chart" id="c-bihar" role="img" aria-label="Bar chart of Bihar SIR deletions by sex: 22.74 lakh women deleted versus 15.55 lakh men."></div>
+      <details class="dv-data-toggle"><summary>View data table</summary>
+        <div class="dv-table-scroll"><table class="dv-table"><thead><tr><th>Group</th><th>Deletions (lakh)</th></tr></thead>
+        <tbody><tr><td>Women</td><td class="num">22.74</td></tr><tr><td>Men</td><td class="num">15.55</td></tr></tbody></table></div>
+      </details>
+      <figcaption><strong>Source:</strong> Election Commission of India figures, as reported (Patna Press). These attributed counts are measured against the January 2025 roll and should not be added to the 47-lakh net-deletion figure, which nets out new additions on a different date.</figcaption>
+    </figure>
+
+    <p>The sex ratio of the roll tells the same story from another angle. Bihar's electoral sex ratio — women voters per 1,000 men — fell from 914 at the start of 2025 to 892 on the final roll, sliding in every district but one. A subsequent investigation by <em>The Hindu</em> found that the constituencies with the <em>highest</em> female turnout in the previous election tended to see the <em>largest</em> drops in roll sex ratio afterwards: exactly the seats where women had shown up to vote were the seats where women's names most often fell away.</p>
+
+    <div class="dv-section-kicker">02 — Why the documents matter</div>
+    <h2>The papers women don't have</h2>
+    <p>To stay on the roll, a voter had to establish identity and descent from a list of accepted documents. That list <em>excluded</em> the papers poor and mobile citizens most commonly hold — Aadhaar, the voter ID card itself, and ration cards — and leaned instead on the birth certificate, the matriculation (class-10) certificate, and a parent's documents to prove lineage.</p>
+
+    <p>Each of those requirements has a gender edge. In Bihar, NFHS-5 records that about 39% of women have never attended school (against 18% of men), and only around 16% of women have completed twelve years of schooling (against 28% of men) — so a matriculation certificate as proof of identity excludes far more women than men by construction. And because marriage was the reason for roughly two-thirds of all female migration in the last census — with most women moving to their husband's village — a woman's birth and school records typically sit in her <em>natal</em> district, not the marital constituency where she now votes.</p>
+
+    <figure class="dv-fig">
+      <div class="dv-fig-title">The paperwork gap that the ID rules ran into — Bihar</div>
+      <div class="dv-fig-sub">Each row compares women and men on a measure the SIR's accepted documents depend on. The wider the gap, the more the document requirement falls on women.</div>
+      <div class="dv-chart" id="c-docs" role="img" aria-label="Dumbbell chart comparing Bihar women and men on three schooling measures from NFHS-5: never attended school (women 39 percent, men 18), completed 12 or more years of schooling (women 16, men 28), and literacy (women 55, men 76)."></div>
+      <details class="dv-data-toggle"><summary>View data table</summary>
+        <div class="dv-table-scroll"><table class="dv-table"><thead><tr><th>Measure (Bihar, NFHS-5)</th><th>Women</th><th>Men</th></tr></thead>
+        <tbody>
+          <tr><td>Never attended school (%)</td><td class="num">39</td><td class="num">18</td></tr>
+          <tr><td>Completed 12+ years of schooling (%)</td><td class="num">16</td><td class="num">28</td></tr>
+          <tr><td>Literate (%)</td><td class="num">55</td><td class="num">76</td></tr>
+        </tbody></table></div>
+      </details>
+      <figcaption><strong>Source:</strong> National Family Health Survey-5 (2019-21), Bihar state report. These are the underlying gaps petitioners pointed to — not a measured cause of any specific deletion.</figcaption>
+    </figure>
+
+    <p>The Supreme Court intervened repeatedly: it ordered the Commission to publish a booth-level, searchable list of the deleted names with reasons, and later directed that Aadhaar be treated as an additional identity document — while maintaining that Aadhaar is not, by itself, proof of citizenship. In May 2026 the Court upheld the constitutional validity of the revision itself.</p>
+
+    <div class="dv-section-kicker">03 — Reading the numbers honestly</div>
+    <h2>What this data can and can't tell you</h2>
+    <p>This is a live, contested exercise, and the numbers demand more caution than most. Here is where the honest lines are.</p>
+    <div class="dv-method">
+      <div class="dv-method-label">How to read this responsibly</div>
+      <ul>
+        <li><strong>The gender split and the net figure use different clocks.</strong> The 22.7-lakh / 15.6-lakh women-and-men deletions are measured against the January 2025 roll; the 47-lakh net drop compares the pre-SIR total to the final roll and nets out new additions. They are not slices of the same pie — don't add or subtract one from the other.</li>
+        <li><strong>"More women deleted" is not "women deleted for being women."</strong> No published breakdown gives the <em>reason</em> for deletion by sex. Women being a larger share of deletions is consistent with the documentation mechanism described here, but the data cannot, on its own, prove intent or even the mechanism.</li>
+        <li><strong>The schooling gaps are context, not a measured cause.</strong> NFHS-5 tells us women are less likely to hold the accepted documents. It does not tell us how many deletions actually traced to a missing certificate — that link is argued by petitioners, not quantified in the roll data.</li>
+        <li><strong>The turnout-vs-deletion pattern is an ecological correlation.</strong> "High-female-turnout seats saw bigger sex-ratio drops" is a relationship across constituencies, not a statement about any individual voter.</li>
+        <li><strong>Bihar and West Bengal were measured slightly differently,</strong> at different stages of their revisions. Compare them as two readings of the same phenomenon, not as identical statistics. And no reliable caste- or religion-by-sex breakdown of deletions exists — claims about which women were hit hardest run ahead of the data.</li>
+      </ul>
+      <p>Read carefully, the data supports a specific, defensible claim: <strong>women were removed from the rolls in greater numbers than men in both states where sex-disaggregated figures exist, and the verification rules relied on documents women are measurably less likely to possess.</strong> It does not, by itself, establish why — and the missing "why" is the number worth demanding next.</p>
+    </div>
+
+    <div class="dv-method">
+      <div class="dv-method-label">Sources &amp; data</div>
+      <ul class="dv-sources">
+        <li>Election Commission of India — SIR draft and final rolls; deletion figures as reported by <a href="https://patnapress.com/bihar-sir-female-voters-deletion-sex-ratio-improves-11-districts/" target="_blank" rel="noopener">Patna Press</a>.</li>
+        <li><a href="https://m.thewire.in/article/politics/why-fall-in-share-of-women-voters-in-bihar-sirs-final-rolls-signals-a-serious-regression" target="_blank" rel="noopener">The Wire</a>, citing a <em>The Hindu</em> investigation — sex-ratio decline and the turnout correlation.</li>
+        <li><a href="https://behanbox.com/2026/04/13/over-61-lakh-women-dropped-from-bengal-voter-rolls-data-show-stark-gender-bias-in-sir/" target="_blank" rel="noopener">BehanBox</a> — West Bengal deletions by sex.</li>
+        <li><a href="https://adrindia.org/content/eci-exclusion-aadhaar-card-adr" target="_blank" rel="noopener">ADR</a> — the accepted-documents list and the Aadhaar exclusion.</li>
+        <li>National Family Health Survey-5 (2019-21), <a href="https://dhsprogram.com/pubs/pdf/FR374/FR374_Bihar.pdf" target="_blank" rel="noopener">Bihar report</a> — schooling and literacy by sex; Census 2011 — marriage as the reason for female migration.</li>
+      </ul>
+    </div>
+
+    <div class="dv-related">
+      <div class="dv-related-label">Go deeper on ImpactMojo</div>
+      <ul>
+        <li><a href="/DeepDives/data-power-global-south.html">Deep Dive — Data, Power, and the Global South</a>: who counts, who is counted, and who decides.</li>
+        <li><a href="/DeepDives/measuring-empowerment.html">Deep Dive — Measuring Empowerment</a>: agency, autonomy, and the trouble with proxies.</li>
+        <li><a href="/DeepDives/india-female-labour-force-participation.html">Deep Dive — India's Female Labour-Force Puzzle</a>: women, work, and visibility in the data.</li>
+        <li><a href="/DataDives/state-welfare-budgets.html">Data Dive — The welfare-spending scoreboard</a>: another look at what official numbers hide.</li>
+      </ul>
+    </div>
+
+    <div class="dv-cite-block">
+      <div class="dv-cite-label">Suggested citation</div>
+      <p class="dv-cite-text">ImpactMojo Data (2026). "The women dropping off the voter list." <em>ImpactMojo Data Dives</em>. Retrieved from https://impactmojo.in/DataDives/women-and-the-sir.html</p>
+    </div>
+
+    <div class="dv-cta">
+      <h3>Have a dataset worth digging into?</h3>
+      <p>Data Dives are independent investigations built from public data. If you know a number that deserves a closer look, tell us.</p>
+      <a href="/contact.html?topic=DataDive">Pitch a Data Dive →</a>
+    </div>
+  </div>
+</main>
+
+<footer class="im-footer" role="contentinfo">
+  <div class="im-footer-content">
+    <p class="im-footer-made">Made with ♥ by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+    <div class="im-footer-grid">
+      <div class="im-footer-section"><h4>About ImpactMojo</h4><ul><li><a href="/about.html">About Us</a></li><li><a href="/contact.html">Contact</a></li><li><a href="https://github.com/ImpactMojo/ImpactMojo" rel="noopener noreferrer" target="_blank">GitHub</a></li><li><a href="/transparency.html">Transparency</a></li></ul></div>
+      <div class="im-footer-section"><h4>Legal</h4><ul><li><a href="/privacy-policy.html">Privacy Policy</a></li><li><a href="/terms-of-service.html">Terms of Service</a></li><li><a href="/disclaimer.html">Disclaimer</a></li><li><a href="/data-protection.html">Data Protection</a></li></ul></div>
+      <div class="im-footer-section"><h4>Quick Links</h4><ul><li><a href="/catalog.html">All Courses</a></li><li><a href="/DataDives/">Data Dives</a></li><li><a href="/DeepDives/">Deep Dives</a></li><li><a href="/premium.html">Premium</a></li></ul></div>
+      <div class="im-footer-section"><h4>Resources</h4><ul><li><a href="/handouts.html">Handouts</a></li><li><a href="/blog.html">Blog</a></li><li><a href="/faq.html">FAQ</a></li><li><a href="/sitemap.html">Sitemap</a></li></ul></div>
+    </div>
+    <div class="im-footer-bottom">
+      <p>&copy; 2026 ImpactMojo. All content for educational purposes only.</p>
+      <p>Released under <strong>MIT License</strong> | Supported by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+    </div>
+  </div>
+</footer>
+
+<script src="/js/theme.js"></script>
+<script src="/DataDives/datadive.js"></script>
+<script>
+DataDive.barChart(document.getElementById('c-bihar'), {
+  data: [ { label: 'Women', value: 22.74, hl: true }, { label: 'Men', value: 15.55 } ],
+  max: 25, ticks: [0, 10, 20], suffix: 'L', tipLabel: 'Deletions',
+  valueFmt: function (v) { return v + ' lakh'; }
+});
+DataDive.dumbbellChart(document.getElementById('c-docs'), {
+  data: [
+    { label: 'Never went to school', a: 39, b: 18 },
+    { label: 'Completed 12+ years', a: 16, b: 28 },
+    { label: 'Literate', a: 55, b: 76 }
+  ],
+  max: 100, ticks: [0, 25, 50, 75, 100], suffix: '%',
+  aLabel: 'Women', bLabel: 'Men', valueFmt: function (v) { return v + '%'; }
+});
+</script>
+
+<script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script defer src="/js/state-manager.js"></script>
+<script defer src="/js/config.js"></script>
+<script defer src="/js/auth.js"></script>
+<script src="/js/translate-sarvam.js" defer></script>
+<script src="/js/site-chrome.js" defer></script>
+</body>
+</html>

--- a/data/data-dives.json
+++ b/data/data-dives.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.1.0",
   "updated": "2026-07-11",
   "description": "Independent data investigations built from public data. Each Data Dive interrogates one dataset — with original charts, a clear argument, and an honest account of what the numbers can and can't show.",
   "data_dives": [
@@ -13,21 +13,78 @@
       "dataset": "RBI State Finances 2025-26",
       "read_time": "8 min",
       "chart_count": 3,
-      "sections": [
-        "The spending spectrum",
-        "Spending vs outcomes",
-        "Budgeting for women",
-        "Reading the numbers honestly"
-      ],
-      "tags": [
-        "public-finance",
-        "welfare",
-        "state-budgets",
-        "india",
-        "health",
-        "gender-budgeting",
-        "social-policy"
-      ],
+      "sections": ["The spending spectrum", "Spending vs outcomes", "Budgeting for women", "Reading the numbers honestly"],
+      "tags": ["public-finance", "welfare", "state-budgets", "india", "health", "gender-budgeting", "social-policy"],
+      "published": "2026-07-11"
+    },
+    {
+      "id": "women-and-the-sir",
+      "title": "The women dropping off the voter list",
+      "tagline": "When India revised its electoral rolls, women were deleted in far greater numbers than men — and the documents demanded fall hardest on women. The gendered edge of the Special Intensive Revision.",
+      "topic": "Democracy & Data",
+      "url": "/DataDives/women-and-the-sir.html",
+      "author": "ImpactMojo Data",
+      "dataset": "ECI · The Hindu · NFHS-5",
+      "read_time": "7 min",
+      "chart_count": 2,
+      "sections": ["Who got deleted", "Why the documents matter", "Reading the numbers honestly"],
+      "tags": ["gender", "elections", "electoral-rolls", "india", "women", "data-justice", "documentation"],
+      "published": "2026-07-11"
+    },
+    {
+      "id": "whose-name-on-the-house",
+      "title": "Whose name is on the house?",
+      "tagline": "India's housing scheme puts homes in women's names by mandate — up to 97% of them. Yet only 42% of women own a house at all, and just 13% in their sole name. The gap between the paperwork and the deed.",
+      "topic": "Gender & Assets",
+      "url": "/DataDives/whose-name-on-the-house.html",
+      "author": "ImpactMojo Data",
+      "dataset": "PMAY · NFHS-5",
+      "read_time": "6 min",
+      "chart_count": 3,
+      "sections": ["Paper vs deed", "The gap between assets", "Where women own most", "Reading the numbers honestly"],
+      "tags": ["gender", "property", "housing", "pmay", "india", "women", "land-ownership"],
+      "published": "2026-07-11"
+    },
+    {
+      "id": "honorarium-not-a-wage",
+      "title": "Paid an honorarium, not a wage",
+      "tagline": "India runs its nutrition and rural-health systems on ~34 lakh women paid a central 'honorarium' of ₹4,500 a month or less — below the wage floor. Calling the work voluntary is what keeps it cheap.",
+      "topic": "Care & Work",
+      "url": "/DataDives/honorarium-not-a-wage.html",
+      "author": "ImpactMojo Data",
+      "dataset": "MWCD · NHM · Supreme Court",
+      "read_time": "6 min",
+      "chart_count": 2,
+      "sections": ["Below the floor", "The geography lottery", "Reading the numbers honestly"],
+      "tags": ["care-economy", "labour", "anganwadi", "asha", "women", "wages", "india"],
+      "published": "2026-07-11"
+    },
+    {
+      "id": "the-safety-fund-nobody-spends",
+      "title": "The safety fund nobody spends",
+      "tagline": "India's Nirbhaya Fund for women's safety is either 76% spent or barely a fifth spent, depending on what you divide by. How one fund produces three official utilisation figures — and where the money sits.",
+      "topic": "Public Money",
+      "url": "/DataDives/the-safety-fund-nobody-spends.html",
+      "author": "ImpactMojo Data",
+      "dataset": "MWCD · Parliament · CAG",
+      "read_time": "6 min",
+      "chart_count": 2,
+      "sections": ["One fund, three truths", "The widening gap", "Reading the numbers honestly"],
+      "tags": ["public-finance", "women", "safety", "nirbhaya-fund", "utilisation", "india", "accountability"],
+      "published": "2026-07-11"
+    },
+    {
+      "id": "the-pension-that-never-got-a-raise",
+      "title": "The pension that never got a raise",
+      "tagline": "India's central old-age pension has been ₹200 a month since 2006. Inflation cut its real value by two-thirds; what an elderly person actually receives now depends mostly on which state they live in.",
+      "topic": "Social Security",
+      "url": "/DataDives/the-pension-that-never-got-a-raise.html",
+      "author": "ImpactMojo Data",
+      "dataset": "NSAP · Labour Bureau CPI",
+      "read_time": "6 min",
+      "chart_count": 2,
+      "sections": ["The flat line and the falling line", "The geography of a pension", "Reading the numbers honestly"],
+      "tags": ["social-security", "pensions", "elderly", "inflation", "nsap", "india", "welfare"],
       "published": "2026-07-11"
     }
   ]

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -6776,6 +6776,51 @@
     ]
   },
   {
+    "id": "DV002",
+    "title": "The women dropping off the voter list",
+    "description": "An independent data investigation: women were deleted from India's electoral rolls in far greater numbers than men during the Special Intensive Revision, and the documents demanded fall hardest on women. Built from ECI, The Hindu, and NFHS-5 data.",
+    "type": "data-dive",
+    "category": "Data Dives",
+    "url": "/DataDives/women-and-the-sir.html",
+    "tags": ["gender", "elections", "electoral rolls", "sir", "india", "women", "data justice", "voter list"]
+  },
+  {
+    "id": "DV003",
+    "title": "Whose name is on the house?",
+    "description": "An independent data investigation into the gap between the PMAY women-ownership mandate — up to 97% of homes in women's names — and the reality that only 42% of Indian women own a house at all, and 13% in their sole name. Built from PMAY and NFHS-5 data.",
+    "type": "data-dive",
+    "category": "Data Dives",
+    "url": "/DataDives/whose-name-on-the-house.html",
+    "tags": ["gender", "property", "housing", "pmay", "land ownership", "india", "women"]
+  },
+  {
+    "id": "DV004",
+    "title": "Paid an honorarium, not a wage",
+    "description": "An independent data investigation into the pay of India's ~34 lakh Anganwadi and ASHA workers — almost all women — paid a central honorarium of ₹4,500 a month or less, below the minimum wage, frozen since 2018. Built from MWCD, NHM, and Supreme Court sources.",
+    "type": "data-dive",
+    "category": "Data Dives",
+    "url": "/DataDives/honorarium-not-a-wage.html",
+    "tags": ["care economy", "labour", "anganwadi", "asha", "wages", "women", "minimum wage", "india"]
+  },
+  {
+    "id": "DV005",
+    "title": "The safety fund nobody spends",
+    "description": "An independent data investigation into India's Nirbhaya Fund for women's safety — 76% spent or a fifth spent depending on the denominator, with specific safety schemes entirely unused. Built from MWCD, parliamentary, and CAG data.",
+    "type": "data-dive",
+    "category": "Data Dives",
+    "url": "/DataDives/the-safety-fund-nobody-spends.html",
+    "tags": ["public finance", "women", "safety", "nirbhaya fund", "utilisation", "accountability", "india"]
+  },
+  {
+    "id": "DV006",
+    "title": "The pension that never got a raise",
+    "description": "An independent data investigation into India's central old-age pension — ₹200 a month since 2006, its real value cut by two-thirds by inflation, with what an elderly person receives set mostly by their state. Built from NSAP and Labour Bureau CPI data.",
+    "type": "data-dive",
+    "category": "Data Dives",
+    "url": "/DataDives/the-pension-that-never-got-a-raise.html",
+    "tags": ["social security", "pensions", "elderly", "inflation", "nsap", "welfare", "india"]
+  },
+  {
     "id": "DD001",
     "title": "Reading Indian Political Economy",
     "description": "From colonial legacies to coalition capitalism — a curated reading list on how power, markets, and the state co-evolve in India. Curated by Sukhmeet Bedi.",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,7 +24,13 @@ The Interactive Labs library is now **30** and the handout library is **89**.
 
 ### For Learners
 
-- **Data Dives** — a new kind of content: independent data investigations that take one public dataset, chart it, make an argument, and spell out what the numbers can't show. Browse them at [/DataDives/](https://www.impactmojo.in/DataDives/). The first, [**The states that spend most on welfare have the least to show for it**](https://www.impactmojo.in/DataDives/state-welfare-budgets.html), digs into the RBI's 2025-26 state budgets: India's biggest social-sector spenders record its worst welfare outcomes, while low-spending Kerala and Tamil Nadu lead — with three interactive charts and a plain-English guide to reading the data honestly. Distinct from our reading-list Deep Dives.
+- **Data Dives** — a new kind of content: independent data investigations that take one public dataset, chart it, make an argument, and spell out what the numbers can't show. Browse them at [/DataDives/](https://www.impactmojo.in/DataDives/). Six to start, each with fancy interactive charts (that also work on your phone) and a plain-English "what this data can and can't tell you" guide:
+  - [**The states that spend most on welfare have the least to show for it**](https://www.impactmojo.in/DataDives/state-welfare-budgets.html) — India's biggest social-sector spenders record its worst welfare outcomes (RBI state budgets).
+  - [**The women dropping off the voter list**](https://www.impactmojo.in/DataDives/women-and-the-sir.html) — women deleted from the electoral rolls in far greater numbers than men.
+  - [**Whose name is on the house?**](https://www.impactmojo.in/DataDives/whose-name-on-the-house.html) — the gap between the housing scheme's women-ownership mandate and who actually owns a home.
+  - [**Paid an honorarium, not a wage**](https://www.impactmojo.in/DataDives/honorarium-not-a-wage.html) — the ~34 lakh women who run India's nutrition and health systems, paid below the wage floor.
+  - [**The safety fund nobody spends**](https://www.impactmojo.in/DataDives/the-safety-fund-nobody-spends.html) — how the Nirbhaya Fund is "76% spent" and "a fifth spent" at the same time.
+  - [**The pension that never got a raise**](https://www.impactmojo.in/DataDives/the-pension-that-never-got-a-raise.html) — the ₹200 old-age pension, unchanged since 2006, worth a third of what it was.
 
 ## v10.103.0 — July 11, 2026 (One comprehensive MEL Lab)
 

--- a/docs/data-dives-guide.md
+++ b/docs/data-dives-guide.md
@@ -20,6 +20,11 @@ If you want to know *what to read* on a topic, use a [Deep Dive](deep-dives-guid
 | Data Dive | Topic | Dataset | Charts | Link |
 |-----------|-------|---------|--------|------|
 | **The states that spend most on welfare have the least to show for it** | Public Finance | RBI State Finances 2025-26 | 3 | [Open](/DataDives/state-welfare-budgets.html) |
+| **The women dropping off the voter list** | Democracy & Data | ECI · The Hindu · NFHS-5 | 2 | [Open](/DataDives/women-and-the-sir.html) |
+| **Whose name is on the house?** | Gender & Assets | PMAY · NFHS-5 | 3 | [Open](/DataDives/whose-name-on-the-house.html) |
+| **Paid an honorarium, not a wage** | Care & Work | MWCD · NHM · Supreme Court | 2 | [Open](/DataDives/honorarium-not-a-wage.html) |
+| **The safety fund nobody spends** | Public Money | MWCD · Parliament · CAG | 2 | [Open](/DataDives/the-safety-fund-nobody-spends.html) |
+| **The pension that never got a raise** | Social Security | NSAP · Labour Bureau CPI | 2 | [Open](/DataDives/the-pension-that-never-got-a-raise.html) |
 
 Browse all Data Dives at [/DataDives/](/DataDives/).
 

--- a/index.html
+++ b/index.html
@@ -2697,6 +2697,56 @@ window.addEventListener('authStateChanged', function(e) {
 <p class="card-description">India's biggest social-sector spenders record its worst welfare outcomes, while the states that spend the least pull ahead. What the RBI's 2025-26 state-budget data really shows — and what it can't.</p>
 </a>
 </div>
+<div class="card">
+<a href="/DataDives/women-and-the-sir.html">
+<div class="card-header">
+<span class="card-number"><svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Activity"/></svg> DV2</span>
+<span class="learner-badge">2 charts</span>
+</div>
+<h3 class="card-title">The women dropping off the voter list</h3>
+<p class="card-description">When India revised its electoral rolls, women were deleted in far greater numbers than men — and the documents demanded fall hardest on women. The gendered edge of the Special Intensive Revision.</p>
+</a>
+</div>
+<div class="card">
+<a href="/DataDives/whose-name-on-the-house.html">
+<div class="card-header">
+<span class="card-number"><svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Activity"/></svg> DV3</span>
+<span class="learner-badge">3 charts</span>
+</div>
+<h3 class="card-title">Whose name is on the house?</h3>
+<p class="card-description">India's housing scheme puts homes in women's names by mandate — up to 97% of them. Yet only 42% of women own a house at all, and just 13% in their sole name. The gap between the paperwork and the deed.</p>
+</a>
+</div>
+<div class="card">
+<a href="/DataDives/honorarium-not-a-wage.html">
+<div class="card-header">
+<span class="card-number"><svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Activity"/></svg> DV4</span>
+<span class="learner-badge">2 charts</span>
+</div>
+<h3 class="card-title">Paid an honorarium, not a wage</h3>
+<p class="card-description">India runs its nutrition and rural-health systems on ~34 lakh women paid a central 'honorarium' of ₹4,500 a month or less — below the wage floor. Calling the work voluntary is what keeps it cheap.</p>
+</a>
+</div>
+<div class="card">
+<a href="/DataDives/the-safety-fund-nobody-spends.html">
+<div class="card-header">
+<span class="card-number"><svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Activity"/></svg> DV5</span>
+<span class="learner-badge">2 charts</span>
+</div>
+<h3 class="card-title">The safety fund nobody spends</h3>
+<p class="card-description">India's Nirbhaya Fund for women's safety is either 76% spent or barely a fifth spent, depending on what you divide by. How one fund produces three official utilisation figures — and where the money sits.</p>
+</a>
+</div>
+<div class="card">
+<a href="/DataDives/the-pension-that-never-got-a-raise.html">
+<div class="card-header">
+<span class="card-number"><svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Activity"/></svg> DV6</span>
+<span class="learner-badge">2 charts</span>
+</div>
+<h3 class="card-title">The pension that never got a raise</h3>
+<p class="card-description">India's central old-age pension has been ₹200 a month since 2006. Inflation cut its real value by two-thirds; what an elderly person actually receives now depends mostly on which state they live in.</p>
+</a>
+</div>
 </div>
 <div class="action-buttons">
 <a class="btn btn-primary" href="/DataDives/">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1524,6 +1524,36 @@
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
+    <url>
+        <loc>https://www.impactmojo.in/DataDives/women-and-the-sir.html</loc>
+        <lastmod>2026-07-11</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.7</priority>
+    </url>
+    <url>
+        <loc>https://www.impactmojo.in/DataDives/whose-name-on-the-house.html</loc>
+        <lastmod>2026-07-11</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.7</priority>
+    </url>
+    <url>
+        <loc>https://www.impactmojo.in/DataDives/honorarium-not-a-wage.html</loc>
+        <lastmod>2026-07-11</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.7</priority>
+    </url>
+    <url>
+        <loc>https://www.impactmojo.in/DataDives/the-safety-fund-nobody-spends.html</loc>
+        <lastmod>2026-07-11</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.7</priority>
+    </url>
+    <url>
+        <loc>https://www.impactmojo.in/DataDives/the-pension-that-never-got-a-raise.html</loc>
+        <lastmod>2026-07-11</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.7</priority>
+    </url>
 
     <!-- Deep Dives -->
     <url>


### PR DESCRIPTION
Builds the Data Dives collection out to six, adds a shared responsive chart engine, and upgrades all charts to be visually rich (while staying honest).

### Shared engine (`DataDives/datadive.css` + `datadive.js`)
- **Mobile-fixed:** charts render at the container's real pixel width (viewBox = measured px), so text stays readable on a phone instead of shrinking; bar charts switch to a compact "labels above bars" layout under ~520px; every chart re-renders on resize.
- **Chart types:** horizontal bar, scatter, dumbbell, and line — each with a hover tooltip and a `<details>` data-table fallback.
- **Fancy, honest:** gradient fills, glossy gradient dots, soft shadows, grow-in bars / draw-on lines / gradient area fills. Entrance animation is gated behind `prefers-reduced-motion`. Scales are never distorted.
- The first investigation was refactored onto this shared engine.

### Five new investigations (real, sourced data + a "what this data can and can't tell you" block)
- **The women dropping off the voter list** — the gendered edge of the SIR electoral-roll revision (ECI · The Hindu · NFHS-5).
- **Whose name is on the house?** — PMAY's women-ownership mandate vs actual ownership (PMAY · NFHS-5).
- **Paid an honorarium, not a wage** — Anganwadi/ASHA pay vs the wage floor (MWCD · NHM · Supreme Court).
- **The safety fund nobody spends** — the Nirbhaya Fund's three utilisation figures (MWCD · Parliament · CAG).
- **The pension that never got a raise** — the frozen ₹200 NSAP old-age pension's real-value erosion (NSAP · Labour Bureau CPI).

Each foregrounds its caveats (denominators, stocks-vs-flows, association-not-causation, contested figures); the SIR piece in particular leads with them.

### Wiring
Registry (`data/data-dives.json`), search index, sitemap, homepage cards (DV2–DV6), docs guide table, and the changelog `For Learners` entry.

### Verified
- `data-dives.json` + `search-index.json` valid JSON; `check-mojibake.py` PASS; `node --check datadive.js` OK.
- All four chart types rendered in headless Chromium at desktop and at a true 360px container (mobile compact layout, no clipping, no label collisions), in the fancy style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QoV2865kws9MaCYD6DcKM

---
_Generated by [Claude Code](https://claude.ai/code/session_011QoV2865kws9MaCYD6DcKM)_