### PR TITLE
Site-wide WhatsApp share button + complete Showcase nav (Timelines, Research to Action)

### DIFF
--- a/index.html
+++ b/index.html
@@ -637,6 +637,8 @@ window.addEventListener('click', function(e) {
     <li id="nav-marginalia"><a href='/specials/marginalia/' style='color: #EC4899; font-weight: 600;'><svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Book"/></svg> Marginalia</a></li>
     <li id="nav-longview"><a href='/the-long-view.html' style='color: #764ba2; font-weight: 600;'><svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Flare"/></svg> The Long View</a></li>
     <li id="nav-maps"><a href='/maps/' style='color: #7C3AED; font-weight: 600;'><svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Globe_detailed"/></svg> Maps <span style="background:#7C3AED;color:#fff;font-size:0.55rem;padding:0.1rem 0.35rem;border-radius:4px;margin-left:0.3rem;text-transform:uppercase;letter-spacing:0.5px;vertical-align:middle">New</span></a></li>
+    <li id="nav-timelines"><a href='/timelines/' style='color: #0EA5E9; font-weight: 600;'><svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Activity"/></svg> Timelines</a></li>
+    <li id="nav-research-to-action"><a href='/research-to-action/' style='color: #F97316; font-weight: 600;'><svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Album"/></svg> Research to Action</a></li>
   </ul>
 </li>
 </ul>
@@ -3595,5 +3597,7 @@ document.addEventListener('DOMContentLoaded', function() {
 })();
 </script>
 <script src="/js/mojini-ai.js" defer></script>
+<!-- Shared chrome loader: on the homepage this only injects the shared WhatsApp share button (the standard bar/footer are skipped via the homepage opt-out). -->
+<script src="/js/site-chrome.js" defer></script>
 </body>
 </html>

--- a/js/site-chrome.js
+++ b/js/site-chrome.js
@@ -29,7 +29,8 @@
   var path = location.pathname.replace(/index\.html$/, '');
   var isHome = root.hasAttribute('data-im-home') || (document.body && document.body.hasAttribute('data-im-home'))
     || meta('im-chrome') === 'off' || path === '/' || path === '';
-  if (isHome) return;
+  // Note: on the homepage (isHome) we keep the page's own chrome and skip build(),
+  // but the shared WhatsApp share button (below) is still injected on every page.
 
   // ── Page name for the breadcrumb ───────────────────────────────────
   function pageName() {
@@ -210,6 +211,25 @@
 
   function escapeHtml(s) { return String(s).replace(/[&<>"]/g, function (c) { return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c]; }); }
 
-  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', build);
-  else build();
+  // ── Shared WhatsApp "share ImpactMojo" button — every page, homepage included ──
+  // Pre-encoded href (no emoji literals in source) matching the site-standard share
+  // message. Guarded against duplicates; skipped if the page already has one.
+  function injectWhatsApp() {
+    if (!document.body || document.getElementById('im-wa-fab')) return;
+    var a = document.createElement('a');
+    a.id = 'im-wa-fab';
+    a.href = 'https://wa.me/?text=%F0%9F%8E%93%20I%27ve%20been%20learning%20with%20ImpactMojo%20-%20a%20fantastic%20FREE%20platform%20for%20development%20professionals!%0A%0A%E2%9C%85%2050%2B%20courses%2C%20labs%20%26%20tools%20for%20development%20professionals%0A%E2%9C%85%20Interactive%20labs%20and%20economics%20games%0A%E2%9C%85%20Perfect%20for%20NGO%20teams%2C%20students%20%26%20researchers%0A%0AIf%20you%20work%20in%20the%20development%20sector%2C%20check%20it%20out%3A%20https%3A%2F%2Fwww.impactmojo.in';
+    a.target = '_blank'; a.rel = 'noopener noreferrer';
+    a.setAttribute('aria-label', 'Share ImpactMojo on WhatsApp');
+    a.title = 'Share ImpactMojo on WhatsApp';
+    a.style.cssText = 'position:fixed;left:18px;bottom:18px;z-index:9998;width:52px;height:52px;border-radius:50%;background:#25D366;box-shadow:0 6px 20px rgba(37,211,102,.45);display:flex;align-items:center;justify-content:center;text-decoration:none;transition:transform .15s ease';
+    a.addEventListener('mouseenter', function () { a.style.transform = 'scale(1.08)'; });
+    a.addEventListener('mouseleave', function () { a.style.transform = 'scale(1)'; });
+    a.innerHTML = '<svg viewBox="0 0 24 24" width="28" height="28" fill="#fff" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z"/></svg>';
+    document.body.appendChild(a);
+  }
+
+  function boot() { injectWhatsApp(); if (!isHome) build(); }
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', boot);
+  else boot();
 })();


### PR DESCRIPTION
## What does this PR do?

- **Shared prefilled WhatsApp share button on every page.** Injected by `site-chrome.js` (which loads on 744/775 pages) as a single floating button (bottom-left) with the site-standard prefilled "Share ImpactMojo" message. The homepage previously didn't load `site-chrome.js`, so it's now included there too — guarded so it **only** injects the button and skips the standard chrome build, leaving the homepage's own nav/footer untouched. Dedup-guarded against double injection. Verified in headless Chromium: present on the homepage and regular pages, exactly one instance, homepage nav intact.
- **Completed the Specials → Showcase nav:** added **Timelines** and **Research to Action** (both were missing). (Reading Companions intentionally left out — they live under Libraries, per maintainer note.)

## Type of change

- [x] New feature or tool
- [x] Accessibility improvement (button has an aria-label; icon-only link)

## Checklist

- [x] `site-chrome.js` syntax-checked; mojibake guard passes
- [x] Browser-verified (headless Chromium): button on homepage + regular pages, no duplicates, homepage chrome preserved
- [x] New nav links resolve (`/timelines/`, `/research-to-action/`)
- [ ] Tested on mobile browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vCjtQ9UfNkZYsKdATscwJ

---
_Generated by [Claude Code](https://claude.ai/code/session_011vCjtQ9UfNkZYsKdATscwJ)_