### PR TITLE
Queue 5 missing flagships in the NotebookLM registry

### DIFF
--- a/data/notebooklm-registry.json
+++ b/data/notebooklm-registry.json
@@ -65,6 +65,36 @@
       "id": "34a0b42c-3be6-4309-b916-84742b02fde8",
       "title": "Power BI for Practitioners",
       "url": "https://notebooklm.google.com/notebook/34a0b42c-3be6-4309-b916-84742b02fde8"
+    },
+    "causal": {
+      "id": null,
+      "title": "Causal Inference for Development",
+      "url": null,
+      "status": "pending"
+    },
+    "intervention": {
+      "id": null,
+      "title": "Designing What Works: Development Interventions",
+      "url": null,
+      "status": "pending"
+    },
+    "livelihoods": {
+      "id": null,
+      "title": "Livelihoods in India: Rural, Urban, and Skills",
+      "url": null,
+      "status": "pending"
+    },
+    "nvc-rj": {
+      "id": null,
+      "title": "Nonviolence in Practice: Communication, Resistance & Repair",
+      "url": null,
+      "status": "pending"
+    },
+    "pubchoice": {
+      "id": null,
+      "title": "Public Choice: Decisions, Incentives & Institutions",
+      "url": null,
+      "status": "pending"
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Adds pending entries (`id`/`url` null, `status: pending`) to `data/notebooklm-registry.json` for the five flagships that don't yet have an AI study companion — **causal, intervention, livelihoods, nvc-rj, pubchoice** — so all 18 flagships are tracked. The URLs get filled in once the notebooks are created in NotebookLM.

Registry is management-tooling only (not rendered on the site), and the manage script tolerates null ids.

## Type of change

- [x] Documentation update / tracking

## Checklist

- [x] No console errors (registry JSON validates)
- [x] Links are working (n/a — not site-rendered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgDJcnAiEfc5NQL4DjbrJY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgDJcnAiEfc5NQL4DjbrJY)_