### PR TITLE
Homepage: signup-callout lines lead with content & approach

### DIFF
--- a/index.html
+++ b/index.html
@@ -886,7 +886,7 @@ window.addEventListener('authStateChanged', function(e) {
         <div class="v3-callout-arrow"></div>
         <div class="v3-callout-content">
             <div style="font-weight:700;font-size:0.82rem;line-height:1.45;margin-bottom:8px;">
-                <span data-i18n="benefits.content_lead">Everything free &mdash; 68 courses &middot; 135 games &middot; 31 labs &middot; 105 reading companions &amp; more</span>
+                <span data-i18n="benefits.content_lead">Everything free &mdash; 68 courses &middot; 135 games &middot; 31 labs &middot; 128 reading companions &amp; more</span>
                 <span style="display:block;font-weight:600;opacity:.75;font-size:0.76rem;" data-i18n="benefits.plus_account">&mdash; practitioner-built, and yours to keep:</span>
             </div>
             <span class="v3-benefit-item">

--- a/index.html
+++ b/index.html
@@ -886,27 +886,27 @@ window.addEventListener('authStateChanged', function(e) {
         <div class="v3-callout-arrow"></div>
         <div class="v3-callout-content">
             <div style="font-weight:700;font-size:0.82rem;line-height:1.45;margin-bottom:8px;">
-                <span data-i18n="benefits.content_lead">68 free courses &middot; 135 games &middot; 31 labs &amp; more</span>
-                <span style="display:block;font-weight:600;opacity:.75;font-size:0.76rem;" data-i18n="benefits.plus_account">&mdash; plus a free account to:</span>
+                <span data-i18n="benefits.content_lead">Everything free &mdash; 68 courses &middot; 135 games &middot; 31 labs &middot; 105 reading companions &amp; more</span>
+                <span style="display:block;font-weight:600;opacity:.75;font-size:0.76rem;" data-i18n="benefits.plus_account">&mdash; practitioner-built, and yours to keep:</span>
             </div>
             <span class="v3-benefit-item">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-benefit-icon"><use href="#si_Check_circle"/></svg>
-                <span data-i18n="benefits.track_progress">Track Progress</span>
+                <span data-i18n="benefits.track_progress">Learn by doing &mdash; labs, games &amp; practice packs</span>
             </span>
             <span class="v3-benefit-item">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-benefit-icon"><use href="#si_Check_circle"/></svg>
-                <span data-i18n="benefits.save_bookmarks">Save Bookmarks</span>
+                <span data-i18n="benefits.save_bookmarks">Evidence-based &amp; South Asia&ndash;first</span>
             </span>
             <span class="v3-benefit-item">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-benefit-icon"><use href="#si_Check_circle"/></svg>
-                <span data-i18n="benefits.personal_notes">Personal Notes</span>
+                <span data-i18n="benefits.personal_notes">Built by practitioners &middot; open-source, no paywalls</span>
             </span>
             <span class="v3-benefit-item">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-benefit-icon"><use href="#si_Check_circle"/></svg>
-                <span data-i18n="benefits.cloud_sync">Cloud Sync</span>
+                <span data-i18n="benefits.cloud_sync">A free account saves your progress, notes &amp; path</span>
             </span>
         </div>
-        <div class="v3-callout-footer"><span data-i18n="benefits.all_free">All free with signup!</span> <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Flare"/></svg></div>
+        <div class="v3-callout-footer"><span data-i18n="benefits.all_free">Free forever &mdash; sign up in seconds</span> <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Flare"/></svg></div>
     </div>
     
     <!-- Premium link for those interested -->


### PR DESCRIPTION
## What does this PR do?

Reworks the homepage sign-up callout so it's about **what ImpactMojo is**, not account plumbing. The four bullets were mechanical account features (Track Progress / Save Bookmarks / Personal Notes / Cloud Sync); replaced with content- and approach-led lines, folding the account value into one:

**Before**
> 68 free courses · 135 games · 31 labs & more — plus a free account to:
> ✓ Track Progress ✓ Save Bookmarks ✓ Personal Notes ✓ Cloud Sync · *All free with signup!*

**After**
> Everything free — 68 courses · 135 games · 31 labs · 128 reading companions & more — practitioner-built, and yours to keep:
> ✓ Learn by doing — labs, games & practice packs
> ✓ Evidence-based & South Asia–first
> ✓ Built by practitioners · open-source, no paywalls
> ✓ A free account saves your progress, notes & path
> *Free forever — sign up in seconds*

The homepage translates live via Sarvam, so the new copy is picked up automatically in every language (the `data-i18n` attributes on this block are vestigial there). Companion count set to 128 to match premium.html / the companion files.

## Type of change

- [x] Content / copy

## Checklist

- [x] encoding/mojibake guard passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuankGiPWNhuR1hmN4osrc

---
_Generated by [Claude Code](https://claude.ai/code/session_01LuankGiPWNhuR1hmN4osrc)_