### PR TITLE
v10.134.1 — Teach page findability, footer Studios label, nav cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to ImpactMojo are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.134.1] - 2026-07-19
+
+### Changed
+
+- teach.html linked from site-chrome shared footer (every page) + homepage footer Learn column; site-chrome footer "Labs" label -> "Studios".
+- Removed `nav-sampling-toolkit` from the homepage Specials menu (reachable via Studios/catalog/search).
+- handouts.html stat tile counts HTML handouts only (89), matching the hero and canonical counts.
+
 ## [10.134.0] - 2026-07-19
 
 ### For Learners

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,15 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.134.1 — July 19, 2026 (Findability follow-ups)
+
+### Changed
+
+- **Teach with ImpactMojo is now easy to find** — linked from the shared footer on every page and the homepage footer's Learn column, alongside the existing Services → For Instructors menu entry.
+- **Footer says Studios** — the shared footer's "Labs" link label updated to the new name.
+- **Sampling Toolkit left the navigation** — it's one of the 35 studios, so it now lives with the rest of them (Studios page, catalog, and search) instead of holding a top-level menu slot.
+- **Handouts page counts agree with themselves** — the stat tile now counts the same 89 HTML handouts the hero describes.
+
 ## v10.134.0 — July 19, 2026 (Studios, a fixed catalog, and a smarter starting quiz)
 
 ### For Learners

--- a/handouts.html
+++ b/handouts.html
@@ -1862,7 +1862,8 @@ async function loadHandouts() {
                 path: node.path,
                 type: type
             });
-            totalFileCount++;
+            // Count HTML handouts only, matching the hero's canonical count
+            if (type === 'html') totalFileCount++;
         });
         Object.values(groups).forEach(g => { g.subs = [...g.subs]; });
         totalCategories.textContent = Object.keys(groups).length;

--- a/index.html
+++ b/index.html
@@ -664,7 +664,6 @@ window.addEventListener('click', function(e) {
   </button>
   <ul class="dropdown-section-items">
     <li id="nav-challenges"><a href='/challenges.html' style='color: #EF4444; font-weight: 600;'><svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Crosshair_detailed"/></svg> <span data-i18n="nav.challenges">Challenges</span></a></li>
-    <li id="nav-sampling-toolkit"><a href='/labs/sampling-toolkit.html' style='color: #0EA5E9; font-weight: 600;'><svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Bar_chart"/></svg> Sampling Toolkit <span style="background:#0EA5E9;color:#fff;font-size:0.55rem;padding:0.1rem 0.35rem;border-radius:4px;margin-left:0.3rem;text-transform:uppercase;letter-spacing:0.5px;vertical-align:middle">New</span></a></li>
     <li id="nav-prostudio"><a href='/premium-tools/' style='color: #6366F1; font-weight: 600;'><svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Flare"/></svg> Pro Studio</a></li>
     <li id="nav-practicepacks"><a href='/practice-packs/' style='color: #0EA5E9; font-weight: 600;'><svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Flare"/></svg> Practice Packs <span style="background:#0EA5E9;color:#fff;font-size:0.55rem;padding:0.1rem 0.35rem;border-radius:4px;margin-left:0.3rem;text-transform:uppercase;letter-spacing:0.5px;vertical-align:middle">New</span></a></li>
   </ul>
@@ -2201,6 +2200,7 @@ window.addEventListener('authStateChanged', function(e) {
 <li><a href="/101-courses/">101 Course Decks</a></li>
 <li><a href="/labs/">All Studios</a></li>
 <li><a href="/BookSummaries/">Reading Companions</a></li>
+<li><a href="/teach.html">Teach with ImpactMojo</a></li>
 <li><a href="/catalog.html">Full Catalog</a></li>
 </ul>
 </div>

--- a/js/site-chrome.js
+++ b/js/site-chrome.js
@@ -178,7 +178,8 @@
           '<p>Free, open-source development education for South Asia &mdash; flagship courses, 101 decks, labs, games and research tools.</p></div>' +
         '<div class="im-sc-foot-col"><h4>Learn</h4>' +
           '<a href="' + SITE + '/courses/">Flagship Courses</a><a href="' + SITE + '/101-courses/">101 Series</a>' +
-          '<a href="' + SITE + '/Labs/">Labs</a><a href="' + SITE + '/catalog.html">Full Catalog</a></div>' +
+          '<a href="' + SITE + '/Labs/">Studios</a><a href="' + SITE + '/teach.html">Teach with ImpactMojo</a>' +
+          '<a href="' + SITE + '/catalog.html">Full Catalog</a></div>' +
         '<div class="im-sc-foot-col"><h4>Explore</h4>' +
           '<a href="' + SITE + '/libraries.html"><b>All Libraries</b></a><a href="' + SITE + '/dataverse.html">Dataverse</a>' +
           '<a href="' + SITE + '/BookSummaries/">Reading Companions</a><a href="' + SITE + '/dojos.html">Dojos &amp; Practice</a>' +


### PR DESCRIPTION
Follow-ups from user feedback on v10.134.0:

- **teach.html now findable**: linked from the shared site-chrome footer (every page) and the homepage footer Learn column, in addition to Services → For Instructors.
- **Shared footer label**: "Labs" → "Studios" (missed string form in the rebrand).
- **Sampling Toolkit removed from the Specials nav** — it's one of the 35 studios; reachable via the Studios index, catalog, and search.
- **handouts.html**: stat tile counted all 90 files while the hero says 89 handouts — tile now counts HTML handouts only (89), consistent with canonical.
- Reviewed all remaining card-heavy pages (game-library, handouts, timelines, practice-packs, DeepDives, BookSummaries): each already has grouped/filtered structure — no flat card walls remain after the challenges/catalog work in v10.134.0.

Verified: handouts tile renders 89 in Chromium; counts + mojibake guards PASS; `node --check` on site-chrome.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFkh8CZWfPJMqBUWuN1dYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFkh8CZWfPJMqBUWuN1dYo)_