### PR TITLE
Disability flagship: per-module mini-projects + dual coach prompts

### DIFF
--- a/courses/nothing-about-us/index.html
+++ b/courses/nothing-about-us/index.html
@@ -1548,6 +1548,29 @@ body.dark-mode, [data-theme="dark"] {
         .callout-green { background: var(--callout-green); }
         .callout-gray { background: var(--callout-gray); }
         .callout-brown { background: var(--callout-brown); }
+
+        /* Per-module "Try it in your work" mini-projects */
+        .data-exercise {
+            margin: var(--spacing-xl) 0;
+            padding: 1.25rem 1.4rem;
+            background: linear-gradient(135deg, rgba(16,185,129,0.07) 0%, rgba(14,165,233,0.07) 100%);
+            border: 1px solid rgba(16,185,129,0.30);
+            border-left: 4px solid #10B981;
+            border-radius: 10px;
+        }
+        .data-exercise h4 {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-size: 1.02rem;
+            margin: 0 0 0.5rem;
+            color: var(--text-primary);
+        }
+        .data-exercise h4 svg { width: 20px; height: 20px; flex-shrink: 0; stroke: #10B981; }
+        .data-exercise p { margin: 0 0 0.6rem; color: var(--text-secondary); }
+        .data-exercise ol { margin: 0.25rem 0 0 1.25rem; padding: 0; color: var(--text-secondary); }
+        .data-exercise ol li { margin-bottom: 0.45rem; }
+        .data-exercise ol li:last-child { margin-bottom: 0; }
         
         /* Key Insight Box */
         .key-insight {


### PR DESCRIPTION
## What does this PR do?

Brings the **Nothing About Us Without Us** flagship on par with the template's coaching + project density:

- **Per-module mini-projects** — every one of the 9 modules now has a "Try it in your work" `data-exercise` (a concrete apply-to-your-programme task with 3 steps), where before only Module 9's capstone existed.
- **Dual alternating coach prompts** — every module now carries **both** Vandana and Varna (was 1/module), so the coaching alternates within each module, not just across them.
- The course content was written into the Supabase `course_content` table and is **already served live** via the `serve-course-content` edge function. This PR adds the one static piece that needs a deploy: **`.data-exercise` CSS** in the course shell (`courses/nothing-about-us/index.html`), since the shell had `coach-callout` styling but not the exercise-box styling.

Verified by rendering Module 1 against the shell styles: the mini-project renders as a styled green-accented box, and both coach prompts render (cyan name + gray message).

## Type of change

- [x] New content (course depth)

## Checklist

- [x] Tested on desktop browser (headless render of the module content)
- [x] No console errors
- [x] Links are working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgDJcnAiEfc5NQL4DjbrJY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgDJcnAiEfc5NQL4DjbrJY)_