### PR TITLE
GA4 without sign-in: Apps Script → Supabase snapshot bridge

### DIFF
--- a/admin/ga4-bridge.gs
+++ b/admin/ga4-bridge.gs
@@ -1,0 +1,69 @@
+/**
+ * ImpactMojo — GA4 → Supabase bridge (Google Apps Script)
+ * =======================================================
+ *
+ * Pulls GA4 numbers daily under YOUR Google login (no service-account key, so it
+ * works even when the org disables downloadable keys) and pushes them to
+ * impactmojo.in/api/ga4-ingest, which stores a snapshot the admin dashboard reads.
+ * Result: the admin Analytics tab shows data with no per-admin sign-in.
+ *
+ * ONE-TIME SETUP (~2 min):
+ *   1. Go to https://script.google.com → New project. Delete the sample code and
+ *      paste this whole file.
+ *   2. Left sidebar → Services (the + next to "Services") → find
+ *      "Google Analytics Data API" → Add. (Its identifier must be AnalyticsData.)
+ *   3. Put your ingest token in INGEST_TOKEN below (Claude will give it to you).
+ *   4. Select pushGA4Snapshot in the function dropdown → Run. Authorize when
+ *      prompted (your own Google account). Check the Execution log ends in "200".
+ *   5. Left sidebar → Triggers (clock icon) → Add Trigger →
+ *      function: pushGA4Snapshot, event source: Time-driven, type: Day timer.
+ *      Save. Done — it now refreshes daily.
+ */
+
+var PROPERTY_ID  = '514001382';
+var INGEST_URL   = 'https://impactmojo.in/api/ga4-ingest';
+var INGEST_TOKEN = 'PASTE_YOUR_TOKEN_HERE';   // <-- replace with the token Claude gives you
+
+function pushGA4Snapshot() {
+  var range = [{ startDate: '30daysAgo', endDate: 'today' }];
+
+  var overview = AnalyticsData.Properties.runReport({
+    dateRanges: range,
+    metrics: [
+      { name: 'totalUsers' }, { name: 'newUsers' }, { name: 'sessions' },
+      { name: 'screenPageViews' }, { name: 'averageSessionDuration' },
+      { name: 'bounceRate' }, { name: 'engagedSessions' }
+    ]
+  }, 'properties/' + PROPERTY_ID);
+
+  var geo = AnalyticsData.Properties.runReport({
+    dateRanges: range,
+    dimensions: [{ name: 'country' }],
+    metrics: [{ name: 'totalUsers' }, { name: 'sessions' }],
+    orderBys: [{ metric: { metricName: 'totalUsers' }, desc: true }],
+    limit: 30
+  }, 'properties/' + PROPERTY_ID);
+
+  var names = ['Total Users', 'New Users', 'Sessions', 'Pageviews',
+               'Avg Session Duration', 'Bounce Rate', 'Engaged Sessions'];
+  var ov = {};
+  if (overview.rows && overview.rows[0]) {
+    overview.rows[0].metricValues.forEach(function (v, i) { ov[names[i]] = parseFloat(v.value); });
+  }
+  var geography = (geo.rows || []).map(function (r) {
+    return {
+      country: r.dimensionValues[0].value,
+      users: parseFloat(r.metricValues[0].value),
+      sessions: parseFloat(r.metricValues[1].value)
+    };
+  });
+
+  var resp = UrlFetchApp.fetch(INGEST_URL, {
+    method: 'post',
+    contentType: 'application/json',
+    headers: { Authorization: 'Bearer ' + INGEST_TOKEN },
+    payload: JSON.stringify({ overview: ov, geography: geography }),
+    muteHttpExceptions: true
+  });
+  Logger.log(resp.getResponseCode() + ' ' + resp.getContentText());
+}

--- a/admin/index.html
+++ b/admin/index.html
@@ -1981,11 +1981,13 @@ async function loadServerGA4() {
         ga4Data = { overview: data.overview || {}, geography: data.geography || [] };
         try { localStorage.setItem(GA4_CONFIG.CACHE_KEY, JSON.stringify({ data: ga4Data, timestamp: Date.now() })); } catch (e) {}
         render();
-        updateGA4Status('live', 'Live data (server) — auto-updated');
+        var when = '';
+        if (data.updatedAt) { try { when = ' · updated ' + new Date(data.updatedAt).toLocaleDateString('en-IN', { day: 'numeric', month: 'short' }); } catch (e) {} }
+        updateGA4Status('live', 'GA4 connected (auto)' + when);
         var btn = document.getElementById('ga4SignIn');
         if (btn) btn.style.display = 'none';
         var msg = document.getElementById('ga4Message');
-        if (msg) msg.textContent = 'Live GA4 analytics are connected via a service account — no sign-in needed.';
+        if (msg) msg.textContent = 'GA4 analytics are connected automatically (refreshed daily) — no sign-in needed.';
     } catch (e) { /* network/parse — keep the sign-in fallback */ }
 }
 

--- a/netlify/functions/ga4-ingest.mjs
+++ b/netlify/functions/ga4-ingest.mjs
@@ -1,0 +1,60 @@
+// GA4 snapshot ingest — receives a daily GA4 report from the Apps Script bridge
+// and stores it in Supabase (public.ga4_snapshot, single 'latest' row).
+//
+// Why this exists: the org disables downloadable service-account keys, so instead
+// a Google Apps Script (running under the maintainer's own Google login, no key)
+// pulls GA4 daily and POSTs the numbers here. This endpoint is guarded by a shared
+// secret (GA4_INGEST_TOKEN) and writes with the Supabase service-role key, so the
+// powerful key never leaves the server. The admin page then reads via /api/ga4.
+
+const SUPABASE_URL = (process.env.SUPABASE_URL || "https://ddyszmfffyedolkcugld.supabase.co").replace(/\/$/, "");
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const INGEST_TOKEN = process.env.GA4_INGEST_TOKEN;
+
+function json(obj, status = 200) {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+  });
+}
+
+export default async (req) => {
+  if (req.method !== "POST") return json({ error: "POST only" }, 405);
+  if (!INGEST_TOKEN) return json({ error: "ingest not configured" }, 501);
+  if (!SERVICE_KEY) return json({ error: "supabase not configured" }, 501);
+
+  // auth: shared bearer token
+  const auth = req.headers.get("authorization") || "";
+  const token = auth.replace(/^Bearer\s+/i, "").trim();
+  if (token !== INGEST_TOKEN) return json({ error: "unauthorized" }, 401);
+
+  let body;
+  try { body = await req.json(); } catch (e) { return json({ error: "invalid JSON" }, 400); }
+  if (!body || typeof body !== "object" || !body.overview) {
+    return json({ error: "expected { overview, geography }" }, 400);
+  }
+
+  const snapshot = {
+    overview: body.overview || {},
+    geography: Array.isArray(body.geography) ? body.geography : [],
+  };
+
+  // upsert the single 'latest' row
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/ga4_snapshot?on_conflict=id`, {
+    method: "POST",
+    headers: {
+      apikey: SERVICE_KEY,
+      Authorization: "Bearer " + SERVICE_KEY,
+      "Content-Type": "application/json",
+      Prefer: "resolution=merge-duplicates,return=minimal",
+    },
+    body: JSON.stringify({ id: "latest", data: snapshot, updated_at: new Date().toISOString() }),
+  });
+  if (!res.ok) {
+    const t = await res.text();
+    return json({ error: "store failed: " + t.slice(0, 200) }, 502);
+  }
+  return json({ ok: true, stored: Object.keys(snapshot.overview).length + " metrics, " + snapshot.geography.length + " countries" });
+};
+
+export const config = { path: "/api/ga4-ingest" };

--- a/netlify/functions/ga4.mjs
+++ b/netlify/functions/ga4.mjs
@@ -21,12 +21,31 @@ import crypto from "node:crypto";
 const PROPERTY_ID = process.env.GA4_PROPERTY_ID || "514001382";
 const TOKEN_URL = "https://oauth2.googleapis.com/token";
 const SCOPE = "https://www.googleapis.com/auth/analytics.readonly";
+const SUPABASE_URL = (process.env.SUPABASE_URL || "https://ddyszmfffyedolkcugld.supabase.co").replace(/\/$/, "");
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 function json(obj, status = 200, cache = "no-store") {
   return new Response(JSON.stringify(obj), {
     status,
     headers: { "Content-Type": "application/json", "Cache-Control": cache },
   });
+}
+
+// Preferred source (org has no service-account keys): a daily snapshot pushed by
+// the Apps Script bridge into Supabase. Returns the stored report if present.
+async function readSnapshot() {
+  if (!SERVICE_KEY) return null;
+  try {
+    const res = await fetch(`${SUPABASE_URL}/rest/v1/ga4_snapshot?id=eq.latest&select=data,updated_at`, {
+      headers: { apikey: SERVICE_KEY, Authorization: "Bearer " + SERVICE_KEY },
+    });
+    if (!res.ok) return null;
+    const rows = await res.json();
+    if (Array.isArray(rows) && rows[0] && rows[0].data) {
+      return { ...rows[0].data, updatedAt: rows[0].updated_at };
+    }
+  } catch (e) { /* fall through */ }
+  return null;
 }
 
 function b64url(buf) {
@@ -93,8 +112,16 @@ async function runReport(token, body) {
 }
 
 export default async (req) => {
+  // 1. Preferred: the daily snapshot from the Apps Script bridge (no keys needed).
+  const snap = await readSnapshot();
+  if (snap && snap.overview && Object.keys(snap.overview).length) {
+    return json({ configured: true, source: "snapshot", updatedAt: snap.updatedAt,
+                  overview: snap.overview, geography: snap.geography || [] }, 200, "public, max-age=1800");
+  }
+
+  // 2. Optional fallback: a service account, if one is ever configured.
   const sa = readServiceAccount();
-  if (!sa) return json({ configured: false, reason: "GA4_SERVICE_ACCOUNT not set" }, 200, "no-store");
+  if (!sa) return json({ configured: false, reason: "no snapshot yet and GA4_SERVICE_ACCOUNT not set" }, 200, "no-store");
 
   try {
     const token = await getAccessToken(sa);

--- a/supabase/migrations/20260712_ga4_snapshot.sql
+++ b/supabase/migrations/20260712_ga4_snapshot.sql
@@ -1,0 +1,17 @@
+-- GA4 snapshot store (2026-07-12)
+--
+-- Holds a single 'latest' row of GA4 numbers pushed daily by the Apps Script
+-- bridge (admin/ga4-bridge.gs) via netlify/functions/ga4-ingest.mjs, and read
+-- back by netlify/functions/ga4.mjs for the admin dashboard — so live-ish GA4
+-- data shows with no per-admin Google sign-in and no service-account key.
+-- Only the service role (via those functions) touches this table; RLS is on
+-- with no public policies. Created ad hoc in production; captured here so a
+-- fresh environment reproduces it. Idempotent.
+
+create table if not exists public.ga4_snapshot (
+  id text primary key default 'latest',
+  data jsonb not null,
+  updated_at timestamptz not null default now()
+);
+
+alter table public.ga4_snapshot enable row level security;


### PR DESCRIPTION
## What does this PR do?

Removes the per-admin Google sign-in from the admin Analytics tab **without** a service-account key (the org disables downloadable keys), using a Google Apps Script bridge.

- **`admin/ga4-bridge.gs`** — a Google Apps Script that runs under the maintainer's own Google login (no key), pulls the GA4 30-day overview + geography daily, and POSTs them to the site.
- **`netlify/functions/ga4-ingest.mjs`** — guarded by a shared `GA4_INGEST_TOKEN`; upserts the snapshot into `public.ga4_snapshot` using the Supabase service-role key (which never leaves the server).
- **`netlify/functions/ga4.mjs`** — now serves that snapshot first, so the admin tab loads with no sign-in; the service-account path stays as an optional fallback and OAuth still works if no snapshot exists yet.
- **`admin/index.html`** — `loadServerGA4` shows "GA4 connected (auto) · updated &lt;date&gt;".
- **`supabase/migrations/20260712_ga4_snapshot.sql`** — captures the new table.

**Ships safe before setup:** with no snapshot and no key, `/api/ga4` returns `configured:false` and the existing one-click sign-in still works. The `GA4_INGEST_TOKEN` env var and the `ga4_snapshot` table are already set on production.

## Type of change

- [x] New feature or tool
- [x] Documentation / infra

## Checklist

- [x] No console errors (functions + inline JS syntax-checked; encoding/mojibake guard passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuankGiPWNhuR1hmN4osrc

---
_Generated by [Claude Code](https://claude.ai/code/session_01LuankGiPWNhuR1hmN4osrc)_