### PR TITLE
Fix broken footer "Courses" link across labs (../courses.html 404)

### DIFF
--- a/Labs/before-we-fall-apart-lab.html
+++ b/Labs/before-we-fall-apart-lab.html
@@ -592,7 +592,7 @@ body { padding-top: 56px; }
 <div class="im-footer-section">
 <h4>Learn</h4>
 <ul>
-<li><a href="../courses.html">Courses</a></li>
+<li><a href="../courses/">Courses</a></li>
 <li><a href="index.html">Interactive Labs</a></li>
 <li><a href="../Games/">Games</a></li>
 <li><a href="../catalog.html">Full Catalog</a></li>

--- a/Labs/budget-fiscal-lab.html
+++ b/Labs/budget-fiscal-lab.html
@@ -689,7 +689,7 @@ body { padding-top: 56px; }
 <div class="im-footer-section">
 <h4>Learn</h4>
 <ul>
-<li><a href="../courses.html">Courses</a></li>
+<li><a href="../courses/">Courses</a></li>
 <li><a href="index.html">Interactive Labs</a></li>
 <li><a href="../Games/">Games</a></li>
 <li><a href="../catalog.html">Full Catalog</a></li>

--- a/Labs/climate-adaptation-lab.html
+++ b/Labs/climate-adaptation-lab.html
@@ -797,7 +797,7 @@ body { padding-top: 56px; }
 <div class="im-footer-section">
 <h4>Learn</h4>
 <ul>
-<li><a href="../courses.html">Courses</a></li>
+<li><a href="../courses/">Courses</a></li>
 <li><a href="index.html">Interactive Labs</a></li>
 <li><a href="../Games/">Games</a></li>
 <li><a href="../catalog.html">Full Catalog</a></li>

--- a/Labs/data-feminism-lab.html
+++ b/Labs/data-feminism-lab.html
@@ -634,7 +634,7 @@ body { padding-top: 56px; }
 <div class="im-footer-section">
 <h4>Learn</h4>
 <ul>
-<li><a href="../courses.html">Courses</a></li>
+<li><a href="../courses/">Courses</a></li>
 <li><a href="index.html">Interactive Labs</a></li>
 <li><a href="../Games/">Games</a></li>
 <li><a href="../catalog.html">Full Catalog</a></li>

--- a/Labs/dpi-lab.html
+++ b/Labs/dpi-lab.html
@@ -850,7 +850,7 @@ body { padding-top: 56px; }
 <div class="im-footer-section">
 <h4>Learn</h4>
 <ul>
-<li><a href="../courses.html">Courses</a></li>
+<li><a href="../courses/">Courses</a></li>
 <li><a href="index.html">Interactive Labs</a></li>
 <li><a href="../Games/">Games</a></li>
 <li><a href="../catalog.html">Full Catalog</a></li>

--- a/Labs/ethics-research-lab.html
+++ b/Labs/ethics-research-lab.html
@@ -741,7 +741,7 @@ body { padding-top: 56px; }
 <div class="im-footer-section">
 <h4>Learn</h4>
 <ul>
-<li><a href="../courses.html">Courses</a></li>
+<li><a href="../courses/">Courses</a></li>
 <li><a href="index.html">Interactive Labs</a></li>
 <li><a href="../Games/">Games</a></li>
 <li><a href="../catalog.html">Full Catalog</a></li>

--- a/Labs/grant-writing-lab.html
+++ b/Labs/grant-writing-lab.html
@@ -665,7 +665,7 @@ body { padding-top: 56px; }
 <div class="im-footer-section">
 <h4>Learn</h4>
 <ul>
-<li><a href="../courses.html">Courses</a></li>
+<li><a href="../courses/">Courses</a></li>
 <li><a href="index.html">Interactive Labs</a></li>
 <li><a href="../Games/">Games</a></li>
 <li><a href="../catalog.html">Full Catalog</a></li>

--- a/Labs/impact-evaluation-lab.html
+++ b/Labs/impact-evaluation-lab.html
@@ -560,7 +560,7 @@ body { padding-top: 56px; }
 <div class="im-footer-section">
 <h4>Learn</h4>
 <ul>
-<li><a href="../courses.html">Courses</a></li>
+<li><a href="../courses/">Courses</a></li>
 <li><a href="index.html">Interactive Labs</a></li>
 <li><a href="../Games/">Games</a></li>
 <li><a href="../catalog.html">Full Catalog</a></li>

--- a/Labs/livelihoods-value-chain-lab.html
+++ b/Labs/livelihoods-value-chain-lab.html
@@ -634,7 +634,7 @@ body { padding-top: 56px; }
 <div class="im-footer-section">
 <h4>Learn</h4>
 <ul>
-<li><a href="../courses.html">Courses</a></li>
+<li><a href="../courses/">Courses</a></li>
 <li><a href="index.html">Interactive Labs</a></li>
 <li><a href="../Games/">Games</a></li>
 <li><a href="../catalog.html">Full Catalog</a></li>

--- a/Labs/nvc-mediation-lab.html
+++ b/Labs/nvc-mediation-lab.html
@@ -513,7 +513,7 @@ body { padding-top: 56px; }
 <div class="im-footer-section">
 <h4>Learn</h4>
 <ul>
-<li><a href="../courses.html">Courses</a></li>
+<li><a href="../courses/">Courses</a></li>
 <li><a href="index.html">Interactive Labs</a></li>
 <li><a href="../Games/">Games</a></li>
 <li><a href="../catalog.html">Full Catalog</a></li>

--- a/Labs/participatory-methods-lab.html
+++ b/Labs/participatory-methods-lab.html
@@ -812,7 +812,7 @@ body { padding-top: 56px; }
 <div class="im-footer-section">
 <h4>Learn</h4>
 <ul>
-<li><a href="../courses.html">Courses</a></li>
+<li><a href="../courses/">Courses</a></li>
 <li><a href="index.html">Interactive Labs</a></li>
 <li><a href="../Games/">Games</a></li>
 <li><a href="../catalog.html">Full Catalog</a></li>

--- a/Labs/policy-brief-lab.html
+++ b/Labs/policy-brief-lab.html
@@ -675,7 +675,7 @@ body { padding-top: 56px; }
 <div class="im-footer-section">
 <h4>Learn</h4>
 <ul>
-<li><a href="../courses.html">Courses</a></li>
+<li><a href="../courses/">Courses</a></li>
 <li><a href="index.html">Interactive Labs</a></li>
 <li><a href="../Games/">Games</a></li>
 <li><a href="../catalog.html">Full Catalog</a></li>

--- a/Labs/r-python-dev.html
+++ b/Labs/r-python-dev.html
@@ -491,7 +491,7 @@ cat("Share low-expenditure:", round(mean(df$low_exp), 2), "\n")  # 4. headline</
 <p class="im-footer-made">Made with &#10084; by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
 <div class="im-footer-grid">
 <div class="im-footer-section"><h4>Learn</h4><ul>
-<li><a href="../courses.html">Courses</a></li>
+<li><a href="../courses/">Courses</a></li>
 <li><a href="index.html">Interactive Labs</a></li>
 <li><a href="../101-courses/index.html">101 Series</a></li>
 <li><a href="../catalog.html">Full Catalog</a></li>

--- a/Labs/rct-readiness-lab.html
+++ b/Labs/rct-readiness-lab.html
@@ -571,7 +571,7 @@ body { padding-top: 56px; }
 <div class="im-footer-section">
 <h4>Learn</h4>
 <ul>
-<li><a href="../courses.html">Courses</a></li>
+<li><a href="../courses/">Courses</a></li>
 <li><a href="index.html">Interactive Labs</a></li>
 <li><a href="../Games/">Games</a></li>
 <li><a href="../catalog.html">Full Catalog</a></li>

--- a/Labs/stakeholder-mapping-lab.html
+++ b/Labs/stakeholder-mapping-lab.html
@@ -696,7 +696,7 @@ body { padding-top: 56px; }
 <div class="im-footer-section">
 <h4>Learn</h4>
 <ul>
-<li><a href="../courses.html">Courses</a></li>
+<li><a href="../courses/">Courses</a></li>
 <li><a href="index.html">Interactive Labs</a></li>
 <li><a href="../Games/">Games</a></li>
 <li><a href="../catalog.html">Full Catalog</a></li>

--- a/Labs/survey-design-lab.html
+++ b/Labs/survey-design-lab.html
@@ -682,7 +682,7 @@ body { padding-top: 56px; }
 <div class="im-footer-section">
 <h4>Learn</h4>
 <ul>
-<li><a href="../courses.html">Courses</a></li>
+<li><a href="../courses/">Courses</a></li>
 <li><a href="index.html">Interactive Labs</a></li>
 <li><a href="../Games/">Games</a></li>
 <li><a href="../catalog.html">Full Catalog</a></li>

--- a/Labs/systems-thinking-lab.html
+++ b/Labs/systems-thinking-lab.html
@@ -767,7 +767,7 @@ body { padding-top: 56px; }
 <div class="im-footer-section">
 <h4>Learn</h4>
 <ul>
-<li><a href="../courses.html">Courses</a></li>
+<li><a href="../courses/">Courses</a></li>
 <li><a href="index.html">Interactive Labs</a></li>
 <li><a href="../Games/">Games</a></li>
 <li><a href="../catalog.html">Full Catalog</a></li>

--- a/Labs/urban-boundaries-lab.html
+++ b/Labs/urban-boundaries-lab.html
@@ -552,7 +552,7 @@ body { padding-top: 56px; }
 <div class="im-footer-section">
 <h4>Learn</h4>
 <ul>
-<li><a href="../courses.html">Courses</a></li>
+<li><a href="../courses/">Courses</a></li>
 <li><a href="index.html">Interactive Labs</a></li>
 <li><a href="../Games/">Games</a></li>
 <li><a href="../catalog.html">Full Catalog</a></li>

--- a/dataverse-india.html
+++ b/dataverse-india.html
@@ -420,7 +420,7 @@ body { padding-top: 56px; }
 <div class="im-footer-section">
 <h4>Learn</h4>
 <ul>
-<li><a href="courses.html">Courses</a></li>
+<li><a href="courses/">Courses</a></li>
 <li><a href="Labs/index.html">Interactive Labs</a></li>
 <li><a href="Games/">Games</a></li>
 <li><a href="catalog.html">Full Catalog</a></li>


### PR DESCRIPTION
## What does this PR do?

Fixes a pre-existing broken link in the shared Lab-template footer. The footer's **"Courses"** link pointed to `../courses.html`, which doesn't exist at the site root — a 404 on **18 lab pages** plus the relocated `dataverse-india.html`.

Repoints it to the real courses landing at **`/courses/`** (`courses/index.html` — the "17 Flagship Courses" page), the same target other pages already use.

No content or layout changes — a one-line `href` correction per file.

## Type of change

- [x] Bug fix (broken link, layout, JS error)

## Checklist

- [x] Tested on desktop browser (link target `courses/index.html` confirmed to exist)
- [ ] Tested on mobile browser
- [x] No console errors (mojibake check passes)
- [x] Links are working (no `courses.html` references remain outside Backups)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgDJcnAiEfc5NQL4DjbrJY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgDJcnAiEfc5NQL4DjbrJY)_