### PR TITLE
Hero: one centered column — fix mobile scroll-to-content & desktop dead-space

### DIFF
--- a/css/imx-main.css
+++ b/css/imx-main.css
@@ -5245,11 +5245,12 @@ body.dark-mode .v3-blob-4 { background: radial-gradient(circle, rgba(245, 158, 1
 /* ---------- V3 HERO SECTION ---------- */
 .v3-hero {
     position: relative;
-    min-height: 70vh;
+    min-height: auto;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding: 4rem 2rem;
+    padding: 2.75rem 2rem 3.25rem;
     /* Impact Bold light alignment: soft tinted band echoing the bold pages'
        coloured hero bands, kept light so the dark hero text stays AA. */
     background: linear-gradient(135deg, #EFF6FF 0%, #F5F3FF 55%, #ECFDF5 100%);
@@ -5272,7 +5273,7 @@ body.dark-mode .v3-hero, [data-theme="dark"] .v3-hero {
     text-transform: uppercase;
     /* WCAG AA: sky-800 #075985 = 7.56:1 on white. Was sky-500 #0EA5E9 = 2.77:1. */
     color: #075985;
-    margin-bottom: 1.5rem;
+    margin-bottom: 1.1rem;
     display: inline-block;
     padding: 0.5rem 1.25rem;
     background: rgba(14, 165, 233, 0.1);
@@ -5678,17 +5679,26 @@ footer::before {
    so the speech-bubble callout never overlaps the headline and paragraph. */
 @media (max-width: 1024px) {
     .v3-hero {
-        flex-direction: column;
-        padding: 3rem 1.5rem;
-        min-height: auto;
+        padding: 2.5rem 1.5rem 3rem;
     }
     .v3-hero-content { max-width: 100%; }
-    .v3-hero-cta-wrapper { width: 100%; margin-top: 2rem; }
-    .v3-benefits-callout { max-width: 100%; transform: rotate(0deg); }
+    .v3-hero-cta-wrapper { margin-top: 1.5rem; }
+    .v3-benefits-callout { max-width: 560px; transform: rotate(0deg); }
+}
+/* Mobile: compact the trust strip into a single scrollable row so the H1
+   reaches the viewport fast, and shrink hero padding further. */
+@media (max-width: 700px) {
+    .practitioner-trust-strip { padding: 0.6rem 1rem !important; }
+    .practitioner-trust-strip > div { flex-wrap: nowrap !important; overflow-x: auto; justify-content: flex-start !important; -webkit-overflow-scrolling: touch; scrollbar-width: none; }
+    .practitioner-trust-strip > div::-webkit-scrollbar { display: none; }
+    .practitioner-trust-strip > div > div { flex-wrap: nowrap !important; }
+    .practitioner-trust-strip > div > span { white-space: nowrap; }
+    .practitioner-trust-strip .imx-tag-muted { white-space: nowrap; font-size: 0.7rem; }
 }
 @media (max-width: 480px) {
-    .v3-hero { padding: 2.25rem 1.1rem 2.75rem; }
-    .v3-hero-cta-wrapper { gap: 1.5rem; }
+    .v3-hero { padding: 1.75rem 1.1rem 2.5rem; }
+    .v3-hero-eyebrow { margin-bottom: 0.85rem; }
+    .v3-hero-cta-wrapper { gap: 1.5rem; margin-top: 1.5rem; }
     .v3-hero-buttons { width: 100%; }
     .v3-btn-primary, .v3-btn-secondary { flex: 1 1 100%; justify-content: center; }
     .v3-benefits-callout { animation: none; }
@@ -5733,9 +5743,10 @@ footer::before {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 2rem;
-    margin-top: 2.5rem;
+    gap: 1.75rem;
+    margin-top: 1.75rem;
     position: relative;
+    width: 100%;
 }
 
 .v3-hero-buttons {
@@ -5811,7 +5822,8 @@ footer::before {
     border: 2px dashed #10B981;
     border-radius: 20px;
     padding: 1.25rem 1.75rem;
-    max-width: 420px;
+    max-width: 560px;
+    width: 100%;
     transform: rotate(1deg);
     box-shadow: 5px 5px 0 rgba(16, 185, 129, 0.15);
     animation: v3-gentle-wobble 6s ease-in-out infinite;


### PR DESCRIPTION
## What & why

Two layout problems in the homepage hero, both reported from a real device:

- **Mobile:** the practitioner trust strip wrapped into ~3 rows *above* the headline, so it took a scroll to reach "Explore. Learn. Make Impact." — the actual main point.
- **Desktop:** the hero was `display:flex` with no direction (a **row**), so the text block and the CTA/benefits column sat side by side. The green "speech bubble" callout became a narrow, tall box stranded on the right with blank space beside it — and its up-pointing arrow pointed at nothing.

## Changes (`css/imx-main.css`)

- `.v3-hero` → `flex-direction: column` + `min-height: auto`, trimmed top padding (`4rem` → `2.75rem`). The callout now renders **below** the buttons with its arrow correctly pointing up at "Sign Up Free" — the design it was always meant to have.
- `.v3-benefits-callout` widened `420px` → `560px` (full-width to that cap) so it reads as a wide bubble, not a tall narrow column; benefit items wrap.
- Mobile (`≤700px`): trust strip collapses to a single horizontally-scrollable row instead of wrapping to 3 rows, so the headline sits near the top.
- Tightened eyebrow margin and CTA-wrapper gap/margin on small screens.

## Verification

- Headless renders at **390px** and **1280px** confirm the new layout; document `scrollWidth` ≤ viewport (no horizontal overflow introduced).
- `python3 scripts/check-mojibake.py` → PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LuankGiPWNhuR1hmN4osrc)_