### PR TITLE
Tours on homepage only; center the Dataverse hero

### DIFF
--- a/dataverse.html
+++ b/dataverse.html
@@ -11,8 +11,6 @@
 <link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="/css/impact-bold.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/intro.js/8.3.2/introjs.min.css">
-<link rel="stylesheet" href="/css/tour-theme.css">
-
 <!-- Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
 <script>
@@ -404,6 +402,9 @@ img { max-width: 100%; display: block; }
     max-width: 800px;
     margin: 0 auto;
 }
+/* .ib-hero (shared CSS) resets margin to 0, which left-pins the capped hero.
+   Re-center the hero box. */
+.hero.ib-hero { margin-left: auto; margin-right: auto; }
 .hero-title {
     font-family: 'Inter', sans-serif;
     font-size: 2.8rem;
@@ -2269,13 +2270,6 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
 <!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
-<script>
-(function(){
-  var idle = ['https://cdnjs.cloudflare.com/ajax/libs/intro.js/8.3.2/intro.min.js', '/js/tours.js'];
-  function load() { idle.forEach(function(s){ var el=document.createElement('script'); el.src=s; document.body.appendChild(el); }); }
-  'requestIdleCallback' in window ? requestIdleCallback(load, {timeout:3000}) : setTimeout(load, 2000);
-})();
-</script>
 <!-- ImpactMojo Theme Toggle JS -->
 <script src="/js/theme.js"></script>
 <!-- ImpactMojo Paper Plane -->

--- a/js/tours.js
+++ b/js/tours.js
@@ -124,43 +124,11 @@
       { element: '#nav-labs', intro: '<strong>Labs</strong><br>Hands-on interactive tools — build a Theory of Change, design MEL frameworks, and more.' },
       { element: '#nav-games', intro: '<strong>Games</strong><br>Learn behavioral economics, game theory, and policy concepts through play.' },
       { element: '#nav-specials', intro: '<strong>Explore</strong><br>The Game Library, reference tools (Dataverse, ImpactLex), Book Companions, Deep Dives, the Research to Action poster series, Dojos, and more.' },
-      { element: '#nav-dataverse', intro: '<strong>Dataverse</strong><br>320 curated data tools, APIs, and datasets for development research.' },
+      { element: '#nav-dataverse', intro: '<strong>Dataverse</strong><br>321 curated data tools, APIs, and datasets for development research.' },
       { element: '.theme-selector', intro: '<strong>Theme</strong><br>Switch between light, dark, and system themes.' },
       { element: '#pro-studio', intro: '<strong>Pro Studio</strong><br>Professional-grade tools like VaniScribe AI, Code Convert Pro, and Qual Insights Lab.' }
-    ],
-
-    catalog: [
-      { intro: '<strong>Course Catalog</strong><br>Browse all courses, labs, games, and premium tools in one place.' },
-      { element: '#searchInput', intro: '<strong>Search</strong><br>Find courses by name, topic, or keyword.' },
-      { element: '.filter-tabs', intro: '<strong>Filter by Type</strong><br>Narrow down to Flagship courses, Labs, Games, or Premium tools.' },
-      { element: '.track-filters', intro: '<strong>Filter by Track</strong><br>Focus on a specific topic like MEL, Economics, or Gender Studies.' },
-      { element: '#cardsGrid', intro: '<strong>Content Cards</strong><br>Click any card to open the course, lab, or game.' }
-    ],
-
-    dataverse: [
-      { intro: '<strong>ImpactMojo Dataverse</strong><br>A curated collection of 320 data tools, APIs, datasets, and MCP servers for development work.' },
-      { element: '#searchInput', intro: '<strong>Search</strong><br>Search across all resources by name, description, or tag.' },
-      { element: '#typeFilters', intro: '<strong>Filter by Type</strong><br>Show only APIs, datasets, tools, or MCP servers.' },
-      { element: '#categoryFilters', intro: '<strong>Browse Categories</strong><br>Explore resources by domain — government data, health, climate, legal, and more.' },
-      { element: '#cardGrid', intro: '<strong>Resource Cards</strong><br>Click any card for details, links, and tags.' },
-      { element: '#statTotal', intro: '<strong>Stats</strong><br>See how many resources are available and what percentage are free.' }
-    ],
-
-    premium: [
-      { intro: '<strong>Premium Membership</strong><br>Unlock advanced AI tools, exports and expert support &mdash; while the core platform stays free forever.' },
-      { element: '.tiers', intro: '<strong>Choose your tier</strong><br>Compare what each level includes. Explorer is free forever; the paid tiers add tool exports, AI tools and certificates.' },
-      { element: '.t-pr', intro: '<strong>Most popular</strong><br>Practitioner (&#8377;399/month) unlocks all 18 Practice Packs, tool exports, the Theory of Change Workbench Pro and shareable certificates.' },
-      { element: '.t-pro', intro: '<strong>Professional</strong><br>&#8377;999/month adds the AI toolkit &mdash; Advisory Board Pro, VaniScribe, DevData (840K+ rows), the Viz Cookbook and priority coaching.' },
-      { element: '.t-team', intro: '<strong>Team Plan</strong><br>Full Professional access for your whole team, plus a dashboard, branded certificates, invoice billing and an account manager.' }
-    ],
-
-    transparency: [
-      { intro: '<strong>Transparency Dashboard</strong><br>See exactly how ImpactMojo is used — all numbers, all public.' },
-      { element: '.tier-grid', intro: '<strong>Revenue Model</strong><br>Our free vs paid tier structure and pricing.' },
-      { element: '#kpiGrid', intro: '<strong>Platform Numbers</strong><br>Cumulative users, sessions, and engagement across the platform.' },
-      { element: '#courseChart', intro: '<strong>Course Engagement</strong><br>See how each course performs over time.' },
-      { element: '#platformTable', intro: '<strong>Content Library</strong><br>Full breakdown of everything on the platform.' }
     ]
+    // Tours run on the homepage only. Do not add per-page tours here.
   };
 
   // ── Detect current page and auto-start tour ───────────────────────

--- a/premium.html
+++ b/premium.html
@@ -25,8 +25,6 @@
 <link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
 <link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/intro.js/8.3.2/introjs.min.css">
-<link rel="stylesheet" href="/css/tour-theme.css">
-
 <!-- Supabase -->
 <script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 
@@ -2363,13 +2361,6 @@ function toggleTierDetail(id) {
 <!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
 <script src="/js/search.js" defer></script>
 <script defer src="js/auto-refresh.js"></script>
-<script>
-(function(){
-  var idle = ['https://cdnjs.cloudflare.com/ajax/libs/intro.js/8.3.2/intro.min.js', '/js/tours.js'];
-  function load() { idle.forEach(function(s){ var el=document.createElement('script'); el.src=s; document.body.appendChild(el); }); }
-  'requestIdleCallback' in window ? requestIdleCallback(load, {timeout:3000}) : setTimeout(load, 2000);
-})();
-</script>
 <!-- ImpactMojo Theme Toggle JS -->
 <script src="/js/theme.js"></script>
 <script src="/js/translate-sarvam.js" defer></script>

--- a/transparency.html
+++ b/transparency.html
@@ -20,8 +20,6 @@
 <link href="https://fonts.googleapis.com/css2?family=Amaranth:wght@400;700&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="/css/impact-bold.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/intro.js/8.3.2/introjs.min.css">
-<link rel="stylesheet" href="/css/tour-theme.css">
-
 <style>
 :root {
     --primary-bg: #FFFFFF;
@@ -1408,13 +1406,6 @@ window.addEventListener('resize', function() {
         drawBarChart('toolChart', LEGACY.toolUsers, 'purple');
     }, 150);
 });
-</script>
-<script>
-(function(){
-  var idle = ['https://cdnjs.cloudflare.com/ajax/libs/intro.js/8.3.2/intro.min.js', '/js/tours.js'];
-  function load() { idle.forEach(function(s){ var el=document.createElement('script'); el.src=s; document.body.appendChild(el); }); }
-  'requestIdleCallback' in window ? requestIdleCallback(load, {timeout:3000}) : setTimeout(load, 2000);
-})();
 </script>
 <!-- ImpactMojo Theme Toggle JS -->
 <script src="/js/theme.js"></script>


### PR DESCRIPTION
## What does this PR do?

- **Tours are now homepage-only.** Removed the per-page tour definitions (catalog, dataverse, premium, transparency) from `js/tours.js`, and stripped the now-inert tour includes (intro.js loader, tours.js, tour-theme.css) from `dataverse.html`, `premium.html`, and `transparency.html`. Only the homepage runs a tour.
- **Centered the Dataverse hero.** The shared `.ib-hero` rule reset the hero's margin, which left-pinned the width-capped hero box; re-centered it with `.hero.ib-hero { margin: auto }`. Verified the box is symmetric (equal gaps both sides).
- Fixed a stale Dataverse count (320 → 321) in the homepage tour copy.

## Type of change

- [x] Bug fix (unwanted tours; hero alignment)

## Checklist

- [x] Tested on desktop browser (headless: hero centered, `node --check` on tours.js passes)
- [x] No console errors
- [x] Links are working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgDJcnAiEfc5NQL4DjbrJY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgDJcnAiEfc5NQL4DjbrJY)_