### PR TITLE
Routine: wire up Livelihoods course lexicon links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to ImpactMojo are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.144.0] - 2026-07-20
+
+### Fixed
+
+- **Livelihoods lexicon was unreachable from the course page**: `courses/livelihoods/lexicon.html` (53 terms) shipped in v10.136.0 alongside the Media and Power BI lexicons, but only those two got linked — the Livelihoods course sidebar, hero resource row, and its `courses/index.html` card never pointed to it. Added all three links; card-meta now shows "53 lexicon terms" like the other 17 flagships.
+
 ## [10.143.0] - 2026-07-19
 
 ### Fixed

--- a/courses/index.html
+++ b/courses/index.html
@@ -324,7 +324,7 @@ html,body{font-family:var(--font-body);color:var(--ink);background:var(--paper);
   <div class="card-track">Economics &amp; Policy</div>
   <div class="card-title">Livelihoods in India: Rural, Urban, and Skills</div>
   <div class="card-desc">A comprehensive flagship on Indian livelihoods &mdash; rural (NRLM, SHGs, agriculture), urban (informal work, gig economy, vendors), and skills (Skill India, FLFPR). Evidence-driven and practitioner-oriented.</div>
-  <div class="card-meta"><span>17 modules</span> &middot; <span>Self-paced</span> &middot; <span>India-centred</span></div>
+  <div class="card-meta"><span>17 modules</span> &middot; <span>53 lexicon terms</span> &middot; <span>Self-paced</span> &middot; <span>India-centred</span></div>
   <div class="card-outline-wrap">
     <button class="card-outline-toggle" aria-expanded="false">Course outline (17 modules)<span class="chev" aria-hidden="true">&#9662;</span></button>
     <ol class="card-outline-list">
@@ -349,6 +349,7 @@ html,body{font-family:var(--font-body);color:var(--ink);background:var(--paper);
   </div>
   <div class="card-actions">
     <a class="card-cta" href="/courses/livelihoods/">Open course &rarr;</a>
+    <a class="card-lexicon" href="/courses/livelihoods/lexicon.html">Lexicon</a>
   </div>
 </div>
 

--- a/courses/livelihoods/index.html
+++ b/courses/livelihoods/index.html
@@ -3268,6 +3268,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                     <div class="nav-section-title">Overview</div>
                     <a href="#hero" class="nav-link active"><span class="nav-link-number">&rarr;</span>Introduction</a>
                     <a href="#framing" class="nav-link"><span class="nav-link-number"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Map.svg" alt="" class="nav-icon"></span>Framing the Field</a>
+                    <a href="lexicon.html" class="nav-link"><span class="nav-link-number"><img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.6/Icons/Line/si_Flare.svg" alt="" class="nav-icon"></span>Lexicon (53 Terms)</a>
                 </div>
                 <div class="nav-section">
                     <div class="nav-section-title">Part 1 &middot; Rural</div>
@@ -3328,6 +3329,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
                         <a href="#framing" class="hero-resource-btn"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg> Start the Course</a>
                         <a href="https://www.impactmojo.in/courses/devecon/" class="hero-resource-btn"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/></svg> Companion: Dev Economics</a>
                         <a href="https://www.impactmojo.in/courses/mel/" class="hero-resource-btn"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg> Companion: MEL</a>
+                        <a class='hero-resource-btn' href='lexicon.html'><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/></svg> Interactive Lexicon</a>
                     </div>
                     <div class="stat-grid">
                         <div class="stat-card"><span class="stat-num">~90%</span><div class="stat-label">Workers in informal employment (ILO India Employment Report 2024)</div></div>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.144.0 — July 20, 2026 (Livelihoods lexicon now reachable)
+
+### For Learners
+
+- **The Livelihoods course lexicon is linked at last** — the 53-term interactive glossary has existed since v10.136.0, but the course page never linked to it. It's now in the sidebar and resource bar, same as every other flagship.
+
 ## v10.141.1 — July 19, 2026 (The numbers are right now)
 
 ### For Learners


### PR DESCRIPTION
Autonomous maintenance routine (new-content wiring check) → shepherded to PR.

`courses/livelihoods/lexicon.html` (53 terms) shipped in v10.136.0 but was never linked from the course page or catalog card. Adds:

- sidebar nav link + hero resource button on `courses/livelihoods/index.html`
- Lexicon action + "53 lexicon terms" meta on the `courses/index.html` card
- changelog entries (v10.144.0)

Verified: target `courses/livelihoods/lexicon.html` exists on main (53KB). Low risk, additive links only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFkh8CZWfPJMqBUWuN1dYo)_