### PR TITLE
SIR Data Dive: turnout-vs-deletion scatter + biggest-declines bar

### DIFF
--- a/DataDives/datadive.js
+++ b/DataDives/datadive.js
@@ -166,7 +166,7 @@
       var data = opts.data;
       var H = Math.round(Math.max(300, Math.min(460, W * (compact ? 0.95 : 0.66))));
       var padL = compact ? 44 : 60, padR = 20, padT = 22, padB = 54;
-      var xMin = opts.xMin, xMax = opts.xMax, yMin = 0, yMax = opts.yMax;
+      var xMin = opts.xMin, xMax = opts.xMax, yMin = (opts.yMin != null ? opts.yMin : 0), yMax = opts.yMax;
       var xs = opts.xSuffix != null ? opts.xSuffix : '%';
       var px = function (v) { return padL + (v - xMin) / (xMax - xMin) * (W - padL - padR); };
       var py = function (v) { return H - padB - (v - yMin) / (yMax - yMin) * (H - padT - padB); };
@@ -183,26 +183,35 @@
       });
       svg.appendChild(el('line', { x1: padL, y1: padT, x2: padL, y2: H - padB, class: 'dv-axis-line' }));
       svg.appendChild(el('line', { x1: padL, y1: H - padB, x2: W - padR, y2: H - padB, class: 'dv-axis-line' }));
+      // zero baseline (when values cross zero) and optional vertical reference
+      if (yMin < 0) svg.appendChild(el('line', { x1: padL, y1: py(0), x2: W - padR, y2: py(0), class: 'dv-axis-line' }));
+      if (opts.xRef != null) {
+        var rx = px(opts.xRef);
+        svg.appendChild(el('line', { x1: rx, y1: padT, x2: rx, y2: H - padB, class: 'dv-ref-line' }));
+        if (opts.xRefLabel) svg.appendChild(el('text', { x: rx, y: padT - 6, 'text-anchor': 'middle', class: 'dv-ref-lbl' }, opts.xRefLabel));
+      }
       if (opts.xTitle) svg.appendChild(el('text', { x: (padL + W - padR) / 2, y: H - 10, 'text-anchor': 'middle', class: 'dv-axis-title' }, opts.xTitle));
       if (opts.yTitle) {
         var cy = (padT + H - padB) / 2;
         svg.appendChild(el('text', { x: 14, y: cy, 'text-anchor': 'middle', class: 'dv-axis-title', transform: 'rotate(-90 14 ' + cy + ')' }, opts.yTitle));
       }
 
+      var many = data.length > 20;
       data.forEach(function (d) {
         var cx = px(d.x), cy = py(d.y);
         var g = el('g');
-        var dot = el('circle', { cx: cx, cy: cy, r: 9, class: 'dv-dot dv-anim-dot' });
-        dot.style.fill = 'url(#' + gid + '-dotA)';
+        var dot = el('circle', { cx: cx, cy: cy, r: d.big ? 9 : (many ? 6 : 9), class: 'dv-dot dv-anim-dot' + (d.hl ? ' hl' : '') });
+        dot.style.fill = 'url(#' + gid + (d.hl ? '-dotB' : '-dotA') + ')';
         g.appendChild(dot);
-        var anchor = d.anchor || (d.x > (xMin + xMax) / 2 ? 'end' : 'start');
-        var lx = anchor === 'end' ? cx - 13 : cx + 13;
-        var nameY = d.vpos === 'down' ? cy + 19 : cy - 19;
-        var subY = d.vpos === 'down' ? cy + 33 : cy - 5;
-        g.appendChild(el('text', { x: lx, y: nameY, 'text-anchor': anchor, class: 'dv-dot-lbl' }, d.label));
-        if (!compact || d.sub !== false)
-          g.appendChild(el('text', { x: lx, y: subY, 'text-anchor': anchor, class: 'dv-dot-sub' }, fmt(d.x) + xs + ' · ' + fmt(d.y)));
-        attachTip(g, '<b>' + d.label + '</b><br>' + (opts.tipX || 'x') + ': ' + fmt(d.x) + xs + '<br>' + (opts.tipY || 'y') + ': ' + fmt(d.y));
+        if (d.label) {
+          var anchor = d.anchor || (d.x > (xMin + xMax) / 2 ? 'end' : 'start');
+          var lx = anchor === 'end' ? cx - 12 : cx + 12;
+          var nameY = d.vpos === 'down' ? cy + 18 : cy - 16;
+          g.appendChild(el('text', { x: lx, y: nameY, 'text-anchor': anchor, class: 'dv-dot-lbl' }, d.label));
+          if (d.sub !== false)
+            g.appendChild(el('text', { x: lx, y: d.vpos === 'down' ? cy + 31 : cy - 3, 'text-anchor': anchor, class: 'dv-dot-sub' }, fmt(d.x) + xs + ' · ' + fmt(d.y)));
+        }
+        attachTip(g, '<b>' + (d.name || d.label || '') + '</b><br>' + (opts.tipX || 'x') + ': ' + fmt(d.x) + xs + '<br>' + (opts.tipY || 'y') + ': ' + fmt(d.y));
         svg.appendChild(g);
       });
       return svg;

--- a/DataDives/women-and-the-sir.html
+++ b/DataDives/women-and-the-sir.html
@@ -81,7 +81,7 @@
     <span class="dv-tag">Investigation</span>
     <span><strong>ImpactMojo Data</strong></span>
     <span class="dv-dot">·</span><span>11 July 2026</span>
-    <span class="dv-dot">·</span><span>7 min read</span>
+    <span class="dv-dot">·</span><span>9 min read</span>
     <span class="dv-dot">·</span><span>Source: ECI · The Hindu · NFHS-5</span>
   </div>
 
@@ -142,7 +142,88 @@
 
     <p>The Supreme Court intervened repeatedly: it ordered the Commission to publish a booth-level, searchable list of the deleted names with reasons, and later directed that Aadhaar be treated as an additional identity document — while maintaining that Aadhaar is not, by itself, proof of citizenship. In May 2026 the Court upheld the constitutional validity of the revision itself.</p>
 
-    <div class="dv-section-kicker">03 — Reading the numbers honestly</div>
+    <div class="dv-section-kicker">03 — The pattern across seats</div>
+    <h2>Where women voted most, women's names fell most</h2>
+    <p>The Hindu's data team lined up each of Bihar's 40 parliamentary constituencies two ways: how strongly women turned out to vote in the 2024 general election, and how far the constituency's roll gender ratio fell after the SIR. The seats where women had voted in the greatest numbers tended to be the ones that then lost the most women from the rolls. The relationship is real — if only moderate.</p>
+
+    <figure class="dv-fig">
+      <div class="dv-fig-title">Female turnout vs the drop in roll gender ratio</div>
+      <div class="dv-fig-sub">Each dot is one of Bihar's 40 parliamentary constituencies. Left–right: women who voted per 1,000 men in 2024. Bottom–top: the % fall in the roll's gender ratio after the SIR. The dashed line marks equal turnout; the three dots below zero actually rose.</div>
+      <div class="dv-chart" id="c-turnout" role="img" aria-label="Scatter plot of 40 Bihar parliamentary constituencies. Horizontal axis: female turnout per 1,000 men in 2024. Vertical axis: percentage drop in the roll's gender ratio after the SIR. Gopalganj, highest female turnout at 1,218, had the largest drop at 8.38 percent; Kishanganj 1,066 and 7.11 percent. Three constituencies — Bhagalpur, Banka, and Patna Sahib — rose slightly. The overall association is positive but moderate."></div>
+      <details class="dv-data-toggle"><summary>View data table (all 40 constituencies)</summary>
+        <div class="dv-table-scroll"><table class="dv-table"><thead><tr><th>Parliamentary constituency</th><th>Female turnout /1,000 men (2024)</th><th>% gender-ratio drop</th></tr></thead>
+        <tbody>
+          <tr><td>Gopalganj</td><td class="num">1,218</td><td class="num">8.38</td></tr>
+          <tr><td>Kishanganj</td><td class="num">1,066</td><td class="num">7.11</td></tr>
+          <tr><td>Siwan</td><td class="num">1,140</td><td class="num">3.96</td></tr>
+          <tr><td>Sasaram</td><td class="num">887</td><td class="num">3.49</td></tr>
+          <tr><td>Jhanjharpur</td><td class="num">1,167</td><td class="num">3.15</td></tr>
+          <tr><td>Supaul</td><td class="num">1,155</td><td class="num">3.09</td></tr>
+          <tr><td>Maharajganj</td><td class="num">1,149</td><td class="num">3.08</td></tr>
+          <tr><td>Katihar</td><td class="num">1,080</td><td class="num">2.72</td></tr>
+          <tr><td>Aurangabad</td><td class="num">881</td><td class="num">2.70</td></tr>
+          <tr><td>Purnia</td><td class="num">1,024</td><td class="num">2.65</td></tr>
+          <tr><td>Sheohar</td><td class="num">1,100</td><td class="num">2.54</td></tr>
+          <tr><td>Karakat</td><td class="num">883</td><td class="num">2.53</td></tr>
+          <tr><td>Jahanabad</td><td class="num">917</td><td class="num">2.17</td></tr>
+          <tr><td>Madhubani</td><td class="num">1,168</td><td class="num">2.15</td></tr>
+          <tr><td>Purvi Champaran</td><td class="num">1,067</td><td class="num">2.14</td></tr>
+          <tr><td>Valmiki Nagar</td><td class="num">1,066</td><td class="num">2.13</td></tr>
+          <tr><td>Ujiarpur</td><td class="num">1,066</td><td class="num">2.13</td></tr>
+          <tr><td>Sitamarhi</td><td class="num">1,110</td><td class="num">2.12</td></tr>
+          <tr><td>Gaya</td><td class="num">884</td><td class="num">2.07</td></tr>
+          <tr><td>Samastipur</td><td class="num">1,077</td><td class="num">2.04</td></tr>
+          <tr><td><strong>Bihar (average)</strong></td><td class="num">1,017</td><td class="num">2.01</td></tr>
+          <tr><td>Khagaria</td><td class="num">1,107</td><td class="num">2.00</td></tr>
+          <tr><td>Begusarai</td><td class="num">1,054</td><td class="num">1.99</td></tr>
+          <tr><td>Buxar</td><td class="num">896</td><td class="num">1.98</td></tr>
+          <tr><td>Madhepura</td><td class="num">1,099</td><td class="num">1.92</td></tr>
+          <tr><td>Nalanda</td><td class="num">1,011</td><td class="num">1.57</td></tr>
+          <tr><td>Araria</td><td class="num">1,090</td><td class="num">1.48</td></tr>
+          <tr><td>Saran</td><td class="num">1,020</td><td class="num">1.43</td></tr>
+          <tr><td>Nawada</td><td class="num">899</td><td class="num">1.29</td></tr>
+          <tr><td>Jamui</td><td class="num">956</td><td class="num">1.26</td></tr>
+          <tr><td>Patliputra</td><td class="num">848</td><td class="num">1.20</td></tr>
+          <tr><td>Hajipur</td><td class="num">1,001</td><td class="num">1.05</td></tr>
+          <tr><td>Vaishali</td><td class="num">1,072</td><td class="num">0.75</td></tr>
+          <tr><td>Munger</td><td class="num">897</td><td class="num">0.69</td></tr>
+          <tr><td>Muzaffarpur</td><td class="num">1,018</td><td class="num">0.40</td></tr>
+          <tr><td>Paschim Champaran</td><td class="num">1,021</td><td class="num">0.35</td></tr>
+          <tr><td>Darbhanga</td><td class="num">1,082</td><td class="num">0.15</td></tr>
+          <tr><td>Arrah</td><td class="num">874</td><td class="num">0.06</td></tr>
+          <tr><td>Patna Sahib</td><td class="num">811</td><td class="num">−0.26</td></tr>
+          <tr><td>Banka</td><td class="num">1,024</td><td class="num">−0.34</td></tr>
+          <tr><td>Bhagalpur</td><td class="num">946</td><td class="num">−1.16</td></tr>
+        </tbody></table></div>
+      </details>
+      <figcaption><strong>Source:</strong> The Hindu data team, "The unexplained drop in gender ratio following Bihar's SIR" (3 Nov 2025). Turnout is the 2024 Lok Sabha election; the drop is measured from the 2024 roll to the final SIR roll (statewide 907 → 892). The Hindu reports the correlation as moderate (about 0.45) — a real tendency, not a tight line.</figcaption>
+    </figure>
+
+    <p>At the extreme sits Gopalganj, where 1,218 women voted for every 1,000 men in 2024, and whose roll gender ratio then fell 8.38%, from 967 to 886. But it is a tendency, not a law: some constituencies with below-average female turnout also saw sizeable drops, and three moved the other way. The point is not that the rolls targeted women who vote — the data can't show intent — but that the correction, whatever drove it, landed hardest where women's electoral presence was strongest.</p>
+
+    <figure class="dv-fig">
+      <div class="dv-fig-title">The assembly seats that lost the most</div>
+      <div class="dv-fig-sub">Gender-ratio points lost between the January and September 2025 rolls, for the ten hardest-hit assembly seats.</div>
+      <div class="dv-chart" id="c-seatdrop" role="img" aria-label="Bar chart of the ten Bihar assembly seats with the largest fall in roll gender ratio between January and September 2025: Kuchaikote lost 95 points, Gopalganj 90, Amour 81, Kishanganj 80, Barauli 76, Hathua 76, Bhorey 66, Baikunthpur 65, Sultanganj 64, and Kochadhaman 61."></div>
+      <details class="dv-data-toggle"><summary>View data table</summary>
+        <div class="dv-table-scroll"><table class="dv-table"><thead><tr><th>Assembly seat</th><th>Gender-ratio points lost</th></tr></thead>
+        <tbody>
+          <tr><td>Kuchaikote</td><td class="num">95</td></tr>
+          <tr><td>Gopalganj</td><td class="num">90</td></tr>
+          <tr><td>Amour</td><td class="num">81</td></tr>
+          <tr><td>Kishanganj</td><td class="num">80</td></tr>
+          <tr><td>Barauli</td><td class="num">76</td></tr>
+          <tr><td>Hathua</td><td class="num">76</td></tr>
+          <tr><td>Bhorey</td><td class="num">66</td></tr>
+          <tr><td>Baikunthpur</td><td class="num">65</td></tr>
+          <tr><td>Sultanganj</td><td class="num">64</td></tr>
+          <tr><td>Kochadhaman</td><td class="num">61</td></tr>
+        </tbody></table></div>
+      </details>
+      <figcaption><strong>Source:</strong> The Hindu data team (3 Nov 2025), 243-seat dataset. Change measured between the January and September 2025 rolls, by assembly constituency. Only five of 243 seats rose — including Barhara (+34) and Arrah (+14), both in Bhojpur, the one district to improve overall.</figcaption>
+    </figure>
+
+    <div class="dv-section-kicker">04 — Reading the numbers honestly</div>
     <h2>What this data can and can't tell you</h2>
     <p>This is a live, contested exercise, and the numbers demand more caution than most. Here is where the honest lines are.</p>
     <div class="dv-method">
@@ -153,6 +234,8 @@
         <li><strong>The schooling gaps are context, not a measured cause.</strong> NFHS-5 tells us women are less likely to hold the accepted documents. It does not tell us how many deletions actually traced to a missing certificate — that link is argued by petitioners, not quantified in the roll data.</li>
         <li><strong>The turnout-vs-deletion pattern is an ecological correlation.</strong> "High-female-turnout seats saw bigger sex-ratio drops" is a relationship across constituencies, not a statement about any individual voter.</li>
         <li><strong>Bihar and West Bengal were measured slightly differently,</strong> at different stages of their revisions. Compare them as two readings of the same phenomenon, not as identical statistics. And no reliable caste- or religion-by-sex breakdown of deletions exists — claims about which women were hit hardest run ahead of the data.</li>
+        <li><strong>The turnout–deletion link is moderate, not mechanical.</strong> The correlation across constituencies is about 0.45 — a real tendency, but many seats break it and three saw their gender ratio rise. Read the scatter as a pattern, not a rule that predicts any single seat, and never as evidence of intent.</li>
+        <li><strong>The charts use different baselines and units.</strong> The constituency scatter measures the drop from the 2024 election roll to the final SIR roll (907 → 892); the seat bars measure the change between the January and September 2025 rolls (914 → 892). They also span three geographies — 40 parliamentary constituencies, 243 assembly seats, 38 districts — so the figures are not interchangeable.</li>
       </ul>
       <p>Read carefully, the data supports a specific, defensible claim: <strong>women were removed from the rolls in greater numbers than men in both states where sex-disaggregated figures exist, and the verification rules relied on documents women are measurably less likely to possess.</strong> It does not, by itself, establish why — and the missing "why" is the number worth demanding next.</p>
     </div>
@@ -161,7 +244,8 @@
       <div class="dv-method-label">Sources &amp; data</div>
       <ul class="dv-sources">
         <li>Election Commission of India — SIR draft and final rolls; deletion figures as reported by <a href="https://patnapress.com/bihar-sir-female-voters-deletion-sex-ratio-improves-11-districts/" target="_blank" rel="noopener">Patna Press</a>.</li>
-        <li><a href="https://m.thewire.in/article/politics/why-fall-in-share-of-women-voters-in-bihar-sirs-final-rolls-signals-a-serious-regression" target="_blank" rel="noopener">The Wire</a>, citing a <em>The Hindu</em> investigation — sex-ratio decline and the turnout correlation.</li>
+        <li>The Hindu data team, "<a href="https://www.thehindu.com/data/the-unexplained-drop-in-gender-ratio-following-bihars-sir/article70162911.ece" target="_blank" rel="noopener">The unexplained drop in gender ratio following Bihar's SIR</a>" (3 Nov 2025) — the constituency turnout-vs-drop dataset and the 243-seat gender-ratio change.</li>
+        <li><a href="https://m.thewire.in/article/politics/why-fall-in-share-of-women-voters-in-bihar-sirs-final-rolls-signals-a-serious-regression" target="_blank" rel="noopener">The Wire</a>, on the sex-ratio decline and its regression.</li>
         <li><a href="https://behanbox.com/2026/04/13/over-61-lakh-women-dropped-from-bengal-voter-rolls-data-show-stark-gender-bias-in-sir/" target="_blank" rel="noopener">BehanBox</a> — West Bengal deletions by sex.</li>
         <li><a href="https://adrindia.org/content/eci-exclusion-aadhaar-card-adr" target="_blank" rel="noopener">ADR</a> — the accepted-documents list and the Aadhaar exclusion.</li>
         <li>National Family Health Survey-5 (2019-21), <a href="https://dhsprogram.com/pubs/pdf/FR374/FR374_Bihar.pdf" target="_blank" rel="noopener">Bihar report</a> — schooling and literacy by sex; Census 2011 — marriage as the reason for female migration.</li>
@@ -223,6 +307,53 @@ DataDive.dumbbellChart(document.getElementById('c-docs'), {
   ],
   max: 100, ticks: [0, 25, 50, 75, 100], suffix: '%',
   aLabel: 'Women', bLabel: 'Men', valueFmt: function (v) { return v + '%'; }
+});
+
+DataDive.scatterChart(document.getElementById('c-turnout'), {
+  data: [
+    { name: 'Gopalganj', label: 'Gopalganj', x: 1218, y: 8.38, anchor: 'end', vpos: 'up' },
+    { name: 'Kishanganj', label: 'Kishanganj', x: 1066, y: 7.11, anchor: 'end', vpos: 'up' },
+    { name: 'Siwan', label: 'Siwan', x: 1140, y: 3.96, anchor: 'end', vpos: 'up' },
+    { name: 'Sasaram', x: 887, y: 3.49 }, { name: 'Jhanjharpur', x: 1167, y: 3.15 },
+    { name: 'Supaul', x: 1155, y: 3.09 }, { name: 'Maharajganj', x: 1149, y: 3.08 },
+    { name: 'Katihar', x: 1080, y: 2.72 }, { name: 'Aurangabad', x: 881, y: 2.70 },
+    { name: 'Purnia', x: 1024, y: 2.65 }, { name: 'Sheohar', x: 1100, y: 2.54 },
+    { name: 'Karakat', x: 883, y: 2.53 }, { name: 'Jahanabad', x: 917, y: 2.17 },
+    { name: 'Madhubani', x: 1168, y: 2.15 }, { name: 'Purvi Champaran', x: 1067, y: 2.14 },
+    { name: 'Valmiki Nagar', x: 1066, y: 2.13 }, { name: 'Ujiarpur', x: 1066, y: 2.13 },
+    { name: 'Sitamarhi', x: 1110, y: 2.12 }, { name: 'Gaya', x: 884, y: 2.07 },
+    { name: 'Samastipur', x: 1077, y: 2.04 },
+    { name: 'Bihar average', label: 'Bihar avg', x: 1017, y: 2.01, big: true, anchor: 'start', vpos: 'down' },
+    { name: 'Khagaria', x: 1107, y: 2.00 }, { name: 'Begusarai', x: 1054, y: 1.99 },
+    { name: 'Buxar', x: 896, y: 1.98 }, { name: 'Madhepura', x: 1099, y: 1.92 },
+    { name: 'Nalanda', x: 1011, y: 1.57 }, { name: 'Araria', x: 1090, y: 1.48 },
+    { name: 'Saran', x: 1020, y: 1.43 }, { name: 'Nawada', x: 899, y: 1.29 },
+    { name: 'Jamui', x: 956, y: 1.26 }, { name: 'Patliputra', x: 848, y: 1.20 },
+    { name: 'Hajipur', x: 1001, y: 1.05 }, { name: 'Vaishali', x: 1072, y: 0.75 },
+    { name: 'Munger', x: 897, y: 0.69 }, { name: 'Muzaffarpur', x: 1018, y: 0.40 },
+    { name: 'Paschim Champaran', x: 1021, y: 0.35 }, { name: 'Darbhanga', x: 1082, y: 0.15 },
+    { name: 'Arrah', x: 874, y: 0.06 },
+    { name: 'Patna Sahib', label: 'Patna Sahib', x: 811, y: -0.26, hl: true, anchor: 'start', vpos: 'up' },
+    { name: 'Banka', label: 'Banka', x: 1024, y: -0.34, hl: true, anchor: 'end', vpos: 'down' },
+    { name: 'Bhagalpur', label: 'Bhagalpur', x: 946, y: -1.16, hl: true, anchor: 'start', vpos: 'down' }
+  ],
+  xMin: 800, xMax: 1250, yMin: -2, yMax: 9,
+  xTicks: [800, 900, 1000, 1100, 1200], yTicks: [0, 2, 4, 6, 8],
+  xSuffix: '', xRef: 1000, xRefLabel: 'Equal turnout',
+  xTitle: 'Female turnout per 1,000 men (2024) →', yTitle: '% drop in gender ratio →',
+  tipX: 'Female turnout /1,000 men', tipY: '% gender-ratio drop'
+});
+
+DataDive.barChart(document.getElementById('c-seatdrop'), {
+  data: [
+    { label: 'Kuchaikote', value: 95 }, { label: 'Gopalganj', value: 90 },
+    { label: 'Amour', value: 81 }, { label: 'Kishanganj', value: 80 },
+    { label: 'Barauli', value: 76 }, { label: 'Hathua', value: 76 },
+    { label: 'Bhorey', value: 66 }, { label: 'Baikunthpur', value: 65 },
+    { label: 'Sultanganj', value: 64 }, { label: 'Kochadhaman', value: 61 }
+  ],
+  max: 100, ticks: [0, 25, 50, 75, 100], suffix: '',
+  tipLabel: 'Gender-ratio points lost', valueFmt: function (v) { return v; }
 });
 </script>
 

--- a/data/data-dives.json
+++ b/data/data-dives.json
@@ -25,9 +25,9 @@
       "url": "/DataDives/women-and-the-sir.html",
       "author": "ImpactMojo Data",
       "dataset": "ECI · The Hindu · NFHS-5",
-      "read_time": "7 min",
-      "chart_count": 2,
-      "sections": ["Who got deleted", "Why the documents matter", "Reading the numbers honestly"],
+      "read_time": "9 min",
+      "chart_count": 4,
+      "sections": ["Who got deleted", "Why the documents matter", "The pattern across seats", "Reading the numbers honestly"],
       "tags": ["gender", "elections", "electoral-rolls", "india", "women", "data-justice", "documentation"],
       "published": "2026-07-11"
     },

--- a/index.html
+++ b/index.html
@@ -2701,7 +2701,7 @@ window.addEventListener('authStateChanged', function(e) {
 <a href="/DataDives/women-and-the-sir.html">
 <div class="card-header">
 <span class="card-number"><svg class="icon-sm" viewBox="0 0 24 24" fill="none"><use href="#si_Activity"/></svg> DV2</span>
-<span class="learner-badge">2 charts</span>
+<span class="learner-badge">4 charts</span>
 </div>
 <h3 class="card-title">The women dropping off the voter list</h3>
 <p class="card-description">When India revised its electoral rolls, women were deleted in far greater numbers than men — and the documents demanded fall hardest on women. The gendered edge of the Special Intensive Revision.</p>


### PR DESCRIPTION
Adds the two follow-up charts to **The women dropping off the voter list**, built from The Hindu data team's published Bihar SIR dataset (3 Nov 2025).

### New charts (new section "The pattern across seats")
- **40-constituency scatter** — 2024 female turnout (women per 1,000 men) against the post-SIR drop in each constituency's roll gender ratio. The seats where women voted most tended to lose the most women from the rolls. The three constituencies that *rose* are shown below a zero baseline; an "equal turnout" reference line marks parity.
- **Biggest-declines bar** — the ten assembly seats with the largest gender-ratio falls (Jan→Sep 2025 rolls).

Both ship full data tables and sourced captions.

### Honesty notes
- The correlation is stated as **moderate (~0.45)** — a real tendency, not a rule, and explicitly not evidence of intent. Two new methodology bullets flag that the scatter and the bar use **different baselines** (2024-roll→final vs Jan→Sep) and **different geographies** (40 parliamentary constituencies vs 243 assembly seats vs 38 districts), so their numbers aren't interchangeable.
- The **38-district before/after slope was deliberately not built** — that granular table isn't public, so drawing it would be fabrication. This is documented in the commit.

### Engine
`scatterChart` now supports negative-y values (with a zero baseline), an optional vertical reference line, and selective point labelling (label a few, tooltip the rest) so a 40-point cloud stays readable.

Registry `chart_count` (2→4) and homepage badge updated for the SIR dive.

### Verified
`node --check` OK; JSON valid; `check-mojibake.py` PASS; scatter + bar rendered in headless Chromium (40 dots, risers in amber below zero, parity line, no label collisions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QoV2865kws9MaCYD6DcKM

---
_Generated by [Claude Code](https://claude.ai/code/session_011QoV2865kws9MaCYD6DcKM)_