### PR TITLE
GA4 bridge: use canonical www host in Apps Script ingest URL

### DIFF
--- a/admin/ga4-bridge.gs
+++ b/admin/ga4-bridge.gs
@@ -21,7 +21,7 @@
  */
 
 var PROPERTY_ID  = '514001382';
-var INGEST_URL   = 'https://impactmojo.in/api/ga4-ingest';
+var INGEST_URL   = 'https://www.impactmojo.in/api/ga4-ingest';
 var INGEST_TOKEN = 'PASTE_YOUR_TOKEN_HERE';   // <-- replace with the token Claude gives you
 
 function pushGA4Snapshot() {


### PR DESCRIPTION
The apex `impactmojo.in` 301-redirects to `www.impactmojo.in`, and Apps Script's `UrlFetchApp` downgrades a redirected POST to a GET — so the GA4 ingest call hit the function as GET and returned `405 "POST only"`. Points `INGEST_URL` in `admin/ga4-bridge.gs` straight at the canonical `https://www.impactmojo.in/api/ga4-ingest`.

Reference-script only (not served); no redeploy needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuankGiPWNhuR1hmN4osrc

---
_Generated by [Claude Code](https://claude.ai/code/session_01LuankGiPWNhuR1hmN4osrc)_