### PR TITLE
NotebookLM study-companion kit for all 19 flagships (prompts + readings + generator)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,6 @@ __pycache__/
 /downloads/*.pdf
 i18n/_*.json
 scratchpad/
+
+# NotebookLM full source packs — regenerated from DB, not committed (anti-fork)
+notebooklm/packs/

--- a/docs/notebooklm-setup.md
+++ b/docs/notebooklm-setup.md
@@ -81,3 +81,7 @@ notebooklm audio <notebook-id>           # Generate audio overview
 - **Interactive auth** — `notebooklm login` requires a browser, cannot run in CI/headless
 - **Per-machine credentials** — auth tokens are stored locally, not in the repo
 - **Rate limits** — Google may throttle requests; avoid rapid-fire operations
+
+## Study-companion kit (prompts + source packs)
+
+Reusable prompts and cited-readings lists for every flagship live in `notebooklm/` (built by `scripts/notebooklm-build-pack.py`). See `notebooklm/README.md`. Full source packs are generated locally and git-ignored (course content is DB-backed / anti-fork).

--- a/notebooklm/README.md
+++ b/notebooklm/README.md
@@ -1,0 +1,26 @@
+# NotebookLM AI Study Companion kit
+
+Reusable prompts + source material to build a NotebookLM "AI Study Companion" for
+every ImpactMojo flagship course. Generated from the live course content by
+`scripts/notebooklm-build-pack.py`.
+
+## What's here
+- `prompts/<slug>.md` — a ready-to-use study-companion + audio-overview steering prompt, plus suggested seed questions, per flagship. **Committed.**
+- `readings/<slug>.md` — the open-access readings cited across the course, as ready-to-run `add-source` commands. **Committed.**
+- `packs/<slug>-source-pack.md` — the full course text (all modules) to upload to NotebookLM. **Git-ignored** — course content is DB-backed on purpose (anti-fork); regenerate locally when needed.
+
+## Regenerate
+```bash
+set -a; . .claude/.env.keys; set +a          # needs SUPABASE_PAT
+python3 scripts/notebooklm-build-pack.py                 # all flagships
+python3 scripts/notebooklm-build-pack.py social-movements # one course
+```
+
+## Create a notebook for a course (per docs/notebooklm-setup.md)
+1. `notebooklm login` (one-time Google OAuth, on your machine — not CI/sandbox).
+2. Create the notebook in NotebookLM; upload `packs/<slug>-source-pack.md`.
+3. Add the cited readings: run the `add-source` commands in `readings/<slug>.md`.
+4. Paste the `prompts/<slug>.md` audio-overview steering prompt into NotebookLM's "Customise".
+5. Register it: add `<slug>` → notebook-id to `data/notebooklm-registry.json`, put the share
+   URL in the course shell's "AI Study Companion" button, then optionally
+   `python3 scripts/notebooklm-manage.py generate-audio <slug>`.

--- a/notebooklm/prompts/SEL.md
+++ b/notebooklm/prompts/SEL.md
@@ -1,0 +1,22 @@
+# Social & Emotional Learning — NotebookLM study-companion prompt
+
+**Course:** Social & Emotional Learning (ImpactMojo flagship, 13 modules). South Asia-first development education for practitioners, students and educators.
+
+## 1. Sources to load
+Upload `notebooklm/packs/SEL-source-pack.md` and add the cited readings in `notebooklm/readings/SEL.md`.
+
+## 2. Audio Overview steering prompt (paste into NotebookLM's "Customise")
+> Create a ~12-minute study-companion overview for a practitioner audience. Ground every concept in the course's South Asian examples and cited evidence — do not invent statistics or cases. Move module by module across: What is Social-Emotional Learning?; Self-Awareness & Emotional Literacy; Self-Management & Emotional Regulation; Social Awareness, Empathy & Perspective-Taking; Relationship Skills & Communication; Responsible Decision-Making in Complex Systems; SEL in Indian Education Policy; Facilitation Skills for Development Practitioners; Trauma-Informed Development Practice; Conflict Resolution & Peacebuilding; Practitioner Wellbeing & Burnout Prevention; Measuring SEL Outcomes. For each, give the core idea, one concrete South Asian example from the sources, and one "use it in your work" takeaway. Close with the capstone challenge. Keep the tone rigorous but accessible; define jargon on first use.
+
+## 3. Suggested questions to seed the notebook
+- What is the single most important idea in this course, and what evidence supports it?
+- Summarise each module in two sentences: the concept and its South Asian application.
+- Which cited readings should I go to first, and why?
+- Turn the capstone into a step-by-step plan I can apply to my own work.
+- Quiz me with 10 questions across the whole course, then mark my answers.
+- Where do the sources disagree or leave open questions?
+
+## 4. Wire-up (maintainer)
+After creating the notebook, register it: add `SEL` -> notebook-id to `data/notebooklm-registry.json`,
+put the share URL in the course shell's AI Study Companion button, then optionally
+`python3 scripts/notebooklm-manage.py generate-audio SEL`.

--- a/notebooklm/prompts/causal.md
+++ b/notebooklm/prompts/causal.md
@@ -1,0 +1,22 @@
+# Causal Inference & Impact Evaluation — NotebookLM study-companion prompt
+
+**Course:** Causal Inference & Impact Evaluation (ImpactMojo flagship, 13 modules). South Asia-first development education for practitioners, students and educators.
+
+## 1. Sources to load
+Upload `notebooklm/packs/causal-source-pack.md` and add the cited readings in `notebooklm/readings/causal.md`.
+
+## 2. Audio Overview steering prompt (paste into NotebookLM's "Customise")
+> Create a ~12-minute study-companion overview for a practitioner audience. Ground every concept in the course's South Asian examples and cited evidence — do not invent statistics or cases. Move module by module across: The Counterfactual Problem; Selection Bias and the Identifying Assumption; Causal Graphs: Confounders, Colliders, and Bad Controls; Randomisation and the RCT; Matching and Propensity Scores; Instrumental Variables; Regression Discontinuity; Difference-in-Differences; Synthetic Control; Causal Machine Learning; Reading and Interrogating an Evaluation; When There Is No Counterfactual. For each, give the core idea, one concrete South Asian example from the sources, and one "use it in your work" takeaway. Close with the capstone challenge. Keep the tone rigorous but accessible; define jargon on first use.
+
+## 3. Suggested questions to seed the notebook
+- What is the single most important idea in this course, and what evidence supports it?
+- Summarise each module in two sentences: the concept and its South Asian application.
+- Which cited readings should I go to first, and why?
+- Turn the capstone into a step-by-step plan I can apply to my own work.
+- Quiz me with 10 questions across the whole course, then mark my answers.
+- Where do the sources disagree or leave open questions?
+
+## 4. Wire-up (maintainer)
+After creating the notebook, register it: add `causal` -> notebook-id to `data/notebooklm-registry.json`,
+put the share URL in the course shell's AI Study Companion button, then optionally
+`python3 scripts/notebooklm-manage.py generate-audio causal`.

--- a/notebooklm/prompts/dataviz.md
+++ b/notebooklm/prompts/dataviz.md
@@ -1,0 +1,22 @@
+# Data Visualization — NotebookLM study-companion prompt
+
+**Course:** Data Visualization (ImpactMojo flagship, 12 modules). South Asia-first development education for practitioners, students and educators.
+
+## 1. Sources to load
+Upload `notebooklm/packs/dataviz-source-pack.md` and add the cited readings in `notebooklm/readings/dataviz.md`.
+
+## 2. Audio Overview steering prompt (paste into NotebookLM's "Customise")
+> Create a ~12-minute study-companion overview for a practitioner audience. Ground every concept in the course's South Asian examples and cited evidence — do not invent statistics or cases. Move module by module across: Why Visualize? Purpose & Principles; Data Types & Quality Structures & Challenges; Visual Encoding Graphical Perception; Color & Accessibility Inclusive Design; Chart Selection Frameworks & Common Mistakes; Design Process Style Guides & Iteration; Storytelling Narrative & Audience; Tool Landscape Selection & Evaluation; Interactive Visualization Web & Dynamic; M&E Dashboards Development Applications; Advanced Topics Specialized Approaches; Capstone Project Portfolio Development. For each, give the core idea, one concrete South Asian example from the sources, and one "use it in your work" takeaway. Close with the capstone challenge. Keep the tone rigorous but accessible; define jargon on first use.
+
+## 3. Suggested questions to seed the notebook
+- What is the single most important idea in this course, and what evidence supports it?
+- Summarise each module in two sentences: the concept and its South Asian application.
+- Which cited readings should I go to first, and why?
+- Turn the capstone into a step-by-step plan I can apply to my own work.
+- Quiz me with 10 questions across the whole course, then mark my answers.
+- Where do the sources disagree or leave open questions?
+
+## 4. Wire-up (maintainer)
+After creating the notebook, register it: add `dataviz` -> notebook-id to `data/notebooklm-registry.json`,
+put the share URL in the course shell's AI Study Companion button, then optionally
+`python3 scripts/notebooklm-manage.py generate-audio dataviz`.

--- a/notebooklm/prompts/devai.md
+++ b/notebooklm/prompts/devai.md
@@ -1,0 +1,22 @@
+# Development & AI — NotebookLM study-companion prompt
+
+**Course:** Development & AI (ImpactMojo flagship, 12 modules). South Asia-first development education for practitioners, students and educators.
+
+## 1. Sources to load
+Upload `notebooklm/packs/devai-source-pack.md` and add the cited readings in `notebooklm/readings/devai.md`.
+
+## 2. Audio Overview steering prompt (paste into NotebookLM's "Customise")
+> Create a ~12-minute study-companion overview for a practitioner audience. Ground every concept in the course's South Asian examples and cited evidence — do not invent statistics or cases. Move module by module across: The AI-M&E Landscape; Needs Assessment for AI Integration; AI for Data Collection; Computer Vision & Geospatial Analysis; NLP for Qualitative Data; Algorithmic Targeting & Beneficiary Selection; Real-Time Monitoring & Anomaly Detection; AI for Adaptive Programming; The Limits of AI in Causal Inference; Ethics, Bias & Accountability; Context Assessment: Case Studies; Strategy Building: Build vs. Buy, Pilot Design, Sustainability. For each, give the core idea, one concrete South Asian example from the sources, and one "use it in your work" takeaway. Close with the capstone challenge. Keep the tone rigorous but accessible; define jargon on first use.
+
+## 3. Suggested questions to seed the notebook
+- What is the single most important idea in this course, and what evidence supports it?
+- Summarise each module in two sentences: the concept and its South Asian application.
+- Which cited readings should I go to first, and why?
+- Turn the capstone into a step-by-step plan I can apply to my own work.
+- Quiz me with 10 questions across the whole course, then mark my answers.
+- Where do the sources disagree or leave open questions?
+
+## 4. Wire-up (maintainer)
+After creating the notebook, register it: add `devai` -> notebook-id to `data/notebooklm-registry.json`,
+put the share URL in the course shell's AI Study Companion button, then optionally
+`python3 scripts/notebooklm-manage.py generate-audio devai`.

--- a/notebooklm/prompts/devecon.md
+++ b/notebooklm/prompts/devecon.md
@@ -1,0 +1,22 @@
+# Development Economics — NotebookLM study-companion prompt
+
+**Course:** Development Economics (ImpactMojo flagship, 13 modules). South Asia-first development education for practitioners, students and educators.
+
+## 1. Sources to load
+Upload `notebooklm/packs/devecon-source-pack.md` and add the cited readings in `notebooklm/readings/devecon.md`.
+
+## 2. Audio Overview steering prompt (paste into NotebookLM's "Customise")
+> Create a ~12-minute study-companion overview for a practitioner audience. Ground every concept in the course's South Asian examples and cited evidence — do not invent statistics or cases. Move module by module across: What is Development?; Measuring Development; Poverty & Inequality; Growth Models; Agriculture & Rural Development; Industrialization & Structural Change; Education & Human Capital; Health & Nutrition; Credit & Financial Inclusion; Trade & Globalization; Institutions & Governance; Policy Evaluation & the RCT Revolution. For each, give the core idea, one concrete South Asian example from the sources, and one "use it in your work" takeaway. Close with the capstone challenge. Keep the tone rigorous but accessible; define jargon on first use.
+
+## 3. Suggested questions to seed the notebook
+- What is the single most important idea in this course, and what evidence supports it?
+- Summarise each module in two sentences: the concept and its South Asian application.
+- Which cited readings should I go to first, and why?
+- Turn the capstone into a step-by-step plan I can apply to my own work.
+- Quiz me with 10 questions across the whole course, then mark my answers.
+- Where do the sources disagree or leave open questions?
+
+## 4. Wire-up (maintainer)
+After creating the notebook, register it: add `devecon` -> notebook-id to `data/notebooklm-registry.json`,
+put the share URL in the course shell's AI Study Companion button, then optionally
+`python3 scripts/notebooklm-manage.py generate-audio devecon`.

--- a/notebooklm/prompts/gandhi.md
+++ b/notebooklm/prompts/gandhi.md
@@ -1,0 +1,22 @@
+# Gandhi & Nonviolence — NotebookLM study-companion prompt
+
+**Course:** Gandhi & Nonviolence (ImpactMojo flagship, 13 modules). South Asia-first development education for practitioners, students and educators.
+
+## 1. Sources to load
+Upload `notebooklm/packs/gandhi-source-pack.md` and add the cited readings in `notebooklm/readings/gandhi.md`.
+
+## 2. Audio Overview steering prompt (paste into NotebookLM's "Customise")
+> Create a ~12-minute study-companion overview for a practitioner audience. Ground every concept in the course's South Asian examples and cited evidence — do not invent statistics or cases. Move module by module across: What is Politics?; Swaraj स्वराज; Satya & Ahimsa सत्य अहिंसा; Satyagraha सत्याग्रह; Constructive Programme रचनात्मक कार्यक्रम; Tapasya & Suffering तपस्या; Swadeshi & Khadi स्वदेशी खादी; Trusteeship न्यासधारिता; Gram Swaraj ग्राम स्वराज; The Karyakarta कार्यकर्ता; Communal Harmony साम्प्रदायिक एकता; Contemporary Applications समकालीन प्रयोग. For each, give the core idea, one concrete South Asian example from the sources, and one "use it in your work" takeaway. Close with the capstone challenge. Keep the tone rigorous but accessible; define jargon on first use.
+
+## 3. Suggested questions to seed the notebook
+- What is the single most important idea in this course, and what evidence supports it?
+- Summarise each module in two sentences: the concept and its South Asian application.
+- Which cited readings should I go to first, and why?
+- Turn the capstone into a step-by-step plan I can apply to my own work.
+- Quiz me with 10 questions across the whole course, then mark my answers.
+- Where do the sources disagree or leave open questions?
+
+## 4. Wire-up (maintainer)
+After creating the notebook, register it: add `gandhi` -> notebook-id to `data/notebooklm-registry.json`,
+put the share URL in the course shell's AI Study Companion button, then optionally
+`python3 scripts/notebooklm-manage.py generate-audio gandhi`.

--- a/notebooklm/prompts/gender.md
+++ b/notebooklm/prompts/gender.md
@@ -1,0 +1,22 @@
+# Gender & Development — NotebookLM study-companion prompt
+
+**Course:** Gender & Development (ImpactMojo flagship, 16 modules). South Asia-first development education for practitioners, students and educators.
+
+## 1. Sources to load
+Upload `notebooklm/packs/gender-source-pack.md` and add the cited readings in `notebooklm/readings/gender.md`.
+
+## 2. Audio Overview steering prompt (paste into NotebookLM's "Customise")
+> Create a ~12-minute study-companion overview for a practitioner audience. Ground every concept in the course's South Asian examples and cited evidence — do not invent statistics or cases. Move module by module across: What is Gender?; History of Feminist Thought; Intersectionality; Political Economy of Gender; Care Work &amp; Social Reproduction; Gender &amp; Labour Markets; Personal Laws &amp; Legal Pluralism; Sexual Violence, Law &amp; Justice; Women's Political Representation; Women's Movements in India; Gender &amp; Caste; Masculinities &amp; Non-Conforming Identities. For each, give the core idea, one concrete South Asian example from the sources, and one "use it in your work" takeaway. Close with the capstone challenge. Keep the tone rigorous but accessible; define jargon on first use.
+
+## 3. Suggested questions to seed the notebook
+- What is the single most important idea in this course, and what evidence supports it?
+- Summarise each module in two sentences: the concept and its South Asian application.
+- Which cited readings should I go to first, and why?
+- Turn the capstone into a step-by-step plan I can apply to my own work.
+- Quiz me with 10 questions across the whole course, then mark my answers.
+- Where do the sources disagree or leave open questions?
+
+## 4. Wire-up (maintainer)
+After creating the notebook, register it: add `gender` -> notebook-id to `data/notebooklm-registry.json`,
+put the share URL in the course shell's AI Study Companion button, then optionally
+`python3 scripts/notebooklm-manage.py generate-audio gender`.

--- a/notebooklm/prompts/intervention.md
+++ b/notebooklm/prompts/intervention.md
@@ -1,0 +1,22 @@
+# Intervention Design — NotebookLM study-companion prompt
+
+**Course:** Intervention Design (ImpactMojo flagship, 14 modules). South Asia-first development education for practitioners, students and educators.
+
+## 1. Sources to load
+Upload `notebooklm/packs/intervention-source-pack.md` and add the cited readings in `notebooklm/readings/intervention.md`.
+
+## 2. Audio Overview steering prompt (paste into NotebookLM's "Customise")
+> Create a ~12-minute study-companion overview for a practitioner audience. Ground every concept in the course's South Asian examples and cited evidence — do not invent statistics or cases. Move module by module across: The Intervention Mindset; Diagnosing the Problem; Theory of Change as a Design Instrument; Cash — Transfers, Targeting & Delivery Rails; Bundles & Sequencing — The Graduation Approach; Human Infrastructure — Frontline Workers & the Last Mile; Institutions of the Poor — SHGs, Federations & Collective Models; Getting the Level Right — Service-Delivery Redesign; The Delivery Chain; Incentives, Targeting & Cost-Effectiveness; Why Things Don't Scale — The Voltage Effect; Pathways to Scale. For each, give the core idea, one concrete South Asian example from the sources, and one "use it in your work" takeaway. Close with the capstone challenge. Keep the tone rigorous but accessible; define jargon on first use.
+
+## 3. Suggested questions to seed the notebook
+- What is the single most important idea in this course, and what evidence supports it?
+- Summarise each module in two sentences: the concept and its South Asian application.
+- Which cited readings should I go to first, and why?
+- Turn the capstone into a step-by-step plan I can apply to my own work.
+- Quiz me with 10 questions across the whole course, then mark my answers.
+- Where do the sources disagree or leave open questions?
+
+## 4. Wire-up (maintainer)
+After creating the notebook, register it: add `intervention` -> notebook-id to `data/notebooklm-registry.json`,
+put the share URL in the course shell's AI Study Companion button, then optionally
+`python3 scripts/notebooklm-manage.py generate-audio intervention`.

--- a/notebooklm/prompts/law.md
+++ b/notebooklm/prompts/law.md
@@ -1,0 +1,22 @@
+# Law & Justice — NotebookLM study-companion prompt
+
+**Course:** Law & Justice (ImpactMojo flagship, 13 modules). South Asia-first development education for practitioners, students and educators.
+
+## 1. Sources to load
+Upload `notebooklm/packs/law-source-pack.md` and add the cited readings in `notebooklm/readings/law.md`.
+
+## 2. Audio Overview steering prompt (paste into NotebookLM's "Customise")
+> Create a ~12-minute study-companion overview for a practitioner audience. Ground every concept in the course's South Asian examples and cited evidence — do not invent statistics or cases. Move module by module across: Making of the Indian Constitution; Fundamental Rights (Part III); Directive Principles &amp; Fundamental Duties; Federal Structure &amp; Centre-State Relations; Judiciary, PIL &amp; Access to Justice; Article 21 &mdash; Life, Liberty &amp; Expanding Rights; Reservations, Social Justice &amp; Affirmative Action; Rights-Based Legislation; Criminal Justice, Policing &amp; Human Rights; Environmental Law &amp; Climate Justice; Digital Rights, Data Protection &amp; Surveillance; Comparative Constitutional Systems in South Asia. For each, give the core idea, one concrete South Asian example from the sources, and one "use it in your work" takeaway. Close with the capstone challenge. Keep the tone rigorous but accessible; define jargon on first use.
+
+## 3. Suggested questions to seed the notebook
+- What is the single most important idea in this course, and what evidence supports it?
+- Summarise each module in two sentences: the concept and its South Asian application.
+- Which cited readings should I go to first, and why?
+- Turn the capstone into a step-by-step plan I can apply to my own work.
+- Quiz me with 10 questions across the whole course, then mark my answers.
+- Where do the sources disagree or leave open questions?
+
+## 4. Wire-up (maintainer)
+After creating the notebook, register it: add `law` -> notebook-id to `data/notebooklm-registry.json`,
+put the share URL in the course shell's AI Study Companion button, then optionally
+`python3 scripts/notebooklm-manage.py generate-audio law`.

--- a/notebooklm/prompts/livelihoods.md
+++ b/notebooklm/prompts/livelihoods.md
@@ -1,0 +1,22 @@
+# Livelihoods in India — NotebookLM study-companion prompt
+
+**Course:** Livelihoods in India (ImpactMojo flagship, 17 modules). South Asia-first development education for practitioners, students and educators.
+
+## 1. Sources to load
+Upload `notebooklm/packs/livelihoods-source-pack.md` and add the cited readings in `notebooklm/readings/livelihoods.md`.
+
+## 2. Audio Overview steering prompt (paste into NotebookLM's "Customise")
+> Create a ~12-minute study-companion overview for a practitioner audience. Ground every concept in the course's South Asian examples and cited evidence — do not invent statistics or cases. Move module by module across: Framing the Field; Why Rural Still Dominates Indian Livelihoods Policy; NRLM and the SHG Federation Architecture; Agriculture and Diversification: The Smallholder Question; MGNREGA: India's Largest Public Employment Programme; Financial Inclusion: From Microcredit to UPI; The Urbanisation Reality; Informal Sector Work and Street Vendor Policy; The Gig and Platform Economy; Domestic Workers: The Largest Invisible Workforce; Urban Policy Tools: SVAMITVA, DAY-NULM, and the Missing Layers; Skill India: Promise vs Evidence. For each, give the core idea, one concrete South Asian example from the sources, and one "use it in your work" takeaway. Close with the capstone challenge. Keep the tone rigorous but accessible; define jargon on first use.
+
+## 3. Suggested questions to seed the notebook
+- What is the single most important idea in this course, and what evidence supports it?
+- Summarise each module in two sentences: the concept and its South Asian application.
+- Which cited readings should I go to first, and why?
+- Turn the capstone into a step-by-step plan I can apply to my own work.
+- Quiz me with 10 questions across the whole course, then mark my answers.
+- Where do the sources disagree or leave open questions?
+
+## 4. Wire-up (maintainer)
+After creating the notebook, register it: add `livelihoods` -> notebook-id to `data/notebooklm-registry.json`,
+put the share URL in the course shell's AI Study Companion button, then optionally
+`python3 scripts/notebooklm-manage.py generate-audio livelihoods`.

--- a/notebooklm/prompts/media.md
+++ b/notebooklm/prompts/media.md
@@ -1,0 +1,22 @@
+# Media & Information — NotebookLM study-companion prompt
+
+**Course:** Media & Information (ImpactMojo flagship, 12 modules). South Asia-first development education for practitioners, students and educators.
+
+## 1. Sources to load
+Upload `notebooklm/packs/media-source-pack.md` and add the cited readings in `notebooklm/readings/media.md`.
+
+## 2. Audio Overview steering prompt (paste into NotebookLM's "Customise")
+> Create a ~12-minute study-companion overview for a practitioner audience. Ground every concept in the course's South Asian examples and cited evidence — do not invent statistics or cases. Move module by module across: The Cause-Impact Gap; Post-Humanitarianism: Beyond Pity; Who Tells the Story?; Exploitative Imagery and the Question of Dignity; Consent, Power, and Ethical Storytelling; Communicating Failure: When Things Don't Work; PARI and the Reinvention of Rural Journalism; Khabar Lahariya: Dalit Women Redefining News; Video Volunteers and the Community Media Movement; Data Journalism for Development; AI, Deepfakes, and New Media Ethics; Capstone: Your Communication Strategy. For each, give the core idea, one concrete South Asian example from the sources, and one "use it in your work" takeaway. Close with the capstone challenge. Keep the tone rigorous but accessible; define jargon on first use.
+
+## 3. Suggested questions to seed the notebook
+- What is the single most important idea in this course, and what evidence supports it?
+- Summarise each module in two sentences: the concept and its South Asian application.
+- Which cited readings should I go to first, and why?
+- Turn the capstone into a step-by-step plan I can apply to my own work.
+- Quiz me with 10 questions across the whole course, then mark my answers.
+- Where do the sources disagree or leave open questions?
+
+## 4. Wire-up (maintainer)
+After creating the notebook, register it: add `media` -> notebook-id to `data/notebooklm-registry.json`,
+put the share URL in the course shell's AI Study Companion button, then optionally
+`python3 scripts/notebooklm-manage.py generate-audio media`.

--- a/notebooklm/prompts/mel.md
+++ b/notebooklm/prompts/mel.md
@@ -1,0 +1,22 @@
+# Monitoring, Evaluation & Learning (MEAL) — NotebookLM study-companion prompt
+
+**Course:** Monitoring, Evaluation & Learning (MEAL) (ImpactMojo flagship, 14 modules). South Asia-first development education for practitioners, students and educators.
+
+## 1. Sources to load
+Upload `notebooklm/packs/mel-source-pack.md` and add the cited readings in `notebooklm/readings/mel.md`.
+
+## 2. Audio Overview steering prompt (paste into NotebookLM's "Customise")
+> Create a ~12-minute study-companion overview for a practitioner audience. Ground every concept in the course's South Asian examples and cited evidence — do not invent statistics or cases. Move module by module across: MEL—History, Variations & Foundations; Theory of Change & Logic Models; Indicator Design & Frameworks; Baselines, Targets & Benchmarks; Data Collection Methods; Data Quality Assurance; Quantitative Analysis; Qualitative Analysis; Evaluation Design & the OECD-DAC Framework; Learning Systems & Adaptive Management; MEL Technology & Data Systems; MEL Leadership & Sustainability. For each, give the core idea, one concrete South Asian example from the sources, and one "use it in your work" takeaway. Close with the capstone challenge. Keep the tone rigorous but accessible; define jargon on first use.
+
+## 3. Suggested questions to seed the notebook
+- What is the single most important idea in this course, and what evidence supports it?
+- Summarise each module in two sentences: the concept and its South Asian application.
+- Which cited readings should I go to first, and why?
+- Turn the capstone into a step-by-step plan I can apply to my own work.
+- Quiz me with 10 questions across the whole course, then mark my answers.
+- Where do the sources disagree or leave open questions?
+
+## 4. Wire-up (maintainer)
+After creating the notebook, register it: add `mel` -> notebook-id to `data/notebooklm-registry.json`,
+put the share URL in the course shell's AI Study Companion button, then optionally
+`python3 scripts/notebooklm-manage.py generate-audio mel`.

--- a/notebooklm/prompts/nothing-about-us.md
+++ b/notebooklm/prompts/nothing-about-us.md
@@ -1,0 +1,22 @@
+# Nothing About Us Without Us (Disability) — NotebookLM study-companion prompt
+
+**Course:** Nothing About Us Without Us (Disability) (ImpactMojo flagship, 9 modules). South Asia-first development education for practitioners, students and educators.
+
+## 1. Sources to load
+Upload `notebooklm/packs/nothing-about-us-source-pack.md` and add the cited readings in `notebooklm/readings/nothing-about-us.md`.
+
+## 2. Audio Overview steering prompt (paste into NotebookLM's "Customise")
+> Create a ~12-minute study-companion overview for a practitioner audience. Ground every concept in the course's South Asian examples and cited evidence — do not invent statistics or cases. Move module by module across: Models & History — How We Think About Disability; The Rights Architecture — CRPD, Law & Entitlements; Counting Disability & the Politics of Data; Barriers & Accessibility; Disability & Development — Across the Sectors; Intersectionality; Inclusive Programming & MEL; Voice, Movements & Culture; Practice, Ethics & Allyship. For each, give the core idea, one concrete South Asian example from the sources, and one "use it in your work" takeaway. Close with the capstone challenge. Keep the tone rigorous but accessible; define jargon on first use.
+
+## 3. Suggested questions to seed the notebook
+- What is the single most important idea in this course, and what evidence supports it?
+- Summarise each module in two sentences: the concept and its South Asian application.
+- Which cited readings should I go to first, and why?
+- Turn the capstone into a step-by-step plan I can apply to my own work.
+- Quiz me with 10 questions across the whole course, then mark my answers.
+- Where do the sources disagree or leave open questions?
+
+## 4. Wire-up (maintainer)
+After creating the notebook, register it: add `nothing-about-us` -> notebook-id to `data/notebooklm-registry.json`,
+put the share URL in the course shell's AI Study Companion button, then optionally
+`python3 scripts/notebooklm-manage.py generate-audio nothing-about-us`.

--- a/notebooklm/prompts/nvc-rj.md
+++ b/notebooklm/prompts/nvc-rj.md
@@ -1,0 +1,22 @@
+# Nonviolent Communication & Restorative Justice — NotebookLM study-companion prompt
+
+**Course:** Nonviolent Communication & Restorative Justice (ImpactMojo flagship, 12 modules). South Asia-first development education for practitioners, students and educators.
+
+## 1. Sources to load
+Upload `notebooklm/packs/nvc-rj-source-pack.md` and add the cited readings in `notebooklm/readings/nvc-rj.md`.
+
+## 2. Audio Overview steering prompt (paste into NotebookLM's "Customise")
+> Create a ~12-minute study-companion overview for a practitioner audience. Ground every concept in the course's South Asian examples and cited evidence — do not invent statistics or cases. Move module by module across: The Practice of Nonviolence; NVC Foundations; The Four Components; Empathy, Self-Empathy & the Uses of Force; NVR & New Authority; NVR in Action; The Restorative Paradigm; Restorative Practices; Roots, Power & Critique; Choosing & Combining the Practices; Fieldcraft & Facilitation; Capstone — Design a Nonviolent Response. For each, give the core idea, one concrete South Asian example from the sources, and one "use it in your work" takeaway. Close with the capstone challenge. Keep the tone rigorous but accessible; define jargon on first use.
+
+## 3. Suggested questions to seed the notebook
+- What is the single most important idea in this course, and what evidence supports it?
+- Summarise each module in two sentences: the concept and its South Asian application.
+- Which cited readings should I go to first, and why?
+- Turn the capstone into a step-by-step plan I can apply to my own work.
+- Quiz me with 10 questions across the whole course, then mark my answers.
+- Where do the sources disagree or leave open questions?
+
+## 4. Wire-up (maintainer)
+After creating the notebook, register it: add `nvc-rj` -> notebook-id to `data/notebooklm-registry.json`,
+put the share URL in the course shell's AI Study Companion button, then optionally
+`python3 scripts/notebooklm-manage.py generate-audio nvc-rj`.

--- a/notebooklm/prompts/poa.md
+++ b/notebooklm/prompts/poa.md
@@ -1,0 +1,22 @@
+# Policy & Advocacy — NotebookLM study-companion prompt
+
+**Course:** Policy & Advocacy (ImpactMojo flagship, 13 modules). South Asia-first development education for practitioners, students and educators.
+
+## 1. Sources to load
+Upload `notebooklm/packs/poa-source-pack.md` and add the cited readings in `notebooklm/readings/poa.md`.
+
+## 2. Audio Overview steering prompt (paste into NotebookLM's "Customise")
+> Create a ~12-minute study-companion overview for a practitioner audience. Ground every concept in the course's South Asian examples and cited evidence — do not invent statistics or cases. Move module by module across: What is Aspiration?; Risk & Insurance for the Poor; India's Political Economy 1947-1991; Right to Information (RTI); NREGA – The Right to Work; Land Rights & Food Security; Education, Learning & Human Capital; Gender, Caste & Social Stratification; Migration, Mobility & Aspirations; South Asia Comparative Analysis; Future Challenges & Emerging Issues; Practitioner Synthesis. For each, give the core idea, one concrete South Asian example from the sources, and one "use it in your work" takeaway. Close with the capstone challenge. Keep the tone rigorous but accessible; define jargon on first use.
+
+## 3. Suggested questions to seed the notebook
+- What is the single most important idea in this course, and what evidence supports it?
+- Summarise each module in two sentences: the concept and its South Asian application.
+- Which cited readings should I go to first, and why?
+- Turn the capstone into a step-by-step plan I can apply to my own work.
+- Quiz me with 10 questions across the whole course, then mark my answers.
+- Where do the sources disagree or leave open questions?
+
+## 4. Wire-up (maintainer)
+After creating the notebook, register it: add `poa` -> notebook-id to `data/notebooklm-registry.json`,
+put the share URL in the course shell's AI Study Companion button, then optionally
+`python3 scripts/notebooklm-manage.py generate-audio poa`.

--- a/notebooklm/prompts/powerBI.md
+++ b/notebooklm/prompts/powerBI.md
@@ -1,0 +1,22 @@
+# Power BI for Development — NotebookLM study-companion prompt
+
+**Course:** Power BI for Development (ImpactMojo flagship, 8 modules). South Asia-first development education for practitioners, students and educators.
+
+## 1. Sources to load
+Upload `notebooklm/packs/powerBI-source-pack.md` and add the cited readings in `notebooklm/readings/powerBI.md`.
+
+## 2. Audio Overview steering prompt (paste into NotebookLM's "Customise")
+> Create a ~12-minute study-companion overview for a practitioner audience. Ground every concept in the course's South Asian examples and cited evidence — do not invent statistics or cases. Move module by module across: Getting Power BI Free; Get Data; Power Query; Data Modelling; DAX Foundations; Visualisation Done Honestly; Report Design and Interactivity; Sharing the Free Way. For each, give the core idea, one concrete South Asian example from the sources, and one "use it in your work" takeaway. Close with the capstone challenge. Keep the tone rigorous but accessible; define jargon on first use.
+
+## 3. Suggested questions to seed the notebook
+- What is the single most important idea in this course, and what evidence supports it?
+- Summarise each module in two sentences: the concept and its South Asian application.
+- Which cited readings should I go to first, and why?
+- Turn the capstone into a step-by-step plan I can apply to my own work.
+- Quiz me with 10 questions across the whole course, then mark my answers.
+- Where do the sources disagree or leave open questions?
+
+## 4. Wire-up (maintainer)
+After creating the notebook, register it: add `powerBI` -> notebook-id to `data/notebooklm-registry.json`,
+put the share URL in the course shell's AI Study Companion button, then optionally
+`python3 scripts/notebooklm-manage.py generate-audio powerBI`.

--- a/notebooklm/prompts/pubchoice.md
+++ b/notebooklm/prompts/pubchoice.md
@@ -1,0 +1,22 @@
+# Public Choice — NotebookLM study-companion prompt
+
+**Course:** Public Choice (ImpactMojo flagship, 13 modules). South Asia-first development education for practitioners, students and educators.
+
+## 1. Sources to load
+Upload `notebooklm/packs/pubchoice-source-pack.md` and add the cited readings in `notebooklm/readings/pubchoice.md`.
+
+## 2. Audio Overview steering prompt (paste into NotebookLM's "Customise")
+> Create a ~12-minute study-companion overview for a practitioner audience. Ground every concept in the course's South Asian examples and cited evidence — do not invent statistics or cases. Move module by module across: The Public Choice Lens; Voting Rules and Their Consequences; The Logic of Collective Action; Rent-Seeking and Regulatory Capture; Bureaucracy and the Principal-Agent Problem; Distributive Politics and Pork-Barrel Spending; Commons and the Ostrom Programme; The Institutional Analysis and Development (IAD) Framework; Constitutional Political Economy; Fiscal Federalism; Public Goods, Clubs, and the Politics of Provision; Information, Transparency, and Accountability. For each, give the core idea, one concrete South Asian example from the sources, and one "use it in your work" takeaway. Close with the capstone challenge. Keep the tone rigorous but accessible; define jargon on first use.
+
+## 3. Suggested questions to seed the notebook
+- What is the single most important idea in this course, and what evidence supports it?
+- Summarise each module in two sentences: the concept and its South Asian application.
+- Which cited readings should I go to first, and why?
+- Turn the capstone into a step-by-step plan I can apply to my own work.
+- Quiz me with 10 questions across the whole course, then mark my answers.
+- Where do the sources disagree or leave open questions?
+
+## 4. Wire-up (maintainer)
+After creating the notebook, register it: add `pubchoice` -> notebook-id to `data/notebooklm-registry.json`,
+put the share URL in the course shell's AI Study Companion button, then optionally
+`python3 scripts/notebooklm-manage.py generate-audio pubchoice`.

--- a/notebooklm/prompts/pubpol.md
+++ b/notebooklm/prompts/pubpol.md
@@ -1,0 +1,22 @@
+# Public Policy — NotebookLM study-companion prompt
+
+**Course:** Public Policy (ImpactMojo flagship, 16 modules). South Asia-first development education for practitioners, students and educators.
+
+## 1. Sources to load
+Upload `notebooklm/packs/pubpol-source-pack.md` and add the cited readings in `notebooklm/readings/pubpol.md`.
+
+## 2. Audio Overview steering prompt (paste into NotebookLM's "Customise")
+> Create a ~12-minute study-companion overview for a practitioner audience. Ground every concept in the course's South Asian examples and cited evidence — do not invent statistics or cases. Move module by module across: What is Public Policy?; The Indian State: Architecture &amp; Capacity; History of Indian Planning; How Policy Gets Made in India; Federalism &amp; Centre-State Relations; Bureaucracy &amp; Implementation; Public Finance &amp; Fiscal Federalism; Budgeting in India; Taxation &amp; Revenue; Regulatory Governance; Social Policy Architecture; Environmental &amp; Land Policy. For each, give the core idea, one concrete South Asian example from the sources, and one "use it in your work" takeaway. Close with the capstone challenge. Keep the tone rigorous but accessible; define jargon on first use.
+
+## 3. Suggested questions to seed the notebook
+- What is the single most important idea in this course, and what evidence supports it?
+- Summarise each module in two sentences: the concept and its South Asian application.
+- Which cited readings should I go to first, and why?
+- Turn the capstone into a step-by-step plan I can apply to my own work.
+- Quiz me with 10 questions across the whole course, then mark my answers.
+- Where do the sources disagree or leave open questions?
+
+## 4. Wire-up (maintainer)
+After creating the notebook, register it: add `pubpol` -> notebook-id to `data/notebooklm-registry.json`,
+put the share URL in the course shell's AI Study Companion button, then optionally
+`python3 scripts/notebooklm-manage.py generate-audio pubpol`.

--- a/notebooklm/prompts/social-movements.md
+++ b/notebooklm/prompts/social-movements.md
@@ -1,0 +1,22 @@
+# Social Movements & Protests — NotebookLM study-companion prompt
+
+**Course:** Social Movements & Protests (ImpactMojo flagship, 13 modules). South Asia-first development education for practitioners, students and educators.
+
+## 1. Sources to load
+Upload `notebooklm/packs/social-movements-source-pack.md` and add the cited readings in `notebooklm/readings/social-movements.md`.
+
+## 2. Audio Overview steering prompt (paste into NotebookLM's "Customise")
+> Create a ~12-minute study-companion overview for a practitioner audience. Ground every concept in the course's South Asian examples and cited evidence — do not invent statistics or cases. Move module by module across: What Is a Social Movement?; Why Movements Emerge; Framing &amp; Collective Identity; Repertoires of Contention; Nonviolent Resistance &amp; People Power; Gandhi &amp; the Freedom Struggle as a Movement; Environmental &amp; Land Movements in South Asia; Caste, Dalit &amp; Adivasi Assertion; Farmers&rsquo; &amp; Workers&rsquo; Movements; Feminist & Gender Movements; Digital & Networked Activism; Repression, Backlash & Movement Outcomes. For each, give the core idea, one concrete South Asian example from the sources, and one "use it in your work" takeaway. Close with the capstone challenge. Keep the tone rigorous but accessible; define jargon on first use.
+
+## 3. Suggested questions to seed the notebook
+- What is the single most important idea in this course, and what evidence supports it?
+- Summarise each module in two sentences: the concept and its South Asian application.
+- Which cited readings should I go to first, and why?
+- Turn the capstone into a step-by-step plan I can apply to my own work.
+- Quiz me with 10 questions across the whole course, then mark my answers.
+- Where do the sources disagree or leave open questions?
+
+## 4. Wire-up (maintainer)
+After creating the notebook, register it: add `social-movements` -> notebook-id to `data/notebooklm-registry.json`,
+put the share URL in the course shell's AI Study Companion button, then optionally
+`python3 scripts/notebooklm-manage.py generate-audio social-movements`.

--- a/notebooklm/readings/SEL.md
+++ b/notebooklm/readings/SEL.md
@@ -1,0 +1,23 @@
+# Social & Emotional Learning — cited readings
+
+Open-access sources cited across the course. Add to the notebook with:
+
+```bash
+# after `notebooklm login` and creating the notebook:
+python3 scripts/notebooklm-manage.py add-source SEL https://casel.org/fundamentals-of-sel/what-is-the-casel-framework/
+python3 scripts/notebooklm-manage.py add-source SEL https://iris.who.int/handle/10665/63552
+python3 scripts/notebooklm-manage.py add-source SEL https://static.pib.gov.in/WriteReadData/userfiles/NEP_Final_English_0.pdf
+python3 scripts/notebooklm-manage.py add-source SEL https://iris.who.int/handle/10665/44615
+python3 scripts/notebooklm-manage.py add-source SEL https://www.unesco.org/en/legal-affairs/constitution
+python3 scripts/notebooklm-manage.py add-source SEL https://www.who.int/news/item/28-05-2019-burn-out-an-occupational-phenomenon-international-classification-of-diseases
+python3 scripts/notebooklm-manage.py add-source SEL https://www.oecd.org/content/dam/oecd/en/about/programmes/edu/survey-on-social-and-emotional-skills/Technical%20Report%20SSES.pdf
+```
+
+## URLs
+- https://casel.org/fundamentals-of-sel/what-is-the-casel-framework/
+- https://iris.who.int/handle/10665/63552
+- https://static.pib.gov.in/WriteReadData/userfiles/NEP_Final_English_0.pdf
+- https://iris.who.int/handle/10665/44615
+- https://www.unesco.org/en/legal-affairs/constitution
+- https://www.who.int/news/item/28-05-2019-burn-out-an-occupational-phenomenon-international-classification-of-diseases
+- https://www.oecd.org/content/dam/oecd/en/about/programmes/edu/survey-on-social-and-emotional-skills/Technical%20Report%20SSES.pdf

--- a/notebooklm/readings/causal.md
+++ b/notebooklm/readings/causal.md
@@ -1,0 +1,85 @@
+# Causal Inference & Impact Evaluation — cited readings
+
+Open-access sources cited across the course. Add to the notebook with:
+
+```bash
+# after `notebooklm login` and creating the notebook:
+python3 scripts/notebooklm-manage.py add-source causal https://miguelhernan.org/whatifbook
+python3 scripts/notebooklm-manage.py add-source causal https://www.tandfonline.com/doi/abs/10.1080/01621459.1986.10478354
+python3 scripts/notebooklm-manage.py add-source causal https://press.princeton.edu/books/paperback/9780691120355/mostly-harmless-econometrics
+python3 scripts/notebooklm-manage.py add-source causal https://www.aeaweb.org/articles?id=10.1257/app.20130401
+python3 scripts/notebooklm-manage.py add-source causal https://mixtape.scunning.com/05-matching_and_subclassification
+python3 scripts/notebooklm-manage.py add-source causal https://academic.oup.com/biomet/article/70/1/41/240879
+python3 scripts/notebooklm-manage.py add-source causal https://mixtape.scunning.com/03-directed_acyclical_graphs
+python3 scripts/notebooklm-manage.py add-source causal https://journals.sagepub.com/doi/10.1177/00491241221099552
+python3 scripts/notebooklm-manage.py add-source causal https://www.hsph.harvard.edu/miguel-hernan/causal-inference-book/
+python3 scripts/notebooklm-manage.py add-source causal https://www.povertyactionlab.org/resource/introduction-randomized-evaluations
+python3 scripts/notebooklm-manage.py add-source causal https://www.bmj.com/content/340/bmj.c2220
+python3 scripts/notebooklm-manage.py add-source causal https://www.povertyactionlab.org/resource/quick-guide-randomization-practice
+python3 scripts/notebooklm-manage.py add-source causal https://www.jstor.org/stable/2335942
+python3 scripts/notebooklm-manage.py add-source causal https://projecteuclid.org/journals/statistical-science/volume-25/issue-1/Matching-Methods-for-Causal-Inference-A-Review-and-a-Look/10.1214/09-STS313.full
+python3 scripts/notebooklm-manage.py add-source causal https://mixtape.scunning.com/07-instrumental_variables
+python3 scripts/notebooklm-manage.py add-source causal https://www.jstor.org/stable/2951620
+python3 scripts/notebooklm-manage.py add-source causal https://academic.oup.com/qje/article/122/2/601/1942113
+python3 scripts/notebooklm-manage.py add-source causal https://mixtape.scunning.com/06-regression_discontinuity
+python3 scripts/notebooklm-manage.py add-source causal https://www.aeaweb.org/articles?id=10.1257/jel.48.2.281
+python3 scripts/notebooklm-manage.py add-source causal https://rdpackages.github.io/references/Cattaneo-Idrobo-Titiunik_2020_CUP-Vol1.pdf
+python3 scripts/notebooklm-manage.py add-source causal https://mixtape.scunning.com/09-difference_in_differences
+python3 scripts/notebooklm-manage.py add-source causal https://www.sciencedirect.com/science/article/pii/S0304407621001445
+python3 scripts/notebooklm-manage.py add-source causal https://bcallaway11.github.io/did/
+python3 scripts/notebooklm-manage.py add-source causal https://mixtape.scunning.com/10-synthetic_control
+python3 scripts/notebooklm-manage.py add-source causal https://www.aeaweb.org/articles?id=10.1257/jel.20191450
+python3 scripts/notebooklm-manage.py add-source causal https://web.stanford.edu/~jhain/Paper/JASA2010.pdf
+python3 scripts/notebooklm-manage.py add-source causal https://arxiv.org/abs/1608.00060
+python3 scripts/notebooklm-manage.py add-source causal https://academic.oup.com/ectj/article/21/1/C1/5056401
+python3 scripts/notebooklm-manage.py add-source causal https://grf-labs.github.io/grf/
+python3 scripts/notebooklm-manage.py add-source causal https://documents1.worldbank.org/curated/en/698441474029568469/pdf/108270-PUB-Box396299B-PUBLIC-PUBDATE-9-13-16.pdf
+python3 scripts/notebooklm-manage.py add-source causal https://www.worldbank.org/en/programs/sief-trust-fund/publication/impact-evaluation-in-practice
+python3 scripts/notebooklm-manage.py add-source causal https://www.sciencedirect.com/science/article/pii/S0277953617307359
+python3 scripts/notebooklm-manage.py add-source causal https://www.3ieimpact.org/sites/default/files/2019-01/working_paper_15.pdf
+python3 scripts/notebooklm-manage.py add-source causal https://journals.sagepub.com/doi/10.1177/1356389012451663
+python3 scripts/notebooklm-manage.py add-source causal https://www.betterevaluation.org/methods-approaches/approaches/contribution-analysis
+python3 scripts/notebooklm-manage.py add-source causal https://www.povertyactionlab.org/resource/elements-randomized-evaluation
+python3 scripts/notebooklm-manage.py add-source causal https://www.povertyactionlab.org/research-resources
+python3 scripts/notebooklm-manage.py add-source causal https://www.3ieimpact.org/
+```
+
+## URLs
+- https://miguelhernan.org/whatifbook
+- https://www.tandfonline.com/doi/abs/10.1080/01621459.1986.10478354
+- https://press.princeton.edu/books/paperback/9780691120355/mostly-harmless-econometrics
+- https://www.aeaweb.org/articles?id=10.1257/app.20130401
+- https://mixtape.scunning.com/05-matching_and_subclassification
+- https://academic.oup.com/biomet/article/70/1/41/240879
+- https://mixtape.scunning.com/03-directed_acyclical_graphs
+- https://journals.sagepub.com/doi/10.1177/00491241221099552
+- https://www.hsph.harvard.edu/miguel-hernan/causal-inference-book/
+- https://www.povertyactionlab.org/resource/introduction-randomized-evaluations
+- https://www.bmj.com/content/340/bmj.c2220
+- https://www.povertyactionlab.org/resource/quick-guide-randomization-practice
+- https://www.jstor.org/stable/2335942
+- https://projecteuclid.org/journals/statistical-science/volume-25/issue-1/Matching-Methods-for-Causal-Inference-A-Review-and-a-Look/10.1214/09-STS313.full
+- https://mixtape.scunning.com/07-instrumental_variables
+- https://www.jstor.org/stable/2951620
+- https://academic.oup.com/qje/article/122/2/601/1942113
+- https://mixtape.scunning.com/06-regression_discontinuity
+- https://www.aeaweb.org/articles?id=10.1257/jel.48.2.281
+- https://rdpackages.github.io/references/Cattaneo-Idrobo-Titiunik_2020_CUP-Vol1.pdf
+- https://mixtape.scunning.com/09-difference_in_differences
+- https://www.sciencedirect.com/science/article/pii/S0304407621001445
+- https://bcallaway11.github.io/did/
+- https://mixtape.scunning.com/10-synthetic_control
+- https://www.aeaweb.org/articles?id=10.1257/jel.20191450
+- https://web.stanford.edu/~jhain/Paper/JASA2010.pdf
+- https://arxiv.org/abs/1608.00060
+- https://academic.oup.com/ectj/article/21/1/C1/5056401
+- https://grf-labs.github.io/grf/
+- https://documents1.worldbank.org/curated/en/698441474029568469/pdf/108270-PUB-Box396299B-PUBLIC-PUBDATE-9-13-16.pdf
+- https://www.worldbank.org/en/programs/sief-trust-fund/publication/impact-evaluation-in-practice
+- https://www.sciencedirect.com/science/article/pii/S0277953617307359
+- https://www.3ieimpact.org/sites/default/files/2019-01/working_paper_15.pdf
+- https://journals.sagepub.com/doi/10.1177/1356389012451663
+- https://www.betterevaluation.org/methods-approaches/approaches/contribution-analysis
+- https://www.povertyactionlab.org/resource/elements-randomized-evaluation
+- https://www.povertyactionlab.org/research-resources
+- https://www.3ieimpact.org/

--- a/notebooklm/readings/dataviz.md
+++ b/notebooklm/readings/dataviz.md
@@ -1,0 +1,205 @@
+# Data Visualization — cited readings
+
+Open-access sources cited across the course. Add to the notebook with:
+
+```bash
+# after `notebooklm login` and creating the notebook:
+python3 scripts/notebooklm-manage.py add-source dataviz https://clauswilke.com/dataviz/introduction.html
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.edwardtufte.com/book/the-visual-display-of-quantitative-information/
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.thefunctionalart.com/p/the-truthful-art-book.html
+python3 scripts/notebooklm-manage.py add-source dataviz https://data-feminism.mitpress.mit.edu/
+python3 scripts/notebooklm-manage.py add-source dataviz https://101.impactmojo.in/data-lit
+python3 scripts/notebooklm-manage.py add-source dataviz https://data-feminism.mitpress.mit.edu/pub/vi8obxh7
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.tandfonline.com/doi/abs/10.1080/01621459.1973.10481362
+python3 scripts/notebooklm-manage.py add-source dataviz https://101.impactmojo.in/visual-eth
+python3 scripts/notebooklm-manage.py add-source dataviz https://101.impactmojo.in/data-feminism
+python3 scripts/notebooklm-manage.py add-source dataviz https://clauswilke.com/dataviz/aesthetic-mapping.html
+python3 scripts/notebooklm-manage.py add-source dataviz https://data.worldbank.org/
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.gapminder.org/data/
+python3 scripts/notebooklm-manage.py add-source dataviz https://dhsprogram.com/data/
+python3 scripts/notebooklm-manage.py add-source dataviz https://ourworldindata.org/
+python3 scripts/notebooklm-manage.py add-source dataviz https://data.humdata.org/
+python3 scripts/notebooklm-manage.py add-source dataviz https://unstats.un.org/sdgs/dataportal
+python3 scripts/notebooklm-manage.py add-source dataviz https://101.impactmojo.in/eda-hhs
+python3 scripts/notebooklm-manage.py add-source dataviz https://101.impactmojo.in/code-convert-pro
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.wired.com/2012/07/how-to-lie-with-data-visualization/
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.interagencystandingcommittee.org/operational-response/iasc-information-management-guidelines
+python3 scripts/notebooklm-manage.py add-source dataviz https://dhsprogram.com/data/Guide-to-DHS-Statistics/index.cfm
+python3 scripts/notebooklm-manage.py add-source dataviz https://101.impactmojo.in/econometrics-101
+python3 scripts/notebooklm-manage.py add-source dataviz https://101.impactmojo.in/qual-methods
+python3 scripts/notebooklm-manage.py add-source dataviz https://socviz.co/01-look-at-data.html
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.jstor.org/stable/2288400
+python3 scripts/notebooklm-manage.py add-source dataviz https://ieeexplore.ieee.org/document/5613434
+python3 scripts/notebooklm-manage.py add-source dataviz https://link.springer.com/book/10.1007/0-387-28695-0
+python3 scripts/notebooklm-manage.py add-source dataviz https://ggplot2-book.org/
+python3 scripts/notebooklm-manage.py add-source dataviz https://observablehq.com/@d3/gallery
+python3 scripts/notebooklm-manage.py add-source dataviz https://vega.github.io/vega-lite/examples/
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.data-to-viz.com/
+python3 scripts/notebooklm-manage.py add-source dataviz https://clauswilke.com/dataviz/color-pitfalls.html
+python3 scripts/notebooklm-manage.py add-source dataviz https://colorbrewer2.org/
+python3 scripts/notebooklm-manage.py add-source dataviz https://colororacle.org/
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.color-blindness.com/coblis-color-blindness-simulator/
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.nature.com/articles/s41467-020-19160-7
+python3 scripts/notebooklm-manage.py add-source dataviz https://bids.github.io/colormap/
+python3 scripts/notebooklm-manage.py add-source dataviz https://colorbrewer2.org/learnmore/schemes_full.html
+python3 scripts/notebooklm-manage.py add-source dataviz https://cran.r-project.org/web/packages/viridis/
+python3 scripts/notebooklm-manage.py add-source dataviz https://clauswilke.com/dataviz/directory-of-visualizations.html
+python3 scripts/notebooklm-manage.py add-source dataviz https://data-to-viz.com/
+python3 scripts/notebooklm-manage.py add-source dataviz https://ft-interactive.github.io/visual-vocabulary/
+python3 scripts/notebooklm-manage.py add-source dataviz https://stephanieevergreen.com/
+python3 scripts/notebooklm-manage.py add-source dataviz https://policyviz.com/2014/09/09/graphic-continuum/
+python3 scripts/notebooklm-manage.py add-source dataviz https://depictdatastudio.com/charts/
+python3 scripts/notebooklm-manage.py add-source dataviz https://policyviz.com/2021/02/08/five-charts-youve-never-used-but-should/
+python3 scripts/notebooklm-manage.py add-source dataviz https://101.impactmojo.in/obs2insight
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.storytellingwithdata.com/books
+python3 scripts/notebooklm-manage.py add-source dataviz https://policyviz.com/better-data-visualizations/
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.perceptualedge.com/articles/b-eye/choosing_a_chart.pdf
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.youtube.com/watch?v=AdSZJzb-aX8
+python3 scripts/notebooklm-manage.py add-source dataviz https://101.impactmojo.in/mel-basics
+python3 scripts/notebooklm-manage.py add-source dataviz https://101.impactmojo.in/storytelling-lab
+python3 scripts/notebooklm-manage.py add-source dataviz https://socviz.co/08-polishing.html
+python3 scripts/notebooklm-manage.py add-source dataviz https://urbaninstitute.github.io/graphics-styleguide/
+python3 scripts/notebooklm-manage.py add-source dataviz https://wbg-vis-design.vercel.app/
+python3 scripts/notebooklm-manage.py add-source dataviz https://github.com/PovertyAction/ipaplots
+python3 scripts/notebooklm-manage.py add-source dataviz https://clauswilke.com/dataviz/telling-a-story.html
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.storytellingwithdata.com/lets-practice
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.youtube.com/watch?v=8EMW7io4rSI
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.thefunctionalart.com/p/the-functional-art-an-introduction.html
+python3 scripts/notebooklm-manage.py add-source dataviz https://101.impactmojo.in/bcc-comms
+python3 scripts/notebooklm-manage.py add-source dataviz https://101.impactmojo.in/advocacy-basics
+python3 scripts/notebooklm-manage.py add-source dataviz https://socviz.co/02-intro.html
+python3 scripts/notebooklm-manage.py add-source dataviz https://colab.research.google.com/github/ggplot2-book/ggplot2-book/blob/main/introduction.Rmd
+python3 scripts/notebooklm-manage.py add-source dataviz https://colab.research.google.com/github/matplotlib/matplotlib/blob/main/galleries/users_explain/quick_start.ipynb
+python3 scripts/notebooklm-manage.py add-source dataviz https://observablehq.com/@observablehq/vega-lite
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.datawrapper.de/
+python3 scripts/notebooklm-manage.py add-source dataviz https://flourish.studio/
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.rawgraphs.io/
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.youtube.com/watch?v=hVimVzgtD6w
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.youtube.com/watch?v=jbkSRLYSojo
+python3 scripts/notebooklm-manage.py add-source dataviz https://r4ds.hadley.nz/data-visualize
+python3 scripts/notebooklm-manage.py add-source dataviz https://matplotlib.org/stable/tutorials/index.html
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.gapminder.org/about/
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.cs.umd.edu/~ben/papers/Shneiderman1996eyes.pdf
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.youtube.com/watch?v=ySO9bLiDrLY
+python3 scripts/notebooklm-manage.py add-source dataviz https://alignedleft.com/work/d3-book-2e
+python3 scripts/notebooklm-manage.py add-source dataviz https://ourworldindata.org/sdgs
+python3 scripts/notebooklm-manage.py add-source dataviz https://101.impactmojo.in/toc-workbench
+python3 scripts/notebooklm-manage.py add-source dataviz https://101.impactmojo.in/mel-design-lab
+python3 scripts/notebooklm-manage.py add-source dataviz https://101.impactmojo.in/mel-plan-lab
+python3 scripts/notebooklm-manage.py add-source dataviz https://dhis2.org/
+python3 scripts/notebooklm-manage.py add-source dataviz https://docs.dhis2.org/en/use/user-guides/dhis-core-version-master/analysing-data/dashboards.html
+python3 scripts/notebooklm-manage.py add-source dataviz https://stephanieevergreen.com/data-visualization/
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.youtube.com/watch?v=MWBBtQMNLZc
+python3 scripts/notebooklm-manage.py add-source dataviz https://clauswilke.com/dataviz/visualizing-uncertainty.html
+python3 scripts/notebooklm-manage.py add-source dataviz https://101.impactmojo.in/gender-studies
+python3 scripts/notebooklm-manage.py add-source dataviz https://101.impactmojo.in/decolonize-dev
+python3 scripts/notebooklm-manage.py add-source dataviz https://showyourstripes.info/
+python3 scripts/notebooklm-manage.py add-source dataviz https://makingmaps.net/
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.youtube.com/watch?v=DsMuzGLf_FA
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.esri.com/arcgis-blog/products/arcgis-living-atlas/mapping/30daymapchallengeday-1-points-map/
+python3 scripts/notebooklm-manage.py add-source dataviz https://ourworldindata.org/about
+python3 scripts/notebooklm-manage.py add-source dataviz https://flowingdata.com/
+python3 scripts/notebooklm-manage.py add-source dataviz https://pudding.cool/
+python3 scripts/notebooklm-manage.py add-source dataviz https://informationisbeautiful.net/
+python3 scripts/notebooklm-manage.py add-source dataviz https://www.youtube.com/watch?v=5Zg-C8AAIGg
+```
+
+## URLs
+- https://clauswilke.com/dataviz/introduction.html
+- https://www.edwardtufte.com/book/the-visual-display-of-quantitative-information/
+- https://www.thefunctionalart.com/p/the-truthful-art-book.html
+- https://data-feminism.mitpress.mit.edu/
+- https://101.impactmojo.in/data-lit
+- https://data-feminism.mitpress.mit.edu/pub/vi8obxh7
+- https://www.tandfonline.com/doi/abs/10.1080/01621459.1973.10481362
+- https://101.impactmojo.in/visual-eth
+- https://101.impactmojo.in/data-feminism
+- https://clauswilke.com/dataviz/aesthetic-mapping.html
+- https://data.worldbank.org/
+- https://www.gapminder.org/data/
+- https://dhsprogram.com/data/
+- https://ourworldindata.org/
+- https://data.humdata.org/
+- https://unstats.un.org/sdgs/dataportal
+- https://101.impactmojo.in/eda-hhs
+- https://101.impactmojo.in/code-convert-pro
+- https://www.wired.com/2012/07/how-to-lie-with-data-visualization/
+- https://www.interagencystandingcommittee.org/operational-response/iasc-information-management-guidelines
+- https://dhsprogram.com/data/Guide-to-DHS-Statistics/index.cfm
+- https://101.impactmojo.in/econometrics-101
+- https://101.impactmojo.in/qual-methods
+- https://socviz.co/01-look-at-data.html
+- https://www.jstor.org/stable/2288400
+- https://ieeexplore.ieee.org/document/5613434
+- https://link.springer.com/book/10.1007/0-387-28695-0
+- https://ggplot2-book.org/
+- https://observablehq.com/@d3/gallery
+- https://vega.github.io/vega-lite/examples/
+- https://www.data-to-viz.com/
+- https://clauswilke.com/dataviz/color-pitfalls.html
+- https://colorbrewer2.org/
+- https://colororacle.org/
+- https://www.color-blindness.com/coblis-color-blindness-simulator/
+- https://www.nature.com/articles/s41467-020-19160-7
+- https://bids.github.io/colormap/
+- https://colorbrewer2.org/learnmore/schemes_full.html
+- https://cran.r-project.org/web/packages/viridis/
+- https://clauswilke.com/dataviz/directory-of-visualizations.html
+- https://data-to-viz.com/
+- https://ft-interactive.github.io/visual-vocabulary/
+- https://stephanieevergreen.com/
+- https://policyviz.com/2014/09/09/graphic-continuum/
+- https://depictdatastudio.com/charts/
+- https://policyviz.com/2021/02/08/five-charts-youve-never-used-but-should/
+- https://101.impactmojo.in/obs2insight
+- https://www.storytellingwithdata.com/books
+- https://policyviz.com/better-data-visualizations/
+- https://www.perceptualedge.com/articles/b-eye/choosing_a_chart.pdf
+- https://www.youtube.com/watch?v=AdSZJzb-aX8
+- https://101.impactmojo.in/mel-basics
+- https://101.impactmojo.in/storytelling-lab
+- https://socviz.co/08-polishing.html
+- https://urbaninstitute.github.io/graphics-styleguide/
+- https://wbg-vis-design.vercel.app/
+- https://github.com/PovertyAction/ipaplots
+- https://clauswilke.com/dataviz/telling-a-story.html
+- https://www.storytellingwithdata.com/lets-practice
+- https://www.youtube.com/watch?v=8EMW7io4rSI
+- https://www.thefunctionalart.com/p/the-functional-art-an-introduction.html
+- https://101.impactmojo.in/bcc-comms
+- https://101.impactmojo.in/advocacy-basics
+- https://socviz.co/02-intro.html
+- https://colab.research.google.com/github/ggplot2-book/ggplot2-book/blob/main/introduction.Rmd
+- https://colab.research.google.com/github/matplotlib/matplotlib/blob/main/galleries/users_explain/quick_start.ipynb
+- https://observablehq.com/@observablehq/vega-lite
+- https://www.datawrapper.de/
+- https://flourish.studio/
+- https://www.rawgraphs.io/
+- https://www.youtube.com/watch?v=hVimVzgtD6w
+- https://www.youtube.com/watch?v=jbkSRLYSojo
+- https://r4ds.hadley.nz/data-visualize
+- https://matplotlib.org/stable/tutorials/index.html
+- https://www.gapminder.org/about/
+- https://www.cs.umd.edu/~ben/papers/Shneiderman1996eyes.pdf
+- https://www.youtube.com/watch?v=ySO9bLiDrLY
+- https://alignedleft.com/work/d3-book-2e
+- https://ourworldindata.org/sdgs
+- https://101.impactmojo.in/toc-workbench
+- https://101.impactmojo.in/mel-design-lab
+- https://101.impactmojo.in/mel-plan-lab
+- https://dhis2.org/
+- https://docs.dhis2.org/en/use/user-guides/dhis-core-version-master/analysing-data/dashboards.html
+- https://stephanieevergreen.com/data-visualization/
+- https://www.youtube.com/watch?v=MWBBtQMNLZc
+- https://clauswilke.com/dataviz/visualizing-uncertainty.html
+- https://101.impactmojo.in/gender-studies
+- https://101.impactmojo.in/decolonize-dev
+- https://showyourstripes.info/
+- https://makingmaps.net/
+- https://www.youtube.com/watch?v=DsMuzGLf_FA
+- https://www.esri.com/arcgis-blog/products/arcgis-living-atlas/mapping/30daymapchallengeday-1-points-map/
+- https://ourworldindata.org/about
+- https://flowingdata.com/
+- https://pudding.cool/
+- https://informationisbeautiful.net/
+- https://www.youtube.com/watch?v=5Zg-C8AAIGg

--- a/notebooklm/readings/devai.md
+++ b/notebooklm/readings/devai.md
@@ -1,0 +1,33 @@
+# Development & AI — cited readings
+
+Open-access sources cited across the course. Add to the notebook with:
+
+```bash
+# after `notebooklm login` and creating the notebook:
+python3 scripts/notebooklm-manage.py add-source devai https://ourworldindata.org/artificial-intelligence
+python3 scripts/notebooklm-manage.py add-source devai https://digitalprinciples.org/principle/understand-the-existing-ecosystem/
+python3 scripts/notebooklm-manage.py add-source devai https://www.worldbank.org/en/publication/wdr2021
+python3 scripts/notebooklm-manage.py add-source devai https://arxiv.org/abs/1510.00098
+python3 scripts/notebooklm-manage.py add-source devai https://jmlr.org/papers/v3/blei03a.html
+python3 scripts/notebooklm-manage.py add-source devai https://fairmlbook.org/
+python3 scripts/notebooklm-manage.py add-source devai https://arxiv.org/abs/2007.02500
+python3 scripts/notebooklm-manage.py add-source devai https://bsc.hks.harvard.edu/
+python3 scripts/notebooklm-manage.py add-source devai https://www.miguelhernan.org/whatifbook
+python3 scripts/notebooklm-manage.py add-source devai https://www.unesco.org/en/artificial-intelligence/recommendation-ethics
+python3 scripts/notebooklm-manage.py add-source devai https://ourworldindata.org/technology-adoption
+python3 scripts/notebooklm-manage.py add-source devai https://www.worldbank.org/en/publication/wdr2016
+```
+
+## URLs
+- https://ourworldindata.org/artificial-intelligence
+- https://digitalprinciples.org/principle/understand-the-existing-ecosystem/
+- https://www.worldbank.org/en/publication/wdr2021
+- https://arxiv.org/abs/1510.00098
+- https://jmlr.org/papers/v3/blei03a.html
+- https://fairmlbook.org/
+- https://arxiv.org/abs/2007.02500
+- https://bsc.hks.harvard.edu/
+- https://www.miguelhernan.org/whatifbook
+- https://www.unesco.org/en/artificial-intelligence/recommendation-ethics
+- https://ourworldindata.org/technology-adoption
+- https://www.worldbank.org/en/publication/wdr2016

--- a/notebooklm/readings/devecon.md
+++ b/notebooklm/readings/devecon.md
@@ -1,0 +1,93 @@
+# Development Economics — cited readings
+
+Open-access sources cited across the course. Add to the notebook with:
+
+```bash
+# after `notebooklm login` and creating the notebook:
+python3 scripts/notebooklm-manage.py add-source devecon https://ourworldindata.org/human-development-index
+python3 scripts/notebooklm-manage.py add-source devecon https://www.dropbox.com/scl/fo/4n8bwqatkgxnva49kwfkb/AAcW4EFP_CRjI8mf5DVhd18?rlkey=iqykledl0yp2zsra3qcb5388m&st=466lm3zc&dl=0
+python3 scripts/notebooklm-manage.py add-source devecon https://mru.org/courses/development-economics/what-is-economic-growth
+python3 scripts/notebooklm-manage.py add-source devecon https://ourworldindata.org/economic-growth
+python3 scripts/notebooklm-manage.py add-source devecon https://data.worldbank.org/
+python3 scripts/notebooklm-manage.py add-source devecon https://hdr.undp.org/data-center
+python3 scripts/notebooklm-manage.py add-source devecon https://dhsprogram.com/
+python3 scripts/notebooklm-manage.py add-source devecon https://pip.worldbank.org/
+python3 scripts/notebooklm-manage.py add-source devecon https://hdr.undp.org/content/human-development-report-2023-24
+python3 scripts/notebooklm-manage.py add-source devecon https://ophi.org.uk/global-mpi
+python3 scripts/notebooklm-manage.py add-source devecon https://mru.org/courses/development-economics/hdi-human-development-index
+python3 scripts/notebooklm-manage.py add-source devecon https://ourworldindata.org/income-inequality
+python3 scripts/notebooklm-manage.py add-source devecon https://wir2022.wid.world/
+python3 scripts/notebooklm-manage.py add-source devecon https://mru.org/courses/development-economics/gini-coefficient
+python3 scripts/notebooklm-manage.py add-source devecon https://www.imf.org/en/Publications/WP/Issues/2016/12/31/Solow-Versus-Harrod-Domar-Reexamining-the-Aid-Costs-of-the-First-Millennium-Development-Goal-19917
+python3 scripts/notebooklm-manage.py add-source devecon https://mru.org/courses/development-economics/solow-model-economic-growth
+python3 scripts/notebooklm-manage.py add-source devecon https://ourworldindata.org/employment-in-agriculture
+python3 scripts/notebooklm-manage.py add-source devecon https://www.imf.org/en/Publications/WP/Issues/2018/09/28/Rethinking-Development-Policy-Deindustrialization-Servicification-and-Structural-46253
+python3 scripts/notebooklm-manage.py add-source devecon https://ourworldindata.org/global-education
+python3 scripts/notebooklm-manage.py add-source devecon https://ourworldindata.org/hunger-and-undernourishment
+python3 scripts/notebooklm-manage.py add-source devecon https://mru.org/courses/development-economics/child-labor-poverty
+python3 scripts/notebooklm-manage.py add-source devecon https://www.worldbank.org/en/publication/globalfindex
+python3 scripts/notebooklm-manage.py add-source devecon https://ourworldindata.org/trade-and-globalization
+python3 scripts/notebooklm-manage.py add-source devecon https://ourworldindata.org/corruption
+python3 scripts/notebooklm-manage.py add-source devecon https://www.povertyactionlab.org/about-j-pal
+python3 scripts/notebooklm-manage.py add-source devecon https://www.povertyactionlab.org/
+python3 scripts/notebooklm-manage.py add-source devecon https://mru.org/courses/development-economics/randomized-controlled-trial-explained
+python3 scripts/notebooklm-manage.py add-source devecon https://ourworldindata.org/much-better-awful-can-be-better
+python3 scripts/notebooklm-manage.py add-source devecon https://www.dropbox.com/scl/fi/0tw89748114gbo2va3isn/Development-Economics-Lexicon.xlsx?rlkey=n2imp5yhb8ma7l0fg7qk1w3r6&dl=1
+python3 scripts/notebooklm-manage.py add-source devecon https://www.linkedin.com/in/varnasriraman
+python3 scripts/notebooklm-manage.py add-source devecon https://twitter.com/varnasriraman
+python3 scripts/notebooklm-manage.py add-source devecon https://varnasriraman.notion.site
+python3 scripts/notebooklm-manage.py add-source devecon https://www.linkedin.com/in/vandana-soni-138a1012
+python3 scripts/notebooklm-manage.py add-source devecon https://mru.org/development-economics
+python3 scripts/notebooklm-manage.py add-source devecon https://ocw.mit.edu/courses/14-73-the-challenge-of-world-poverty-spring-2011/
+python3 scripts/notebooklm-manage.py add-source devecon https://notebooklm.google.com/notebook/959c243c-7fcf-4a1b-b9e4-30ec00fe5b3c
+python3 scripts/notebooklm-manage.py add-source devecon https://www.rug.nl/ggdc/productivity/pwt/
+python3 scripts/notebooklm-manage.py add-source devecon https://asercentre.org/
+python3 scripts/notebooklm-manage.py add-source devecon https://wid.world/
+python3 scripts/notebooklm-manage.py add-source devecon https://www.worldbank.org/en/research
+python3 scripts/notebooklm-manage.py add-source devecon https://www.undp.org/
+python3 scripts/notebooklm-manage.py add-source devecon https://ourworldindata.org/
+```
+
+## URLs
+- https://ourworldindata.org/human-development-index
+- https://www.dropbox.com/scl/fo/4n8bwqatkgxnva49kwfkb/AAcW4EFP_CRjI8mf5DVhd18?rlkey=iqykledl0yp2zsra3qcb5388m&st=466lm3zc&dl=0
+- https://mru.org/courses/development-economics/what-is-economic-growth
+- https://ourworldindata.org/economic-growth
+- https://data.worldbank.org/
+- https://hdr.undp.org/data-center
+- https://dhsprogram.com/
+- https://pip.worldbank.org/
+- https://hdr.undp.org/content/human-development-report-2023-24
+- https://ophi.org.uk/global-mpi
+- https://mru.org/courses/development-economics/hdi-human-development-index
+- https://ourworldindata.org/income-inequality
+- https://wir2022.wid.world/
+- https://mru.org/courses/development-economics/gini-coefficient
+- https://www.imf.org/en/Publications/WP/Issues/2016/12/31/Solow-Versus-Harrod-Domar-Reexamining-the-Aid-Costs-of-the-First-Millennium-Development-Goal-19917
+- https://mru.org/courses/development-economics/solow-model-economic-growth
+- https://ourworldindata.org/employment-in-agriculture
+- https://www.imf.org/en/Publications/WP/Issues/2018/09/28/Rethinking-Development-Policy-Deindustrialization-Servicification-and-Structural-46253
+- https://ourworldindata.org/global-education
+- https://ourworldindata.org/hunger-and-undernourishment
+- https://mru.org/courses/development-economics/child-labor-poverty
+- https://www.worldbank.org/en/publication/globalfindex
+- https://ourworldindata.org/trade-and-globalization
+- https://ourworldindata.org/corruption
+- https://www.povertyactionlab.org/about-j-pal
+- https://www.povertyactionlab.org/
+- https://mru.org/courses/development-economics/randomized-controlled-trial-explained
+- https://ourworldindata.org/much-better-awful-can-be-better
+- https://www.dropbox.com/scl/fi/0tw89748114gbo2va3isn/Development-Economics-Lexicon.xlsx?rlkey=n2imp5yhb8ma7l0fg7qk1w3r6&dl=1
+- https://www.linkedin.com/in/varnasriraman
+- https://twitter.com/varnasriraman
+- https://varnasriraman.notion.site
+- https://www.linkedin.com/in/vandana-soni-138a1012
+- https://mru.org/development-economics
+- https://ocw.mit.edu/courses/14-73-the-challenge-of-world-poverty-spring-2011/
+- https://notebooklm.google.com/notebook/959c243c-7fcf-4a1b-b9e4-30ec00fe5b3c
+- https://www.rug.nl/ggdc/productivity/pwt/
+- https://asercentre.org/
+- https://wid.world/
+- https://www.worldbank.org/en/research
+- https://www.undp.org/
+- https://ourworldindata.org/

--- a/notebooklm/readings/gandhi.md
+++ b/notebooklm/readings/gandhi.md
@@ -1,0 +1,81 @@
+# Gandhi & Nonviolence — cited readings
+
+Open-access sources cited across the course. Add to the notebook with:
+
+```bash
+# after `notebooklm login` and creating the notebook:
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.mkgandhi.org/hindswaraj/chap13_truecivilization.php
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.gandhiheritageportal.org/the-collected-works-of-mahatma-gandhi
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.cambridge.org/core/books/gandhis-philosophy-and-the-quest-for-harmony/E8D5F5A5B5C5D5E5F5G5H5I5
+python3 scripts/notebooklm-manage.py add-source gandhi https://archive.org/search?query=parekh+gandhi+political+philosophy
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.mkgandhi.org/hindswaraj/chap04_whatisswaraj.php
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.gandhiheritageportal.org/
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.gandhiheritageportal.org/cwmg
+python3 scripts/notebooklm-manage.py add-source gandhi https://101.impactmojo.in
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.mkgandhi.org/yeravda/chap02.php
+python3 scripts/notebooklm-manage.py add-source gandhi https://archive.org/search?query=iyer+moral+political+thought+gandhi
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.mkgandhi.org/hindswaraj/chap17_passiveresistance.php
+python3 scripts/notebooklm-manage.py add-source gandhi https://archive.org/search?query=bondurant+conquest+violence+gandhi
+python3 scripts/notebooklm-manage.py add-source gandhi https://archive.org/search?query=weber+salt+march+gandhi
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.mkgandhi.org/cnstrct/intro.php
+python3 scripts/notebooklm-manage.py add-source gandhi https://archive.org/search?query=kumarappa+economy+permanence
+python3 scripts/notebooklm-manage.py add-source gandhi https://archive.org/search?query=hardiman+gandhi+time+ours
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.mkgandhi.org/epigrams/n.php
+python3 scripts/notebooklm-manage.py add-source gandhi https://archive.org/search?query=alter+gandhi+body
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.gandhiheritageportal.org/journals/harijan
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.mkgandhi.org/articles/swadeshi1.php
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.cambridge.org/core/books/cambridge-companion-to-gandhi
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.mkgandhi.org/voiceoftruth/trusteeship.php
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.mkgandhi.org/indiadreams/chap24.php
+python3 scripts/notebooklm-manage.py add-source gandhi https://legislative.gov.in/constitution-of-india/
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.epw.in/
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.mkgandhi.org/cnstrct/chap20.php
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.mkgandhi.org/cnstrct/chap01.php
+python3 scripts/notebooklm-manage.py add-source gandhi https://archive.org/search?query=bhargava+secularism+critics
+python3 scripts/notebooklm-manage.py add-source gandhi https://archive.org/search?query=mani+gandhi+minority+rights
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.mkgandhi.org/hindswaraj/chap19_machinery.php
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.ericachenoweth.com/research/wcrw
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.aeinstein.org/nonviolentaction/198-methods-of-nonviolent-action/
+python3 scripts/notebooklm-manage.py add-source gandhi https://archive.org/search?query=guha+gandhi+years+changed+world
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.mkgandhi.org/gquots1.php
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.gandhiheritageportal.org/audio-video
+python3 scripts/notebooklm-manage.py add-source gandhi https://www.dropbox.com/scl/fi/9foplmubg4xen9seywr9s/Gandhian-Lexicon-Annotated.xlsx?rlkey=6dcghlcrkdqmlq807kuqhs0jl&st=ugj6g0s1&dl=1
+```
+
+## URLs
+- https://www.mkgandhi.org/hindswaraj/chap13_truecivilization.php
+- https://www.gandhiheritageportal.org/the-collected-works-of-mahatma-gandhi
+- https://www.cambridge.org/core/books/gandhis-philosophy-and-the-quest-for-harmony/E8D5F5A5B5C5D5E5F5G5H5I5
+- https://archive.org/search?query=parekh+gandhi+political+philosophy
+- https://www.mkgandhi.org/hindswaraj/chap04_whatisswaraj.php
+- https://www.gandhiheritageportal.org/
+- https://www.gandhiheritageportal.org/cwmg
+- https://101.impactmojo.in
+- https://www.mkgandhi.org/yeravda/chap02.php
+- https://archive.org/search?query=iyer+moral+political+thought+gandhi
+- https://www.mkgandhi.org/hindswaraj/chap17_passiveresistance.php
+- https://archive.org/search?query=bondurant+conquest+violence+gandhi
+- https://archive.org/search?query=weber+salt+march+gandhi
+- https://www.mkgandhi.org/cnstrct/intro.php
+- https://archive.org/search?query=kumarappa+economy+permanence
+- https://archive.org/search?query=hardiman+gandhi+time+ours
+- https://www.mkgandhi.org/epigrams/n.php
+- https://archive.org/search?query=alter+gandhi+body
+- https://www.gandhiheritageportal.org/journals/harijan
+- https://www.mkgandhi.org/articles/swadeshi1.php
+- https://www.cambridge.org/core/books/cambridge-companion-to-gandhi
+- https://www.mkgandhi.org/voiceoftruth/trusteeship.php
+- https://www.mkgandhi.org/indiadreams/chap24.php
+- https://legislative.gov.in/constitution-of-india/
+- https://www.epw.in/
+- https://www.mkgandhi.org/cnstrct/chap20.php
+- https://www.mkgandhi.org/cnstrct/chap01.php
+- https://archive.org/search?query=bhargava+secularism+critics
+- https://archive.org/search?query=mani+gandhi+minority+rights
+- https://www.mkgandhi.org/hindswaraj/chap19_machinery.php
+- https://www.ericachenoweth.com/research/wcrw
+- https://www.aeinstein.org/nonviolentaction/198-methods-of-nonviolent-action/
+- https://archive.org/search?query=guha+gandhi+years+changed+world
+- https://www.mkgandhi.org/gquots1.php
+- https://www.gandhiheritageportal.org/audio-video
+- https://www.dropbox.com/scl/fi/9foplmubg4xen9seywr9s/Gandhian-Lexicon-Annotated.xlsx?rlkey=6dcghlcrkdqmlq807kuqhs0jl&st=ugj6g0s1&dl=1

--- a/notebooklm/readings/gender.md
+++ b/notebooklm/readings/gender.md
@@ -1,0 +1,51 @@
+# Gender & Development — cited readings
+
+Open-access sources cited across the course. Add to the notebook with:
+
+```bash
+# after `notebooklm login` and creating the notebook:
+python3 scripts/notebooklm-manage.py add-source gender https://documents.worldbank.org/en/publication/documents-reports/documentdetail/492221468136792185
+python3 scripts/notebooklm-manage.py add-source gender https://www.jstor.org/stable/27640853
+python3 scripts/notebooklm-manage.py add-source gender https://www.gutenberg.org/ebooks/3420
+python3 scripts/notebooklm-manage.py add-source gender https://www.jstor.org/stable/1395054
+python3 scripts/notebooklm-manage.py add-source gender https://chicagounbound.uchicago.edu/uclf/vol1989/iss1/8/
+python3 scripts/notebooklm-manage.py add-source gender http://www.historyisaweapon.com/defcon1/combrivercoll.html
+python3 scripts/notebooklm-manage.py add-source gender https://www.jstor.org/stable/1229039
+python3 scripts/notebooklm-manage.py add-source gender https://www.jstor.org/stable/4407323
+python3 scripts/notebooklm-manage.py add-source gender https://www.jstor.org/stable/4403327
+python3 scripts/notebooklm-manage.py add-source gender https://www.ilo.org/publications/major-publications/care-work-and-care-jobs-future-decent-work
+python3 scripts/notebooklm-manage.py add-source gender https://www.gutenberg.org/ebooks/27083
+python3 scripts/notebooklm-manage.py add-source gender https://www.who.int/news-room/fact-sheets/detail/violence-against-women
+python3 scripts/notebooklm-manage.py add-source gender https://indiankanoon.org/doc/1031794/
+python3 scripts/notebooklm-manage.py add-source gender https://economics.mit.edu/files/792
+python3 scripts/notebooklm-manage.py add-source gender https://en.wikisource.org/wiki/Castes_in_India:_Their_Mechanism,_Genesis_and_Development
+python3 scripts/notebooklm-manage.py add-source gender https://www.jstor.org/stable/4399556
+python3 scripts/notebooklm-manage.py add-source gender https://www.columbia.edu/itc/mealac/pritchett/00ambedkar/txt_ambedkar_castes.html
+python3 scripts/notebooklm-manage.py add-source gender https://hdr.undp.org/content/2023-gender-social-norms-index-gsni
+python3 scripts/notebooklm-manage.py add-source gender https://indiankanoon.org/doc/193543132/
+python3 scripts/notebooklm-manage.py add-source gender https://www.itu.int/itu-d/reports/statistics/2024/11/10/ff24-the-gender-digital-divide/
+python3 scripts/notebooklm-manage.py add-source gender https://hdr.undp.org/data-center/thematic-composite-indices/gender-inequality-index
+```
+
+## URLs
+- https://documents.worldbank.org/en/publication/documents-reports/documentdetail/492221468136792185
+- https://www.jstor.org/stable/27640853
+- https://www.gutenberg.org/ebooks/3420
+- https://www.jstor.org/stable/1395054
+- https://chicagounbound.uchicago.edu/uclf/vol1989/iss1/8/
+- http://www.historyisaweapon.com/defcon1/combrivercoll.html
+- https://www.jstor.org/stable/1229039
+- https://www.jstor.org/stable/4407323
+- https://www.jstor.org/stable/4403327
+- https://www.ilo.org/publications/major-publications/care-work-and-care-jobs-future-decent-work
+- https://www.gutenberg.org/ebooks/27083
+- https://www.who.int/news-room/fact-sheets/detail/violence-against-women
+- https://indiankanoon.org/doc/1031794/
+- https://economics.mit.edu/files/792
+- https://en.wikisource.org/wiki/Castes_in_India:_Their_Mechanism,_Genesis_and_Development
+- https://www.jstor.org/stable/4399556
+- https://www.columbia.edu/itc/mealac/pritchett/00ambedkar/txt_ambedkar_castes.html
+- https://hdr.undp.org/content/2023-gender-social-norms-index-gsni
+- https://indiankanoon.org/doc/193543132/
+- https://www.itu.int/itu-d/reports/statistics/2024/11/10/ff24-the-gender-digital-divide/
+- https://hdr.undp.org/data-center/thematic-composite-indices/gender-inequality-index

--- a/notebooklm/readings/intervention.md
+++ b/notebooklm/readings/intervention.md
@@ -1,0 +1,31 @@
+# Intervention Design — cited readings
+
+Open-access sources cited across the course. Add to the notebook with:
+
+```bash
+# after `notebooklm login` and creating the notebook:
+python3 scripts/notebooklm-manage.py add-source intervention https://openknowledge.worldbank.org/handle/10986/20597
+python3 scripts/notebooklm-manage.py add-source intervention https://library.oapen.org/handle/20.500.12657/31857
+python3 scripts/notebooklm-manage.py add-source intervention https://assets.publishing.service.gov.uk/media/57a08a5ded915d3cfd00071a/DFID_ToC_Review_VogelV7.pdf
+python3 scripts/notebooklm-manage.py add-source intervention https://ourworldindata.org/global-inequality-opportunity-to-give
+python3 scripts/notebooklm-manage.py add-source intervention https://www.povertyactionlab.org/policy-insight/building-stable-livelihoods-ultra-poor
+python3 scripts/notebooklm-manage.py add-source intervention https://www.povertyactionlab.org/policy-insight/improving-health-worker-performance-through-pay-performance-programs
+python3 scripts/notebooklm-manage.py add-source intervention https://www.povertyactionlab.org/policy-insight/designing-financial-services-and-social-protection-programs-enhance-womens-economic
+python3 scripts/notebooklm-manage.py add-source intervention https://www.povertyactionlab.org/evidence-effect/teaching-at-the-right-level
+python3 scripts/notebooklm-manage.py add-source intervention https://www.povertyactionlab.org/evaluation/effectively-targeting-anti-poverty-programs-indonesia
+python3 scripts/notebooklm-manage.py add-source intervention https://www.gov.uk/research-for-development-outputs/scaling-up-what-works-experimental-evidence-on-external-validity-in-kenyan-education
+python3 scripts/notebooklm-manage.py add-source intervention https://www.3ieimpact.org/blogs/scaling-development-interventions-requires-planning-beginning-3ies-expert-panel-says
+```
+
+## URLs
+- https://openknowledge.worldbank.org/handle/10986/20597
+- https://library.oapen.org/handle/20.500.12657/31857
+- https://assets.publishing.service.gov.uk/media/57a08a5ded915d3cfd00071a/DFID_ToC_Review_VogelV7.pdf
+- https://ourworldindata.org/global-inequality-opportunity-to-give
+- https://www.povertyactionlab.org/policy-insight/building-stable-livelihoods-ultra-poor
+- https://www.povertyactionlab.org/policy-insight/improving-health-worker-performance-through-pay-performance-programs
+- https://www.povertyactionlab.org/policy-insight/designing-financial-services-and-social-protection-programs-enhance-womens-economic
+- https://www.povertyactionlab.org/evidence-effect/teaching-at-the-right-level
+- https://www.povertyactionlab.org/evaluation/effectively-targeting-anti-poverty-programs-indonesia
+- https://www.gov.uk/research-for-development-outputs/scaling-up-what-works-experimental-evidence-on-external-validity-in-kenyan-education
+- https://www.3ieimpact.org/blogs/scaling-development-interventions-requires-planning-beginning-3ies-expert-panel-says

--- a/notebooklm/readings/law.md
+++ b/notebooklm/readings/law.md
@@ -1,0 +1,37 @@
+# Law & Justice — cited readings
+
+Open-access sources cited across the course. Add to the notebook with:
+
+```bash
+# after `notebooklm login` and creating the notebook:
+python3 scripts/notebooklm-manage.py add-source law https://www.constitutionofindia.net/constitution-of-india/preamble/
+python3 scripts/notebooklm-manage.py add-source law https://www.constitutionofindia.net/articles/article-14-equality-before-law/
+python3 scripts/notebooklm-manage.py add-source law https://www.constitutionofindia.net/articles/article-37-application-of-the-principles-contained-in-this-part/
+python3 scripts/notebooklm-manage.py add-source law https://www.constitutionofindia.net/articles/article-1-name-and-territory-of-the-union/
+python3 scripts/notebooklm-manage.py add-source law https://www.constitutionofindia.net/
+python3 scripts/notebooklm-manage.py add-source law https://www.constitutionofindia.net/articles/article-32-remedies-for-enforcement-of-rights-conferred-by-this-part/
+python3 scripts/notebooklm-manage.py add-source law https://www.constitutionofindia.net/articles/article-21-protection-of-life-and-personal-liberty/
+python3 scripts/notebooklm-manage.py add-source law https://www.constitutionofindia.net/articles/article-16-equality-of-opportunity-in-matters-of-public-employment/
+python3 scripts/notebooklm-manage.py add-source law https://www.constitutionofindia.net/articles/article-21a-right-to-education/
+python3 scripts/notebooklm-manage.py add-source law https://www.constitutionofindia.net/articles/article-22-protection-against-arrest-and-detention-in-certain-cases/
+python3 scripts/notebooklm-manage.py add-source law https://indiankanoon.org/
+python3 scripts/notebooklm-manage.py add-source law https://www.constitutionofindia.net/articles/article-48a-protection-and-improvement-of-environment-and-safeguarding-of-forests-and-wild-life/
+python3 scripts/notebooklm-manage.py add-source law https://www.un.org/en/about-us/universal-declaration-of-human-rights
+python3 scripts/notebooklm-manage.py add-source law https://www.constituteproject.org/constitution/Nepal_2015
+```
+
+## URLs
+- https://www.constitutionofindia.net/constitution-of-india/preamble/
+- https://www.constitutionofindia.net/articles/article-14-equality-before-law/
+- https://www.constitutionofindia.net/articles/article-37-application-of-the-principles-contained-in-this-part/
+- https://www.constitutionofindia.net/articles/article-1-name-and-territory-of-the-union/
+- https://www.constitutionofindia.net/
+- https://www.constitutionofindia.net/articles/article-32-remedies-for-enforcement-of-rights-conferred-by-this-part/
+- https://www.constitutionofindia.net/articles/article-21-protection-of-life-and-personal-liberty/
+- https://www.constitutionofindia.net/articles/article-16-equality-of-opportunity-in-matters-of-public-employment/
+- https://www.constitutionofindia.net/articles/article-21a-right-to-education/
+- https://www.constitutionofindia.net/articles/article-22-protection-against-arrest-and-detention-in-certain-cases/
+- https://indiankanoon.org/
+- https://www.constitutionofindia.net/articles/article-48a-protection-and-improvement-of-environment-and-safeguarding-of-forests-and-wild-life/
+- https://www.un.org/en/about-us/universal-declaration-of-human-rights
+- https://www.constituteproject.org/constitution/Nepal_2015

--- a/notebooklm/readings/livelihoods.md
+++ b/notebooklm/readings/livelihoods.md
@@ -1,0 +1,39 @@
+# Livelihoods in India — cited readings
+
+Open-access sources cited across the course. Add to the notebook with:
+
+```bash
+# after `notebooklm login` and creating the notebook:
+python3 scripts/notebooklm-manage.py add-source livelihoods https://www.worldbank.org/en/news/press-release/2013/04/25/jobs-cornerstone-development-world-development-report-2013
+python3 scripts/notebooklm-manage.py add-source livelihoods https://ourworldindata.org/employment-in-agriculture
+python3 scripts/notebooklm-manage.py add-source livelihoods https://www.worldbank.org/en/news/feature/2017/06/20/scaling-up-womens-economic-empowerment-india
+python3 scripts/notebooklm-manage.py add-source livelihoods https://blogs.worldbank.org/en/endpovertyinsouthasia/birds-eye-view-mahatma-gandhi-national-rural-employment-guarantee-act
+python3 scripts/notebooklm-manage.py add-source livelihoods https://www.worldbank.org/en/publication/globalfindex
+python3 scripts/notebooklm-manage.py add-source livelihoods https://ourworldindata.org/urbanization
+python3 scripts/notebooklm-manage.py add-source livelihoods https://www.ilo.org/publications/women-and-men-informal-economy-statistical-picture-third-edition
+python3 scripts/notebooklm-manage.py add-source livelihoods https://www.ilo.org/resource/world-employment-and-social-outlook-2021-role-digital-labour-platforms
+python3 scripts/notebooklm-manage.py add-source livelihoods https://www.ilo.org/publications/making-decent-work-reality-domestic-workers-progress-and-prospects-ten
+python3 scripts/notebooklm-manage.py add-source livelihoods https://www.worldbank.org/en/country/india/brief/leveraging-urbanization-india
+python3 scripts/notebooklm-manage.py add-source livelihoods https://www.ilo.org/resource/article/what-skills-mismatch-and-why-should-we-care
+python3 scripts/notebooklm-manage.py add-source livelihoods https://www.ilo.org/topics-and-sectors/apprenticeships
+python3 scripts/notebooklm-manage.py add-source livelihoods https://ourworldindata.org/female-labor-supply
+python3 scripts/notebooklm-manage.py add-source livelihoods https://www.worldbank.org/en/news/feature/2017/03/16/expectations-and-reality-collide-in-active-labor-market-policies
+python3 scripts/notebooklm-manage.py add-source livelihoods https://documents.worldbank.org/curated/en/256001490191438119/How-effective-are-active-labor-market-policies-in-developing-countries-a-critical-review-of-recent-evidence
+```
+
+## URLs
+- https://www.worldbank.org/en/news/press-release/2013/04/25/jobs-cornerstone-development-world-development-report-2013
+- https://ourworldindata.org/employment-in-agriculture
+- https://www.worldbank.org/en/news/feature/2017/06/20/scaling-up-womens-economic-empowerment-india
+- https://blogs.worldbank.org/en/endpovertyinsouthasia/birds-eye-view-mahatma-gandhi-national-rural-employment-guarantee-act
+- https://www.worldbank.org/en/publication/globalfindex
+- https://ourworldindata.org/urbanization
+- https://www.ilo.org/publications/women-and-men-informal-economy-statistical-picture-third-edition
+- https://www.ilo.org/resource/world-employment-and-social-outlook-2021-role-digital-labour-platforms
+- https://www.ilo.org/publications/making-decent-work-reality-domestic-workers-progress-and-prospects-ten
+- https://www.worldbank.org/en/country/india/brief/leveraging-urbanization-india
+- https://www.ilo.org/resource/article/what-skills-mismatch-and-why-should-we-care
+- https://www.ilo.org/topics-and-sectors/apprenticeships
+- https://ourworldindata.org/female-labor-supply
+- https://www.worldbank.org/en/news/feature/2017/03/16/expectations-and-reality-collide-in-active-labor-market-policies
+- https://documents.worldbank.org/curated/en/256001490191438119/How-effective-are-active-labor-market-policies-in-developing-countries-a-critical-review-of-recent-evidence

--- a/notebooklm/readings/media.md
+++ b/notebooklm/readings/media.md
@@ -1,0 +1,111 @@
+# Media & Information — cited readings
+
+Open-access sources cited across the course. Add to the notebook with:
+
+```bash
+# after `notebooklm login` and creating the notebook:
+python3 scripts/notebooklm-manage.py add-source media https://reutersinstitute.politics.ox.ac.uk/digital-news-report/2024/dnr-executive-summary
+python3 scripts/notebooklm-manage.py add-source media https://journals.sagepub.com/doi/10.1177/0957926510366199
+python3 scripts/notebooklm-manage.py add-source media https://www.tandfonline.com/doi/abs/10.1080/14616700701556104
+python3 scripts/notebooklm-manage.py add-source media https://asercentre.org/
+python3 scripts/notebooklm-manage.py add-source media https://www.semanticscholar.org/paper/Finding-frames:-new-ways-to-engage-the-UK-public-in-Darnton-Kirk/d014db665268760e320bb736d6e80879c4b39ba5
+python3 scripts/notebooklm-manage.py add-source media https://www.wiley.com/en-us/The+Ironic+Spectator:+Solidarity+in+the+Age+of+Post+Humanitarianism-p-9780745642109
+python3 scripts/notebooklm-manage.py add-source media https://www.routledge.com/Compassion-Fatigue-How-the-Media-Sell-Disease-Famine-War-and-Death/Moeller/p/book/9780415920988
+python3 scripts/notebooklm-manage.py add-source media https://www.bloomsburycollections.com/book/representations-of-global-poverty-aid-development-and-international-ngos/
+python3 scripts/notebooklm-manage.py add-source media https://www.ted.com/talks/chimamanda_ngozi_adichie_the_danger_of_a_single_story/transcript
+python3 scripts/notebooklm-manage.py add-source media https://journals.sagepub.com/doi/10.1177/109019819702400309
+python3 scripts/notebooklm-manage.py add-source media https://us.sagepub.com/en-us/nam/why-voice-matters/book233759
+python3 scripts/notebooklm-manage.py add-source media https://www.edmundricedevelopment.org/about/governance/dochas-code-of-conduct-on-images-and-messages/
+python3 scripts/notebooklm-manage.py add-source media https://cjc.utppublishing.com/doi/10.22230/cjc.2013v38n1a2587
+python3 scripts/notebooklm-manage.py add-source media https://www.radiaid.com/
+python3 scripts/notebooklm-manage.py add-source media https://onlinelibrary.wiley.com/doi/10.1111/j.1467-8330.2008.00627.x
+python3 scripts/notebooklm-manage.py add-source media https://etheses.dur.ac.uk/136/
+python3 scripts/notebooklm-manage.py add-source media https://washmatters.wateraid.org/publications/ethical-image-policy
+python3 scripts/notebooklm-manage.py add-source media https://www.bond.org.uk/resources/putting-the-people-in-the-pictures-first/
+python3 scripts/notebooklm-manage.py add-source media https://www.videovolunteers.org
+python3 scripts/notebooklm-manage.py add-source media https://this.org/2011/12/01/admitting-failure/
+python3 scripts/notebooklm-manage.py add-source media https://global.oup.com/academic/product/the-goldilocks-challenge-9780199366088
+python3 scripts/notebooklm-manage.py add-source media https://issuu.com/ewb-isf/docs/ewb_failure_report_english
+python3 scripts/notebooklm-manage.py add-source media https://www.admittingfailure.org/
+python3 scripts/notebooklm-manage.py add-source media https://www.wiley.com/en-us/The+Fearless+Organization%3A+Creating+Psychological+Safety+in+the+Workplace+for+Learning%2C+Innovation%2C+and+Growth-p-9781119477266
+python3 scripts/notebooklm-manage.py add-source media https://ruralindiaonline.org/en/
+python3 scripts/notebooklm-manage.py add-source media https://www.penguin.co.in/book/everybody-loves-a-good-drought/
+python3 scripts/notebooklm-manage.py add-source media https://ruralindiaonline.org/
+python3 scripts/notebooklm-manage.py add-source media https://datajournalism.com/read/handbook/one
+python3 scripts/notebooklm-manage.py add-source media https://www.un.org/democracyfund/en/news/how-undef-funded-award-winning-local-newspaper-empowers-rural-women-india
+python3 scripts/notebooklm-manage.py add-source media https://khabarlahariya.org/
+python3 scripts/notebooklm-manage.py add-source media https://en.wikipedia.org/wiki/Writing_with_Fire
+python3 scripts/notebooklm-manage.py add-source media https://www.videovolunteers.org/about/
+python3 scripts/notebooklm-manage.py add-source media https://www.videovolunteers.org/
+python3 scripts/notebooklm-manage.py add-source media https://video4change.org/video-volunteers-and-measuring-impact/
+python3 scripts/notebooklm-manage.py add-source media https://gen-ai.witness.org
+python3 scripts/notebooklm-manage.py add-source media https://datajournalism.com/read/handbook/one/introduction/what-is-data-journalism
+python3 scripts/notebooklm-manage.py add-source media https://datajournalismhandbook.org/
+python3 scripts/notebooklm-manage.py add-source media https://www.indiaspend.com/
+python3 scripts/notebooklm-manage.py add-source media https://africacheck.org/
+python3 scripts/notebooklm-manage.py add-source media https://www.unesco.org/en/artificial-intelligence/recommendation-ethics
+python3 scripts/notebooklm-manage.py add-source media https://www.gen-ai.witness.org/
+python3 scripts/notebooklm-manage.py add-source media https://reutersinstitute.politics.ox.ac.uk/types-sources-and-claims-covid-19-misinformation
+python3 scripts/notebooklm-manage.py add-source media https://international-review.icrc.org/articles/ai-and-machine-learning-in-armed-conflict-a-human-centred-approach-913
+python3 scripts/notebooklm-manage.py add-source media https://www.unesco.org/en/articles/journalism-fake-news-and-disinformation-handbook-journalism-education-and-training
+python3 scripts/notebooklm-manage.py add-source media https://ruralindiaonline.org
+python3 scripts/notebooklm-manage.py add-source media https://khabarlahariya.org
+python3 scripts/notebooklm-manage.py add-source media https://www.witness.org
+python3 scripts/notebooklm-manage.py add-source media https://www.bond.org.uk/resources/putting-the-people-in-the-pictures-first
+python3 scripts/notebooklm-manage.py add-source media https://www.indiaspend.com
+python3 scripts/notebooklm-manage.py add-source media https://asercentre.org
+python3 scripts/notebooklm-manage.py add-source media https://www.comminit.com
+```
+
+## URLs
+- https://reutersinstitute.politics.ox.ac.uk/digital-news-report/2024/dnr-executive-summary
+- https://journals.sagepub.com/doi/10.1177/0957926510366199
+- https://www.tandfonline.com/doi/abs/10.1080/14616700701556104
+- https://asercentre.org/
+- https://www.semanticscholar.org/paper/Finding-frames:-new-ways-to-engage-the-UK-public-in-Darnton-Kirk/d014db665268760e320bb736d6e80879c4b39ba5
+- https://www.wiley.com/en-us/The+Ironic+Spectator:+Solidarity+in+the+Age+of+Post+Humanitarianism-p-9780745642109
+- https://www.routledge.com/Compassion-Fatigue-How-the-Media-Sell-Disease-Famine-War-and-Death/Moeller/p/book/9780415920988
+- https://www.bloomsburycollections.com/book/representations-of-global-poverty-aid-development-and-international-ngos/
+- https://www.ted.com/talks/chimamanda_ngozi_adichie_the_danger_of_a_single_story/transcript
+- https://journals.sagepub.com/doi/10.1177/109019819702400309
+- https://us.sagepub.com/en-us/nam/why-voice-matters/book233759
+- https://www.edmundricedevelopment.org/about/governance/dochas-code-of-conduct-on-images-and-messages/
+- https://cjc.utppublishing.com/doi/10.22230/cjc.2013v38n1a2587
+- https://www.radiaid.com/
+- https://onlinelibrary.wiley.com/doi/10.1111/j.1467-8330.2008.00627.x
+- https://etheses.dur.ac.uk/136/
+- https://washmatters.wateraid.org/publications/ethical-image-policy
+- https://www.bond.org.uk/resources/putting-the-people-in-the-pictures-first/
+- https://www.videovolunteers.org
+- https://this.org/2011/12/01/admitting-failure/
+- https://global.oup.com/academic/product/the-goldilocks-challenge-9780199366088
+- https://issuu.com/ewb-isf/docs/ewb_failure_report_english
+- https://www.admittingfailure.org/
+- https://www.wiley.com/en-us/The+Fearless+Organization%3A+Creating+Psychological+Safety+in+the+Workplace+for+Learning%2C+Innovation%2C+and+Growth-p-9781119477266
+- https://ruralindiaonline.org/en/
+- https://www.penguin.co.in/book/everybody-loves-a-good-drought/
+- https://ruralindiaonline.org/
+- https://datajournalism.com/read/handbook/one
+- https://www.un.org/democracyfund/en/news/how-undef-funded-award-winning-local-newspaper-empowers-rural-women-india
+- https://khabarlahariya.org/
+- https://en.wikipedia.org/wiki/Writing_with_Fire
+- https://www.videovolunteers.org/about/
+- https://www.videovolunteers.org/
+- https://video4change.org/video-volunteers-and-measuring-impact/
+- https://gen-ai.witness.org
+- https://datajournalism.com/read/handbook/one/introduction/what-is-data-journalism
+- https://datajournalismhandbook.org/
+- https://www.indiaspend.com/
+- https://africacheck.org/
+- https://www.unesco.org/en/artificial-intelligence/recommendation-ethics
+- https://www.gen-ai.witness.org/
+- https://reutersinstitute.politics.ox.ac.uk/types-sources-and-claims-covid-19-misinformation
+- https://international-review.icrc.org/articles/ai-and-machine-learning-in-armed-conflict-a-human-centred-approach-913
+- https://www.unesco.org/en/articles/journalism-fake-news-and-disinformation-handbook-journalism-education-and-training
+- https://ruralindiaonline.org
+- https://khabarlahariya.org
+- https://www.witness.org
+- https://www.bond.org.uk/resources/putting-the-people-in-the-pictures-first
+- https://www.indiaspend.com
+- https://asercentre.org
+- https://www.comminit.com

--- a/notebooklm/readings/mel.md
+++ b/notebooklm/readings/mel.md
@@ -1,0 +1,95 @@
+# Monitoring, Evaluation & Learning (MEAL) — cited readings
+
+Open-access sources cited across the course. Add to the notebook with:
+
+```bash
+# after `notebooklm login` and creating the notebook:
+python3 scripts/notebooklm-manage.py add-source mel https://documents1.worldbank.org/curated/en/698441474029568469/pdf/Impact-evaluation-in-practice.pdf
+python3 scripts/notebooklm-manage.py add-source mel https://www.intrac.org/wpcms/wp-content/uploads/2017/01/Monitoring-and-evaluation-series-overview.pdf
+python3 scripts/notebooklm-manage.py add-source mel https://usaidlearninglab.org/cla/cla-toolkit
+python3 scripts/notebooklm-manage.py add-source mel https://www.betterevaluation.org/
+python3 scripts/notebooklm-manage.py add-source mel https://odi.org/en/publications/doing-development-differently-who-we-are-what-were-doing-and-what-were-learning/
+python3 scripts/notebooklm-manage.py add-source mel https://www.theoryofchange.org/what-is-theory-of-change/
+python3 scripts/notebooklm-manage.py add-source mel https://www.intrac.org/wpcms/wp-content/uploads/2017/01/Theory-of-change.pdf
+python3 scripts/notebooklm-manage.py add-source mel https://www.outcomemapping.ca/
+python3 scripts/notebooklm-manage.py add-source mel https://www.dropbox.com/scl/fi/560e61msf1tayf67sjwto/mel-exercise-02-toc.xlsx?rlkey=eb00qi2oykep12u2t8osl2k7v&dl=1
+python3 scripts/notebooklm-manage.py add-source mel https://101.impactmojo.in/mel-design-lab
+python3 scripts/notebooklm-manage.py add-source mel https://www.intrac.org/wpcms/wp-content/uploads/2017/01/Indicators.pdf
+python3 scripts/notebooklm-manage.py add-source mel https://www.asercentre.org/
+python3 scripts/notebooklm-manage.py add-source mel https://www.dropbox.com/scl/fi/jcz9uiqlfxjbi2h4e0b3q/mel-exercise-03-indicators.xlsx?rlkey=d7rjlz2oa40u5cbtfpn1xnnm3&dl=1
+python3 scripts/notebooklm-manage.py add-source mel https://www.dropbox.com/scl/fi/bzsu3e8px3x87epzli609/mel-exercise-04-baselines.xlsx?rlkey=qma3jjauiqrf0lvc01t8b6ass&dl=1
+python3 scripts/notebooklm-manage.py add-source mel https://www.intrac.org/wpcms/wp-content/uploads/2017/01/Baselines.pdf
+python3 scripts/notebooklm-manage.py add-source mel https://www.intrac.org/wpcms/wp-content/uploads/2017/01/Data-collection-methods.pdf
+python3 scripts/notebooklm-manage.py add-source mel https://www.kobotoolbox.org/
+python3 scripts/notebooklm-manage.py add-source mel https://www.dropbox.com/scl/fi/cqif8egyot3e40ndcl75b/mel-exercise-05-sampling.xlsx?rlkey=ejd9j0abyqm3f9unhj5s759u2&dl=1
+python3 scripts/notebooklm-manage.py add-source mel https://www.usaid.gov/sites/default/files/2022-12/How-To_Note_Data_Quality_Assessment_Checklist.pdf
+python3 scripts/notebooklm-manage.py add-source mel https://www.dropbox.com/scl/fi/0cgwneyqq0nugbtch784u/mel-exercise-06-dataquality.xlsx?rlkey=ayby3806a49zj0eo3896f014o&dl=1
+python3 scripts/notebooklm-manage.py add-source mel https://miguelhernan.org/whatifbook
+python3 scripts/notebooklm-manage.py add-source mel https://www.intrac.org/wpcms/wp-content/uploads/2017/01/Quantitative-analysis.pdf
+python3 scripts/notebooklm-manage.py add-source mel https://www.dropbox.com/scl/fi/nlp5usaunhj629qsmoyme/mel-exercise-07-analysis.xlsx?rlkey=8uo1kxf1dz0tv3q6ffxchetin&dl=1
+python3 scripts/notebooklm-manage.py add-source mel https://www.intrac.org/wpcms/wp-content/uploads/2017/01/Qualitative-analysis.pdf
+python3 scripts/notebooklm-manage.py add-source mel https://www.tandfonline.com/doi/abs/10.1191/1478088706qp063oa
+python3 scripts/notebooklm-manage.py add-source mel https://www.deval.org/fileadmin/Redaktion/PDF/05-Publikationen/Policy_Briefs/2018_9_DAC_Evaluierungskriterien/DEval_Policy_Brief_DAC_Evaluation_Criteria_2018_EN.pdf
+python3 scripts/notebooklm-manage.py add-source mel https://www.oecd.org/dac/evaluation/daccriteriaforevaluatingdevelopmentassistance.htm
+python3 scripts/notebooklm-manage.py add-source mel https://www.oecd.org/en/topics/sub-issues/development-evaluation-and-effectiveness/evaluation-criteria.html
+python3 scripts/notebooklm-manage.py add-source mel https://www.povertyactionlab.org/research-resources
+python3 scripts/notebooklm-manage.py add-source mel https://www.intrac.org/wpcms/wp-content/uploads/2017/01/Contribution-analysis.pdf
+python3 scripts/notebooklm-manage.py add-source mel https://www.oecd.org/content/dam/oecd/en/publications/reports/2021/03/development-co-operation-tips-tools-insights-practices_d307b396/usaid-collaborating-learning-and-adapting_d5fb345a/bb879930-en.pdf
+python3 scripts/notebooklm-manage.py add-source mel https://www.odi.org/publications/10367-doing-development-differently
+python3 scripts/notebooklm-manage.py add-source mel https://www.kobotoolbox.org/resources/
+python3 scripts/notebooklm-manage.py add-source mel https://dhis2.org/
+python3 scripts/notebooklm-manage.py add-source mel https://101.impactmojo.in/mel-plan-lab
+python3 scripts/notebooklm-manage.py add-source mel https://usaidlearninglab.org/sites/default/files/resource/files/cla_maturity_tool.pdf
+python3 scripts/notebooklm-manage.py add-source mel https://openknowledge.worldbank.org/handle/10986/14926
+python3 scripts/notebooklm-manage.py add-source mel https://www.intrac.org/resources/monitoring-evaluation-series/
+python3 scripts/notebooklm-manage.py add-source mel https://www.dropbox.com/scl/fo/4bxck9fg67r3a5qajn21s/APtQiVIejLNWuA2ib7IVZ4U?rlkey=g9bsvm03yssln0bjxk6bqkyv5&dl=0
+python3 scripts/notebooklm-manage.py add-source mel https://notebooklm.google.com/notebook/cc450613-e857-4889-9406-a85638f42966
+python3 scripts/notebooklm-manage.py add-source mel https://www.worldbank.org/en/programs/sief-trust-fund/publication/impact-evaluation-in-practice
+python3 scripts/notebooklm-manage.py add-source mel https://www.betterevaluation.org/methods-approaches/approaches/developmental-evaluation
+python3 scripts/notebooklm-manage.py add-source mel https://www.dropbox.com/scl/fi/rt6d5qyrd5ql1rfmxa2ed/mel-lexicon.xlsx?rlkey=slrmibf5ckj2xoyr2j6lal03s&dl=1
+```
+
+## URLs
+- https://documents1.worldbank.org/curated/en/698441474029568469/pdf/Impact-evaluation-in-practice.pdf
+- https://www.intrac.org/wpcms/wp-content/uploads/2017/01/Monitoring-and-evaluation-series-overview.pdf
+- https://usaidlearninglab.org/cla/cla-toolkit
+- https://www.betterevaluation.org/
+- https://odi.org/en/publications/doing-development-differently-who-we-are-what-were-doing-and-what-were-learning/
+- https://www.theoryofchange.org/what-is-theory-of-change/
+- https://www.intrac.org/wpcms/wp-content/uploads/2017/01/Theory-of-change.pdf
+- https://www.outcomemapping.ca/
+- https://www.dropbox.com/scl/fi/560e61msf1tayf67sjwto/mel-exercise-02-toc.xlsx?rlkey=eb00qi2oykep12u2t8osl2k7v&dl=1
+- https://101.impactmojo.in/mel-design-lab
+- https://www.intrac.org/wpcms/wp-content/uploads/2017/01/Indicators.pdf
+- https://www.asercentre.org/
+- https://www.dropbox.com/scl/fi/jcz9uiqlfxjbi2h4e0b3q/mel-exercise-03-indicators.xlsx?rlkey=d7rjlz2oa40u5cbtfpn1xnnm3&dl=1
+- https://www.dropbox.com/scl/fi/bzsu3e8px3x87epzli609/mel-exercise-04-baselines.xlsx?rlkey=qma3jjauiqrf0lvc01t8b6ass&dl=1
+- https://www.intrac.org/wpcms/wp-content/uploads/2017/01/Baselines.pdf
+- https://www.intrac.org/wpcms/wp-content/uploads/2017/01/Data-collection-methods.pdf
+- https://www.kobotoolbox.org/
+- https://www.dropbox.com/scl/fi/cqif8egyot3e40ndcl75b/mel-exercise-05-sampling.xlsx?rlkey=ejd9j0abyqm3f9unhj5s759u2&dl=1
+- https://www.usaid.gov/sites/default/files/2022-12/How-To_Note_Data_Quality_Assessment_Checklist.pdf
+- https://www.dropbox.com/scl/fi/0cgwneyqq0nugbtch784u/mel-exercise-06-dataquality.xlsx?rlkey=ayby3806a49zj0eo3896f014o&dl=1
+- https://miguelhernan.org/whatifbook
+- https://www.intrac.org/wpcms/wp-content/uploads/2017/01/Quantitative-analysis.pdf
+- https://www.dropbox.com/scl/fi/nlp5usaunhj629qsmoyme/mel-exercise-07-analysis.xlsx?rlkey=8uo1kxf1dz0tv3q6ffxchetin&dl=1
+- https://www.intrac.org/wpcms/wp-content/uploads/2017/01/Qualitative-analysis.pdf
+- https://www.tandfonline.com/doi/abs/10.1191/1478088706qp063oa
+- https://www.deval.org/fileadmin/Redaktion/PDF/05-Publikationen/Policy_Briefs/2018_9_DAC_Evaluierungskriterien/DEval_Policy_Brief_DAC_Evaluation_Criteria_2018_EN.pdf
+- https://www.oecd.org/dac/evaluation/daccriteriaforevaluatingdevelopmentassistance.htm
+- https://www.oecd.org/en/topics/sub-issues/development-evaluation-and-effectiveness/evaluation-criteria.html
+- https://www.povertyactionlab.org/research-resources
+- https://www.intrac.org/wpcms/wp-content/uploads/2017/01/Contribution-analysis.pdf
+- https://www.oecd.org/content/dam/oecd/en/publications/reports/2021/03/development-co-operation-tips-tools-insights-practices_d307b396/usaid-collaborating-learning-and-adapting_d5fb345a/bb879930-en.pdf
+- https://www.odi.org/publications/10367-doing-development-differently
+- https://www.kobotoolbox.org/resources/
+- https://dhis2.org/
+- https://101.impactmojo.in/mel-plan-lab
+- https://usaidlearninglab.org/sites/default/files/resource/files/cla_maturity_tool.pdf
+- https://openknowledge.worldbank.org/handle/10986/14926
+- https://www.intrac.org/resources/monitoring-evaluation-series/
+- https://www.dropbox.com/scl/fo/4bxck9fg67r3a5qajn21s/APtQiVIejLNWuA2ib7IVZ4U?rlkey=g9bsvm03yssln0bjxk6bqkyv5&dl=0
+- https://notebooklm.google.com/notebook/cc450613-e857-4889-9406-a85638f42966
+- https://www.worldbank.org/en/programs/sief-trust-fund/publication/impact-evaluation-in-practice
+- https://www.betterevaluation.org/methods-approaches/approaches/developmental-evaluation
+- https://www.dropbox.com/scl/fi/rt6d5qyrd5ql1rfmxa2ed/mel-lexicon.xlsx?rlkey=slrmibf5ckj2xoyr2j6lal03s&dl=1

--- a/notebooklm/readings/nothing-about-us.md
+++ b/notebooklm/readings/nothing-about-us.md
@@ -1,0 +1,10 @@
+# Nothing About Us Without Us (Disability) — cited readings
+
+Open-access sources cited across the course. Add to the notebook with:
+
+```bash
+# after `notebooklm login` and creating the notebook:
+# (none found)
+```
+
+## URLs

--- a/notebooklm/readings/nvc-rj.md
+++ b/notebooklm/readings/nvc-rj.md
@@ -1,0 +1,23 @@
+# Nonviolent Communication & Restorative Justice — cited readings
+
+Open-access sources cited across the course. Add to the notebook with:
+
+```bash
+# after `notebooklm login` and creating the notebook:
+python3 scripts/notebooklm-manage.py add-source nvc-rj https://www.mkgandhi.org/yeravda/chap02.php
+python3 scripts/notebooklm-manage.py add-source nvc-rj https://pmc.ncbi.nlm.nih.gov/articles/PMC10916228/
+python3 scripts/notebooklm-manage.py add-source nvc-rj https://www.mkgandhi.org/hindswaraj/chap17_passiveresistance.php
+python3 scripts/notebooklm-manage.py add-source nvc-rj https://www.engaged-zen.org/PDFarchive/From_Dictatorship_to_Democracy.pdf
+python3 scripts/notebooklm-manage.py add-source nvc-rj https://www.unodc.org/documents/justice-and-prison-reform/20-01146_Handbook_on_Restorative_Justice_Programmes.pdf
+python3 scripts/notebooklm-manage.py add-source nvc-rj https://johnbraithwaite.com/wp-content/uploads/2016/05/2006_Shame-Restorative-Justice-an.pdf
+python3 scripts/notebooklm-manage.py add-source nvc-rj https://www.ohchr.org/sites/default/files/UDHR/Documents/UDHR_Translations/eng.pdf
+```
+
+## URLs
+- https://www.mkgandhi.org/yeravda/chap02.php
+- https://pmc.ncbi.nlm.nih.gov/articles/PMC10916228/
+- https://www.mkgandhi.org/hindswaraj/chap17_passiveresistance.php
+- https://www.engaged-zen.org/PDFarchive/From_Dictatorship_to_Democracy.pdf
+- https://www.unodc.org/documents/justice-and-prison-reform/20-01146_Handbook_on_Restorative_Justice_Programmes.pdf
+- https://johnbraithwaite.com/wp-content/uploads/2016/05/2006_Shame-Restorative-Justice-an.pdf
+- https://www.ohchr.org/sites/default/files/UDHR/Documents/UDHR_Translations/eng.pdf

--- a/notebooklm/readings/poa.md
+++ b/notebooklm/readings/poa.md
@@ -1,0 +1,55 @@
+# Policy & Advocacy — cited readings
+
+Open-access sources cited across the course. Add to the notebook with:
+
+```bash
+# after `notebooklm login` and creating the notebook:
+python3 scripts/notebooklm-manage.py add-source poa https://www.worldbank.org/en/news/feature/2015/06/15/wdr2015-mind-society-and-behavior
+python3 scripts/notebooklm-manage.py add-source poa https://www.dropbox.com/scl/fo/4n8bwqatkgxnva49kwfkb/AAcW4EFP_CRjI8mf5DVhd18?rlkey=iqykledl0yp2zsra3qcb5388m&st=466lm3zc&dl=0
+python3 scripts/notebooklm-manage.py add-source poa https://mru.org/courses/development-economics/what-is-economic-growth
+python3 scripts/notebooklm-manage.py add-source poa https://www.ilo.org/topics/social-protection
+python3 scripts/notebooklm-manage.py add-source poa https://www.dropbox.com/scl/fo/2i9s1ylfhcj7lvxctf1e7/AKubLP2UqzoaBc2VHVxd_0Y?rlkey=0pgsruji07uglbjmzwccuz7hk&st=z3eqg2j9&dl=0
+python3 scripts/notebooklm-manage.py add-source poa https://ourworldindata.org/economic-growth
+python3 scripts/notebooklm-manage.py add-source poa https://www.indiacode.nic.in/handle/123456789/2065
+python3 scripts/notebooklm-manage.py add-source poa https://rti.gov.in/
+python3 scripts/notebooklm-manage.py add-source poa https://www.indiacode.nic.in/handle/123456789/12887
+python3 scripts/notebooklm-manage.py add-source poa https://nrega.nic.in
+python3 scripts/notebooklm-manage.py add-source poa https://en.wikipedia.org/wiki/Forest_Rights_Act,_2006
+python3 scripts/notebooklm-manage.py add-source poa https://tribal.nic.in/fra.aspx
+python3 scripts/notebooklm-manage.py add-source poa https://ourworldindata.org/global-education
+python3 scripts/notebooklm-manage.py add-source poa https://ourworldindata.org/women-rights
+python3 scripts/notebooklm-manage.py add-source poa https://hdr.undp.org/content/human-development-report-2009
+python3 scripts/notebooklm-manage.py add-source poa https://ourworldindata.org/life-expectancy
+python3 scripts/notebooklm-manage.py add-source poa https://ourworldindata.org/extreme-poverty
+python3 scripts/notebooklm-manage.py add-source poa https://notebooklm.google.com/notebook/1e5a60e9-03b6-4ebb-89cb-869b9f5d0c62
+python3 scripts/notebooklm-manage.py add-source poa https://www.dropbox.com/scl/fi/q8n5vh6bn7ljbacutswi2/poa-lexicon.xlsx?rlkey=m9on238kpl8ffv0bfqvvtawqn&dl=0
+python3 scripts/notebooklm-manage.py add-source poa https://www.linkedin.com/in/varnasriraman
+python3 scripts/notebooklm-manage.py add-source poa https://twitter.com/varnasriraman
+python3 scripts/notebooklm-manage.py add-source poa https://varnasriraman.notion.site
+python3 scripts/notebooklm-manage.py add-source poa https://www.linkedin.com/in/vandana-soni-138a1012
+```
+
+## URLs
+- https://www.worldbank.org/en/news/feature/2015/06/15/wdr2015-mind-society-and-behavior
+- https://www.dropbox.com/scl/fo/4n8bwqatkgxnva49kwfkb/AAcW4EFP_CRjI8mf5DVhd18?rlkey=iqykledl0yp2zsra3qcb5388m&st=466lm3zc&dl=0
+- https://mru.org/courses/development-economics/what-is-economic-growth
+- https://www.ilo.org/topics/social-protection
+- https://www.dropbox.com/scl/fo/2i9s1ylfhcj7lvxctf1e7/AKubLP2UqzoaBc2VHVxd_0Y?rlkey=0pgsruji07uglbjmzwccuz7hk&st=z3eqg2j9&dl=0
+- https://ourworldindata.org/economic-growth
+- https://www.indiacode.nic.in/handle/123456789/2065
+- https://rti.gov.in/
+- https://www.indiacode.nic.in/handle/123456789/12887
+- https://nrega.nic.in
+- https://en.wikipedia.org/wiki/Forest_Rights_Act,_2006
+- https://tribal.nic.in/fra.aspx
+- https://ourworldindata.org/global-education
+- https://ourworldindata.org/women-rights
+- https://hdr.undp.org/content/human-development-report-2009
+- https://ourworldindata.org/life-expectancy
+- https://ourworldindata.org/extreme-poverty
+- https://notebooklm.google.com/notebook/1e5a60e9-03b6-4ebb-89cb-869b9f5d0c62
+- https://www.dropbox.com/scl/fi/q8n5vh6bn7ljbacutswi2/poa-lexicon.xlsx?rlkey=m9on238kpl8ffv0bfqvvtawqn&dl=0
+- https://www.linkedin.com/in/varnasriraman
+- https://twitter.com/varnasriraman
+- https://varnasriraman.notion.site
+- https://www.linkedin.com/in/vandana-soni-138a1012

--- a/notebooklm/readings/powerBI.md
+++ b/notebooklm/readings/powerBI.md
@@ -1,0 +1,71 @@
+# Power BI for Development — cited readings
+
+Open-access sources cited across the course. Add to the notebook with:
+
+```bash
+# after `notebooklm login` and creating the notebook:
+python3 scripts/notebooklm-manage.py add-source powerBI https://learn.microsoft.com/en-us/power-bi/fundamentals/power-bi-overview
+python3 scripts/notebooklm-manage.py add-source powerBI https://powerbi.microsoft.com/desktop/
+python3 scripts/notebooklm-manage.py add-source powerBI https://learn.microsoft.com/power-bi/fundamentals/
+python3 scripts/notebooklm-manage.py add-source powerBI https://www.microsoft.com/power-platform/products/power-bi/pricing
+python3 scripts/notebooklm-manage.py add-source powerBI https://learn.microsoft.com/en-us/power-bi/connect-data/desktop-data-sources
+python3 scripts/notebooklm-manage.py add-source powerBI http://rchiips.org/nfhs/factsheet_NFHS-5.shtml
+python3 scripts/notebooklm-manage.py add-source powerBI https://data.gov.in/
+python3 scripts/notebooklm-manage.py add-source powerBI https://learn.microsoft.com/power-bi/connect-data/
+python3 scripts/notebooklm-manage.py add-source powerBI https://learn.microsoft.com/en-us/power-bi/transform-model/desktop-query-overview
+python3 scripts/notebooklm-manage.py add-source powerBI https://learn.microsoft.com/power-query/
+python3 scripts/notebooklm-manage.py add-source powerBI https://www.jstatsoft.org/article/view/v059i10
+python3 scripts/notebooklm-manage.py add-source powerBI https://asercentre.org/
+python3 scripts/notebooklm-manage.py add-source powerBI https://learn.microsoft.com/en-us/power-bi/guidance/star-schema
+python3 scripts/notebooklm-manage.py add-source powerBI https://learn.microsoft.com/power-bi/guidance/star-schema
+python3 scripts/notebooklm-manage.py add-source powerBI https://learn.microsoft.com/power-bi/transform-model/desktop-relationships-understand
+python3 scripts/notebooklm-manage.py add-source powerBI https://learn.microsoft.com/power-bi/guidance/model-date-tables
+python3 scripts/notebooklm-manage.py add-source powerBI https://learn.microsoft.com/en-us/power-bi/transform-model/desktop-quickstart-learn-dax-basics
+python3 scripts/notebooklm-manage.py add-source powerBI https://learn.microsoft.com/dax/
+python3 scripts/notebooklm-manage.py add-source powerBI https://dax.guide/
+python3 scripts/notebooklm-manage.py add-source powerBI https://learn.microsoft.com/power-bi/transform-model/desktop-measures
+python3 scripts/notebooklm-manage.py add-source powerBI https://www.impactmojo.in/courses/dataviz/
+python3 scripts/notebooklm-manage.py add-source powerBI https://clauswilke.com/dataviz/aesthetic-mapping.html
+python3 scripts/notebooklm-manage.py add-source powerBI https://learn.microsoft.com/power-bi/create-reports/desktop-accessibility-overview
+python3 scripts/notebooklm-manage.py add-source powerBI https://learn.microsoft.com/power-bi/visuals/power-bi-visualization-types-for-reports-and-q-and-a
+python3 scripts/notebooklm-manage.py add-source powerBI https://learn.microsoft.com/en-us/power-bi/create-reports/service-dashboards-design-tips
+python3 scripts/notebooklm-manage.py add-source powerBI https://learn.microsoft.com/power-bi/create-reports/desktop-drillthrough
+python3 scripts/notebooklm-manage.py add-source powerBI https://learn.microsoft.com/power-bi/create-reports/desktop-bookmarks
+python3 scripts/notebooklm-manage.py add-source powerBI https://learn.microsoft.com/power-bi/create-reports/desktop-report-themes
+python3 scripts/notebooklm-manage.py add-source powerBI https://learn.microsoft.com/en-us/power-bi/collaborate-share/service-publish-to-web
+python3 scripts/notebooklm-manage.py add-source powerBI https://www.meity.gov.in/data-protection-framework
+python3 scripts/notebooklm-manage.py add-source powerBI https://learn.microsoft.com/power-bi/enterprise/service-admin-rls
+```
+
+## URLs
+- https://learn.microsoft.com/en-us/power-bi/fundamentals/power-bi-overview
+- https://powerbi.microsoft.com/desktop/
+- https://learn.microsoft.com/power-bi/fundamentals/
+- https://www.microsoft.com/power-platform/products/power-bi/pricing
+- https://learn.microsoft.com/en-us/power-bi/connect-data/desktop-data-sources
+- http://rchiips.org/nfhs/factsheet_NFHS-5.shtml
+- https://data.gov.in/
+- https://learn.microsoft.com/power-bi/connect-data/
+- https://learn.microsoft.com/en-us/power-bi/transform-model/desktop-query-overview
+- https://learn.microsoft.com/power-query/
+- https://www.jstatsoft.org/article/view/v059i10
+- https://asercentre.org/
+- https://learn.microsoft.com/en-us/power-bi/guidance/star-schema
+- https://learn.microsoft.com/power-bi/guidance/star-schema
+- https://learn.microsoft.com/power-bi/transform-model/desktop-relationships-understand
+- https://learn.microsoft.com/power-bi/guidance/model-date-tables
+- https://learn.microsoft.com/en-us/power-bi/transform-model/desktop-quickstart-learn-dax-basics
+- https://learn.microsoft.com/dax/
+- https://dax.guide/
+- https://learn.microsoft.com/power-bi/transform-model/desktop-measures
+- https://www.impactmojo.in/courses/dataviz/
+- https://clauswilke.com/dataviz/aesthetic-mapping.html
+- https://learn.microsoft.com/power-bi/create-reports/desktop-accessibility-overview
+- https://learn.microsoft.com/power-bi/visuals/power-bi-visualization-types-for-reports-and-q-and-a
+- https://learn.microsoft.com/en-us/power-bi/create-reports/service-dashboards-design-tips
+- https://learn.microsoft.com/power-bi/create-reports/desktop-drillthrough
+- https://learn.microsoft.com/power-bi/create-reports/desktop-bookmarks
+- https://learn.microsoft.com/power-bi/create-reports/desktop-report-themes
+- https://learn.microsoft.com/en-us/power-bi/collaborate-share/service-publish-to-web
+- https://www.meity.gov.in/data-protection-framework
+- https://learn.microsoft.com/power-bi/enterprise/service-admin-rls

--- a/notebooklm/readings/pubchoice.md
+++ b/notebooklm/readings/pubchoice.md
@@ -1,0 +1,25 @@
+# Public Choice — cited readings
+
+Open-access sources cited across the course. Add to the notebook with:
+
+```bash
+# after `notebooklm login` and creating the notebook:
+python3 scripts/notebooklm-manage.py add-source pubchoice https://www.econlib.org/library/Enc/PublicChoice.html
+python3 scripts/notebooklm-manage.py add-source pubchoice https://oll.libertyfund.org/title/buchanan-the-calculus-of-consent-logical-foundations-of-constitutional-democracy
+python3 scripts/notebooklm-manage.py add-source pubchoice https://www.aeaweb.org/articles?id=10.1257/jep.14.3.137
+python3 scripts/notebooklm-manage.py add-source pubchoice https://www.econlib.org/library/Enc/RentSeeking.html
+python3 scripts/notebooklm-manage.py add-source pubchoice https://documents1.worldbank.org/curated/en/527371468166770790/pdf/268950PAPER0WDR02004.pdf
+python3 scripts/notebooklm-manage.py add-source pubchoice https://pmc.ncbi.nlm.nih.gov/articles/PMC2000497/
+python3 scripts/notebooklm-manage.py add-source pubchoice https://documents1.worldbank.org/curated/en/774441485783404216/pdf/102844-WDR-PUBLIC-WDR-2017-Web.pdf
+python3 scripts/notebooklm-manage.py add-source pubchoice https://www.econlib.org/library/Enc/PublicGoodsandExternalities.html
+```
+
+## URLs
+- https://www.econlib.org/library/Enc/PublicChoice.html
+- https://oll.libertyfund.org/title/buchanan-the-calculus-of-consent-logical-foundations-of-constitutional-democracy
+- https://www.aeaweb.org/articles?id=10.1257/jep.14.3.137
+- https://www.econlib.org/library/Enc/RentSeeking.html
+- https://documents1.worldbank.org/curated/en/527371468166770790/pdf/268950PAPER0WDR02004.pdf
+- https://pmc.ncbi.nlm.nih.gov/articles/PMC2000497/
+- https://documents1.worldbank.org/curated/en/774441485783404216/pdf/102844-WDR-PUBLIC-WDR-2017-Web.pdf
+- https://www.econlib.org/library/Enc/PublicGoodsandExternalities.html

--- a/notebooklm/readings/pubpol.md
+++ b/notebooklm/readings/pubpol.md
@@ -1,0 +1,31 @@
+# Public Policy — cited readings
+
+Open-access sources cited across the course. Add to the notebook with:
+
+```bash
+# after `notebooklm login` and creating the notebook:
+python3 scripts/notebooklm-manage.py add-source pubpol https://www.worldbank.org/en/publication/wdr2017
+python3 scripts/notebooklm-manage.py add-source pubpol https://www.impactmojo.in/coaching
+python3 scripts/notebooklm-manage.py add-source pubpol https://www.impactmojo.in/index.html#labs
+python3 scripts/notebooklm-manage.py add-source pubpol https://www.pmindia.gov.in/en/news_updates/government-establishes-niti-aayog-national-institution-for-transforming-india-to-replace-planning-commission/
+python3 scripts/notebooklm-manage.py add-source pubpol https://fincomindia.nic.in/constitutional-provisions
+python3 scripts/notebooklm-manage.py add-source pubpol https://documents.worldbank.org/en/publication/documents-reports/documentdetail/527371468166770790/world-development-report-2004-making-services-work-for-poor-people-overview
+python3 scripts/notebooklm-manage.py add-source pubpol https://www.pib.gov.in/PressReleasePage.aspx?PRID=2220005&reg=3&lang=1
+python3 scripts/notebooklm-manage.py add-source pubpol https://www.pib.gov.in/PressReleasePage.aspx?PRID=2219915&reg=48&lang=2
+python3 scripts/notebooklm-manage.py add-source pubpol https://www.dropbox.com/PLACEHOLDER-PP-LEXICON-XLSX
+python3 scripts/notebooklm-manage.py add-source pubpol https://www.impactmojo.in/impactlex
+python3 scripts/notebooklm-manage.py add-source pubpol https://impactmojo.gitbook.io/impactmojo
+```
+
+## URLs
+- https://www.worldbank.org/en/publication/wdr2017
+- https://www.impactmojo.in/coaching
+- https://www.impactmojo.in/index.html#labs
+- https://www.pmindia.gov.in/en/news_updates/government-establishes-niti-aayog-national-institution-for-transforming-india-to-replace-planning-commission/
+- https://fincomindia.nic.in/constitutional-provisions
+- https://documents.worldbank.org/en/publication/documents-reports/documentdetail/527371468166770790/world-development-report-2004-making-services-work-for-poor-people-overview
+- https://www.pib.gov.in/PressReleasePage.aspx?PRID=2220005&reg=3&lang=1
+- https://www.pib.gov.in/PressReleasePage.aspx?PRID=2219915&reg=48&lang=2
+- https://www.dropbox.com/PLACEHOLDER-PP-LEXICON-XLSX
+- https://www.impactmojo.in/impactlex
+- https://impactmojo.gitbook.io/impactmojo

--- a/notebooklm/readings/social-movements.md
+++ b/notebooklm/readings/social-movements.md
@@ -1,0 +1,131 @@
+# Social Movements & Protests — cited readings
+
+Open-access sources cited across the course. Add to the notebook with:
+
+```bash
+# after `notebooklm login` and creating the notebook:
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.files.ethz.ch/isn/126900/8008_FDTD.pdf
+python3 scripts/notebooklm-manage.py add-source social-movements https://casbs.stanford.edu/power-movement-social-movements-collective-action-and-politics
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.britannica.com/topic/Chipko-movement
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.aljazeera.com/news/2022/7/9/sri-lanka-protesters-storm-president-house-demanding-resignation
+python3 scripts/notebooklm-manage.py add-source social-movements https://cmn-cdn-001.sagepub.com/books/titles/273343/att_sb1_143099.pdf
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.semanticscholar.org/paper/Resource-Mobilization-and-Social-Movements:-A-McCarthy-Zald/a725b7ee90946fc576c9caa0e1be51055f58ea82
+python3 scripts/notebooklm-manage.py add-source social-movements https://acleddata.com/report/unlikely-success-demonstrations-against-farm-laws-india
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.downtoearth.org.in/agriculture/farm-laws-repeal-how-the-farmers-protests-unfolded-in-a-year-80286
+python3 scripts/notebooklm-manage.py add-source social-movements https://voidnetwork.gr/wp-content/uploads/2016/09/Collective-Identity-and-Social-Movements-by-Francesca-Polletta-and-James-M.-Jasper-.pdf
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.annualreviews.org/content/journals/10.1146/annurev.soc.26.1.611
+python3 scripts/notebooklm-manage.py add-source social-movements https://archiv.soms.ethz.ch/teaching/OppFall09/SnowFrame1986.pdf
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.aljazeera.com/news/2020/1/15/shaheen-bagh-protesters-pledge-to-fight-seek-rollback-of-caa-law
+python3 scripts/notebooklm-manage.py add-source social-movements https://en.wikipedia.org/wiki/Self-Respect_Movement
+python3 scripts/notebooklm-manage.py add-source social-movements https://rightlivelihood.org/the-change-makers/find-a-laureate/medha-patkar-and-baba-amte-narmada-bachao-andolan/
+python3 scripts/notebooklm-manage.py add-source social-movements https://voidnetwork.gr/wp-content/uploads/2016/09/Popular-contention-in-Great-Britain-1758-1834-by-Charles-Tilly.pdf
+python3 scripts/notebooklm-manage.py add-source social-movements https://press.uchicago.edu/ucp/books/book/chicago/R/bo4100797.html
+python3 scripts/notebooklm-manage.py add-source social-movements https://onlinelibrary.wiley.com/doi/10.1002/9780470674871.wbespm178
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.aeinstein.org/198-methods-of-nonviolent-action
+python3 scripts/notebooklm-manage.py add-source social-movements https://en.wikipedia.org/wiki/Repertoire_of_contention
+python3 scripts/notebooklm-manage.py add-source social-movements https://cup.columbia.edu/book/why-civil-resistance-works/9780231156837/
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.hks.harvard.edu/faculty-research/policy-topics/advocacy-social-movements/35-rule-understanding-what-makes-protest
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.bmartin.cc/pubs/
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.mkgandhi.org/selectedletters/62viceroy.php
+python3 scripts/notebooklm-manage.py add-source social-movements https://en.wikipedia.org/wiki/Salt_March
+python3 scripts/notebooklm-manage.py add-source social-movements https://en.wikipedia.org/wiki/Quit_India_speech
+python3 scripts/notebooklm-manage.py add-source social-movements https://scholarblogs.emory.edu/postcolonialstudies/2014/06/20/gandhis-salt-march-to-dandi/
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.mkgandhi.org/
+python3 scripts/notebooklm-manage.py add-source social-movements https://ramachandraguha.in/archives/the-rise-and-fall-of-indian-environmentalism.html
+python3 scripts/notebooklm-manage.py add-source social-movements https://archive.org/details/EcologyAndEquity
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.downtoearth.org.in/governance/niyamgiri-10-years-since-india-s-first-environmental-referendum-88850
+python3 scripts/notebooklm-manage.py add-source social-movements https://indiankanoon.org/doc/1938608/
+python3 scripts/notebooklm-manage.py add-source social-movements https://india.mongabay.com/2025/03/the-movement-that-rewrote-indias-environmental-narrative-commentary/
+python3 scripts/notebooklm-manage.py add-source social-movements https://anotherworldarchives.org/br-ambedkar/annihilation
+python3 scripts/notebooklm-manage.py add-source social-movements https://en.wikipedia.org/wiki/Dalit_Panthers
+python3 scripts/notebooklm-manage.py add-source social-movements https://en.wikipedia.org/wiki/Rohith_Vemula
+python3 scripts/notebooklm-manage.py add-source social-movements https://en.wikipedia.org/wiki/Bhim_Army
+python3 scripts/notebooklm-manage.py add-source social-movements https://tribal.nic.in/fra.aspx
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.npr.org/2021/11/26/1059200463/india-farmer-protests-modi-farm-laws
+python3 scripts/notebooklm-manage.py add-source social-movements https://en.wikipedia.org/wiki/2020%E2%80%932021_Indian_farmers%27_protest
+python3 scripts/notebooklm-manage.py add-source social-movements https://en.wikipedia.org/wiki/Naxalbari_uprising
+python3 scripts/notebooklm-manage.py add-source social-movements https://en.wikipedia.org/wiki/All_India_Kisan_Sabha
+python3 scripts/notebooklm-manage.py add-source social-movements https://en.wikipedia.org/wiki/All_India_Trade_Union_Congress
+python3 scripts/notebooklm-manage.py add-source social-movements https://kafila.online/2017/10/24/statement-by-feminists-on-facebook-campaign-to-name-and-shame/
+python3 scripts/notebooklm-manage.py add-source social-movements http://feministlawarchives.pldindia.org/landmark-cases-8/
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.prsindia.org/policy/report-summaries/justice-verma-committee-report-summary
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.humandignitytrust.org/resources/navtej-singh-johar-ors-v-union-of-india-2018-case-digest/
+python3 scripts/notebooklm-manage.py add-source social-movements https://en.wikipedia.org/wiki/Aurat_March
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.researchgate.net/publication/254296720_The_Logic_of_Connective_Action
+python3 scripts/notebooklm-manage.py add-source social-movements https://carnegieendowment.org/research/2026/03/gen-z-protests-across-asia
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.aljazeera.com/features/2026/7/19/why-have-indias-gen-z-protesters-called-for-a-march-to-parliament
+python3 scripts/notebooklm-manage.py add-source social-movements https://acleddata.com/report/economic-shockwaves-iran-war-fuel-protests-across-south-asia
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.accessnow.org/press-release/keepiton-internet-shutdowns-2024-en/
+python3 scripts/notebooklm-manage.py add-source social-movements https://en.wikisource.org/wiki/From_Dictatorship_to_Democracy
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.bmartin.cc/pubs/15Schock.html
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.semanticscholar.org/paper/SOCIAL-MOVEMENT-CONTINUITY:-THE-WOMEN'S-MOVEMENT-IN-Taylor/044eabfc8a31b2bb55399554199c2a91e2aaff75
+python3 scripts/notebooklm-manage.py add-source social-movements https://m.thewire.in/article/government/over-10000-persons-arrests-under-uapa-but-only-335-convictions-between-2019-23
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.omct.org/en/resources/statements/india-human-rights-defender-stan-swamy-dies-in-custody
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.npr.org/2021/11/19/1057127412/india-will-repeal-controversial-farm-laws-that-led-to-massive-protests
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.crisisgroup.org/qna/asia-pacific/sri-lanka/sri-lankas-uprising-forces-out-president-leaves-system-crisis
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.hrw.org/news/2024/08/06/bangladesh-prime-minister-hasina-resigns-amid-mass-protests
+python3 scripts/notebooklm-manage.py add-source social-movements https://www.journalofdemocracy.org/articles/why-gen-z-is-rising/
+```
+
+## URLs
+- https://www.files.ethz.ch/isn/126900/8008_FDTD.pdf
+- https://casbs.stanford.edu/power-movement-social-movements-collective-action-and-politics
+- https://www.britannica.com/topic/Chipko-movement
+- https://www.aljazeera.com/news/2022/7/9/sri-lanka-protesters-storm-president-house-demanding-resignation
+- https://cmn-cdn-001.sagepub.com/books/titles/273343/att_sb1_143099.pdf
+- https://www.semanticscholar.org/paper/Resource-Mobilization-and-Social-Movements:-A-McCarthy-Zald/a725b7ee90946fc576c9caa0e1be51055f58ea82
+- https://acleddata.com/report/unlikely-success-demonstrations-against-farm-laws-india
+- https://www.downtoearth.org.in/agriculture/farm-laws-repeal-how-the-farmers-protests-unfolded-in-a-year-80286
+- https://voidnetwork.gr/wp-content/uploads/2016/09/Collective-Identity-and-Social-Movements-by-Francesca-Polletta-and-James-M.-Jasper-.pdf
+- https://www.annualreviews.org/content/journals/10.1146/annurev.soc.26.1.611
+- https://archiv.soms.ethz.ch/teaching/OppFall09/SnowFrame1986.pdf
+- https://www.aljazeera.com/news/2020/1/15/shaheen-bagh-protesters-pledge-to-fight-seek-rollback-of-caa-law
+- https://en.wikipedia.org/wiki/Self-Respect_Movement
+- https://rightlivelihood.org/the-change-makers/find-a-laureate/medha-patkar-and-baba-amte-narmada-bachao-andolan/
+- https://voidnetwork.gr/wp-content/uploads/2016/09/Popular-contention-in-Great-Britain-1758-1834-by-Charles-Tilly.pdf
+- https://press.uchicago.edu/ucp/books/book/chicago/R/bo4100797.html
+- https://onlinelibrary.wiley.com/doi/10.1002/9780470674871.wbespm178
+- https://www.aeinstein.org/198-methods-of-nonviolent-action
+- https://en.wikipedia.org/wiki/Repertoire_of_contention
+- https://cup.columbia.edu/book/why-civil-resistance-works/9780231156837/
+- https://www.hks.harvard.edu/faculty-research/policy-topics/advocacy-social-movements/35-rule-understanding-what-makes-protest
+- https://www.bmartin.cc/pubs/
+- https://www.mkgandhi.org/selectedletters/62viceroy.php
+- https://en.wikipedia.org/wiki/Salt_March
+- https://en.wikipedia.org/wiki/Quit_India_speech
+- https://scholarblogs.emory.edu/postcolonialstudies/2014/06/20/gandhis-salt-march-to-dandi/
+- https://www.mkgandhi.org/
+- https://ramachandraguha.in/archives/the-rise-and-fall-of-indian-environmentalism.html
+- https://archive.org/details/EcologyAndEquity
+- https://www.downtoearth.org.in/governance/niyamgiri-10-years-since-india-s-first-environmental-referendum-88850
+- https://indiankanoon.org/doc/1938608/
+- https://india.mongabay.com/2025/03/the-movement-that-rewrote-indias-environmental-narrative-commentary/
+- https://anotherworldarchives.org/br-ambedkar/annihilation
+- https://en.wikipedia.org/wiki/Dalit_Panthers
+- https://en.wikipedia.org/wiki/Rohith_Vemula
+- https://en.wikipedia.org/wiki/Bhim_Army
+- https://tribal.nic.in/fra.aspx
+- https://www.npr.org/2021/11/26/1059200463/india-farmer-protests-modi-farm-laws
+- https://en.wikipedia.org/wiki/2020%E2%80%932021_Indian_farmers%27_protest
+- https://en.wikipedia.org/wiki/Naxalbari_uprising
+- https://en.wikipedia.org/wiki/All_India_Kisan_Sabha
+- https://en.wikipedia.org/wiki/All_India_Trade_Union_Congress
+- https://kafila.online/2017/10/24/statement-by-feminists-on-facebook-campaign-to-name-and-shame/
+- http://feministlawarchives.pldindia.org/landmark-cases-8/
+- https://www.prsindia.org/policy/report-summaries/justice-verma-committee-report-summary
+- https://www.humandignitytrust.org/resources/navtej-singh-johar-ors-v-union-of-india-2018-case-digest/
+- https://en.wikipedia.org/wiki/Aurat_March
+- https://www.researchgate.net/publication/254296720_The_Logic_of_Connective_Action
+- https://carnegieendowment.org/research/2026/03/gen-z-protests-across-asia
+- https://www.aljazeera.com/features/2026/7/19/why-have-indias-gen-z-protesters-called-for-a-march-to-parliament
+- https://acleddata.com/report/economic-shockwaves-iran-war-fuel-protests-across-south-asia
+- https://www.accessnow.org/press-release/keepiton-internet-shutdowns-2024-en/
+- https://en.wikisource.org/wiki/From_Dictatorship_to_Democracy
+- https://www.bmartin.cc/pubs/15Schock.html
+- https://www.semanticscholar.org/paper/SOCIAL-MOVEMENT-CONTINUITY:-THE-WOMEN'S-MOVEMENT-IN-Taylor/044eabfc8a31b2bb55399554199c2a91e2aaff75
+- https://m.thewire.in/article/government/over-10000-persons-arrests-under-uapa-but-only-335-convictions-between-2019-23
+- https://www.omct.org/en/resources/statements/india-human-rights-defender-stan-swamy-dies-in-custody
+- https://www.npr.org/2021/11/19/1057127412/india-will-repeal-controversial-farm-laws-that-led-to-massive-protests
+- https://www.crisisgroup.org/qna/asia-pacific/sri-lanka/sri-lankas-uprising-forces-out-president-leaves-system-crisis
+- https://www.hrw.org/news/2024/08/06/bangladesh-prime-minister-hasina-resigns-amid-mass-protests
+- https://www.journalofdemocracy.org/articles/why-gen-z-is-rising/

--- a/scripts/notebooklm-build-pack.py
+++ b/scripts/notebooklm-build-pack.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""notebooklm-build-pack.py — build NotebookLM source packs for ImpactMojo flagships.
+
+For each flagship course it emits, under notebooklm/:
+  packs/<slug>-source-pack.md   full course text (all modules) — UPLOAD THIS to NotebookLM
+                                 (git-ignored: course content is DB-backed / anti-fork)
+  readings/<slug>.md            the cited open-access readings (URLs) — add via `add-source`
+  prompts/<slug>.md             a ready-to-use study-companion + audio-overview prompt
+
+Course content lives in Supabase (course_content); this pulls it with the
+Management API and needs SUPABASE_PAT in the environment. Readings + prompts are
+safe to commit (public URLs / prompt text); the full packs are git-ignored.
+
+Usage:
+  export SUPABASE_PAT=...                 # loaded from .claude/.env.keys at session start
+  python3 scripts/notebooklm-build-pack.py            # all flagships
+  python3 scripts/notebooklm-build-pack.py social-movements devecon   # specific slugs
+"""
+import os, re, sys, json, html, subprocess, pathlib
+
+PROJECT = "ddyszmfffyedolkcugld"
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+OUT = ROOT / "notebooklm"
+TITLES = {
+ "causal":"Causal Inference & Impact Evaluation","dataviz":"Data Visualization",
+ "devai":"Development & AI","devecon":"Development Economics","gandhi":"Gandhi & Nonviolence",
+ "gender":"Gender & Development","intervention":"Intervention Design","law":"Law & Justice",
+ "livelihoods":"Livelihoods in India","media":"Media & Information",
+ "mel":"Monitoring, Evaluation & Learning (MEAL)","nothing-about-us":"Nothing About Us Without Us (Disability)",
+ "nvc-rj":"Nonviolent Communication & Restorative Justice","poa":"Policy & Advocacy",
+ "powerBI":"Power BI for Development","pubchoice":"Public Choice","pubpol":"Public Policy",
+ "SEL":"Social & Emotional Learning","social-movements":"Social Movements & Protests",
+}
+
+def q(sql):
+    """Run a read query via the Supabase Management API (curl avoids the agent-proxy 403)."""
+    pat = os.environ["SUPABASE_PAT"]
+    r = subprocess.run(["curl","-s","-X","POST",
+        f"https://api.supabase.com/v1/projects/{PROJECT}/database/query",
+        "-H",f"Authorization: Bearer {pat}","-H","Content-Type: application/json",
+        "-d",json.dumps({"query":sql})], capture_output=True, text=True)
+    return json.loads(r.stdout)
+
+def strip_html(s):
+    s = re.sub(r"(?is)<svg.*?</svg>", "", s)
+    s = re.sub(r"(?is)<style.*?</style>", "", s)
+    s = re.sub(r"(?is)<script.*?</script>", "", s)
+    s = re.sub(r"(?is)<h[23][^>]*>(.*?)</h[23]>", lambda m: "\n\n## "+re.sub(r"<[^>]+>","",m.group(1)).strip()+"\n", s)
+    s = re.sub(r"(?is)<li[^>]*>(.*?)</li>", lambda m: "\n- "+re.sub(r"<[^>]+>","",m.group(1)).strip(), s)
+    s = re.sub(r"(?is)<[^>]+>", " ", s)
+    s = html.unescape(s)
+    s = re.sub(r"[ \t]+", " ", s)
+    s = re.sub(r"\n\s*\n\s*\n+", "\n\n", s)
+    return s.strip()
+
+def readings_from(content):
+    urls = re.findall(r'href="(https?://[^"]+)"', content)
+    seen, out = set(), []
+    for u in urls:
+        if u in seen: continue
+        seen.add(u); out.append(u)
+    return out
+
+def build(slug):
+    title = TITLES.get(slug, slug)
+    rows = q("select module_number,module_title,content_html from course_content "
+             f"where course_id='{slug}' order by module_number")
+    if not isinstance(rows, list) or not rows:
+        print(f"  ! no content for {slug}"); return
+    (OUT/"packs").mkdir(parents=True, exist_ok=True)
+    (OUT/"readings").mkdir(parents=True, exist_ok=True)
+    (OUT/"prompts").mkdir(parents=True, exist_ok=True)
+    # PACK
+    pack = [f"# {title} — ImpactMojo Flagship Course\n", f"Source pack for a NotebookLM AI Study Companion. {len(rows)} modules.\n"]
+    all_urls, mod_titles = [], []
+    for r in rows:
+        mt = (r.get("module_title") or f"Module {r['module_number']}").strip()
+        mod_titles.append(re.sub(r"^Module\s*\d+[:.]?\s*","",mt))
+        pack.append(f"\n\n# {mt}\n\n{strip_html(r['content_html'])}")
+        all_urls += readings_from(r["content_html"])
+    (OUT/"packs"/f"{slug}-source-pack.md").write_text("\n".join(pack), encoding="utf-8")
+    # READINGS
+    seen, uniq = set(), []
+    for u in all_urls:
+        if u not in seen: seen.add(u); uniq.append(u)
+    rd = [f"# {title} — cited readings\n",
+          "Open-access sources cited across the course. Add to the notebook with:\n",
+          "```bash", f"# after `notebooklm login` and creating the notebook:",
+          "\n".join(f"python3 scripts/notebooklm-manage.py add-source {slug} {u}" for u in uniq) or "# (none found)",
+          "```\n", "## URLs", *[f"- {u}" for u in uniq]]
+    (OUT/"readings"/f"{slug}.md").write_text("\n".join(rd), encoding="utf-8")
+    # PROMPT
+    topics = "; ".join(t for t in mod_titles[:12] if t)
+    prompt = f"""# {title} — NotebookLM study-companion prompt
+
+**Course:** {title} (ImpactMojo flagship, {len(rows)} modules). South Asia-first development education for practitioners, students and educators.
+
+## 1. Sources to load
+Upload `notebooklm/packs/{slug}-source-pack.md` and add the cited readings in `notebooklm/readings/{slug}.md`.
+
+## 2. Audio Overview steering prompt (paste into NotebookLM's "Customise")
+> Create a ~12-minute study-companion overview for a practitioner audience. Ground every concept in the course's South Asian examples and cited evidence — do not invent statistics or cases. Move module by module across: {topics}. For each, give the core idea, one concrete South Asian example from the sources, and one "use it in your work" takeaway. Close with the capstone challenge. Keep the tone rigorous but accessible; define jargon on first use.
+
+## 3. Suggested questions to seed the notebook
+- What is the single most important idea in this course, and what evidence supports it?
+- Summarise each module in two sentences: the concept and its South Asian application.
+- Which cited readings should I go to first, and why?
+- Turn the capstone into a step-by-step plan I can apply to my own work.
+- Quiz me with 10 questions across the whole course, then mark my answers.
+- Where do the sources disagree or leave open questions?
+
+## 4. Wire-up (maintainer)
+After creating the notebook, register it: add `{slug}` -> notebook-id to `data/notebooklm-registry.json`,
+put the share URL in the course shell's AI Study Companion button, then optionally
+`python3 scripts/notebooklm-manage.py generate-audio {slug}`.
+"""
+    (OUT/"prompts"/f"{slug}.md").write_text(prompt, encoding="utf-8")
+    print(f"  {slug}: {len(rows)} modules, {len(uniq)} readings")
+
+def main():
+    slugs = sys.argv[1:] or list(TITLES.keys())
+    print(f"Building NotebookLM kit for {len(slugs)} flagship(s)...")
+    for s in slugs: build(s)
+    print("Done. Packs in notebooklm/packs/ (git-ignored); prompts + readings committed.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Reusable NotebookLM "AI Study Companion" kit for **all 19 flagships**, so anyone can stand up a notebook.

**Added `scripts/notebooklm-build-pack.py`** — pulls each course's content from Supabase and emits, per flagship:
- `notebooklm/prompts/<slug>.md` — a study-companion + audio-overview steering prompt + seed questions **(committed, all 19)**
- `notebooklm/readings/<slug>.md` — the cited open-access readings as ready-to-run `add-source` commands **(committed, all 19)**
- `notebooklm/packs/<slug>-source-pack.md` — the full course text to upload **(git-ignored)**

**Anti-fork note:** the full source packs are the complete course text, which is deliberately kept in the DB (not the repo). So the packs are **git-ignored** and regenerated locally on demand — the prompts + readings (public URLs) are what's committed. `notebooklm/README.md` documents the flow; `docs/notebooklm-setup.md` points to it. Guards (mojibake, internal-links) PASS.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFkh8CZWfPJMqBUWuN1dYo)_