### PR TITLE
Pricing honesty: coaching vs workshops split, real sliding scale, studios count 36

### DIFF
--- a/Labs/index.html
+++ b/Labs/index.html
@@ -3,13 +3,13 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>35 Interactive Studios — Hands-On Tools for Development Practice | ImpactMojo</title>
-<meta name="description" content="The ImpactMojo Interactive Studios — 35 free, browser-based workspaces for development practitioners. Build theories of change, MEL systems, gender analyses, policy briefs, advocacy campaigns, partnership maps and more. Free forever, your work saves to your browser.">
+<title>36 Interactive Studios — Hands-On Tools for Development Practice | ImpactMojo</title>
+<meta name="description" content="The ImpactMojo Interactive Studios — 36 free, browser-based workspaces for development practitioners. Build theories of change, MEL systems, gender analyses, policy briefs, advocacy campaigns, partnership maps and more. Free forever, your work saves to your browser.">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://www.impactmojo.in/Labs/">
 <meta property="og:type" content="website">
-<meta property="og:title" content="35 Interactive Studios — Hands-On Tools for Development Practice">
-<meta property="og:description" content="35 free, browser-based ImpactMojo Studios — theory of change, MEL systems, gender analysis, policy briefs, advocacy, partnerships and more. Free forever, work saves to your browser.">
+<meta property="og:title" content="36 Interactive Studios — Hands-On Tools for Development Practice">
+<meta property="og:description" content="36 free, browser-based ImpactMojo Studios — theory of change, MEL systems, gender analysis, policy briefs, advocacy, partnerships and more. Free forever, work saves to your browser.">
 <meta property="og:url" content="https://www.impactmojo.in/Labs/">
 <meta property="og:image" content="https://www.impactmojo.in/assets/images/og-card.png">
 <meta property="og:site_name" content="ImpactMojo">
@@ -156,7 +156,7 @@ html[data-theme="dark"] .card-badge{color:#6EE7B7}
 <section class="hero">
   <div class="hero-inner">
     <div class="hero-eyebrow">Interactive Studios &middot; Free &amp; Open</div>
-    <h1 class="hero-title">35 Interactive Studios</h1>
+    <h1 class="hero-title">36 Interactive Studios</h1>
     <p class="hero-sub">Hands-on, browser-based workspaces for South Asian development practitioners &mdash; build theories of change, design MEL systems, run gender analyses, draft policy briefs, plan advocacy campaigns, map partnerships, model risk and more. No installs, no sign-up. Free forever, and your work saves to your own browser.</p>
     <div class="hero-stats">
       <div class="hero-stat">
@@ -194,7 +194,7 @@ html[data-theme="dark"] .card-badge{color:#6EE7B7}
 </div>
 
 <main class="labs-section">
-  <div class="section-title">All 35 Interactive Studios</div>
+  <div class="section-title">All 36 Interactive Studios</div>
   <div class="lab-grid" id="labGrid">
 
 <!-- toc -->

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ We provide accessible, high-quality educational materials grounded in South Asia
 | Category | Description |
 |----------|-------------|
 | **69 Courses** | 18 flagship + 51 foundational courses across 6 learning tracks (all foundational decks self-hosted as native HTML slide decks). Every flagship ends with an auto-graded "Assess Yourself" self-check |
-| **35 Interactive Studios** | Hands-on workbenches for MEL, policy, partnerships, budgeting, gender analysis, and more |
+| **36 Interactive Studios** | Hands-on workbenches for MEL, policy, partnerships, budgeting, gender analysis, and more |
 | **135 Game Library** | 18 interactive simulations (MiroFish AI agents, Indian folk art — Warli, Madhubani, Gond, Kalamkari, Pichwai, Pattachitra) + 117 crosswords, quizzes & word searches |
 | **ImpactLex Dictionary** | 390+ development terms with contextual definitions, formulas, and case studies (PWA, hosted on ImpactMojo) |
 | **Dev Case Studies** | 200 evidence-based case studies from 117 countries |

--- a/catalog.html
+++ b/catalog.html
@@ -5,7 +5,7 @@
     |  Version: 3.1.0 - January 28, 2026                                            |
     |                                                                               |
     |  Complete catalog page with V3 design system matching index.html standards.   |
-    |  Features 69 courses (18 flagship + 51 foundational), 35 labs, 135 games, 11 premium tools, plus free tools — Game Library, Peer Review, certificate verification and a Partner API. |
+    |  Features 69 courses (18 flagship + 51 foundational), 36 labs, 135 games, 11 premium tools, plus free tools — Game Library, Peer Review, certificate verification and a Partner API. |
     |                                                                               |
     |  INCLUDED FEATURES (ALL Required Elements):                                   |
     |  [OK] Google Analytics (G-JRCMEB9TBW)                                            |
@@ -136,16 +136,16 @@ window.addEventListener('pageshow', function(event) {
 </script>
 
 <!-- SEO Meta Tags -->
-<meta name="description" content="Browse 18 flagship courses, 69 free courses, 35 interactive studios, and 135 educational games on MEAL, Theory of Change, Research Methods, Gender Studies, and more. ImpactMojo: Free development education for NGOs and impact teams across South Asia.">
+<meta name="description" content="Browse 18 flagship courses, 69 free courses, 36 interactive studios, and 135 educational games on MEAL, Theory of Change, Research Methods, Gender Studies, and more. ImpactMojo: Free development education for NGOs and impact teams across South Asia.">
 <meta property="og:title" content="Course Catalog | ImpactMojo">
-<meta property="og:description" content="Browse 18 flagship courses, 69 free courses, 35 interactive studios, and 135 educational games on MEAL, Theory of Change, Research Methods, Gender Studies, and more.">
+<meta property="og:description" content="Browse 18 flagship courses, 69 free courses, 36 interactive studios, and 135 educational games on MEAL, Theory of Change, Research Methods, Gender Studies, and more.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://www.impactmojo.in/catalog.html">
 <meta property="og:image" content="https://www.impactmojo.in/assets/images/og-card.png">
 <meta property="og:site_name" content="ImpactMojo">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Course Catalog | ImpactMojo">
-<meta name="twitter:description" content="Browse 18 flagship courses, 69 free courses, 35 interactive studios, and 135 educational games on MEAL, Theory of Change, Research Methods, Gender Studies, and more.">
+<meta name="twitter:description" content="Browse 18 flagship courses, 69 free courses, 36 interactive studios, and 135 educational games on MEAL, Theory of Change, Research Methods, Gender Studies, and more.">
 <meta name="twitter:image" content="https://www.impactmojo.in/assets/images/og-card.png">
 
 <title>Course Catalog | ImpactMojo</title>
@@ -2176,7 +2176,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                 <div class="stat-label">Courses</div>
             </div>
             <div class="stat-item">
-                <div class="stat-number" id="statStudios">35</div>
+                <div class="stat-number" id="statStudios">36</div>
                 <div class="stat-label">Studios</div>
             </div>
             <div class="stat-item">
@@ -2205,7 +2205,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
             <button class="filter-tab active" data-filter="all" aria-pressed="true">All</button>
             <button class="filter-tab" data-filter="flagship" aria-pressed="false"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Star.svg" alt="" style="width:1em;height:1em;vertical-align:-0.15em;display:inline-block;" aria-hidden="true"> Flagship (18)</button>
             <button class="filter-tab" data-filter="course" aria-pressed="false">Courses (51)</button>
-            <button class="filter-tab" data-filter="lab" aria-pressed="false">Studios (35)</button>
+            <button class="filter-tab" data-filter="lab" aria-pressed="false">Studios (36)</button>
             <button class="filter-tab" data-filter="game" aria-pressed="false">Games (18)</button>
             <button class="filter-tab" data-filter="deep-dive" aria-pressed="false"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Library_books.svg" alt="" style="width:1em;height:1em;vertical-align:-0.15em;display:inline-block;" aria-hidden="true"> Deep Dives (22)</button>
             <button class="filter-tab" data-filter="book-summary" aria-pressed="false"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Book.svg" alt="" style="width:1em;height:1em;vertical-align:-0.15em;display:inline-block;" aria-hidden="true"> Reading Companions (149)</button>
@@ -2771,7 +2771,7 @@ const allContent = [
     { id: 'lab36', type: 'lab', title: 'LogFrame Builder', description: 'Turn your Theory of Change into a donor-ready Logical Framework — results ladder, SMART indicators, means of verification, assumptions, and the classic 4×4 matrix. Imports from the ToC Workbench.', track: 'mel', rating: 4.9, users: 'New', url: '/Labs/logframe-builder-lab.html' },
     { id: 'dd21', type: 'deep-dive', title: 'Platform & Gig Work in India', description: 'A curated, annotated reading guide on platform labour — algorithmic management, social protection for gig workers, and India\'s regulatory moment.', track: 'policy', rating: 4.9, users: 'New', url: '/DeepDives/platform-gig-work-india.html' },
     { id: 'dd22', type: 'deep-dive', title: 'Water, Sanitation, and the Behaviour Gap', description: 'Why toilets get built but not used — the evidence on sanitation behaviour change, CLTS and its critics, and what actually shifts practice.', track: 'health', rating: 4.9, users: 'New', url: '/DeepDives/water-sanitation-behaviour-gap.html' },
-    { id: 'tool-sampling', type: 'tool', title: 'Sampling Toolkit', description: 'Learn the sampling ideas in plain language, then design your own plan — probability and purposive designs, sample-size logic, and a guided builder.', track: 'mel', rating: 4.9, users: 'New', url: '/Labs/sampling-toolkit.html' },
+    { id: 'tool-sampling', type: 'lab', title: 'Sampling Toolkit', description: 'Learn the sampling ideas in plain language, then design your own plan — probability and purposive designs, sample-size logic, and a guided builder.', track: 'mel', rating: 4.9, users: 'New', url: '/Labs/sampling-toolkit.html' },
     { id: 'tool-dojos', type: 'tool', title: 'Practice Dojos', description: 'A 56-session deliberate-practice programme for development practitioners — short, structured reps across the core skills.', track: 'mel', url: '/dojos.html' }
 ];
 

--- a/coaching.html
+++ b/coaching.html
@@ -1461,16 +1461,12 @@ body.dark-mode .badge-free, body.dark-mode .badge-status-live, body.dark-mode .s
             </div>
             <div>
                 <svg viewBox="0 0 24 24"><line x1="12" y1="1" x2="12" y2="23"></line><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path></svg>
-                <strong>Price:</strong> ₹6,000 (Sliding scale: ₹3,000 - ₹8,000)
+                <strong>Price:</strong> ₹12,000/cohort (Standard) · ₹15,000/cohort (Advanced) — up to 6 people
             </div>
         </div>
 
-        <a href="contact.html" class="btn btn-primary">
-            <svg viewBox="0 0 24 24">
-                <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
-                <polyline points="22,6 12,13 2,6"></polyline>
-            </svg>
-            Contact for Workshop Booking
+        <a href="/workshops.html" class="btn btn-primary">
+            Book on the Workshops page
         </a>
     </div>
 
@@ -1681,7 +1677,7 @@ function sendMessage() {
 
 function selectOption(option) {
     const responses = {
-        'pricing': 'All our services use sliding scale pricing to ensure accessibility. Career counselling starts at ₹400-2,000, Research Design at ₹1,000-3,000, and Data Analysis at ₹800-2,500. Workshops range from ₹3,000-8,000.',
+        'pricing': 'One-on-one coaching uses sliding-scale pricing: Career counselling ₹400-2,000, Research Design ₹1,000-3,000, Data Analysis ₹800-2,500. Team workshops are a separate product priced per cohort — see impactmojo.in/workshops.html.',
         'services': 'We offer: 1) Career Counselling (60 min) for development sector guidance, 2) Research Design Consultation (90 min) for methodology support, 3) Data Analysis Consultation (90 min) for statistical help, and 4) Three-Day Intensive Workshops on any course topic.',
         'booking': 'Click the "Book an appointment" button on any service card to schedule directly via Google Calendar. For workshops, use the Contact form and mention your preferred topic and dates.',
         'contact': 'You can reach us at hello@impactmojo.in for coaching inquiries, or use our Contact page for general questions. We typically respond within 24-48 hours.'
@@ -1703,7 +1699,7 @@ function generateResponse(message) {
     const lower = message.toLowerCase();
     
     if (lower.includes('price') || lower.includes('cost') || lower.includes('fee')) {
-        return 'All services use sliding scale pricing. Career counselling: ₹400-2,000, Research design: ₹1,000-3,000, Data analysis: ₹800-2,500, Workshops: ₹3,000-8,000.';
+        return 'One-on-one coaching is sliding scale: Career counselling ₹400-2,000, Research design ₹1,000-3,000, Data analysis ₹800-2,500. Team workshops are priced per cohort on the Workshops page.';
     }
     if (lower.includes('book') || lower.includes('schedule') || lower.includes('appointment')) {
         return 'Click the "Book an appointment" button on any service card to schedule via Google Calendar. For workshops, please contact us directly.';

--- a/data/counts.json
+++ b/data/counts.json
@@ -1,11 +1,11 @@
 {
-  "_comment": "Canonical content counts — the single source of truth. When content is added/removed, update the number here FIRST, then run `python3 scripts/check-counts.py` to list every file that still shows the old number. Enforced in CI (counts job in ci.yml).",
+  "_comment": "Canonical content counts \u2014 the single source of truth. When content is added/removed, update the number here FIRST, then run `python3 scripts/check-counts.py` to list every file that still shows the old number. Enforced in CI (counts job in ci.yml).",
   "courses": 69,
   "flagship-courses": 18,
   "foundational-courses": 51,
   "games": 135,
   "game-simulations": 18,
-  "labs": 35,
+  "labs": 36,
   "reading-companions": 149,
   "deep-dives": 22,
   "handouts": 89,

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,7 +6,7 @@ Common questions from educators, facilitators, and practitioners.
 
 ## Is ImpactMojo really free?
 
-Yes. All 18 flagship courses (13 modules each), 51 foundational courses, 135 learning games, 35 interactive studios, 89 handouts, the ImpactLex glossary (390+ terms), 200 Dev Case Studies, 500+ DevDiscourses papers, and interactive BookSummaries are completely free.
+Yes. All 18 flagship courses (13 modules each), 51 foundational courses, 135 learning games, 36 interactive studios, 89 handouts, the ImpactLex glossary (390+ terms), 200 Dev Case Studies, 500+ DevDiscourses papers, and interactive BookSummaries are completely free.
 
 There are paid tiers (Practitioner, Professional, and Organization) that unlock additional tools — things like advanced studio features, PDF/PNG export, AI-powered tools, and team dashboards. But the core learning experience is free and always will be.
 
@@ -104,7 +104,7 @@ Here is a straightforward comparison:
 |---------|----------------|------------------------|------------------------|-------------------------------|
 | All 69 courses | Yes | Yes | Yes | Yes |
 | 135 games | Yes | Yes | Yes | Yes |
-| 35 studios | Yes | Yes | Yes | Yes |
+| 36 studios | Yes | Yes | Yes | Yes |
 | 89 handouts | Yes | Yes | Yes | Yes |
 | ImpactLex, DevDiscourses, Case Studies | Yes | Yes | Yes | Yes |
 | Progress tracking and certificates | — | Yes | Yes | Yes |

--- a/docs/labs-guide.md
+++ b/docs/labs-guide.md
@@ -2,13 +2,13 @@
 
 ## What Are the ImpactMojo Studios?
 
-ImpactMojo offers **35 interactive studios** — hands-on workbenches where you build, design, and practice real development skills. Unlike courses (which teach concepts) or games (which simulate dynamics), studios produce **tangible outputs** — a Theory of Change diagram, a MEL plan, a policy brief — that you can export and use in your actual work.
+ImpactMojo offers **36 interactive studios** — hands-on workbenches where you build, design, and practice real development skills. Unlike courses (which teach concepts) or games (which simulate dynamics), studios produce **tangible outputs** — a Theory of Change diagram, a MEL plan, a policy brief — that you can export and use in your actual work.
 
 All studios are **free, browser-based, and require no login**.
 
 ---
 
-## The 35 Studios
+## The 36 Studios
 
 ### MEL & Research Studios
 

--- a/docs/platform-overview.md
+++ b/docs/platform-overview.md
@@ -77,7 +77,7 @@ Each game:
 
 ---
 
-## Interactive Studios (35 studios)
+## Interactive Studios (36 studios)
 
 Studios are browser-based workbenches where you build something. Unlike courses (where you read and reflect), studios are hands-on — you follow a guided workflow and produce a real output.
 
@@ -306,7 +306,7 @@ Switch languages from the platform interface. This makes ImpactMojo usable for t
 
 ## What's Free vs. Premium?
 
-The vast majority of ImpactMojo is **completely free** — this is a genuine commitment, not a marketing strategy. All 69 courses, 135 games, 35 studios, handouts, ImpactLex, case studies, DevDiscourses, and Dataverse are available at no cost.
+The vast majority of ImpactMojo is **completely free** — this is a genuine commitment, not a marketing strategy. All 69 courses, 135 games, 36 studios, handouts, ImpactLex, case studies, DevDiscourses, and Dataverse are available at no cost.
 
 Premium memberships (starting at ₹399/month) unlock additional tools, PDF/PNG export from studios, certificates, and priority access to coaching and workshops.
 

--- a/dojos.html
+++ b/dojos.html
@@ -1871,6 +1871,10 @@ body { padding-top: 70px; }
                     </select>
                 </div>
                 <div class="form-group">
+                    <label for="dojoBudget">Sliding scale — what works for you? (optional)</label>
+                    <input type="text" id="dojoBudget" name="sliding_scale_budget" placeholder="Standard is ₹1,500/session — tell us what you can manage">
+                </div>
+                <div class="form-group">
                     <label>Selected Skills</label>
                     <div class="selected-skills-display" id="selectedSkillsDisplay">Click skills above to build your learning path</div>
                     <input type="hidden" name="selected_skills" id="selectedSkillsInput">

--- a/faq.html
+++ b/faq.html
@@ -1672,7 +1672,7 @@ body.dark-mode .badge-free, body.dark-mode .badge-status-live, body.dark-mode .s
       "name": "How much content is there in total?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "69 courses (18 flagship + 51 foundational), 35 interactive studios, a 135-game library, 149 reading companions, 22 deep dives, 89 handouts, a 321-source Dataverse, and the ImpactLex glossary of 490+ terms — almost all of it free."
+        "text": "69 courses (18 flagship + 51 foundational), 36 interactive studios, a 135-game library, 149 reading companions, 22 deep dives, 89 handouts, a 321-source Dataverse, and the ImpactLex glossary of 490+ terms — almost all of it free."
       }
     },
     {
@@ -1974,7 +1974,7 @@ body.dark-mode .badge-free, body.dark-mode .badge-status-live, body.dark-mode .s
                     <svg class="faq-toggle" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
                 </div>
                 <div class="faq-answer"><div class="faq-answer-content">
-                    69 courses (18 flagship + 51 foundational), 35 interactive studios, a 135-game library, 149 reading companions, 22 deep dives, 89 handouts, a 321-source Dataverse, the ImpactLex glossary (490+ terms) and more &mdash; almost all of it free. Browse it all in the <a href="/catalog.html">catalog</a>.
+                    69 courses (18 flagship + 51 foundational), 36 interactive studios, a 135-game library, 149 reading companions, 22 deep dives, 89 handouts, a 321-source Dataverse, the ImpactLex glossary (490+ terms) and more &mdash; almost all of it free. Browse it all in the <a href="/catalog.html">catalog</a>.
                 </div></div>
             </div>
 

--- a/faq.html
+++ b/faq.html
@@ -2154,7 +2154,7 @@ body.dark-mode .badge-free, body.dark-mode .badge-status-live, body.dark-mode .s
                     <svg class="faq-toggle" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
                 </div>
                 <div class="faq-answer"><div class="faq-answer-content">
-                    <a href="/build-circles.html">Build Circles</a> are 4-week cohorts where a small group each builds a real AI-for-M&amp;E workflow and demos it &mdash; your &#8377;1,000 deposit is refunded when you demo. <a href="/coaching.html">Coaching</a> offers 1-on-1 sessions (career, research design, data analysis) and workshops on a sliding-scale, pay-what-you-can basis.
+                    <a href="/build-circles.html">Build Circles</a> are 4-week cohorts where a small group each builds a real AI-for-M&amp;E workflow and demos it &mdash; your &#8377;1,000 deposit is refunded when you demo. <a href="/coaching.html">Coaching</a> offers 1-on-1 sessions (career, research design, data analysis) on a sliding scale &mdash; every booking and interest form has an optional “what works for your budget” field, and we confirm by email, no questions asked. Team <a href="/workshops.html">workshops</a> are priced per cohort with the same sliding-scale option.
                 </div></div>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -934,7 +934,7 @@ window.addEventListener('authStateChanged', function(e) {
         <div class="v3-callout-arrow"></div>
         <div class="v3-callout-content">
             <div style="font-weight:700;font-size:0.98rem;line-height:1.5;margin-bottom:10px;">
-                <span data-i18n="benefits.content_lead">Everything free &mdash; 69 courses &middot; 135 games &middot; 35 studios &middot; 149 reading companions &amp; more</span>
+                <span data-i18n="benefits.content_lead">Everything free &mdash; 69 courses &middot; 135 games &middot; 36 studios &middot; 149 reading companions &amp; more</span>
                 <span style="display:block;font-weight:600;opacity:.75;font-size:0.86rem;margin-top:2px;" data-i18n="benefits.plus_account">&mdash; practitioner-built, and yours to keep:</span>
             </div>
             <span class="v3-benefit-item">
@@ -1124,7 +1124,7 @@ window.addEventListener('authStateChanged', function(e) {
       </a>
       <a class="tp-tile" href="/Labs/" style="--tc:#10B981">
         <span class="tp-ic"><svg viewBox="0 0 24 24"><path d="M2 12h4l3 8 4-16 3 8h6"/></svg></span>
-        <span class="tp-n">Studios <span class="tp-cnt tp-mono">35</span></span>
+        <span class="tp-n">Studios <span class="tp-cnt tp-mono">36</span></span>
         <span class="tp-d">Hands-on tools &mdash; build a Theory of Change, design a sample, and more.</span>
         <span class="tp-go">Open studios &rarr;</span>
       </a>

--- a/js/tours.js
+++ b/js/tours.js
@@ -119,10 +119,10 @@
   // keep the "<number> <type>" phrasing when editing.
   var TOURS = {
     index: [
-      { intro: '<strong>Welcome to ImpactMojo!</strong><br>Development know-how for South Asia — 69 courses, 135 games and 35 studios, all free, built by practitioners. Here’s a quick lay of the land.' },
+      { intro: '<strong>Welcome to ImpactMojo!</strong><br>Development know-how for South Asia — 69 courses, 135 games and 36 studios, all free, built by practitioners. Here’s a quick lay of the land.' },
       { element: '#nav-learn', intro: '<strong>Learn</strong><br>The heart of the platform: 69 courses (18 flagship + 51 foundational), interactive studios, and practice packs.' },
       { element: '#nav-flagships', intro: '<strong>Flagship courses</strong><br>Semester-depth courses with progress tracking, self-assessments, and free certificates — MEL, development economics, gender studies, causal inference, and more.' },
-      { element: '#nav-labs', intro: '<strong>Studios</strong><br>35 studios where you build real artefacts — a Theory of Change, a LogFrame, a sampling plan, a survey instrument.' },
+      { element: '#nav-labs', intro: '<strong>Studios</strong><br>36 studios where you build real artefacts — a Theory of Change, a LogFrame, a sampling plan, a survey instrument.' },
       { element: '#nav-specials', intro: '<strong>Explore</strong><br>The 135-game library, 149 reading companions, 22 deep dives, citation-backed timelines, and daily practice dojos.' },
       { element: '#nav-libraries', intro: '<strong>Libraries &amp; data</strong><br>Reference collections: the Dataverse of data tools, the ImpactLex glossary, NudgeKit behaviour-change techniques, and Indian policy documents.' },
       { element: '.ims-nav-btn', intro: '<strong>Search everything</strong><br>Press <kbd>Ctrl</kbd>+<kbd>K</kbd> anywhere to search across every course, studio, game and companion.' },

--- a/transparency.html
+++ b/transparency.html
@@ -726,7 +726,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                     <div class="tier-price">Paid</div>
                     <ul class="tier-features">
                         <li>Everything in Explorer</li>
-                        <li>35 interactive studios</li>
+                        <li>36 interactive studios</li>
                         <li>Premium tools (ToC Workbench, MEL Studio, etc.)</li>
                         <li>Live case challenges</li>
                         <li>Certificates &amp; portfolio builder</li>
@@ -1408,7 +1408,7 @@ function renderKPIs() {
         { label: 'Total Interactions', value: formatNum(totalAll), sub: 'Legacy + current analytics', source: 'Combined data sources', color: 'blue' },
         { label: 'Course Interactions', value: formatNum(totalCourseUsers), sub: '69 courses', source: 'Legacy records', color: 'purple' },
         { label: 'Game Interactions', value: formatNum(totalGameUsers), sub: '135 games', source: 'Legacy records', color: 'green' },
-        { label: 'Tool Interactions', value: formatNum(totalToolUsers), sub: '35 interactive studios', source: 'Legacy records', color: 'amber' }
+        { label: 'Tool Interactions', value: formatNum(totalToolUsers), sub: '36 interactive studios', source: 'Legacy records', color: 'amber' }
     ];
 
     grid.innerHTML = kpis.map(function(k) {

--- a/workshops.html
+++ b/workshops.html
@@ -1403,7 +1403,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
 
         <!-- Sliding Scale Notice -->
         <div class="sliding-scale-notice">
-            <p><strong>Sliding Scale Available:</strong> We believe financial constraints should not prevent learning. Contact us at <a href="mailto:hello@impactmojo.in">hello@impactmojo.in</a> if you need a reduced rate. Community organizations and grassroots groups are especially encouraged to reach out.</p>
+            <p><strong>Sliding Scale Available:</strong> Financial constraints should not prevent learning. Tell us what works for your budget in the booking form below — no questions asked, we'll confirm by email. Community organizations and grassroots groups are especially encouraged.</p>
         </div>
 
         <!-- Workshop Topics Card -->
@@ -1528,6 +1528,11 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                     <div class="form-group">
                         <label class="form-label" for="wf-preferred-date">Preferred Start Date <span class="required">*</span></label>
                         <input type="date" class="form-input" id="wf-preferred-date" name="preferred_date" required>
+                    </div>
+
+                    <div class="form-group full-width">
+                        <label class="form-label" for="wf-budget">Sliding scale — what works for your budget? (optional)</label>
+                        <input type="text" class="form-input" id="wf-budget" name="sliding_scale_budget" placeholder="e.g. We're a grassroots group and can manage ₹8,000 for the cohort">
                     </div>
 
                     <div class="form-group full-width">


### PR DESCRIPTION
## What

Three owner-driven honesty fixes:

1. **Coaching vs workshops are different products** (owner clarified: 1-on-1 vs one-to-many). The coaching page no longer quotes stale per-person workshop prices — it shows the real per-cohort pricing and sends booking to `/workshops.html`; chatbot replies updated.
2. **Sliding scale is now real, not just claimed.** The workshops booking form and dojo interest form carry an optional "what works for your budget" field (fits the manual UPI flow), the workshops notice points at the form, and the FAQ describes the actual mechanism.
3. **Studios count reconciled at 36.** The hub's new Sampling Toolkit card made 36 cards vs "35" everywhere else (the search index already said 36). `counts.json` labs → 36, all guard-listed occurrences fixed, catalog reclassifies the toolkit as a studio so computed counts agree.

Guards: counts PASS (15 files), internal links PASS (796 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFkh8CZWfPJMqBUWuN1dYo