### PR TITLE
Add data-backed "CSR in India" map (real ₹) + real figures on the funding map

### DIFF
--- a/data/search-index.json
+++ b/data/search-index.json
@@ -12904,6 +12904,15 @@
     "tags": ["maps", "topics", "discovery", "network", "visualization", "interactive"]
   },
   {
+    "id": "MAP-csr",
+    "title": "CSR in India — The Money and Where It Goes",
+    "description": "An interactive, data-backed map of India's corporate CSR — ₹34,909 crore in FY2023-24, the sectors it flows into (health, education, environment, rural), and the ten biggest corporate spenders. Real figures from public disclosures; node size = rupees.",
+    "type": "page",
+    "category": "Maps",
+    "url": "/maps/csr-india.html",
+    "tags": ["maps", "csr", "corporate-social-responsibility", "philanthropy", "funding", "india", "public-finance", "data"]
+  },
+  {
     "id": "MAP-funding",
     "title": "Funding Map — Who Funds Indian School Education",
     "description": "An interactive, illustrative map of who funds and runs what in Indian school education — corporate foundations, philanthropies, NGOs, and the government systems they converge on. Built from publicly documented relationships.",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,17 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.121.0 — July 13, 2026 (CSR in India map — real data + a site-wide share button)
+
+### For Learners
+
+- **CSR in India: The Money and Where It Goes** (`/maps/csr-india.html`) — a new interactive map built from **real figures**: India's ₹34,909 crore of corporate CSR in FY2023-24, the sectors it flows into (health & sanitation, education, environment, rural), and the ten biggest corporate spenders — every node sized by actual rupees. The companion school-education funding map now also carries the real education-CSR total (~₹11,300 cr).
+
+### Added
+
+- A shared, prefilled **"Share ImpactMojo on WhatsApp"** button now appears on every page (injected via `site-chrome.js`, homepage included).
+- **Timelines** and **Research to Action** added to the Specials → Showcase navigation.
+
 ## v10.120.0 — July 13, 2026 (Interactive Maps — Content Map & Funding Map)
 
 ### For Learners

--- a/maps/csr-india.html
+++ b/maps/csr-india.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CSR in India: The Money and Where It Goes | ImpactMojo</title>
+<meta name="description" content="An interactive, data-backed map of India's corporate CSR — ₹34,909 crore in FY2023-24, the sectors it flows into (health, education, environment, rural), and the biggest corporate spenders. Real figures from public disclosures.">
+<link rel="canonical" href="https://www.impactmojo.in/maps/csr-india.html">
+<meta name="robots" content="index, follow">
+<meta property="og:type" content="website">
+<meta property="og:title" content="CSR in India: The Money and Where It Goes">
+<meta property="og:description" content="A data-backed map of India's ₹34,909 crore corporate CSR (FY2023-24) — the sectors it flows into and the biggest corporate spenders.">
+<meta property="og:url" content="https://www.impactmojo.in/maps/csr-india.html">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<meta property="og:site_name" content="ImpactMojo">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" href="/assets/images/favicon.png" type="image/png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-JRCMEB9TBW');</script>
+<link rel="stylesheet" href="/maps/maps.css">
+<style>
+  .mp-stats { max-width: 1180px; margin: .5rem auto 0; padding: 0 1.25rem; display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: .8rem; }
+  .mp-stat { background: var(--mp-surface); border: 1px solid var(--mp-border); border-radius: 12px; padding: 1rem 1.1rem; }
+  .mp-stat b { display: block; font-family: 'Inter', sans-serif; font-size: 1.5rem; font-weight: 800; color: var(--mp-accent); letter-spacing: -.02em; }
+  .mp-stat span { font-family: 'Inter', sans-serif; font-size: .8rem; color: var(--mp-muted); line-height: 1.4; }
+</style>
+</head>
+<body>
+<a href="#main-content" class="im-skip-link">Skip to content</a>
+<header class="im-topbar" role="banner">
+  <div class="im-topbar-left"><a class="im-topbar-home" href="/" aria-label="ImpactMojo home"><img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo"><span>ImpactMojo</span></a></div>
+  <div class="im-topbar-right">
+    <a href="/catalog.html" class="im-browse-btn" title="Browse all content"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>Browse</a>
+    <a class="im-premium-btn" href="/premium.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>Premium</a>
+    <div class="im-theme-selector" role="group" aria-label="Theme">
+      <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="System theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Light theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/></svg></button>
+      <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Dark theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+    </div>
+  </div>
+</header>
+
+<main id="main-content">
+  <div class="mp-head">
+    <a class="mp-back" href="/maps/">← All maps</a>
+    <div class="mp-eyebrow">ImpactMojo · Maps · Real data</div>
+    <h1 class="mp-title">CSR in India: The Money and Where It Goes</h1>
+    <p class="mp-lede">India's companies are legally required to spend 2% of profits on social causes. In <strong>FY2023-24 that came to ₹34,909 crore.</strong> This map shows where it went — the sectors that absorb it, and the biggest corporate spenders — with <strong>real figures from public disclosures</strong>. Node size = rupees. Drag, zoom, and click.</p>
+  </div>
+
+  <div class="mp-stats">
+    <div class="mp-stat"><b>₹34,909 cr</b><span>total CSR spend, FY2023-24</span></div>
+    <div class="mp-stat"><b>38.4%</b><span>to Health &amp; Sanitation — the largest sector</span></div>
+    <div class="mp-stat"><b>32.4%</b><span>to Education &amp; Skilling</span></div>
+    <div class="mp-stat"><b>₹945 cr</b><span>top single spender (HDFC Bank)</span></div>
+    <div class="mp-stat"><b>17%</b><span>of all CSR from just the top 10 companies</span></div>
+  </div>
+
+  <div class="mp-controls" id="typeFilters" aria-label="Filter"></div>
+
+  <div class="mp-stage">
+    <div class="mp-canvas-wrap">
+      <canvas id="graph" role="img" aria-label="Interactive map of India's corporate CSR by sector and top spender"></canvas>
+      <div class="mp-legend" id="legend"></div>
+      <div class="mp-hint">Node size = ₹ · drag · scroll to zoom · click</div>
+    </div>
+    <aside class="mp-panel" id="panel" aria-live="polite">
+      <p class="mp-panel-empty">Click a <strong>sector</strong> to see its share of national CSR and which big spenders focus on it, or a <strong>company</strong> to see its CSR spend and documented focus areas. The five sector pools are sized by real national spend; the ten companies by their own FY2023-24 CSR.</p>
+    </aside>
+  </div>
+
+  <div class="mp-notes">
+    <div class="mp-method">
+      <h3>What's real here — and what isn't</h3>
+      <ul>
+        <li><strong>The node sizes are real rupees.</strong> Sector pools are sized by national CSR spend by sector (FY2023-24: Health &amp; Sanitation ~38.4%, Education ~32.4%, Environment ~10.9%, Rural Development ~6.9%, everything else ~11.4% of ₹34,909 cr). Company nodes are sized by each firm's actual FY2023-24 CSR spend from its disclosures.</li>
+        <li><strong>The edges are documented focus areas, not exact splits.</strong> A line from a company to a sector means that sector is a stated CSR focus of that company — <em>not</em> a precise rupee amount. Companies don't publish clean per-sector-per-recipient breakdowns, so we show <em>where</em> they focus, not <em>how much</em> down each line. That precise company→sector→NGO→₹ join is the "full pipeline" version still to build.</li>
+        <li><strong>Top 10, not all.</strong> We show the ten largest corporate spenders (≈17% of all CSR); the other 83% comes from thousands of companies not drawn here. Percentages are rounded.</li>
+        <li><strong>Sources.</strong> Total &amp; sector split: Economic Survey / National CSR Portal / Prime Database / <a href="https://indiacsr.in/" target="_blank" rel="noopener">India CSR</a> compilations (FY2023-24). Company figures: FY2023-24 CSR disclosures as reported by the same trackers and company reports. The official record is the <a href="https://www.csr.gov.in/" target="_blank" rel="noopener">National CSR Portal</a>. Educational visualisation, not financial advice.</li>
+      </ul>
+    </div>
+  </div>
+</main>
+
+<footer class="im-footer" role="contentinfo">
+  <div class="im-footer-content">
+    <p class="im-footer-made">Made with ♥ by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+    <div class="im-footer-grid">
+      <div class="im-footer-section"><h4>About ImpactMojo</h4><ul><li><a href="/about.html">About Us</a></li><li><a href="/contact.html">Contact</a></li><li><a href="/transparency.html">Transparency</a></li></ul></div>
+      <div class="im-footer-section"><h4>Maps</h4><ul><li><a href="/maps/">All Maps</a></li><li><a href="/maps/funding-map.html">School-Education Funding</a></li><li><a href="/maps/content-map.html">Content Map</a></li></ul></div>
+      <div class="im-footer-section"><h4>Quick Links</h4><ul><li><a href="/catalog.html">All Content</a></li><li><a href="/DataDives/">Data Dives</a></li><li><a href="/DeepDives/">Deep Dives</a></li></ul></div>
+      <div class="im-footer-section"><h4>Resources</h4><ul><li><a href="/handouts.html">Handouts</a></li><li><a href="/blog.html">Blog</a></li><li><a href="/sitemap.html">Sitemap</a></li></ul></div>
+    </div>
+    <div class="im-footer-bottom"><p>&copy; 2026 ImpactMojo. All content for educational purposes only.</p></div>
+  </div>
+</footer>
+
+<script src="/js/theme.js"></script>
+<script src="/maps/graph.js"></script>
+<script>
+(function () {
+  var TYPES = [
+    { key: 'sector',  label: 'Sector (sized by national CSR ₹)', color: '#334155' },
+    { key: 'company', label: 'Company (sized by its CSR ₹)',     color: '#7C3AED' }
+  ];
+  var DATA = {
+    nodes: [
+      { id: 'health',      name: 'Health & Sanitation', type: 'sector', cr: 13400, pct: 38.4, color: '#DC2626', note: "The single largest CSR sector — hospitals, primary care, WASH, nutrition and sanitation. Roughly ₹13,400 cr, about 38% of all CSR." },
+      { id: 'education',   name: 'Education & Skilling', type: 'sector', cr: 11300, pct: 32.4, color: '#2563EB', note: "Schools, scholarships, digital learning and vocational skilling. Roughly ₹11,300 cr, about 32% of all CSR — the subject of our companion school-education map." },
+      { id: 'environment', name: 'Environment',          type: 'sector', cr: 3800,  pct: 10.9, color: '#0F766E', note: "Afforestation, clean energy, water conservation and animal welfare. Roughly ₹3,800 cr, about 11% of CSR." },
+      { id: 'rural',       name: 'Rural Development',     type: 'sector', cr: 2410,  pct: 6.9,  color: '#D97706', note: "Rural infrastructure, livelihoods and water. Roughly ₹2,410 cr, about 7% of CSR." },
+      { id: 'other',       name: 'Other sectors',        type: 'sector', cr: 3980,  pct: 11.4, color: '#64748B', note: "Everything else — gender & women's empowerment, sports, arts & heritage, disaster relief, government funds and more. Roughly ₹3,980 cr, about 11%." },
+
+      { id: 'hdfc',     name: 'HDFC Bank',            type: 'company', cr: 945, rank: 1,  color: '#7C3AED', foci: ['education','rural','health'], note: "India's largest CSR spender in FY2023-24. Its Parivartan programme spans rural development, education, skilling and healthcare." },
+      { id: 'reliance', name: 'Reliance Industries',  type: 'company', cr: 900, rank: 2,  color: '#7C3AED', foci: ['education','health','rural'], note: "Reliance Foundation works across education, health and rural transformation (plus sports and disaster response)." },
+      { id: 'tcs',      name: 'Tata Consultancy Services', type: 'company', cr: 813, rank: 3, color: '#7C3AED', foci: ['education'], note: "TCS concentrates its CSR on education, employability and digital-skilling programmes." },
+      { id: 'ongc',     name: 'ONGC',                 type: 'company', cr: 612, rank: 4,  color: '#7C3AED', foci: ['health','education'], note: "The state-owned oil major focuses CSR on health and education, largely around its operational areas." },
+      { id: 'tatasteel',name: 'Tata Steel',           type: 'company', cr: 573, rank: 5,  color: '#7C3AED', foci: ['health','education','rural'], note: "Long-standing community programmes in health, education, drinking water and rural livelihoods around its plants." },
+      { id: 'infosys',  name: 'Infosys',              type: 'company', cr: 451, rank: 6,  color: '#7C3AED', foci: ['education','rural','health'], note: "The Infosys Foundation supports education, rural development, healthcare and the arts." },
+      { id: 'iocl',     name: 'Indian Oil (IOCL)',    type: 'company', cr: 436, rank: 7,  color: '#7C3AED', foci: ['health','education'], note: "State-owned refiner with CSR concentrated in health and education near its facilities." },
+      { id: 'jio',      name: 'Reliance Jio',         type: 'company', cr: 403, rank: 8,  color: '#7C3AED', foci: ['education'], note: "Reliance's telecom arm; CSR weighted toward digital education and connectivity for learning." },
+      { id: 'itc',      name: 'ITC',                  type: 'company', cr: 380, rank: 9,  color: '#7C3AED', foci: ['rural','education','health'], note: "ITC's Mission Sunehra Kal centres on rural development (watersheds, agriculture), education and health & sanitation." },
+      { id: 'icici',    name: 'ICICI Bank',           type: 'company', cr: 368, rank: 10, color: '#7C3AED', foci: ['rural','health'], note: "The ICICI Foundation focuses on skilling and sustainable livelihoods (rural) and healthcare." }
+    ]
+  };
+  // build links from company foci
+  DATA.links = [];
+  DATA.nodes.forEach(function (n) { if (n.type === 'company') n.foci.forEach(function (s) { DATA.links.push({ source: n.id, target: s }); }); });
+
+  var byId = {}; DATA.nodes.forEach(function (n) { byId[n.id] = n; });
+  var deg = {}, nbr = {}; DATA.nodes.forEach(function (n) { deg[n.id] = 0; nbr[n.id] = []; });
+  DATA.links.forEach(function (l) { deg[l.source]++; deg[l.target]++; nbr[l.source].push(l.target); nbr[l.target].push(l.source); });
+  var maxCr = Math.max.apply(null, DATA.nodes.map(function (n) { return n.cr; }));
+
+  var active = { sector: true, company: true };
+  var graph = null, panel = document.getElementById('panel');
+
+  function visible() {
+    var ns = DATA.nodes.filter(function (n) { return active[n.type]; });
+    var ok = {}; ns.forEach(function (n) { ok[n.id] = 1; });
+    return {
+      nodes: ns.map(function (n) { return { id: n.id, label: n.name, type: n.type, cr: n.cr, color: n.color }; }),
+      links: DATA.links.filter(function (l) { return ok[l.source] && ok[l.target]; }).map(function (l) { return { source: l.source, target: l.target, weight: 1.4 }; })
+    };
+  }
+  function render() {
+    if (graph) graph.destroy();
+    var gd = visible();
+    graph = ImpactGraph(document.getElementById('graph'), {
+      nodes: gd.nodes, links: gd.links,
+      color: function (n) { return n.color; },
+      radius: function (n) { return 8 + 28 * Math.sqrt(n.cr / maxCr); },
+      onClick: function (n) { showNode(n.id); }
+    });
+  }
+  function money(cr) { return '₹' + String(cr).replace(/\B(?=(\d{3})+(?!\d))/g, ',') + ' cr'; }
+  function showNode(id) {
+    var n = byId[id]; if (!n) return;
+    var html, conns = nbr[id].filter(function (c) { return active[byId[c].type]; });
+    if (n.type === 'sector') {
+      html = '<span class="mp-pill" style="background:' + rgba(n.color, .14) + ';color:' + n.color + '">Sector</span><h2>' + esc(n.name) + '</h2>'
+        + '<div class="sub">' + money(n.cr) + ' · ~' + n.pct + '% of national CSR (FY24)</div>'
+        + '<p class="meta">' + esc(n.note) + '</p>'
+        + '<div class="sub">Top-10 spenders focused here</div><ul>'
+        + conns.map(function (c) { return '<li><a href="#" data-node="' + c + '">' + esc(byId[c].name) + '</a><span class="t">' + money(byId[c].cr) + ' total CSR</span></li>'; }).join('') + '</ul>';
+    } else {
+      html = '<span class="mp-pill" style="background:' + rgba('#7C3AED', .14) + ';color:#7C3AED">Company · rank #' + n.rank + '</span><h2>' + esc(n.name) + '</h2>'
+        + '<div class="sub">' + money(n.cr) + ' CSR in FY2023-24</div>'
+        + '<p class="meta">' + esc(n.note) + '</p>'
+        + '<div class="sub">Documented focus areas</div><ul>'
+        + conns.map(function (c) { return '<li><a href="#" data-node="' + c + '">' + esc(byId[c].name) + '</a><span class="t">' + money(byId[c].cr) + ' national pool</span></li>'; }).join('') + '</ul>';
+    }
+    panel.innerHTML = html; panel.scrollTop = 0;
+    panel.querySelectorAll('a[data-node]').forEach(function (a) {
+      a.addEventListener('click', function (e) { e.preventDefault(); graph.focus(a.getAttribute('data-node')); showNode(a.getAttribute('data-node')); });
+    });
+  }
+  function buildFilters() {
+    var box = document.getElementById('typeFilters');
+    TYPES.forEach(function (t) {
+      var b = document.createElement('button'); b.className = 'mp-filter'; b.type = 'button'; b.setAttribute('aria-pressed', 'true');
+      b.innerHTML = '<span class="dot" style="background:' + t.color + '"></span>' + t.label;
+      b.addEventListener('click', function () { active[t.key] = !active[t.key]; b.setAttribute('aria-pressed', active[t.key] ? 'true' : 'false'); render(); });
+      box.appendChild(b);
+    });
+  }
+  function buildLegend() {
+    document.getElementById('legend').innerHTML = '<div style="font-weight:700;margin-bottom:.35rem;color:var(--mp-text)">Sectors (by ₹)</div>'
+      + DATA.nodes.filter(function (n) { return n.type === 'sector'; }).map(function (n) { return '<div class="row"><span class="dot" style="background:' + n.color + '"></span>' + esc(n.name) + '</div>'; }).join('')
+      + '<div class="row" style="margin-top:.35rem"><span class="dot" style="background:#7C3AED"></span>Company</div>';
+  }
+  function rgba(h, a) { var n = parseInt(h.slice(1), 16); return 'rgba(' + ((n >> 16) & 255) + ',' + ((n >> 8) & 255) + ',' + (n & 255) + ',' + a + ')'; }
+  function esc(s) { return String(s).replace(/[&<>"]/g, function (c) { return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]; }); }
+  buildFilters(); buildLegend(); render();
+})();
+</script>
+
+<script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script defer src="/js/state-manager.js"></script>
+<script defer src="/js/config.js"></script>
+<script defer src="/js/auth.js"></script>
+<script src="/js/translate-sarvam.js" defer></script>
+<script src="/js/site-chrome.js" defer></script>
+</body>
+</html>

--- a/maps/funding-map.html
+++ b/maps/funding-map.html
@@ -21,6 +21,13 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-JRCMEB9TBW');</script>
 <link rel="stylesheet" href="/maps/maps.css">
+<style>
+  .mp-stats { max-width: 1180px; margin: .5rem auto 0; padding: 0 1.25rem; display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: .8rem; }
+  .mp-stat { background: var(--mp-surface); border: 1px solid var(--mp-border); border-radius: 12px; padding: 1rem 1.1rem; }
+  .mp-stat b { display: block; font-family: 'Inter', sans-serif; font-size: 1.4rem; font-weight: 800; color: var(--mp-accent); letter-spacing: -.02em; }
+  .mp-stat span { font-family: 'Inter', sans-serif; font-size: .8rem; color: var(--mp-muted); line-height: 1.4; }
+  .mp-stat a { color: var(--mp-accent); text-decoration: none; border-bottom: 1px dotted; }
+</style>
 </head>
 <body>
 <a href="#main-content" class="im-skip-link">Skip to content</a>
@@ -43,6 +50,13 @@
     <div class="mp-eyebrow">ImpactMojo · Maps · MVP</div>
     <h1 class="mp-title">Funding Map: Indian School Education</h1>
     <p class="mp-lede">Who funds and runs what in India's school-education ecosystem — corporate foundations, philanthropies, NGOs, and the government systems they increasingly converge on. A first, deliberately-small proof of concept: <strong>one sector, publicly documented relationships, no rupee figures.</strong> Drag to explore, scroll to zoom, and <strong>click any organisation</strong> for details.</p>
+  </div>
+
+  <div class="mp-stats">
+    <div class="mp-stat"><b>~₹11,300 cr</b><span>CSR spent on education nationally, FY2023-24</span></div>
+    <div class="mp-stat"><b>32.4%</b><span>of all corporate CSR goes to education</span></div>
+    <div class="mp-stat"><b>#2 sector</b><span>education, after health &amp; sanitation</span></div>
+    <div class="mp-stat"><b>See the money</b><span><a href="/maps/csr-india.html">CSR in India →</a> the real ₹ across all sectors</span></div>
   </div>
 
   <div class="mp-controls" id="typeFilters" aria-label="Filter by organisation type"></div>

--- a/maps/index.html
+++ b/maps/index.html
@@ -62,6 +62,13 @@
       <p>Everything on ImpactMojo as a constellation of topics. Themes that appear together are linked; click any topic to see the courses, dives, games and readings behind it.</p>
       <span class="go">Explore the topics →</span>
     </a>
+    <a class="mp-card" href="/maps/csr-india.html">
+      <div class="mp-dots"><span style="background:#DC2626"></span><span style="background:#2563EB"></span><span style="background:#0F766E"></span><span style="background:#D97706"></span></div>
+      <span class="mp-card-tag">Real data · FY2023-24</span>
+      <h2>CSR in India: The Money</h2>
+      <p>India's ₹34,909 crore of mandated corporate CSR, mapped by real rupees — the sectors it flows into (health, education, environment, rural) and the ten biggest corporate spenders. Node size = money.</p>
+      <span class="go">Follow the money →</span>
+    </a>
     <a class="mp-card" href="/maps/funding-map.html">
       <div class="mp-dots"><span style="background:#2563EB"></span><span style="background:#7C3AED"></span><span style="background:#0EA5E9"></span><span style="background:#D97706"></span></div>
       <span class="mp-card-tag">Illustrative MVP</span>
@@ -76,7 +83,8 @@
       <h3>About these maps</h3>
       <ul>
         <li>The <strong>Content Map</strong> is generated live from the platform's search index, so it always reflects what's published.</li>
-        <li>The <strong>Funding Map</strong> is an early, deliberately-small proof of concept scoped to one sector, built from publicly documented relationships — not a grant ledger, and with no rupee figures. See the map's own notes for what it can and can't show.</li>
+        <li><strong>CSR in India</strong> is built from <strong>real figures</strong> — national CSR spend by sector and the actual FY2023-24 CSR of the ten biggest corporate spenders, sized by rupees. See its notes for exactly what's measured vs. documented.</li>
+        <li>The <strong>School-Education Funding Map</strong> is a deliberately-small proof of concept scoped to one sector, built from publicly documented relationships. See the map's own notes for what it can and can't show.</li>
         <li>Both are self-contained (no external chart libraries) and keyboard/pointer friendly. Got a dataset or a sector worth mapping? <a href="/contact.html?topic=Maps">Tell us</a>.</li>
       </ul>
     </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1575,6 +1575,12 @@
         <priority>0.7</priority>
     </url>
     <url>
+        <loc>https://www.impactmojo.in/maps/csr-india.html</loc>
+        <lastmod>2026-07-13</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.7</priority>
+    </url>
+    <url>
         <loc>https://www.impactmojo.in/maps/funding-map.html</loc>
         <lastmod>2026-07-13</lastmod>
         <changefreq>monthly</changefreq>


### PR DESCRIPTION
## What does this PR do?

Adds the **"real" version** of the funding map you asked for, using actual figures.

- **`/maps/csr-india.html` — CSR in India: The Money and Where It Goes.** India's real corporate CSR from public disclosures: **FY2023-24 total ₹34,909 cr**, with every node sized by real rupees.
  - Five **sector pools** sized by national CSR-by-sector spend: Health & Sanitation 38.4%, Education 32.4%, Environment 10.9%, Rural 6.9%, Other ~11.4%.
  - The **ten largest corporate spenders** sized by their actual FY2023-24 CSR (HDFC ₹945 cr → ICICI ₹368 cr).
  - Edges = each company's **documented CSR focus areas** — with an explicit caveat that these are focus areas, *not* exact per-sector rupee splits (that granular company→sector→NGO→₹ join is the "full pipeline" still to build). Sources cited: Economic Survey / National CSR Portal / Prime Database / India CSR / company reports.
- The **school-education funding map** now carries the real education-CSR total (~₹11,300 cr / 32.4%) and links to the CSR map.
- Landing page (now 3 maps), `search-index.json`, `sitemap.xml`, changelog updated.

This is a direct response to "why is it illustrative?" — node sizes here are **real money** — and to "don't we need more than one map?" (now three).

## Type of change

- [x] New feature or tool
- [x] New content

## Checklist

- [x] Browser-verified (headless Chromium): all three maps render, node interactions work, money formatting correct, no runtime errors
- [x] JS syntax-checked; `search-index.json` + `sitemap.xml` validated; mojibake guard passes
- [x] Internal links resolve
- [ ] Tested on mobile browser

> Honest scope note: sector totals and company totals are real; the *lines between them* show documented focus, not measured per-line amounts. The fully data-joined version (bulk CSR-portal ingest + entity resolution) is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vCjtQ9UfNkZYsKdATscwJ

---
_Generated by [Claude Code](https://claude.ai/code/session_011vCjtQ9UfNkZYsKdATscwJ)_