### PR TITLE
Fix dark-mode contrast in course "Connected Resources" section

### DIFF
--- a/courses/causal/index.html
+++ b/courses/causal/index.html
@@ -2931,6 +2931,12 @@ body.dark-mode, [data-theme="dark"] {
 .resource-card a:hover{text-decoration:underline}
 @media(prefers-color-scheme:dark){
   .resources-section{background:linear-gradient(135deg,#1E293B 0%,#0F172A 100%)}
+  .resources-h2{color:#F1F5F9}
+  .resources-lead{color:#CBD5E1}
+  .resource-card-title{color:#F8FAFC}
+  .resource-card li{color:#CBD5E1}
+  .resource-card a{color:#7DD3FC}
+  .resource-card-body{color:#CBD5E1}
   .resource-card{background:#1E293B;border-color:#334155}
   .resource-card.premium{background:linear-gradient(135deg,#451a03 0%,#7c2d12 100%)}
   .resource-card.premium .resource-card-eyebrow,.resource-card.book .resource-card-eyebrow{color:#FCD34D}

--- a/courses/causal/lexicon.html
+++ b/courses/causal/lexicon.html
@@ -2818,6 +2818,12 @@ body.dark-mode, [data-theme="dark"] {
 .resource-card a:hover{text-decoration:underline}
 @media(prefers-color-scheme:dark){
   .resources-section{background:linear-gradient(135deg,#1E293B 0%,#0F172A 100%)}
+  .resources-h2{color:#F1F5F9}
+  .resources-lead{color:#CBD5E1}
+  .resource-card-title{color:#F8FAFC}
+  .resource-card li{color:#CBD5E1}
+  .resource-card a{color:#7DD3FC}
+  .resource-card-body{color:#CBD5E1}
   .resource-card{background:#1E293B;border-color:#334155}
   .resource-card.premium{background:linear-gradient(135deg,#451a03 0%,#7c2d12 100%)}
   .resource-card.premium .resource-card-eyebrow,.resource-card.book .resource-card-eyebrow{color:#FCD34D}

--- a/courses/dataviz/index.html
+++ b/courses/dataviz/index.html
@@ -2957,6 +2957,12 @@ body.dark-mode, [data-theme="dark"] {
 .resource-card a:hover{text-decoration:underline}
 @media(prefers-color-scheme:dark){
   .resources-section{background:linear-gradient(135deg,#1E293B 0%,#0F172A 100%)}
+  .resources-h2{color:#F1F5F9}
+  .resources-lead{color:#CBD5E1}
+  .resource-card-title{color:#F8FAFC}
+  .resource-card li{color:#CBD5E1}
+  .resource-card a{color:#7DD3FC}
+  .resource-card-body{color:#CBD5E1}
   .resource-card{background:#1E293B;border-color:#334155}
   .resource-card.premium{background:linear-gradient(135deg,#451a03 0%,#7c2d12 100%)}
   .resource-card.premium .resource-card-eyebrow,.resource-card.book .resource-card-eyebrow{color:#FCD34D}

--- a/courses/devai/index.html
+++ b/courses/devai/index.html
@@ -536,6 +536,12 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
 .resource-card a:hover{text-decoration:underline}
 @media(prefers-color-scheme:dark){
   .resources-section{background:linear-gradient(135deg,#1E293B 0%,#0F172A 100%)}
+  .resources-h2{color:#F1F5F9}
+  .resources-lead{color:#CBD5E1}
+  .resource-card-title{color:#F8FAFC}
+  .resource-card li{color:#CBD5E1}
+  .resource-card a{color:#7DD3FC}
+  .resource-card-body{color:#CBD5E1}
   .resource-card{background:#1E293B;border-color:#334155}
   .resource-card.premium{background:linear-gradient(135deg,#451a03 0%,#7c2d12 100%)}
   .resource-card.premium .resource-card-eyebrow,.resource-card.book .resource-card-eyebrow{color:#FCD34D}

--- a/courses/devecon/index.html
+++ b/courses/devecon/index.html
@@ -2817,6 +2817,12 @@ body.dark-mode, [data-theme="dark"] {
 .resource-card a:hover{text-decoration:underline}
 @media(prefers-color-scheme:dark){
   .resources-section{background:linear-gradient(135deg,#1E293B 0%,#0F172A 100%)}
+  .resources-h2{color:#F1F5F9}
+  .resources-lead{color:#CBD5E1}
+  .resource-card-title{color:#F8FAFC}
+  .resource-card li{color:#CBD5E1}
+  .resource-card a{color:#7DD3FC}
+  .resource-card-body{color:#CBD5E1}
   .resource-card{background:#1E293B;border-color:#334155}
   .resource-card.premium{background:linear-gradient(135deg,#451a03 0%,#7c2d12 100%)}
   .resource-card.premium .resource-card-eyebrow,.resource-card.book .resource-card-eyebrow{color:#FCD34D}

--- a/courses/gandhi/index.html
+++ b/courses/gandhi/index.html
@@ -1925,6 +1925,12 @@
 .resource-card a:hover{text-decoration:underline}
 @media(prefers-color-scheme:dark){
   .resources-section{background:linear-gradient(135deg,#1E293B 0%,#0F172A 100%)}
+  .resources-h2{color:#F1F5F9}
+  .resources-lead{color:#CBD5E1}
+  .resource-card-title{color:#F8FAFC}
+  .resource-card li{color:#CBD5E1}
+  .resource-card a{color:#7DD3FC}
+  .resource-card-body{color:#CBD5E1}
   .resource-card{background:#1E293B;border-color:#334155}
   .resource-card.premium{background:linear-gradient(135deg,#451a03 0%,#7c2d12 100%)}
   .resource-card.premium .resource-card-eyebrow,.resource-card.book .resource-card-eyebrow{color:#FCD34D}

--- a/courses/gender/index.html
+++ b/courses/gender/index.html
@@ -1582,6 +1582,12 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
 .resource-card a:hover{text-decoration:underline}
 @media(prefers-color-scheme:dark){
   .resources-section{background:linear-gradient(135deg,#1E293B 0%,#0F172A 100%)}
+  .resources-h2{color:#F1F5F9}
+  .resources-lead{color:#CBD5E1}
+  .resource-card-title{color:#F8FAFC}
+  .resource-card li{color:#CBD5E1}
+  .resource-card a{color:#7DD3FC}
+  .resource-card-body{color:#CBD5E1}
   .resource-card{background:#1E293B;border-color:#334155}
   .resource-card.premium{background:linear-gradient(135deg,#451a03 0%,#7c2d12 100%)}
   .resource-card.premium .resource-card-eyebrow,.resource-card.book .resource-card-eyebrow{color:#FCD34D}

--- a/courses/intervention/index.html
+++ b/courses/intervention/index.html
@@ -2931,6 +2931,12 @@ body.dark-mode, [data-theme="dark"] {
 .resource-card a:hover{text-decoration:underline}
 @media(prefers-color-scheme:dark){
   .resources-section{background:linear-gradient(135deg,#1E293B 0%,#0F172A 100%)}
+  .resources-h2{color:#F1F5F9}
+  .resources-lead{color:#CBD5E1}
+  .resource-card-title{color:#F8FAFC}
+  .resource-card li{color:#CBD5E1}
+  .resource-card a{color:#7DD3FC}
+  .resource-card-body{color:#CBD5E1}
   .resource-card{background:#1E293B;border-color:#334155}
   .resource-card.premium{background:linear-gradient(135deg,#451a03 0%,#7c2d12 100%)}
   .resource-card.premium .resource-card-eyebrow,.resource-card.book .resource-card-eyebrow{color:#FCD34D}

--- a/courses/intervention/lexicon.html
+++ b/courses/intervention/lexicon.html
@@ -2818,6 +2818,12 @@ body.dark-mode, [data-theme="dark"] {
 .resource-card a:hover{text-decoration:underline}
 @media(prefers-color-scheme:dark){
   .resources-section{background:linear-gradient(135deg,#1E293B 0%,#0F172A 100%)}
+  .resources-h2{color:#F1F5F9}
+  .resources-lead{color:#CBD5E1}
+  .resource-card-title{color:#F8FAFC}
+  .resource-card li{color:#CBD5E1}
+  .resource-card a{color:#7DD3FC}
+  .resource-card-body{color:#CBD5E1}
   .resource-card{background:#1E293B;border-color:#334155}
   .resource-card.premium{background:linear-gradient(135deg,#451a03 0%,#7c2d12 100%)}
   .resource-card.premium .resource-card-eyebrow,.resource-card.book .resource-card-eyebrow{color:#FCD34D}

--- a/courses/law/index.html
+++ b/courses/law/index.html
@@ -2785,6 +2785,12 @@ body.dark-mode, [data-theme="dark"] {
 .resource-card a:hover{text-decoration:underline}
 @media(prefers-color-scheme:dark){
   .resources-section{background:linear-gradient(135deg,#1E293B 0%,#0F172A 100%)}
+  .resources-h2{color:#F1F5F9}
+  .resources-lead{color:#CBD5E1}
+  .resource-card-title{color:#F8FAFC}
+  .resource-card li{color:#CBD5E1}
+  .resource-card a{color:#7DD3FC}
+  .resource-card-body{color:#CBD5E1}
   .resource-card{background:#1E293B;border-color:#334155}
   .resource-card.premium{background:linear-gradient(135deg,#451a03 0%,#7c2d12 100%)}
   .resource-card.premium .resource-card-eyebrow,.resource-card.book .resource-card-eyebrow{color:#FCD34D}

--- a/courses/livelihoods/index.html
+++ b/courses/livelihoods/index.html
@@ -2817,6 +2817,12 @@ body.dark-mode, [data-theme="dark"] {
 .resource-card a:hover{text-decoration:underline}
 @media(prefers-color-scheme:dark){
   .resources-section{background:linear-gradient(135deg,#1E293B 0%,#0F172A 100%)}
+  .resources-h2{color:#F1F5F9}
+  .resources-lead{color:#CBD5E1}
+  .resource-card-title{color:#F8FAFC}
+  .resource-card li{color:#CBD5E1}
+  .resource-card a{color:#7DD3FC}
+  .resource-card-body{color:#CBD5E1}
   .resource-card{background:#1E293B;border-color:#334155}
   .resource-card.premium{background:linear-gradient(135deg,#451a03 0%,#7c2d12 100%)}
   .resource-card.premium .resource-card-eyebrow,.resource-card.book .resource-card-eyebrow{color:#FCD34D}

--- a/courses/media/index.html
+++ b/courses/media/index.html
@@ -2817,6 +2817,12 @@ body.dark-mode, [data-theme="dark"] {
 .resource-card a:hover{text-decoration:underline}
 @media(prefers-color-scheme:dark){
   .resources-section{background:linear-gradient(135deg,#1E293B 0%,#0F172A 100%)}
+  .resources-h2{color:#F1F5F9}
+  .resources-lead{color:#CBD5E1}
+  .resource-card-title{color:#F8FAFC}
+  .resource-card li{color:#CBD5E1}
+  .resource-card a{color:#7DD3FC}
+  .resource-card-body{color:#CBD5E1}
   .resource-card{background:#1E293B;border-color:#334155}
   .resource-card.premium{background:linear-gradient(135deg,#451a03 0%,#7c2d12 100%)}
   .resource-card.premium .resource-card-eyebrow,.resource-card.book .resource-card-eyebrow{color:#FCD34D}

--- a/courses/mel/index.html
+++ b/courses/mel/index.html
@@ -2817,6 +2817,12 @@ body.dark-mode, [data-theme="dark"] {
 .resource-card a:hover{text-decoration:underline}
 @media(prefers-color-scheme:dark){
   .resources-section{background:linear-gradient(135deg,#1E293B 0%,#0F172A 100%)}
+  .resources-h2{color:#F1F5F9}
+  .resources-lead{color:#CBD5E1}
+  .resource-card-title{color:#F8FAFC}
+  .resource-card li{color:#CBD5E1}
+  .resource-card a{color:#7DD3FC}
+  .resource-card-body{color:#CBD5E1}
   .resource-card{background:#1E293B;border-color:#334155}
   .resource-card.premium{background:linear-gradient(135deg,#451a03 0%,#7c2d12 100%)}
   .resource-card.premium .resource-card-eyebrow,.resource-card.book .resource-card-eyebrow{color:#FCD34D}

--- a/courses/nothing-about-us/index.html
+++ b/courses/nothing-about-us/index.html
@@ -2840,6 +2840,12 @@ body.dark-mode, [data-theme="dark"] {
 .resource-card a:hover{text-decoration:underline}
 @media(prefers-color-scheme:dark){
   .resources-section{background:linear-gradient(135deg,#1E293B 0%,#0F172A 100%)}
+  .resources-h2{color:#F1F5F9}
+  .resources-lead{color:#CBD5E1}
+  .resource-card-title{color:#F8FAFC}
+  .resource-card li{color:#CBD5E1}
+  .resource-card a{color:#7DD3FC}
+  .resource-card-body{color:#CBD5E1}
   .resource-card{background:#1E293B;border-color:#334155}
   .resource-card.premium{background:linear-gradient(135deg,#451a03 0%,#7c2d12 100%)}
   .resource-card.premium .resource-card-eyebrow,.resource-card.book .resource-card-eyebrow{color:#FCD34D}

--- a/courses/nvc-rj/index.html
+++ b/courses/nvc-rj/index.html
@@ -2941,6 +2941,12 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 .resource-card a:hover{text-decoration:underline}
 @media(prefers-color-scheme:dark){
   .resources-section{background:linear-gradient(135deg,#1E293B 0%,#0F172A 100%)}
+  .resources-h2{color:#F1F5F9}
+  .resources-lead{color:#CBD5E1}
+  .resource-card-title{color:#F8FAFC}
+  .resource-card li{color:#CBD5E1}
+  .resource-card a{color:#7DD3FC}
+  .resource-card-body{color:#CBD5E1}
   .resource-card{background:#1E293B;border-color:#334155}
   .resource-card.premium{background:linear-gradient(135deg,#451a03 0%,#7c2d12 100%)}
   .resource-card.premium .resource-card-eyebrow,.resource-card.book .resource-card-eyebrow{color:#FCD34D}

--- a/courses/poa/index.html
+++ b/courses/poa/index.html
@@ -2891,6 +2891,12 @@ body.dark-mode, [data-theme="dark"] {
 .resource-card a:hover{text-decoration:underline}
 @media(prefers-color-scheme:dark){
   .resources-section{background:linear-gradient(135deg,#1E293B 0%,#0F172A 100%)}
+  .resources-h2{color:#F1F5F9}
+  .resources-lead{color:#CBD5E1}
+  .resource-card-title{color:#F8FAFC}
+  .resource-card li{color:#CBD5E1}
+  .resource-card a{color:#7DD3FC}
+  .resource-card-body{color:#CBD5E1}
   .resource-card{background:#1E293B;border-color:#334155}
   .resource-card.premium{background:linear-gradient(135deg,#451a03 0%,#7c2d12 100%)}
   .resource-card.premium .resource-card-eyebrow,.resource-card.book .resource-card-eyebrow{color:#FCD34D}

--- a/courses/powerBI/powerbi.html
+++ b/courses/powerBI/powerbi.html
@@ -2817,6 +2817,12 @@ body.dark-mode, [data-theme="dark"] {
 .resource-card a:hover{text-decoration:underline}
 @media(prefers-color-scheme:dark){
   .resources-section{background:linear-gradient(135deg,#1E293B 0%,#0F172A 100%)}
+  .resources-h2{color:#F1F5F9}
+  .resources-lead{color:#CBD5E1}
+  .resource-card-title{color:#F8FAFC}
+  .resource-card li{color:#CBD5E1}
+  .resource-card a{color:#7DD3FC}
+  .resource-card-body{color:#CBD5E1}
   .resource-card{background:#1E293B;border-color:#334155}
   .resource-card.premium{background:linear-gradient(135deg,#451a03 0%,#7c2d12 100%)}
   .resource-card.premium .resource-card-eyebrow,.resource-card.book .resource-card-eyebrow{color:#FCD34D}

--- a/courses/powerBI/powerbilexicon.html
+++ b/courses/powerBI/powerbilexicon.html
@@ -2818,6 +2818,12 @@ body.dark-mode, [data-theme="dark"] {
 .resource-card a:hover{text-decoration:underline}
 @media(prefers-color-scheme:dark){
   .resources-section{background:linear-gradient(135deg,#1E293B 0%,#0F172A 100%)}
+  .resources-h2{color:#F1F5F9}
+  .resources-lead{color:#CBD5E1}
+  .resource-card-title{color:#F8FAFC}
+  .resource-card li{color:#CBD5E1}
+  .resource-card a{color:#7DD3FC}
+  .resource-card-body{color:#CBD5E1}
   .resource-card{background:#1E293B;border-color:#334155}
   .resource-card.premium{background:linear-gradient(135deg,#451a03 0%,#7c2d12 100%)}
   .resource-card.premium .resource-card-eyebrow,.resource-card.book .resource-card-eyebrow{color:#FCD34D}

--- a/courses/pubchoice/index.html
+++ b/courses/pubchoice/index.html
@@ -2972,6 +2972,12 @@ body.dark-mode, [data-theme="dark"] {
 .resource-card a:hover{text-decoration:underline}
 @media(prefers-color-scheme:dark){
   .resources-section{background:linear-gradient(135deg,#1E293B 0%,#0F172A 100%)}
+  .resources-h2{color:#F1F5F9}
+  .resources-lead{color:#CBD5E1}
+  .resource-card-title{color:#F8FAFC}
+  .resource-card li{color:#CBD5E1}
+  .resource-card a{color:#7DD3FC}
+  .resource-card-body{color:#CBD5E1}
   .resource-card{background:#1E293B;border-color:#334155}
   .resource-card.premium{background:linear-gradient(135deg,#451a03 0%,#7c2d12 100%)}
   .resource-card.premium .resource-card-eyebrow,.resource-card.book .resource-card-eyebrow{color:#FCD34D}

--- a/courses/pubpol/index.html
+++ b/courses/pubpol/index.html
@@ -661,6 +661,12 @@ body.dark-mode, [data-theme="dark"] {
 .resource-card a:hover{text-decoration:underline}
 @media(prefers-color-scheme:dark){
   .resources-section{background:linear-gradient(135deg,#1E293B 0%,#0F172A 100%)}
+  .resources-h2{color:#F1F5F9}
+  .resources-lead{color:#CBD5E1}
+  .resource-card-title{color:#F8FAFC}
+  .resource-card li{color:#CBD5E1}
+  .resource-card a{color:#7DD3FC}
+  .resource-card-body{color:#CBD5E1}
   .resource-card{background:#1E293B;border-color:#334155}
   .resource-card.premium{background:linear-gradient(135deg,#451a03 0%,#7c2d12 100%)}
   .resource-card.premium .resource-card-eyebrow,.resource-card.book .resource-card-eyebrow{color:#FCD34D}

--- a/courses/sel/index.html
+++ b/courses/sel/index.html
@@ -2941,6 +2941,12 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 .resource-card a:hover{text-decoration:underline}
 @media(prefers-color-scheme:dark){
   .resources-section{background:linear-gradient(135deg,#1E293B 0%,#0F172A 100%)}
+  .resources-h2{color:#F1F5F9}
+  .resources-lead{color:#CBD5E1}
+  .resource-card-title{color:#F8FAFC}
+  .resource-card li{color:#CBD5E1}
+  .resource-card a{color:#7DD3FC}
+  .resource-card-body{color:#CBD5E1}
   .resource-card{background:#1E293B;border-color:#334155}
   .resource-card.premium{background:linear-gradient(135deg,#451a03 0%,#7c2d12 100%)}
   .resource-card.premium .resource-card-eyebrow,.resource-card.book .resource-card-eyebrow{color:#FCD34D}


### PR DESCRIPTION
## What does this PR do?

Fixes a dark-mode contrast bug in the "Connected Resources / Practice the Material & Continue Learning" cross-link section at the bottom of every flagship course.

The `@media(prefers-color-scheme:dark)` block flipped the section **background** and cards to dark navy but never overrode the **text** colors — they stayed on the light-mode `var(--text-primary/-secondary)` near-black defaults (these pages don't redefine those vars under `prefers-color-scheme`). Result: the heading, lead paragraph, card titles and card descriptions were near-invisible (dark text on dark panel), as seen on mobile in OS dark mode.

Adds light text-color overrides inside that same media query — heading, lead, card title, card body, list items, and links — across all 18 flagship shells plus their lexicon pages (**21 files**). Verified by rendering the section with the dark rules applied: every element now has readable contrast.

## Type of change

- [x] Bug fix (broken link, layout, JS error)
- [x] Accessibility improvement

## Checklist

- [x] Rendered the section in dark mode — heading, lead, titles, descriptions, links all legible
- [x] Light mode unchanged (overrides are scoped to the dark media query)
- [x] Mojibake guard passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgDJcnAiEfc5NQL4DjbrJY)_