### PR TITLE
Bring the disability flagship on par: coaching prompts, capstone & lexicon

### DIFF
--- a/courses/index.html
+++ b/courses/index.html
@@ -409,6 +409,7 @@ html,body{font-family:var(--font-body);color:var(--ink);background:var(--paper);
   </div>
   <div class="card-actions">
     <a class="card-cta" href="/courses/nothing-about-us/">Open course &rarr;</a>
+    <a class="card-lexicon" href="/courses/nothing-about-us/lexicon.html">Lexicon</a>
   </div>
 </div>
 

--- a/courses/nothing-about-us/index.html
+++ b/courses/nothing-about-us/index.html
@@ -3267,8 +3267,12 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                         <span class="nav-link-number"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Book.svg" alt="" class="nav-icon"></span>
                         Readings & Resources
                     </a>
+                    <a href="lexicon.html" class="nav-link external-link">
+                        <span class="nav-link-number"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Flare.svg" alt="" class="nav-icon"></span>
+                        Lexicon (38 Terms)
+                    </a>
                 </div>
-                
+
                 <!-- Foundations -->
                 <div class="nav-section">
                     <div class="nav-section-title">Foundations</div>
@@ -3391,7 +3395,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
                             </svg>
-                            9 Modules + Companion Lab
+                            9 Modules · Lexicon · Companion Lab
                         </div>
                         <div class="hero-meta-item">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -3421,6 +3425,10 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                         <a href="../../Labs/disability-inclusive-mel-lab.html" class="hero-resource-btn" title="The hands-on companion lab">
                             <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Rocket.svg" alt="" style="width:16px;height:16px;">
                             Disability-Inclusive MEL Lab
+                        </a>
+                        <a href="lexicon.html" class="hero-resource-btn" title="38-term disability glossary">
+                            <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Flare.svg" alt="" style="width:16px;height:16px;">
+                            Disability Lexicon
                         </a>
                     </div>
                 </section>

--- a/courses/nothing-about-us/lexicon.html
+++ b/courses/nothing-about-us/lexicon.html
@@ -1,0 +1,612 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Disability Lexicon | ImpactMojo</title>
+    <meta name="description" content="Interactive glossary of 38 essential disability terms for practitioners in South Asia — social model, CRPD, Washington Group, universal design, twin-track, disability justice and more.">
+
+<!-- Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-JRCMEB9TBW');
+</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <!-- ImpactMojo Fonts: Amaranth (body) + Inter (headings) + JetBrains Mono (code) -->
+<link href="https://fonts.googleapis.com" rel="preconnect">
+<link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
+<link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+        :root {
+            --primary-bg: #FFFFFF;
+            --secondary-bg: #F8FAFC;
+            --accent-color: #0369A1;
+            --accent-hover: #0284C7;
+            --secondary-accent: #6366F1;
+            --success-color: #10B981;
+            --warning-color: #F59E0B;
+            --text-primary: #0F172A;
+            --text-secondary: #475569;
+            --text-muted: #52627A;
+            --card-bg: #FFFFFF;
+            --hover-bg: #F1F5F9;
+            --border-color: #E2E8F0;
+            --font-sans: 'Amaranth', sans-serif;
+            --font-heading: 'Inter', sans-serif;
+        }
+@media (prefers-color-scheme: dark) { :root {
+            --primary-bg: #0F172A;
+            --secondary-bg: #1E293B;
+            --accent-color: #0EA5E9;
+            --accent-hover: #0284C7;
+            --secondary-accent: #6366F1;
+            --success-color: #10B981;
+            --warning-color: #F59E0B;
+            --text-primary: #F1F5F9;
+            --text-secondary: #CBD5E1;
+            --text-muted: #94A3B8;
+            --card-bg: #1E293B;
+            --hover-bg: #334155;
+            --border-color: #334155;
+            --font-sans: 'Amaranth', sans-serif;
+            --font-heading: 'Inter', sans-serif;
+        } }
+body.light-mode, [data-theme="light"] {
+            --primary-bg: #FFFFFF;
+            --secondary-bg: #F8FAFC;
+            --accent-color: #0369A1;
+            --accent-hover: #0284C7;
+            --secondary-accent: #6366F1;
+            --success-color: #10B981;
+            --warning-color: #F59E0B;
+            --text-primary: #0F172A;
+            --text-secondary: #475569;
+            --text-muted: #52627A;
+            --card-bg: #FFFFFF;
+            --hover-bg: #F1F5F9;
+            --border-color: #E2E8F0;
+            --font-sans: 'Amaranth', sans-serif;
+            --font-heading: 'Inter', sans-serif;
+        }
+body.dark-mode, [data-theme="dark"] {
+            --primary-bg: #0F172A;
+            --secondary-bg: #1E293B;
+            --accent-color: #0EA5E9;
+            --accent-hover: #0284C7;
+            --secondary-accent: #6366F1;
+            --success-color: #10B981;
+            --warning-color: #F59E0B;
+            --text-primary: #F1F5F9;
+            --text-secondary: #CBD5E1;
+            --text-muted: #94A3B8;
+            --card-bg: #1E293B;
+            --hover-bg: #334155;
+            --border-color: #334155;
+            --font-sans: 'Amaranth', sans-serif;
+            --font-heading: 'Inter', sans-serif;
+        }
+        
+        [data-theme="light"] {
+            --primary-bg: #FFFFFF;
+            --secondary-bg: #F8FAFC;
+            --text-primary: #0F172A;
+            --text-secondary: #475569;
+            --text-muted: #52627A;
+            --card-bg: #FFFFFF;
+            --hover-bg: #F1F5F9;
+            --border-color: #E2E8F0;
+        }
+        
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        html { scroll-behavior: smooth; }
+        body { font-family: var(--font-sans); background: var(--primary-bg); color: var(--text-primary); line-height: 1.6; min-height: 100vh; }
+        .container { max-width: 1200px; margin: 0 auto; padding: 2rem; }
+        
+        .header { text-align: center; margin-bottom: 3rem; padding-bottom: 2rem; border-bottom: 1px solid var(--border-color); }
+        .header-badge { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.35rem 1rem; background: rgba(14, 165, 233, 0.15); color: var(--accent-color); border-radius: 20px; font-size: 0.8rem; font-weight: 600; margin-bottom: 1rem; }
+        .header h1 { font-family: var(--font-heading); font-size: clamp(2rem, 5vw, 3rem); margin-bottom: 0.5rem; background: linear-gradient(135deg, var(--accent-color) 0%, var(--secondary-accent) 100%); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+        .header p { color: var(--text-secondary); font-size: 1.1rem; max-width: 600px; margin: 0 auto; }
+        .header-meta { display: flex; justify-content: center; gap: 2rem; margin-top: 1.5rem; flex-wrap: wrap; }
+        .header-meta-item { display: flex; align-items: center; gap: 0.5rem; color: var(--text-muted); font-size: 0.9rem; }
+        .header-meta-item svg { width: 18px; height: 18px; stroke: var(--accent-color); }
+        
+        .controls { display: flex; gap: 1rem; margin-bottom: 2rem; flex-wrap: wrap; }
+        .search-box { flex: 1; min-width: 280px; position: relative; }
+        .search-box input { width: 100%; padding: 0.85rem 1rem 0.85rem 2.75rem; background: var(--secondary-bg); border: 1px solid var(--border-color); border-radius: 10px; color: var(--text-primary); font-size: 1rem; transition: border-color 0.2s ease, box-shadow 0.2s ease; }
+        .search-box input:focus { outline: none; border-color: var(--accent-color); box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.15); }
+        .search-box input::placeholder { color: var(--text-muted); }
+        .search-box svg { position: absolute; left: 1rem; top: 50%; transform: translateY(-50%); width: 18px; height: 18px; stroke: var(--text-muted); }
+        
+        .filter-select { padding: 0.85rem 2.5rem 0.85rem 1rem; background: var(--secondary-bg); border: 1px solid var(--border-color); border-radius: 10px; color: var(--text-primary); font-size: 0.95rem; cursor: pointer; appearance: none; background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%2394A3B8'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M19 9l-7 7-7-7'/%3E%3C/svg%3E"); background-repeat: no-repeat; background-position: right 0.75rem center; background-size: 18px; }
+        .filter-select:focus { outline: none; border-color: var(--accent-color); }
+        
+        .theme-toggle { padding: 0.85rem 1rem; background: var(--secondary-bg); border: 1px solid var(--border-color); border-radius: 10px; color: var(--text-primary); font-size: 0.95rem; cursor: pointer; display: flex; align-items: center; gap: 0.5rem; transition: all 0.2s ease; }
+        .theme-toggle:hover { border-color: var(--accent-color); background: var(--hover-bg); }
+        .theme-toggle svg { width: 18px; height: 18px; }
+        
+        .stats-bar { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem; padding: 0.75rem 1rem; background: var(--secondary-bg); border-radius: 8px; font-size: 0.9rem; color: var(--text-secondary); }
+        .stats-bar strong { color: var(--accent-color); }
+        
+        .category-pills { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 2rem; }
+        .category-pill { padding: 0.4rem 0.85rem; background: var(--secondary-bg); border: 1px solid var(--border-color); border-radius: 20px; font-size: 0.8rem; color: var(--text-secondary); cursor: pointer; transition: all 0.2s ease; }
+        .category-pill:hover, .category-pill.active { background: rgba(14, 165, 233, 0.15); border-color: var(--accent-color); color: var(--accent-color); }
+        .category-pill .count { display: inline-flex; align-items: center; justify-content: center; min-width: 20px; height: 20px; padding: 0 6px; background: var(--border-color); border-radius: 10px; font-size: 0.7rem; margin-left: 0.35rem; }
+        .category-pill.active .count { background: var(--accent-color); color: white; }
+        
+        .lexicon-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(350px, 1fr)); gap: 1.25rem; }
+        .term-card { background: var(--card-bg); border: 1px solid var(--border-color); border-radius: 12px; padding: 1.5rem; transition: all 0.2s ease; }
+        .term-card:hover { border-color: var(--accent-color); transform: translateY(-2px); box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2); }
+        .term-header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 0.75rem; }
+        .term-name { font-family: var(--font-heading); font-size: 1.1rem; font-weight: 600; color: var(--text-primary); }
+        .term-category { font-size: 0.7rem; padding: 0.25rem 0.6rem; background: rgba(99, 102, 241, 0.15); color: var(--secondary-accent); border-radius: 4px; text-transform: uppercase; letter-spacing: 0.5px; font-weight: 500; white-space: nowrap; }
+        .term-definition { color: var(--text-secondary); font-size: 0.95rem; line-height: 1.6; margin-bottom: 1rem; }
+        .term-example { padding: 0.75rem 1rem; background: rgba(16, 185, 129, 0.08); border-left: 3px solid var(--success-color); border-radius: 0 6px 6px 0; font-size: 0.85rem; color: var(--text-secondary); }
+        .term-example strong { color: var(--success-color); font-weight: 600; }
+        
+        .no-results { text-align: center; padding: 4rem 2rem; color: var(--text-muted); }
+        .no-results svg { width: 64px; height: 64px; stroke: var(--border-color); margin-bottom: 1rem; }
+        .no-results h3 { font-size: 1.25rem; color: var(--text-secondary); margin-bottom: 0.5rem; }
+        
+        .back-link { display: inline-flex; align-items: center; gap: 0.5rem; color: var(--accent-color); text-decoration: none; font-size: 0.9rem; margin-bottom: 2rem; transition: color 0.2s ease; }
+        .back-link:hover { color: var(--accent-hover); }
+        .back-link svg { width: 18px; height: 18px; }
+        
+        .footer { margin-top: 4rem; padding-top: 2rem; border-top: 1px solid var(--border-color); text-align: center; color: var(--text-muted); font-size: 0.85rem; }
+        .footer a { color: var(--accent-color); text-decoration: none; }
+        .footer a:hover { text-decoration: underline; }
+        
+        .highlight { background: rgba(14, 165, 233, 0.3); padding: 0 2px; border-radius: 2px; }
+        
+        @media (max-width: 768px) {
+            .container { padding: 1rem; }
+            .lexicon-grid { grid-template-columns: 1fr; }
+            .controls { flex-direction: column; }
+            .search-box { min-width: 100%; }
+            .filter-select { width: 100%; }
+            .header-meta { gap: 1rem; }
+        }
+    </style>
+<style>
+/* ===== ImpactMojo Design System ===== */
+:root {
+    --im-primary-bg: #0F172A;
+    --im-secondary-bg: #1E293B;
+    --im-accent: #0EA5E9;
+    --im-accent-hover: #0284C7;
+    --im-secondary-accent: #6366F1;
+    --im-success: #10B981;
+    --im-text-primary: #F1F5F9;
+    --im-text-secondary: #94A3B8;
+    --im-text-muted: #64748B;
+    --im-card-bg: #1E293B;
+    --im-hover-bg: #334155;
+    --im-border: #334155;
+    --im-nav-bg: rgba(15, 23, 42, 0.95);
+    --im-gradient: linear-gradient(135deg, #0EA5E9 0%, #6366F1 100%);
+}
+[data-theme="light"] {
+    --im-primary-bg: #F8FAFC;
+    --im-secondary-bg: #FFFFFF;
+    --im-accent: #0284C7;
+    --im-accent-hover: #0369A1;
+    --im-text-primary: #0F172A;
+    --im-text-secondary: #475569;
+    --im-text-muted: #64748B;
+    --im-card-bg: #FFFFFF;
+    --im-hover-bg: #F1F5F9;
+    --im-border: #E2E8F0;
+    --im-nav-bg: rgba(248, 250, 252, 0.95);
+}
+
+/* ImpactMojo Top Bar */
+.im-topbar {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 9999;
+    background: var(--im-nav-bg, rgba(15, 23, 42, 0.95));
+    backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px);
+    border-bottom: 1px solid var(--im-border, #334155);
+    padding: 0.5rem 1rem;
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 0.75rem; flex-wrap: wrap;
+    font-family: 'Inter', sans-serif;
+}
+.im-topbar a { text-decoration: none; }
+.im-topbar-left {
+    display: flex; align-items: center; gap: 0.75rem;
+}
+.im-topbar-home {
+    display: flex; align-items: center; gap: 0.5rem;
+    color: var(--im-text-primary, #F1F5F9);
+    font-weight: 700; font-size: 1rem;
+    background: var(--im-gradient);
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+.im-topbar-home svg { width: 24px; height: 24px; flex-shrink: 0; }
+.im-topbar-right {
+    display: flex; align-items: center; gap: 0.5rem;
+}
+.im-premium-btn {
+    background: var(--im-gradient);
+    color: #fff !important;
+    padding: 0.35rem 0.85rem;
+    border-radius: 6px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    display: flex; align-items: center; gap: 0.35rem;
+    transition: opacity 0.2s;
+    -webkit-text-fill-color: #fff;
+}
+.im-browse-btn { display: inline-flex; align-items: center; gap: 0.4rem; font-family: 'Inter', sans-serif; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: var(--im-text, #1C1917); background: var(--im-surface, #FFFFFF); border: 1.5px solid var(--im-border, #E2E8F0); padding: 0.5rem 1rem; border-radius: 0.5rem; text-decoration: none; transition: background 0.18s ease, border-color 0.18s ease, transform 0.15s ease, box-shadow 0.18s ease; }
+.im-browse-btn:hover { background: var(--im-accent, #0EA5E9); color: #FFFFFF; border-color: var(--im-accent, #0EA5E9); transform: translateY(-1px); box-shadow: 0 4px 12px rgba(14, 165, 233, 0.25); }
+.im-browse-btn svg { width: 14px; height: 14px; }
+@media (prefers-color-scheme: dark) { .im-browse-btn { color: rgba(255,255,255,0.9); background: rgba(255,255,255,0.05); border-color: rgba(255,255,255,0.18); } .im-browse-btn:hover { background: var(--im-accent, #0EA5E9); border-color: var(--im-accent, #0EA5E9); color: #FFFFFF; } }
+.im-premium-btn:hover { opacity: 0.9; }
+.im-premium-btn svg { width: 14px; height: 14px; }
+
+/* Theme Selector - 3 mode */
+.im-theme-selector {
+    display: flex; gap: 2px;
+    background: var(--im-card-bg, #1E293B);
+    border: 1px solid var(--im-border, #334155);
+    border-radius: 8px; padding: 2px;
+}
+.im-theme-btn {
+    background: transparent; border: none;
+    color: var(--im-text-secondary, #94A3B8);
+    padding: 6px; border-radius: 5px; cursor: pointer;
+    transition: all 0.2s; display: flex; align-items: center;
+    justify-content: center; width: 30px; height: 30px;
+}
+.im-theme-btn:hover {
+    background: var(--im-hover-bg, #334155);
+    color: var(--im-text-primary, #F1F5F9);
+}
+.im-theme-btn.active {
+    background: var(--im-accent, #0EA5E9);
+    color: #fff;
+}
+.im-theme-btn svg { width: 16px; height: 16px; }
+
+/* Paper Plane */
+.im-paper-plane {
+    position: fixed; top: 15%; right: 8%;
+    width: 120px; height: 120px;
+    opacity: 0.15; z-index: 0;
+    pointer-events: none;
+    animation: im-fly 25s ease-in-out infinite;
+}
+[data-theme="light"] .im-paper-plane { opacity: 0.2; }
+@keyframes im-fly {
+    0%, 100% { transform: translate(0, 0) rotate(0deg); }
+    20% { transform: translate(60px, -40px) rotate(12deg); }
+    40% { transform: translate(120px, 30px) rotate(-8deg); }
+    60% { transform: translate(40px, 60px) rotate(15deg); }
+    80% { transform: translate(-30px, 20px) rotate(-5deg); }
+}
+
+/* ImpactMojo Footer */
+.im-footer {
+    background: var(--im-secondary-bg, #1E293B);
+    border-top: 1px solid var(--im-border, #334155);
+    padding: 2rem 1rem; margin-top: auto;
+    font-family: 'Inter', sans-serif;
+    color: var(--im-text-secondary, #94A3B8);
+}
+.im-footer-content {
+    max-width: 1100px; margin: 0 auto;
+}
+.im-footer-made {
+    text-align: center; margin-bottom: 1.5rem;
+    font-size: 0.9rem; color: var(--im-text-muted, #64748B);
+}
+.im-footer-made a { color: var(--im-accent, #0EA5E9); }
+.im-footer-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.5rem; margin-bottom: 1.5rem;
+}
+.im-footer-section h4 {
+    font-family: 'Inter', sans-serif;
+    color: var(--im-text-primary, #F1F5F9);
+    font-size: 0.9rem; margin-bottom: 0.75rem;
+    font-weight: 600;
+}
+.im-footer-section ul { list-style: none; padding: 0; margin: 0; }
+.im-footer-section li { margin-bottom: 0.4rem; }
+.im-footer-section a {
+    color: var(--im-text-secondary, #94A3B8);
+    text-decoration: none; font-size: 0.85rem;
+    transition: color 0.2s;
+}
+.im-footer-section a:hover { color: var(--im-accent, #0EA5E9); }
+.im-footer-bottom {
+    text-align: center; padding-top: 1rem;
+    border-top: 1px solid var(--im-border, #334155);
+    font-size: 0.8rem; color: var(--im-text-muted, #64748B);
+}
+.im-footer-bottom p { margin: 0.25rem 0; }
+.im-footer-bottom a { color: var(--im-accent, #0EA5E9); text-decoration: none; }
+
+/* Mobile Responsive */
+@media (max-width: 768px) {
+    .im-topbar { padding: 0.4rem 0.75rem; gap: 0.5rem; }
+    .im-topbar-home { font-size: 0.85rem; }
+    .im-topbar-home svg { width: 20px; height: 20px; }
+    .im-premium-btn { padding: 0.3rem 0.6rem; font-size: 0.75rem; }
+    .im-theme-btn { width: 26px; height: 26px; padding: 4px; }
+    .im-theme-btn svg { width: 14px; height: 14px; }
+    .im-paper-plane { width: 80px; height: 80px; top: 10%; right: 5%; }
+    .im-footer-grid { grid-template-columns: repeat(2, 1fr); gap: 1rem; }
+}
+@media (max-width: 480px) {
+    .im-footer-grid { grid-template-columns: 1fr; }
+    .im-topbar-home span { display: none; }
+}
+
+/* ImpactMojo Global Font Overrides */
+body { font-family: 'Amaranth', sans-serif !important; }
+h1, h2, h3, h4, h5, h6 { font-family: 'Inter', sans-serif !important; }
+code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !important; }
+</style>
+<!-- SEO meta (autogenerated) -->
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://www.impactmojo.in/courses/nothing-about-us/lexicon.html">
+<meta property="og:title" content="Disability Lexicon">
+<meta property="og:description" content="Disability Lexicon — 38 essential terms on disability, rights and inclusive development, the companion glossary to the Nothing About Us Without Us flagship. Free from ImpactMojo.">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<meta property="og:url" content="https://www.impactmojo.in/courses/nothing-about-us/lexicon.html">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="ImpactMojo">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Disability Lexicon">
+<meta name="twitter:description" content="Disability Lexicon — 38 essential terms on disability, rights and inclusive development, the companion glossary to the Nothing About Us Without Us flagship. Free from ImpactMojo.">
+<meta name="twitter:image" content="https://www.impactmojo.in/assets/images/ImpactMojo%20Logo.png">
+<style>
+/* Body clears fixed im-topbar (added by site-wide audit fix) */
+body { padding-top: 56px; }
+@media (max-width: 768px) { body { padding-top: 52px; } }
+</style>
+<link rel="icon" type="image/png" href="/assets/images/favicon.png">
+<link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">
+</head>
+<body>
+<!-- ImpactMojo Top Bar -->
+<div class="im-topbar" id="imTopbar">
+    <div class="im-topbar-left">
+        <a href="../../index.html" class="im-topbar-home">
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
+            <span>ImpactMojo</span>
+        </a>
+    </div>
+    <div class="im-topbar-right">
+        <a href="/catalog.html" class="im-browse-btn" title="Browse all content"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>Browse</a>
+    
+        <a href="../../premium.html" class="im-premium-btn">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+            Premium
+        </a>
+        <div class="im-theme-selector" aria-label="Theme selection">
+            <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="Use system theme">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+            </button>
+            <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Use light theme">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+            </button>
+            <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Use dark theme">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
+        </div>
+    </div>
+</div>
+
+    <div class="container">
+        <a href="index.html" class="back-link">
+            <svg fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"/></svg>
+            Back to the Course
+        </a>
+        
+        <header class="header">
+            <div class="header-badge">
+                <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/></svg>
+                Interactive Lexicon
+            </div>
+            <h1>Disability Lexicon</h1>
+            <p>Essential terminology for disability, justice and inclusive development. Search, filter, and get fluent in the language of disability rights &mdash; the companion glossary to the flagship course.</p>
+            <div class="header-meta">
+            </div>
+        </header>
+        
+        <div class="controls">
+            <div class="search-box">
+                <svg fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
+                <input type="text" id="searchInput" aria-label="Search terms" placeholder="Search terms, definitions, or examples...">
+            </div>
+            <select id="categoryFilter" class="filter-select" aria-label="Filter by category"><option value="all">All Categories</option></select>
+            <button class="theme-toggle" onclick="toggleTheme()">
+                <svg id="themeIcon" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                <span id="themeLabel">Light</span>
+            </button>
+        </div>
+        
+        <div class="category-pills" id="categoryPills"></div>
+        <div class="stats-bar"><span>Showing <strong id="visibleCount">38</strong> of <strong>38</strong> terms</span><span id="activeFilter"></span></div>
+        <div class="lexicon-grid" id="lexiconGrid"></div>
+        <div class="no-results" id="noResults" style="display: none;">
+            <svg fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+            <h3>No terms found</h3>
+            <p>Try adjusting your search or filter criteria</p>
+        </div>
+        
+        <footer class="footer"><p>&copy; 2025 <a href="https://www.impactmojo.in">ImpactMojo</a>. Free disability &amp; development resources.</p>    <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Documentation</a></p>
+</footer>
+    </div>
+    
+    <script>
+        const lexiconData = [
+            {term:"Social model of disability",category:"Models & Frameworks",definition:"The understanding that disability is created by barriers in society and the environment meeting a person's impairment — not by the impairment itself. Change the barriers, not the person.",example:"A wheelchair user is 'disabled' by a building's steps and missing ramp, not by their legs."},
+            {term:"Medical model",category:"Models & Frameworks",definition:"The framing of disability as an individual deficit to be cured, rehabilitated or managed by professionals; the person must change to fit the world.",example:"Treating a Deaf child only as someone to be 'fixed' with surgery, rather than providing sign language and accessible schooling."},
+            {term:"Biopsychosocial model (ICF)",category:"Models & Frameworks",definition:"The WHO's International Classification of Functioning, Disability and Health (2001): disability as an interaction of body, activity, participation and environment.",example:"The ICF describes a person's functioning across health conditions, activities and the environmental factors that help or hinder them."},
+            {term:"Human-rights model",category:"Models & Frameworks",definition:"The framing, embodied in the CRPD, of disabled people as rights-holders and decision-makers rather than objects of charity or medicine.",example:"A rights-based programme asks 'what are this person's rights?' not 'what is wrong with them?'"},
+            {term:"Disability justice",category:"Models & Frameworks",definition:"A movement (originating with Sins Invalid) that goes beyond single-issue legal rights: intersectional and collective, it centres the most marginalised disabled people and values interdependence.",example:"Disability justice centres a disabled, poor, queer person of colour rather than the 'easiest to reach' disabled people."},
+            {term:"Ableism",category:"Models & Frameworks",definition:"Discrimination and social prejudice against disabled people, and the assumption that non-disabled bodies and minds are the norm.",example:"Assuming a disabled colleague can't lead a team is ableism, however well-intentioned."},
+            {term:"Impairment vs disability",category:"Models & Frameworks",definition:"In the social model, an impairment is a feature of a body or mind; disability is the disadvantage produced when society fails to accommodate it.",example:"Short-sightedness is an impairment; it is rarely 'disabling' because glasses and accessible print are normalised."},
+            {term:"CRPD",category:"Rights & Law",definition:"The UN Convention on the Rights of Persons with Disabilities (2006; in force 2008), the treaty that shifted disability from welfare to rights. Ratified by all South Asian states.",example:"CRPD Article 9 obliges states to make the built environment, transport and information accessible."},
+            {term:"RPwD Act 2016",category:"Rights & Law",definition:"India's Rights of Persons with Disabilities Act, recognising 21 disabilities, providing reservation in jobs and education, and mandating accessibility and non-discrimination.",example:"Under the RPwD Act, government establishments must provide 4% reservation for persons with benchmark disabilities."},
+            {term:"Reasonable accommodation",category:"Rights & Law",definition:"A necessary individual adjustment for a specific person that does not impose a disproportionate burden. Under the CRPD, denying it is discrimination.",example:"Giving a blind candidate a screen reader and extra time for a written test is a reasonable accommodation."},
+            {term:"Supported decision-making",category:"Rights & Law",definition:"Supporting a person to make their own decisions (CRPD Art 12), as opposed to substituted decision-making or guardianship that decides for them.",example:"Instead of a guardian signing for him, a man with an intellectual disability chooses a trusted supporter to help him decide."},
+            {term:"Legal capacity",category:"Rights & Law",definition:"The right, affirmed by CRPD Art 12, to be recognised as a person before the law and to make one's own legally-recognised decisions.",example:"Denying a psychosocially disabled woman the right to open a bank account violates her legal capacity."},
+            {term:"UDID",category:"Rights & Law",definition:"India's Unique Disability ID — a single card and database intended to streamline access to disability certification and entitlements.",example:"A UDID card lets a person claim the disability pension and travel concessions without repeated certification."},
+            {term:"Washington Group Questions",category:"Counting & Data",definition:"A set of questions that count disability by functional difficulty across domains (seeing, hearing, mobility, cognition, self-care, communication), rather than by asking 'are you disabled?'.",example:"Adding the Washington Group Short Set to a survey lets a programme disaggregate every result by disability."},
+            {term:"Child Functioning Module",category:"Counting & Data",definition:"A Washington Group / UNICEF tool for identifying disability among children, which the adult question set under-identifies.",example:"A school survey uses the Child Functioning Module to see which children face difficulties in learning, playing and communicating."},
+            {term:"Disaggregation",category:"Counting & Data",definition:"Breaking data down by group — including by disability (and by sex, age and WG domain) — to reveal gaps that averages hide.",example:"Disaggregating completion rates by disability shows disabled participants finish at half the rate of others."},
+            {term:"Undercount",category:"Counting & Data",definition:"The systematic under-recording of disability in censuses and surveys, driven by stigma, narrow questions and certification barriers.",example:"India's census records ~2.2% disability against a global estimate near 16% — a large undercount."},
+            {term:"Functional difficulty",category:"Counting & Data",definition:"Difficulty carrying out everyday activities, used as the basis for counting disability in a comparable, less stigmatising way.",example:"'A lot of difficulty seeing, even with glasses' is a functional-difficulty response used to identify disability."},
+            {term:"Universal design",category:"Access & Design",definition:"Designing products, environments and services to be usable by everyone from the start, without special adaptation (Ronald Mace; seven principles).",example:"Captioning all videos is universal design — it serves Deaf viewers and everyone in a noisy room."},
+            {term:"Accessibility",category:"Access & Design",definition:"The extent to which environments, information and services can be used by disabled people; a right under CRPD Art 9.",example:"An accessible clinic has a ramp, an accessible toilet, clear signage and staff who can communicate in multiple ways."},
+            {term:"Assistive technology",category:"Access & Design",definition:"Devices and software that help disabled people carry out activities — wheelchairs, hearing aids, screen readers — with a large global access gap.",example:"A student with low vision uses a screen reader as assistive technology to access digital course materials."},
+            {term:"Web accessibility (WCAG)",category:"Access & Design",definition:"Making websites and apps usable by disabled people, following the Web Content Accessibility Guidelines (and, in India, GIGW).",example:"A WCAG-compliant form has labelled fields, good contrast and full keyboard navigation for screen-reader users."},
+            {term:"Barriers",category:"Access & Design",definition:"The obstacles — physical, attitudinal, institutional, communication and financial — that turn impairment into disability; the attitudinal barrier is often the deepest.",example:"A qualified applicant is turned away not by the stairs but by a manager's low expectations — an attitudinal barrier."},
+            {term:"Accessible India (Sugamya Bharat)",category:"Access & Design",definition:"India's Accessible India Campaign (2015) to make the built environment, transport and ICT accessible, with technical standards (2021).",example:"Under Sugamya Bharat, a railway station adds ramps, tactile paths and accessible toilets."},
+            {term:"Twin-track approach",category:"Programming & MEL",definition:"Combining mainstreaming (making every activity and dataset inclusive) with disability-specific action (targeted work on barriers) at the same time.",example:"A livelihoods programme disaggregates all indicators by disability and also audits its centres for accessibility."},
+            {term:"OPD",category:"Programming & MEL",definition:"An Organisation of Persons with Disabilities — led by disabled people themselves; the key partner for meaningful participation.",example:"The programme co-designs its tools with a local OPD rather than deciding for disabled people."},
+            {term:"Mainstreaming",category:"Programming & MEL",definition:"Making disability inclusion part of every activity, budget and dataset, rather than a separate 'disability project'.",example:"Mainstreaming means the whole education programme is accessible, not just one special school."},
+            {term:"CBID",category:"Programming & MEL",definition:"Community-Based Inclusive Development — the evolution of Community-Based Rehabilitation (CBR) toward rights, inclusion and community-led action.",example:"A CBID programme works with the whole village to remove barriers, not only to rehabilitate individuals."},
+            {term:"Safeguarding (do no harm)",category:"Programming & MEL",definition:"Protecting participants — especially disabled women and children, who face heightened risk — through consent, confidentiality and referral pathways.",example:"Before collecting disability data, the team sets up a referral pathway in case a disclosure of abuse arises."},
+            {term:"Disability-inclusive DRR",category:"Programming & MEL",definition:"Disaster risk reduction that reaches and includes disabled people, who die at higher rates and are often excluded from response.",example:"Inclusive DRR ensures early warnings are accessible and shelters are reachable by wheelchair users."},
+            {term:"Nothing about us without us",category:"Movements & Culture",definition:"The disability movement's core principle: decisions and programmes affecting disabled people must meaningfully involve them.",example:"An accessibility plan built with, not just for, disabled people honours 'nothing about us without us'."},
+            {term:"Inspiration porn",category:"Movements & Culture",definition:"Stella Young's term for portraying disabled people as inspiring simply for existing, to make non-disabled audiences feel good.",example:"A viral post praising a disabled child only to 'motivate' others is inspiration porn."},
+            {term:"Independent Living",category:"Movements & Culture",definition:"A movement and philosophy holding that disabled people should have choice and control over their own lives and support.",example:"Independent Living means a disabled person directs their own personal assistance rather than living in an institution."},
+            {term:"Neurodiversity",category:"Movements & Culture",definition:"The view that neurological differences such as autism and ADHD are natural variations to be accommodated, not only disorders to be cured.",example:"A neurodiversity-affirming workplace offers quiet spaces and flexible communication instead of demanding conformity."},
+            {term:"Identity-first vs person-first",category:"Movements & Culture",definition:"Two respectful ways to refer to disability — 'disabled person' (identity-first, favoured by much of the movement) and 'person with a disability' (person-first, the CRPD convention).",example:"When unsure, ask: some prefer 'autistic person', others 'person with autism'."},
+            {term:"Divyangjan (term debate)",category:"Movements & Culture",definition:"An official Indian term ('divine-bodied') for disabled people, widely criticised by activists as patronising and depoliticising.",example:"Many Indian disability activists reject 'divyangjan', preferring rights-based language."},
+            {term:"Emancipatory research",category:"Ethics & Analysis",definition:"Research designed and led with and by disabled people, serving their priorities, rather than studying them from outside.",example:"In an emancipatory study, disabled people set the questions and co-analyse the findings."},
+            {term:"Intersectionality",category:"Ethics & Analysis",definition:"The idea (associated with Kimberlé Crenshaw) that overlapping identities produce distinct, compounded discrimination — central to disability justice.",example:"A Deaf Dalit woman faces a compounded exclusion that neither disability, caste nor gender advocacy alone fully addresses."}
+        ];
+        
+        const categories = [...new Set(lexiconData.map(item => item.category))];
+        const categoryCounts = categories.map(cat => ({name: cat, count: lexiconData.filter(item => item.category === cat).length}));
+        
+        document.addEventListener('DOMContentLoaded', function() {
+            const categoryFilter = document.getElementById('categoryFilter');
+            categories.forEach(cat => { const option = document.createElement('option'); option.value = cat; option.textContent = cat; categoryFilter.appendChild(option); });
+            
+            const pillsContainer = document.getElementById('categoryPills');
+            const allPill = document.createElement('button');
+            allPill.className = 'category-pill active';
+            allPill.dataset.category = 'all';
+            allPill.innerHTML = `All <span class="count">${lexiconData.length}</span>`;
+            allPill.onclick = () => filterByCategory('all');
+            pillsContainer.appendChild(allPill);
+            
+            categoryCounts.forEach(cat => {
+                const pill = document.createElement('button');
+                pill.className = 'category-pill';
+                pill.dataset.category = cat.name;
+                pill.innerHTML = `${cat.name} <span class="count">${cat.count}</span>`;
+                pill.onclick = () => filterByCategory(cat.name);
+                pillsContainer.appendChild(pill);
+            });
+            
+            renderTerms(lexiconData);
+            document.getElementById('searchInput').addEventListener('input', debounce(handleSearch, 200));
+            categoryFilter.addEventListener('change', function() { filterByCategory(this.value); });
+            initTheme();
+        });
+        
+        function renderTerms(terms, searchQuery = '') {
+            const grid = document.getElementById('lexiconGrid');
+            const noResults = document.getElementById('noResults');
+            const visibleCount = document.getElementById('visibleCount');
+            grid.innerHTML = '';
+            if (terms.length === 0) { noResults.style.display = 'block'; grid.style.display = 'none'; } 
+            else {
+                noResults.style.display = 'none'; grid.style.display = 'grid';
+                terms.forEach(item => {
+                    const card = document.createElement('div');
+                    card.className = 'term-card';
+                    let termName = item.term, definition = item.definition, example = item.example;
+                    if (searchQuery) {
+                        const regex = new RegExp(`(${escapeRegex(searchQuery)})`, 'gi');
+                        termName = termName.replace(regex, '<span class="highlight">$1</span>');
+                        definition = definition.replace(regex, '<span class="highlight">$1</span>');
+                        example = example.replace(regex, '<span class="highlight">$1</span>');
+                    }
+                    card.innerHTML = `<div class="term-header"><h3 class="term-name">${termName}</h3><span class="term-category">${item.category}</span></div><p class="term-definition">${definition}</p><div class="term-example"><strong>Example:</strong> ${example}</div>`;
+                    grid.appendChild(card);
+                });
+            }
+            visibleCount.textContent = terms.length;
+        }
+        
+        function handleSearch() {
+            const searchQuery = document.getElementById('searchInput').value.toLowerCase().trim();
+            const categoryFilter = document.getElementById('categoryFilter').value;
+            let filtered = lexiconData;
+            if (categoryFilter !== 'all') { filtered = filtered.filter(item => item.category === categoryFilter); }
+            if (searchQuery) { filtered = filtered.filter(item => item.term.toLowerCase().includes(searchQuery) || item.definition.toLowerCase().includes(searchQuery) || item.example.toLowerCase().includes(searchQuery)); }
+            renderTerms(filtered, searchQuery);
+            updateActiveFilter(categoryFilter, searchQuery);
+        }
+        
+        function filterByCategory(category) {
+            document.querySelectorAll('.category-pill').forEach(pill => { pill.classList.toggle('active', pill.dataset.category === category); });
+            document.getElementById('categoryFilter').value = category;
+            handleSearch();
+        }
+        
+        function updateActiveFilter(category, search) {
+            const activeFilter = document.getElementById('activeFilter');
+            const parts = [];
+            if (category !== 'all') { parts.push(`Category: ${category}`); }
+            if (search) { parts.push(`Search: "${search}"`); }
+            activeFilter.textContent = parts.length ? parts.join(' | ') : '';
+        }
+        
+        function debounce(func, wait) { let timeout; return function executedFunction(...args) { const later = () => { clearTimeout(timeout); func(...args); }; clearTimeout(timeout); timeout = setTimeout(later, wait); }; }
+        function escapeRegex(string) { return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
+        
+        function initTheme() { const saved = localStorage.getItem('impactmojo-theme'); const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches; const theme = saved || (prefersDark ? 'dark' : 'light'); setTheme(theme); }
+        function setTheme(theme) {
+            document.documentElement.setAttribute('data-theme', theme);
+            localStorage.setItem('impactmojo-theme', theme);
+            const icon = document.getElementById('themeIcon');
+            const label = document.getElementById('themeLabel');
+            if (theme === 'dark') { icon.innerHTML = '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>'; label.textContent = 'Light'; } 
+            else { icon.innerHTML = '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/>'; label.textContent = 'Dark'; }
+        }
+        function toggleTheme() { const current = document.documentElement.getAttribute('data-theme') || 'dark'; setTheme(current === 'dark' ? 'light' : 'dark'); }
+    </script>
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script src="/js/search.js" defer></script>
+<!-- ImpactMojo Theme Toggle JS -->
+<script src="/js/theme.js"></script>
+<!-- ImpactMojo Paper Plane -->
+<svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M80,130 L150,50" stroke="#10B981" stroke-width="2" stroke-dasharray="4,4"/>
+    <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+    <circle cx="40" cy="155" r="2" fill="#0EA5E9" opacity="0.6"/>
+    <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
+    <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
+</svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
+
+<!-- ImpactLex cross-reference -->
+<div data-impactlex-banner data-course="mel" style="padding:0 1rem;"></div>
+<script src="/impactlex/lexicon-embed.js" defer></script>
+
+<script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -169,6 +169,12 @@
         <priority>0.8</priority>
     </url>
     <url>
+        <loc>https://www.impactmojo.in/courses/nothing-about-us/lexicon.html</loc>
+        <lastmod>2026-07-15</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.6</priority>
+    </url>
+    <url>
         <loc>https://www.impactmojo.in/courses/poa/</loc>
         <lastmod>2026-03-21</lastmod>
         <changefreq>monthly</changefreq>


### PR DESCRIPTION
## What does this PR do?

Brings **Nothing About Us Without Us** structurally in line with the other 17 flagships — it was missing the alternating coaching prompts, a capstone project, and a lexicon.

- **Alternating coach callouts** (Varna / Vandana) in all 9 module bodies, each with a practical, context-specific prompt and a "Book 1:1 Coaching" link — authored into Supabase `course_content` (matches how the other courses do it).
- **Capstone project** — a styled `capstone-box` in Module 9 with three project options (inclusion audit / disability-inclusive MEL plan via the lab / accessible service co-designed with an OPD) and a "what good looks like" rubric.
- **Disability Lexicon** — `courses/nothing-about-us/lexicon.html`, **38 terms across 7 categories** (models, rights & law, counting & data, access & design, programming & MEL, movements & culture, ethics), cloned from the MEL lexicon's searchable/filterable structure.
- **Wiring** — lexicon link in the sidebar Overview nav and a hero resource button; a "Lexicon" link on the `/courses/` landing card; hero meta updated; sitemap entry for the lexicon.

The coach callouts and capstone are already live in the production DB; this PR is the lexicon file and shell/landing wiring.

## Type of change

- [x] New content
- [x] New feature or tool

## Checklist

- [x] No console errors (mojibake + sitemap XML pass; lexicon data validated; module content verified in Supabase)
- [x] Links are working (lexicon link from shell, hero and landing card resolve)
- [ ] Tested on desktop browser
- [ ] Tested on mobile browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgDJcnAiEfc5NQL4DjbrJY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgDJcnAiEfc5NQL4DjbrJY)_