### PR TITLE
Apply freemium "free to build, pay to export" gate to the new tools

### DIFF
--- a/Labs/rct-readiness-lab.html
+++ b/Labs/rct-readiness-lab.html
@@ -131,6 +131,8 @@ body.dark-mode, [data-theme="dark"] {
         .btn:hover { border-color: var(--accent-color); background: var(--hover-bg); }
         .btn-primary { background: var(--accent-color); border-color: var(--accent-color); color: #fff; font-weight: 600; }
         .btn-primary:hover { background: var(--accent-hover); color: #fff; }
+        .pro-pill { display:inline-flex; align-items:center; gap:0.25rem; background:linear-gradient(135deg,#F59E0B,#EF4444); color:#fff; font-family:var(--font-heading); font-weight:700; font-size:0.6rem; text-transform:uppercase; letter-spacing:0.4px; padding:0.12rem 0.45rem; border-radius:5px; vertical-align:middle; }
+        .export-note { font-size:0.8rem; color:var(--text-muted); margin-top:0.5rem; }
         .btn:disabled { opacity: 0.5; cursor: not-allowed; }
         .nav-row { display: flex; justify-content: space-between; margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid var(--border-color); gap: 1rem; }
         ul.body-list { margin: 0.5rem 0 0.75rem 1.5rem; color: var(--text-secondary); font-size: 0.92rem; line-height: 1.8; }
@@ -536,7 +538,8 @@ body { padding-top: 56px; }
 
         <h3 class="block-title">Export your readiness memo</h3>
         <p class="body-text">Download a plain-text summary of your stage, gate answers, baseline check and verdict — to share with your team, board or funder before anyone commits a budget.</p>
-        <button class="btn btn-primary" onclick="exportMemo()">Download RCT Readiness Memo</button>
+        <button class="btn btn-primary" onclick="exportMemo()">Download RCT Readiness Memo <span class="pro-pill">★ Premium</span></button>
+        <p class="export-note">Working through the whole diagnostic is free. Exporting the memo is a Premium feature (Practitioner plan and up).</p>
 
         <div class="completion-badge" style="margin-top:2rem;">
             <div class="tick"><svg viewBox="0 0 24 24" fill="none" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></div>
@@ -912,7 +915,18 @@ function calcVerdict() {
 
 /* ===== EXPORT MEMO ===== */
 function ans(v) { return v === 'yes' ? 'Yes' : v === 'partly' ? 'Partly' : v === 'no' ? 'No/unsure' : '(unanswered)'; }
+/* Freemium gate: the diagnostic is free to use; exporting the memo is Premium
+   (practitioner+). Soft gate that fails open if the premium module is absent, so
+   the tool never breaks. */
+function gateOK() {
+    if (!window.IMXPremium || typeof window.IMXPremium.hasAccess !== 'function') return true;
+    if (window.IMXPremium.hasAccess('practitioner')) return true;
+    if (typeof window.IMXPremium.showUpgradeModal === 'function') window.IMXPremium.showUpgradeModal('practitioner');
+    else window.location.href = '/premium';
+    return false;
+}
 function exportMemo() {
+    if (!gateOK()) return;
     var stageObj = stages.filter(function(s){ return s.id === state.stage; })[0];
     var L = [];
     L.push('ImpactMojo — RCT Readiness Memo');
@@ -984,6 +998,7 @@ updateProgress();
   <script src="/js/state-manager.js"></script>
   <script src="/js/config.js"></script>
   <script src="/js/auth.js"></script>
+  <script src="/js/premium.js"></script>
   <script src="/js/translate-sarvam.js" defer></script>
   <script src="/js/site-chrome.js" defer></script>
 </body>

--- a/Labs/urban-boundaries-lab.html
+++ b/Labs/urban-boundaries-lab.html
@@ -105,6 +105,8 @@ body.dark-mode, [data-theme="dark"] {
         .btn:hover { border-color: var(--accent-color); background: var(--hover-bg); }
         .btn-primary { background: var(--accent-color); border-color: var(--accent-color); color: #fff; font-weight: 600; }
         .btn-primary:hover { background: var(--accent-hover); color: #fff; }
+        .pro-pill { display:inline-flex; align-items:center; gap:0.25rem; background:linear-gradient(135deg,#F59E0B,#EF4444); color:#fff; font-family:var(--font-heading); font-weight:700; font-size:0.6rem; text-transform:uppercase; letter-spacing:0.4px; padding:0.12rem 0.45rem; border-radius:5px; vertical-align:middle; }
+        .export-note { font-size:0.8rem; color:var(--text-muted); margin-top:0.5rem; }
         .nav-row { display: flex; justify-content: space-between; margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid var(--border-color); gap: 1rem; }
         ul.body-list { margin: 0.5rem 0 0.75rem 1.5rem; color: var(--text-secondary); font-size: 0.92rem; line-height: 1.8; }
 
@@ -516,7 +518,8 @@ body { padding-top: 56px; }
                     <label for="ubBlind" style="font-family:var(--font-heading);font-size:0.82rem;font-weight:600;color:var(--text-secondary);display:block;margin-bottom:0.3rem;">A blind spot you'll flag in your write-up</label>
                     <input type="text" id="ubBlind" placeholder="e.g., Snapshot in time — can't separate densification from annexation without a second year" oninput="saveNote()" style="width:100%;padding:0.6rem 0.8rem;border:1px solid var(--border-color);border-radius:8px;background:var(--secondary-bg);color:var(--text-primary);font-family:var(--font-sans);font-size:0.9rem;">
                 </div>
-                <button class="btn btn-primary" onclick="exportNote()" style="align-self:flex-start;">Download boundary-decision note</button>
+                <button class="btn btn-primary" onclick="exportNote()" style="align-self:flex-start;">Download boundary-decision note <span class="pro-pill">★ Premium</span></button>
+                <p class="export-note">The lesson and making the call are free. Exporting the note is a Premium feature (Practitioner plan and up).</p>
             </div>
         </div>
 
@@ -640,7 +643,18 @@ function restoreNote() {
     s('ubProject', note.project); s('ubCity', note.city); s('ubWhy', note.why); s('ubBlind', note.blind);
     if (note.boundary) setBoundary(note.boundary);
 }
+/* Freemium gate: the lesson and the decision step are free; exporting the
+   boundary-decision note is Premium (practitioner+). Fails open if the premium
+   module is absent, so the tool never breaks. */
+function gateOK() {
+    if (!window.IMXPremium || typeof window.IMXPremium.hasAccess !== 'function') return true;
+    if (window.IMXPremium.hasAccess('practitioner')) return true;
+    if (typeof window.IMXPremium.showUpgradeModal === 'function') window.IMXPremium.showUpgradeModal('practitioner');
+    else window.location.href = '/premium';
+    return false;
+}
 function exportNote() {
+    if (!gateOK()) return;
     saveNote();
     var map = { admin: 'Administrative / statutory border', econ: 'Economic (built-up) boundary', both: 'Both, compared side by side', undecided: 'Still deciding' };
     var L = [];
@@ -716,6 +730,7 @@ restoreNote();
   <script src="/js/state-manager.js"></script>
   <script src="/js/config.js"></script>
   <script src="/js/auth.js"></script>
+  <script src="/js/premium.js"></script>
   <script src="/js/translate-sarvam.js" defer></script>
   <script src="/js/site-chrome.js" defer></script>
 </body>

--- a/dataverse-india.html
+++ b/dataverse-india.html
@@ -104,6 +104,8 @@ body.dark-mode, [data-theme="dark"] {
         .btn:hover { border-color: var(--accent-color); background: var(--hover-bg); }
         .btn-primary { background: var(--accent-color); border-color: var(--accent-color); color: #fff; font-weight: 600; }
         .btn-primary:hover { background: var(--accent-hover); color: #fff; }
+        .pro-pill { display:inline-flex; align-items:center; gap:0.25rem; background:linear-gradient(135deg,#F59E0B,#EF4444); color:#fff; font-family:var(--font-heading); font-weight:700; font-size:0.6rem; text-transform:uppercase; letter-spacing:0.4px; padding:0.12rem 0.45rem; border-radius:5px; vertical-align:middle; }
+        .export-note { font-size:0.8rem; color:var(--text-muted); margin-top:0.5rem; }
         .btn:disabled { opacity: 0.5; cursor: not-allowed; }
         .nav-row { display: flex; justify-content: space-between; margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid var(--border-color); gap: 1rem; }
         ul.body-list { margin: 0.5rem 0 0.75rem 1.5rem; color: var(--text-secondary); font-size: 0.92rem; line-height: 1.8; }
@@ -345,7 +347,8 @@ body { padding-top: 56px; }
             <strong>Good practice: triangulate.</strong> No single source is the whole truth. Pair a large representative survey (for the level and trend) with routine administrative data (for frequency and coverage) and, where you can, your own primary data (for the specifics of your population). When two independent sources agree, your claim is far harder to dismiss.
         </div>
 
-        <button class="btn btn-primary" onclick="exportPlan()">Download data plan</button>
+        <button class="btn btn-primary" onclick="exportPlan()">Download data plan <span class="pro-pill">★ Premium</span></button>
+        <p class="export-note">Browsing, filtering and shortlisting are free. Exporting the data plan is a Premium feature (Practitioner plan and up).</p>
 
         <div class="nav-row">
             <button class="btn" onclick="switchTab(0)">&larr; Back to datasets</button>
@@ -675,7 +678,18 @@ function renderPlan() {
 }
 
 /* ===== EXPORT ===== */
+/* Freemium gate: browsing and shortlisting are free; exporting the data-sourcing
+   plan is Premium (practitioner+). Fails open if the premium module is absent, so
+   the tool never breaks. */
+function gateOK() {
+    if (!window.IMXPremium || typeof window.IMXPremium.hasAccess !== 'function') return true;
+    if (window.IMXPremium.hasAccess('practitioner')) return true;
+    if (typeof window.IMXPremium.showUpgradeModal === 'function') window.IMXPremium.showUpgradeModal('practitioner');
+    else window.location.href = '/premium';
+    return false;
+}
 function exportPlan() {
+    if (!gateOK()) return;
     saveState();
     var L = [];
     L.push('ImpactMojo — Data-Sourcing Plan');
@@ -723,6 +737,7 @@ updatePlanCount();
   <script src="/js/state-manager.js"></script>
   <script src="/js/config.js"></script>
   <script src="/js/auth.js"></script>
+  <script src="/js/premium.js"></script>
   <script src="/js/translate-sarvam.js" defer></script>
   <script src="/js/site-chrome.js" defer></script>
 </body>


### PR DESCRIPTION
## What does this PR do?

Brings the three new interactive tools in line with the platform's freemium model. They shipped with fully-free exports; per the model (and the **Sampling Design Studio** precedent), the tool is **free to use** but the **export/deliverable is Premium**.

- **RCT Readiness Diagnostic**, **Why City Boundaries Lie**, and the **Indian Data Navigator** now load `/js/premium.js` and route their export through a soft `gateOK()` check (`window.IMXPremium.hasAccess('practitioner')`): free to work through the whole tool, Premium to download the memo / boundary-decision note / data-sourcing plan. The gate **fails open** if the premium module is unavailable, so the tools never break.
- Added a **★ Premium** pill on each download button and an honest note line ("… is free. Exporting … is a Premium feature (Practitioner and up).").

Card badges stay **"Free Lab"** — consistent with the Sampling Studio, which is likewise free to use with a Premium export. No content or count changes.

## Type of change

- [x] New feature or tool

## Checklist

- [ ] Tested on desktop browser
- [ ] Tested on mobile browser
- [x] No console errors (inline-JS syntax + mojibake checks pass; gate matches the existing Sampling Studio implementation and fails open)
- [x] Links are working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgDJcnAiEfc5NQL4DjbrJY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgDJcnAiEfc5NQL4DjbrJY)_