### PR TITLE
v10.141.1 changelogs + memory: owner-confirmed baseline, hide-zeros rule

### DIFF
--- a/.claude/memory.md
+++ b/.claude/memory.md
@@ -25,6 +25,7 @@ Persistent context that carries across Claude Code sessions. Updated automatical
 ## Recent Decisions
 
 <!-- Append new decisions at the top -->
+- **2026-07-19 — Legacy baseline is OWNER-CONFIRMED (do not re-derive)**: public_stats_baseline now holds courses_started=120,700 (legacy cumulative course users), courses_completed=727, certificates_issued=468 (both from owner's Excel), learning_minutes=785,160 (owner-approved estimate: 727×~18h×60). Corrections = UPDATE the table row, NO redeploy. Rule: transparency tiles HIDE when total=0 (uninstrumented ≠ zero). auth.js pings profiles.last_active_at daily (key im-activity-ping).
 - **2026-07-19 — Post-merge deploy verification is mandatory**: Netlify dropped the v10.141.0 merge webhook (previews built, production silently stale). `scripts/verify-deploy.py` polls for the production deploy of origin/main HEAD and auto-triggers a manual build via the API if none starts within the grace window. Run it after every merge (documented in rules/testing.md ship checklist).
 - **2026-07-19 — Offline course downloads stay FREE (user decision)**: no premium gating; matches FAQ/offline-page promises. Also: papers stay on Dropbox (copyright/size), lexicon xlsx now first-party in courses/*/.
 - **2026-07-19 — NO AUTOMATED PAYMENTS, EVER (user decision)**: gateway fees too expensive; manual UPI + email reconciliation is permanent. Never re-suggest payment gateways, webhooks, or "instant fulfilment" automation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to ImpactMojo are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.141.1] - 2026-07-19
+
+### Fixed
+
+- **Transparency live numbers corrected** (owner report: only "40 registered" was right). Root causes: engagement metrics were never backfilled into `public_stats_baseline`, and nothing wrote `profiles.last_active_at`. Now: `get_public_stats()` v3 returns all-time totals (baseline + live DB) per the documented methodology; owner's legacy numbers backfilled live (courses started 120,700; completed 727; certificates 468; learning minutes 785,160 — owner-approved estimate of 727 × ~18h); the card hides any metric whose total is 0 instead of presenting an uninstrumented zero as fact; `auth.js` pings `last_active_at` daily so "Active in last 30 days" measures something real.
+- **Deploy webhook fallback** — `scripts/verify-deploy.py` polls for the production deploy of the merged commit and auto-triggers a manual Netlify build if the webhook is dropped (as happened to v10.141.0). Mandatory ship-checklist step in `rules/testing.md`.
+
 ## [10.141.0] - 2026-07-19
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.141.1 — July 19, 2026 (The numbers are right now)
+
+### For Learners
+
+- **The transparency page now shows true all-time numbers** — 120,700 courses started, 727 completed, 468 certificates earned, and ~13,000 learning hours across the platform's whole history, combined from our legacy records and the live database. If a metric has no reliable data yet, we hide it rather than show a misleading zero.
+
 ## v10.141.0 — July 19, 2026 (Faster everywhere, safer sources, honest numbers)
 
 ### For Learners


### PR DESCRIPTION
Documentation follow-up to #830: changelog entries (technical + learner-facing) for the corrected transparency numbers and deploy verifier, and a memory decision note that the legacy baseline is owner-confirmed (120,700 / 727 / 468 / est. 785,160 min) with the hide-uninstrumented-zeros rule — so no future session re-derives or second-guesses these values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFkh8CZWfPJMqBUWuN1dYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFkh8CZWfPJMqBUWuN1dYo)_