### PR TITLE
Routine: fix stale Studios count (35→36) in guard blind spots

### DIFF
--- a/Labs/index.html
+++ b/Labs/index.html
@@ -14,8 +14,8 @@
 <meta property="og:image" content="https://www.impactmojo.in/assets/images/og-card.png">
 <meta property="og:site_name" content="ImpactMojo">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="35 ImpactMojo Interactive Studios">
-<meta name="twitter:description" content="35 free, browser-based hands-on studios for development practice. Free forever, work saves to your browser.">
+<meta name="twitter:title" content="36 ImpactMojo Interactive Studios">
+<meta name="twitter:description" content="36 free, browser-based hands-on studios for development practice. Free forever, work saves to your browser.">
 <meta name="twitter:image" content="https://www.impactmojo.in/assets/images/og-card.png">
 
 <!-- Google Analytics -->

--- a/about.html
+++ b/about.html
@@ -2088,7 +2088,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                     <div class="stat-label">Courses</div>
                 </div>
                 <div class="stat-card">
-                    <div class="stat-number">35</div>
+                    <div class="stat-number">36</div>
                     <div class="stat-label">Interactive Studios</div>
                 </div>
                 <div class="stat-card">

--- a/teach.html
+++ b/teach.html
@@ -1389,7 +1389,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
     <div class="container">
         
 <section style="max-width:900px;margin:0 auto;padding:1rem 0 0;">
-  <p style="font-size:1.05rem;line-height:1.7;">ImpactMojo is already a complete teaching stack: <strong>18 flagship courses</strong> with auto-graded self-checks, <strong>51 foundational slide decks</strong>, <strong>35 interactive studios</strong>, <strong>135 games</strong>, live case challenges, timelines and reading companions — free, South Asia-first, and usable without logins. This page shows you how to teach with it.</p>
+  <p style="font-size:1.05rem;line-height:1.7;">ImpactMojo is already a complete teaching stack: <strong>18 flagship courses</strong> with auto-graded self-checks, <strong>51 foundational slide decks</strong>, <strong>36 interactive studios</strong>, <strong>135 games</strong>, live case challenges, timelines and reading companions — free, South Asia-first, and usable without logins. This page shows you how to teach with it.</p>
 </section>
 
 <section style="max-width:900px;margin:2rem auto 0;">

--- a/transparency.html
+++ b/transparency.html
@@ -1145,7 +1145,7 @@ var LEGACY = {
     platform: {
         'Flagship Courses': 18,
         'Total Free Courses': 69,
-        'Interactive Studios': 35,
+        'Interactive Studios': 36,
         'Educational Games': 135,
         'Premium Tools': 13,
         'Live Case Challenges': 15,
@@ -1235,7 +1235,7 @@ var LEGACY = {
     features: [
         { name: 'Courses (69 total)', type: 'Learning', users: 120700, status: 'Active' },
         { name: 'Games (135 total)', type: 'Engagement', users: 35400, status: 'Active' },
-        { name: 'Interactive Studios (35)', type: 'Hands-on', users: 43880, status: 'Active' },
+        { name: 'Interactive Studios (36)', type: 'Hands-on', users: 43880, status: 'Active' },
         { name: 'Live Challenges', type: 'Assessment', users: '', status: 'Active' },
         { name: 'Portfolio Builder', type: 'Credentialing', users: '', status: 'Active' },
         { name: 'Certificate Verify', type: 'Credentialing', users: '', status: 'Active' },


### PR DESCRIPTION
Autonomous maintenance routine (count-drift) → shepherded to PR.

Canonical count is `data/counts.json: /labs = 36`. Four locations display a stale `35` in places `check-counts.py` does not scan (its blind spots), so CI passes while these are wrong:

- `Labs/index.html` — twitter:title / twitter:description
- `about.html` — Interactive Studios stat-card
- `teach.html` — teaching-stack prose
- `transparency.html` — LEGACY platform + features data

Verified: canonical = 36, `check-counts.py` still PASSes. Low risk, display-text only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFkh8CZWfPJMqBUWuN1dYo)_