### PR TITLE
Hero callout: clean speech-bubble tail, bigger fonts, even 2×2 alignment

### DIFF
--- a/css/imx-main.css
+++ b/css/imx-main.css
@@ -5825,8 +5825,8 @@ footer::before {
     background: linear-gradient(135deg, rgba(16, 185, 129, 0.12) 0%, rgba(16, 185, 129, 0.06) 100%);
     border: 2px dashed #10B981;
     border-radius: 20px;
-    padding: 1.25rem 1.9rem;
-    max-width: 720px;
+    padding: 1.5rem 2.1rem;
+    max-width: 760px;
     width: 100%;
     transform: rotate(1deg);
     box-shadow: 5px 5px 0 rgba(16, 185, 129, 0.15);
@@ -5838,62 +5838,46 @@ footer::before {
     50% { transform: rotate(-0.5deg); }
 }
 
+/* Speech-bubble tail: a clean upward triangle on the top edge of the box,
+   pointing at the buttons above (replaces the old dangling line + arrow). */
 .v3-callout-arrow {
     position: absolute;
-    top: -30px;
+    top: -12px;
     left: 50%;
     transform: translateX(-50%);
-    width: 60px;
-    height: 30px;
+    width: 0;
+    height: 0;
+    border-left: 13px solid transparent;
+    border-right: 13px solid transparent;
+    border-bottom: 13px solid #10B981;
 }
-
-.v3-callout-arrow::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 3px;
-    height: 20px;
-    background: #10B981;
-    border-radius: 3px;
-}
-
-.v3-callout-arrow::after {
-    content: '↓';
-    position: absolute;
-    bottom: -5px;
-    left: 50%;
-    transform: translateX(-50%);
-    font-size: 1.2rem;
-    color: #10B981;
-    animation: v3-bounce-arrow 1.5s ease-in-out infinite;
-}
-
-@keyframes v3-bounce-arrow {
-    0%, 100% { transform: translateX(-50%) translateY(0); }
-    50% { transform: translateX(-50%) translateY(5px); }
-}
+.v3-callout-arrow::before,
+.v3-callout-arrow::after { content: none; }
 
 .v3-callout-content {
     /* 2x2 benefit grid so the bubble reads landscape (wider than tall),
-       with the intro line spanning both columns above it. */
+       with the intro line spanning both columns above it. The grid is
+       centred as a group under the intro for a balanced composition. */
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 0.55rem 1.75rem;
+    grid-template-columns: auto auto;
+    justify-content: center;
+    gap: 0.7rem 2.5rem;
     align-items: start;
     text-align: left;
 }
 .v3-callout-content > div:first-child {
     grid-column: 1 / -1;
     text-align: center;
+    justify-self: center;
+    max-width: 60ch;
 }
 
 .v3-benefit-item {
     display: flex;
     align-items: flex-start;
-    gap: 0.45rem;
-    font-size: 0.9rem;
+    gap: 0.5rem;
+    font-size: 0.95rem;
+    line-height: 1.4;
     font-weight: 600;
     color: var(--text-primary, #0F172A);
 }
@@ -5914,8 +5898,8 @@ footer::before {
 
 .v3-callout-footer {
     text-align: center;
-    margin-top: 0.75rem;
-    font-size: 0.85rem;
+    margin-top: 1rem;
+    font-size: 0.92rem;
     font-weight: 700;
     color: #10B981;
     letter-spacing: 0.02em;
@@ -5927,9 +5911,9 @@ footer::before {
     align-items: center;
     gap: 0.5rem;
     margin-top: 1rem;
-    font-size: 0.9rem;
+    font-size: 1rem;
     font-weight: 600;
-    color: var(--text-muted, #64748B);
+    color: var(--text-secondary, #475569);
     text-decoration: none;
     transition: all 0.3s;
 }

--- a/index.html
+++ b/index.html
@@ -885,13 +885,13 @@ window.addEventListener('authStateChanged', function(e) {
     <div class="v3-benefits-callout">
         <div class="v3-callout-arrow"></div>
         <div class="v3-callout-content">
-            <div style="font-weight:700;font-size:0.82rem;line-height:1.45;margin-bottom:8px;">
+            <div style="font-weight:700;font-size:0.98rem;line-height:1.5;margin-bottom:10px;">
                 <span data-i18n="benefits.content_lead">Everything free &mdash; 68 courses &middot; 135 games &middot; 31 labs &middot; 128 reading companions &amp; more</span>
-                <span style="display:block;font-weight:600;opacity:.75;font-size:0.76rem;" data-i18n="benefits.plus_account">&mdash; practitioner-built, and yours to keep:</span>
+                <span style="display:block;font-weight:600;opacity:.75;font-size:0.86rem;margin-top:2px;" data-i18n="benefits.plus_account">&mdash; practitioner-built, and yours to keep:</span>
             </div>
             <span class="v3-benefit-item">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-benefit-icon"><use href="#si_Check_circle"/></svg>
-                <span data-i18n="benefits.track_progress">Learn by doing &mdash; labs, games &amp; practice packs</span>
+                <span data-i18n="benefits.track_progress">Learn by doing &mdash; labs, games &amp; practice</span>
             </span>
             <span class="v3-benefit-item">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-benefit-icon"><use href="#si_Check_circle"/></svg>
@@ -899,11 +899,11 @@ window.addEventListener('authStateChanged', function(e) {
             </span>
             <span class="v3-benefit-item">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-benefit-icon"><use href="#si_Check_circle"/></svg>
-                <span data-i18n="benefits.personal_notes">Built by practitioners &middot; open-source, no paywalls</span>
+                <span data-i18n="benefits.personal_notes">Open-source &middot; no paywalls, ever</span>
             </span>
             <span class="v3-benefit-item">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-benefit-icon"><use href="#si_Check_circle"/></svg>
-                <span data-i18n="benefits.cloud_sync">A free account saves your progress, notes &amp; path</span>
+                <span data-i18n="benefits.cloud_sync">Your progress, notes &amp; path &mdash; saved</span>
             </span>
         </div>
         <div class="v3-callout-footer"><span data-i18n="benefits.all_free">Free forever &mdash; sign up in seconds</span> <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Flare"/></svg></div>


### PR DESCRIPTION
## What & why

Desktop polish on the green benefits bubble, from feedback that the fonts were too small, the alignment looked off, and the connector "hung" without connecting to anything.

- **Connector** — replaced the dangling line + bouncing "↓" (it floated in the gap *between* the two buttons, pointing at nothing) with a clean upward triangle tail on the box's top edge, pointing at the button row above.
- **Fonts** — bumped the intro line (0.82→0.98rem), benefit items (0.9→0.95rem), the footer, and the two links below the box (0.9→1rem, and darker) so nothing reads as tiny on desktop.
- **Alignment** — the 2×2 benefit grid is now centered as a group under the intro, and the four benefit phrases were tightened so each fits on **one line** → even rows instead of a ragged mix of one- and two-line cells. ("Practitioner-built" already appears in the intro sub-line, so no meaning is lost.)

## Verification

- Headless renders at **1280px** (even 2×2 landscape card, triangle tail connecting to the buttons) and **390px** (single column, larger fonts).
- `python3 scripts/check-mojibake.py` → PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LuankGiPWNhuR1hmN4osrc)_