### PR TITLE
Move WhatsApp share FAB to bottom-right so it stops covering the cookie button

### DIFF
--- a/js/site-chrome.js
+++ b/js/site-chrome.js
@@ -222,7 +222,11 @@
     a.target = '_blank'; a.rel = 'noopener noreferrer';
     a.setAttribute('aria-label', 'Share ImpactMojo on WhatsApp');
     a.title = 'Share ImpactMojo on WhatsApp';
-    a.style.cssText = 'position:fixed;left:18px;bottom:18px;z-index:9998;width:52px;height:52px;border-radius:50%;background:#25D366;box-shadow:0 6px 20px rgba(37,211,102,.45);display:flex;align-items:center;justify-content:center;text-decoration:none;transition:transform .15s ease';
+    // Bottom-RIGHT corner: the bottom-left is the cookie-consent / learning-tools
+    // speed-dial stack (see css/cookie.css) — placing the share FAB there covered
+    // the cookie button. The language switcher sits higher on the right (bottom:5.5rem),
+    // so this lower-right slot is clear on every page and viewport.
+    a.style.cssText = 'position:fixed;right:18px;bottom:18px;z-index:9998;width:52px;height:52px;border-radius:50%;background:#25D366;box-shadow:0 6px 20px rgba(37,211,102,.45);display:flex;align-items:center;justify-content:center;text-decoration:none;transition:transform .15s ease';
     a.addEventListener('mouseenter', function () { a.style.transform = 'scale(1.08)'; });
     a.addEventListener('mouseleave', function () { a.style.transform = 'scale(1)'; });
     a.innerHTML = '<svg viewBox="0 0 24 24" width="28" height="28" fill="#fff" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z"/></svg>';


### PR DESCRIPTION
## What does this PR do?

The shared WhatsApp "share ImpactMojo" button (injected by `js/site-chrome.js` on every page) was fixed at `left:18px; bottom:18px` — the same bottom-left corner as the cookie-consent widget and the learning-tools speed-dial stack. On web it sat directly on top of the cookie button, hiding it.

Moves the share FAB to `right:18px; bottom:18px`. The bottom-left stack (cookie + speed-dial) is left untouched, and the language switcher already sits higher on the right (`bottom:5.5rem`), so the lower-right slot is clear on every page and viewport. Verified by rendering all three FABs together: cookie bottom-left, WhatsApp bottom-right, language switcher stacked just above it — no overlap.

## Type of change

- [x] Bug fix (broken link, layout, JS error)

## Checklist

- [x] Rendered cookie + WhatsApp + language switcher together — no overlap, clean vertical stack on the right
- [x] Applies to all pages (single shared injector)
- [x] Mojibake guard passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgDJcnAiEfc5NQL4DjbrJY)_