### PR TITLE
ASER Explorer → Showcase data product, corrected labels + skill ladder & school-type trend

### DIFF
--- a/Labs/index.html
+++ b/Labs/index.html
@@ -196,18 +196,6 @@ html[data-theme="dark"] .card-badge{color:#6EE7B7}
 <main class="labs-section">
   <div class="section-title">All 36 Interactive Studios</div>
   <div class="lab-grid" id="labGrid">
-  <div class="lab-card" data-track="research">
-    <span class="card-badge">Data Lab</span>
-    <div class="card-track">Research & Evidence</div>
-    <div class="card-title">ASER Learning Explorer</div>
-    <div class="card-desc">How many children in rural India can actually read a Std II text or do basic arithmetic &mdash; ranked and trended across states, grades and years, from ASER (Annual Status of Education Report) data.</div>
-    <div class="card-meta"><span>Foundational Learning</span> &middot; <span>Browser-based</span> &middot; <span>Free</span></div>
-    <div class="card-actions">
-      <a class="card-cta" href="/Labs/aser-learning-explorer.html">Open explorer &rarr;</a>
-    </div>
-  </div>
-
-
 <!-- toc -->
 <div class="lab-card" data-track="mel">
   <span class="card-badge">Free Studio</span>

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ We provide accessible, high-quality educational materials grounded in South Asia
 | Category | Description |
 |----------|-------------|
 | **70 Courses** | 19 flagship + 51 foundational courses across 6 learning tracks (all foundational decks self-hosted as native HTML slide decks). Every flagship ends with an auto-graded "Assess Yourself" self-check |
-| **37 Interactive Studios** | Hands-on workbenches for MEL, policy, partnerships, budgeting, gender analysis, and more |
+| **36 Interactive Studios** | Hands-on workbenches for MEL, policy, partnerships, budgeting, gender analysis, and more |
 | **135 Game Library** | 18 interactive simulations (MiroFish AI agents, Indian folk art — Warli, Madhubani, Gond, Kalamkari, Pichwai, Pattachitra) + 117 crosswords, quizzes & word searches |
 | **ImpactLex Dictionary** | 390+ development terms with contextual definitions, formulas, and case studies (PWA, hosted on ImpactMojo) |
 | **Dev Case Studies** | 200 evidence-based case studies from 117 countries |

--- a/aser.html
+++ b/aser.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover">
 <meta name="theme-color" content="#0F172A">
 <title>ASER Learning Explorer — foundational reading &amp; arithmetic across India | ImpactMojo</title>
-<meta name="description" content="Explore ASER (Annual Status of Education Report) foundational-learning data — the share of government-school children who can read a Std II text or do basic arithmetic — ranked and trended across Indian states, 2018–2024. Source: ASER Centre / Pratham.">
+<meta name="description" content="Explore ASER (Annual Status of Education Report) foundational-learning data — the share of children who can read a Std II text or do basic arithmetic — ranked across Indian states, trended by school type 2014–2024, with a rung-by-rung skill ladder. Source: ASER Centre / Pratham.">
 <link rel="canonical" href="https://www.impactmojo.in/aser.html">
 <meta property="og:title" content="ASER Learning Explorer — ImpactMojo">
 <meta property="og:description" content="Foundational reading &amp; arithmetic across Indian states, 2018–2024, from ASER data. Rank states, see trends, and read the skill gap. Source: ASER Centre / Pratham.">
@@ -94,7 +94,7 @@ table.data tr.ai td{font-weight:800;color:var(--acc);border-top:2px solid var(--
     <div class="eyebrow">Showcase · Foundational Learning</div>
     <h1>ASER Learning Explorer</h1>
     <p>How many children in rural India can actually read and do basic arithmetic — and how it varies by state, grade and year. Drawn from the <b>Annual Status of Education Report (ASER)</b>, India's largest citizen-led survey of children's learning.</p>
-    <div class="srcbadge">Source: <b>ASER 2024</b>, Table 15 · ASER Centre / Pratham</div>
+    <div class="srcbadge">Source: <b>ASER 2024</b> (Rural), Tables 1–9 &amp; 15 · ASER Centre / Pratham</div>
   </section>
 
   <section class="controls ui" aria-label="Explorer controls">
@@ -122,6 +122,7 @@ table.data tr.ai td{font-weight:800;color:var(--acc);border-top:2px solid var(--
       <div class="seg" id="segView" role="group" aria-label="View">
         <button data-v="rank" aria-pressed="true">Rank states</button>
         <button data-v="trend" aria-pressed="false">Trend</button>
+        <button data-v="ladder" aria-pressed="false">Skill ladder</button>
         <button data-v="table" aria-pressed="false">Table</button>
       </div>
     </div>
@@ -135,21 +136,23 @@ table.data tr.ai td{font-weight:800;color:var(--acc);border-top:2px solid var(--
   <section class="panel" id="panel"></section>
 
   <div class="note">
-    <b>What v1 covers:</b> government-school children, survey years 2018 · 2022 · 2024 (ASER 2024's own comparison window), all 27 major states + All-India, for reading and arithmetic in Std III, V and VIII.
-    <b>Coming next:</b> private &amp; all-school figures, the full skill ladder (letter → word → Std I → Std II text), and earlier survey rounds (2012–2016) — extended the same way from ASER's public reports.
+    <b>What this covers:</b> <b>Rank</b> &amp; <b>Table</b> show all children (government + private) by state for 2018 · 2022 · 2024. <b>Trend</b> shows the national picture by school type (Govt / Private / All) back to 2014. <b>Skill ladder</b> shows the full rung-by-rung distribution for 2024 — from "can't read letters" up to "reads a Std II text".
+    <b>Coming next:</b> per-state figures split by school type, district drill-down, and earlier state-level rounds (2012–2016) — extended the same way from ASER's public reports.
   </div>
 
   <div class="foot">
-    <p><b>Reading</b> = the child can read a Std II-level "story" comfortably. <b>Arithmetic</b> = Std III &amp; V measure basic subtraction / division as ASER reports them (Std III: at least subtraction; Std V &amp; VIII: division). All figures are for children <b>enrolled in government schools</b>, tested one-on-one in the household. The assessment method is unchanged since 2006, so years are comparable.</p>
+    <p><b>Reading</b> = the child can read a Std II-level "story" comfortably. <b>Arithmetic</b> = Std III measures at least subtraction; Std V &amp; VIII measure division, as ASER reports them. State figures (Rank / Table / a state's Trend line) are for <b>all children</b> (government + private); the national Trend also breaks out government vs private schools. All children are tested one-on-one in the household; the assessment method is unchanged since 2006, so years are comparable.</p>
     <p>Data compiled from the <a href="https://asercentre.org/aser-2024/" target="_blank" rel="noopener">Annual Status of Education Report (Rural) 2024</a>, Table 15 (ASER Centre, facilitated by Pratham). This is an independent, source-linked interface for learning and discussion — for methodology and authoritative interpretation, always consult the original ASER reports. ImpactMojo is not affiliated with ASER Centre or Pratham.</p>
   </div>
 </main>
 
 <script>
 window.ASER_DATA={"years":[2018,2022,2024],"states":["Andhra Pradesh","Arunachal Pradesh","Assam","Bihar","Chhattisgarh","Gujarat","Haryana","Himachal Pradesh","Jammu and Kashmir","Jharkhand","Karnataka","Kerala","Madhya Pradesh","Maharashtra","Meghalaya","Mizoram","Nagaland","Odisha","Punjab","Rajasthan","Sikkim","Tamil Nadu","Telangana","Tripura","Uttar Pradesh","Uttarakhand","West Bengal"],"data":{"Andhra Pradesh":{"read":{"3":{"2018":22.4,"2022":10.4,"2024":15.7},"5":{"2018":59.7,"2022":36.4,"2024":37.7},"8":{"2018":78.2,"2022":66.4,"2024":56.2}},"arith":{"3":{"2018":38.4,"2022":33.7,"2024":44.1},"5":{"2018":39.3,"2022":29.6,"2024":36.2},"8":{"2018":47.6,"2022":51.7,"2024":48.4}},"enroll":{"2018":63.2,"2022":70.8,"2024":61.8},"oos":{"2018":9.0,"2022":2.1,"2024":1.3}},"Arunachal Pradesh":{"read":{"3":{"2018":18.8,"2022":10.7,"2024":19.4},"5":{"2018":37.1,"2022":37.8,"2024":41.0},"8":{"2018":70.5,"2022":73.4,"2024":76.0}},"arith":{"3":{"2018":33.9,"2022":35.8,"2024":39.8},"5":{"2018":27.3,"2022":22.9,"2024":30.8},"8":{"2018":50.1,"2022":46.7,"2024":47.7}},"enroll":{"2018":60.1,"2022":62.2,"2024":56.3},"oos":{"2018":10.1,"2022":7.2,"2024":10.0}},"Assam":{"read":{"3":{"2018":19.9,"2022":17.9,"2024":18.2},"5":{"2018":40.1,"2022":36.5,"2024":38.3},"8":{"2018":60.8,"2022":68.8,"2024":65.9}},"arith":{"3":{"2018":29.7,"2022":24.4,"2024":29.2},"5":{"2018":17.8,"2022":15.2,"2024":16.7},"8":{"2018":31.2,"2022":27.8,"2024":29.2}},"enroll":{"2018":71.7,"2022":71.9,"2024":69.9},"oos":{"2018":13.7,"2022":7.0,"2024":5.0}},"Bihar":{"read":{"3":{"2018":23.5,"2022":19.8,"2024":26.1},"5":{"2018":41.3,"2022":42.4,"2024":43.6},"8":{"2018":71.2,"2022":71.2,"2024":72.8}},"arith":{"3":{"2018":28.4,"2022":28.7,"2024":37.4},"5":{"2018":29.9,"2022":35.4,"2024":36.0},"8":{"2018":56.9,"2022":59.4,"2024":63.6}},"enroll":{"2018":78.1,"2022":82.2,"2024":80.1},"oos":{"2018":10.8,"2022":6.4,"2024":8.6}},"Chhattisgarh":{"read":{"3":{"2018":29.8,"2022":24.4,"2024":25.0},"5":{"2018":59.5,"2022":55.4,"2024":54.4},"8":{"2018":78.7,"2022":82.0,"2024":76.0}},"arith":{"3":{"2018":19.3,"2022":19.7,"2024":23.3},"5":{"2018":26.9,"2022":24.8,"2024":25.7},"8":{"2018":31.1,"2022":40.7,"2024":36.7}},"enroll":{"2018":76.4,"2022":81.7,"2024":80.6},"oos":{"2018":21.7,"2022":13.5,"2024":11.8}},"Gujarat":{"read":{"3":{"2018":33.1,"2022":23.9,"2024":25.8},"5":{"2018":53.7,"2022":34.2,"2024":46.3},"8":{"2018":73.2,"2022":52.4,"2024":75.9}},"arith":{"3":{"2018":25.6,"2022":23.2,"2024":19.1},"5":{"2018":20.1,"2022":14.7,"2024":14.3},"8":{"2018":35.6,"2022":31.8,"2024":30.5}},"enroll":{"2018":85.6,"2022":90.9,"2024":86.5},"oos":{"2018":19.8,"2022":6.2,"2024":10.0}},"Haryana":{"read":{"3":{"2018":46.2,"2022":31.5,"2024":44.0},"5":{"2018":69.1,"2022":57.6,"2024":63.5},"8":{"2018":81.2,"2022":80.3,"2024":82.7}},"arith":{"3":{"2018":53.7,"2022":41.7,"2024":51.5},"5":{"2018":50.9,"2022":41.6,"2024":43.2},"8":{"2018":63.2,"2022":62.6,"2024":56.4}},"enroll":{"2018":42.6,"2022":51.9,"2024":46.0},"oos":{"2018":6.8,"2022":4.6,"2024":3.5}},"Himachal Pradesh":{"read":{"3":{"2018":47.8,"2022":28.5,"2024":50.6},"5":{"2018":76.9,"2022":61.4,"2024":71.3},"8":{"2018":89.9,"2022":87.9,"2024":88.3}},"arith":{"3":{"2018":50.2,"2022":41.5,"2024":57.9},"5":{"2018":56.6,"2022":42.5,"2024":50.5},"8":{"2018":61.0,"2022":52.3,"2024":54.4}},"enroll":{"2018":58.9,"2022":66.3,"2024":58.6},"oos":{"2018":2.2,"2022":2.8,"2024":3.0}},"Jammu and Kashmir":{"read":{"3":{"2018":22.3,"2022":19.1,"2024":16.6},"5":{"2018":41.9,"2022":35.1,"2024":37.7},"8":{"2018":64.8,"2022":60.9,"2024":58.5}},"arith":{"3":{"2018":36.2,"2022":38.7,"2024":36.4},"5":{"2018":25.0,"2022":22.3,"2024":25.1},"8":{"2018":32.9,"2022":35.7,"2024":35.8}},"enroll":{"2018":58.3,"2022":55.5,"2024":57.2},"oos":{"2018":9.9,"2022":4.8,"2024":3.8}},"Jharkhand":{"read":{"3":{"2018":18.8,"2022":14.2,"2024":19.6},"5":{"2018":34.4,"2022":35.6,"2024":45.3},"8":{"2018":66.4,"2022":64.9,"2024":69.5}},"arith":{"3":{"2018":22.5,"2022":22.6,"2024":31.7},"5":{"2018":19.0,"2022":24.5,"2024":30.4},"8":{"2018":44.0,"2022":45.3,"2024":50.9}},"enroll":{"2018":78.0,"2022":83.3,"2024":77.4},"oos":{"2018":13.2,"2022":6.1,"2024":6.6}},"Karnataka":{"read":{"3":{"2018":19.2,"2022":8.6,"2024":15.9},"5":{"2018":46.0,"2022":30.2,"2024":34.0},"8":{"2018":70.3,"2022":59.9,"2024":62.1}},"arith":{"3":{"2018":26.3,"2022":22.2,"2024":25.9},"5":{"2018":20.5,"2022":13.3,"2024":20.9},"8":{"2018":39.0,"2022":36.0,"2024":37.9}},"enroll":{"2018":69.9,"2022":76.3,"2024":71.1},"oos":{"2018":7.4,"2022":2.2,"2024":2.8}},"Kerala":{"read":{"3":{"2018":52.3,"2022":38.8,"2024":45.6},"5":{"2018":77.3,"2022":64.7,"2024":66.0},"8":{"2018":89.6,"2022":83.7,"2024":84.5}},"arith":{"3":{"2018":47.7,"2022":38.9,"2024":32.6},"5":{"2018":43.5,"2022":26.8,"2024":21.3},"8":{"2018":51.8,"2022":44.3,"2024":38.2}},"enroll":{"2018":48.0,"2022":64.5,"2024":44.5},"oos":{"2018":0.9,"2022":0.4,"2024":0.3}},"Madhya Pradesh":{"read":{"3":{"2018":17.6,"2022":12.1,"2024":18.8},"5":{"2018":41.6,"2022":35.6,"2024":43.7},"8":{"2018":64.4,"2022":64.4,"2024":66.9}},"arith":{"3":{"2018":13.9,"2022":15.1,"2024":17.6},"5":{"2018":19.8,"2022":19.1,"2024":21.7},"8":{"2018":36.6,"2022":41.9,"2024":38.0}},"enroll":{"2018":69.6,"2022":70.0,"2024":66.9},"oos":{"2018":23.4,"2022":14.9,"2024":14.3}},"Maharashtra":{"read":{"3":{"2018":42.0,"2022":26.6,"2024":37.0},"5":{"2018":66.4,"2022":55.5,"2024":59.6},"8":{"2018":80.2,"2022":76.2,"2024":74.2}},"arith":{"3":{"2018":27.2,"2022":18.7,"2024":31.3},"5":{"2018":30.2,"2022":19.6,"2024":27.7},"8":{"2018":40.5,"2022":34.6,"2024":36.3}},"enroll":{"2018":61.6,"2022":67.4,"2024":60.9},"oos":{"2018":4.3,"2022":1.4,"2024":1.9}},"Meghalaya":{"read":{"3":{"2018":24.6,"2022":16.2,"2024":19.5},"5":{"2018":50.1,"2022":39.2,"2024":42.7},"8":{"2018":82.8,"2022":75.5,"2024":75.4}},"arith":{"3":{"2018":19.2,"2022":18.0,"2024":22.8},"5":{"2018":7.2,"2022":11.8,"2024":16.0},"8":{"2018":28.1,"2022":28.2,"2024":19.2}},"enroll":{"2018":35.7,"2022":43.7,"2024":38.4},"oos":{"2018":12.3,"2022":9.2,"2024":13.9}},"Mizoram":{"read":{"3":{"2018":25.6,"2022":19.8,"2024":29.6},"5":{"2018":64.3,"2022":51.2,"2024":67.5},"8":{"2018":89.4,"2022":85.6,"2024":90.7}},"arith":{"3":{"2018":58.9,"2022":41.8,"2024":57.2},"5":{"2018":40.2,"2022":20.9,"2024":44.7},"8":{"2018":71.0,"2022":44.7,"2024":60.9}},"enroll":{"2018":72.4,"2022":64.7,"2024":59.3},"oos":{"2018":5.3,"2022":7.6,"2024":15.4}},"Nagaland":{"read":{"3":{"2018":22.6,"2022":21.2,"2024":20.3},"5":{"2018":48.0,"2022":48.4,"2024":49.2},"8":{"2018":83.6,"2022":86.2,"2024":79.6}},"arith":{"3":{"2018":36.9,"2022":33.8,"2024":37.9},"5":{"2018":25.8,"2022":15.3,"2024":20.6},"8":{"2018":51.3,"2022":50.2,"2024":40.2}},"enroll":{"2018":49.3,"2022":50.8,"2024":45.6},"oos":{"2018":9.2,"2022":9.4,"2024":12.6}},"Odisha":{"read":{"3":{"2018":38.7,"2022":29.7,"2024":40.0},"5":{"2018":58.7,"2022":52.5,"2024":59.5},"8":{"2018":72.5,"2022":73.4,"2024":76.7}},"arith":{"3":{"2018":30.7,"2022":29.3,"2024":37.7},"5":{"2018":25.4,"2022":28.2,"2024":32.6},"8":{"2018":42.3,"2022":43.0,"2024":48.5}},"enroll":{"2018":88.0,"2022":92.1,"2024":88.6},"oos":{"2018":12.8,"2022":7.4,"2024":6.5}},"Punjab":{"read":{"3":{"2018":39.4,"2022":33.0,"2024":36.5},"5":{"2018":71.6,"2022":66.2,"2024":66.6},"8":{"2018":85.1,"2022":85.4,"2024":82.2}},"arith":{"3":{"2018":49.7,"2022":44.8,"2024":53.3},"5":{"2018":53.0,"2022":41.1,"2024":53.1},"8":{"2018":62.4,"2022":53.7,"2024":63.9}},"enroll":{"2018":46.7,"2022":58.8,"2024":58.0},"oos":{"2018":6.2,"2022":5.2,"2024":3.3}},"Rajasthan":{"read":{"3":{"2018":20.4,"2022":14.2,"2024":18.6},"5":{"2018":49.1,"2022":38.2,"2024":47.6},"8":{"2018":78.3,"2022":71.6,"2024":69.1}},"arith":{"3":{"2018":17.3,"2022":11.8,"2024":20.0},"5":{"2018":23.3,"2022":13.3,"2024":21.9},"8":{"2018":41.6,"2022":35.6,"2024":33.3}},"enroll":{"2018":60.0,"2022":68.5,"2024":59.3},"oos":{"2018":15.7,"2022":8.8,"2024":11.3}},"Sikkim":{"read":{"3":{"2018":29.4,"2022":16.7,"2024":30.4},"5":{"2018":41.7,"2022":31.5,"2024":53.5},"8":{"2018":79.0,"2022":66.8,"2024":76.5}},"arith":{"3":{"2018":41.0,"2022":43.3,"2024":40.3},"5":{"2018":12.5,"2022":19.2,"2024":18.9},"8":{"2018":44.6,"2022":45.1,"2024":27.6}},"enroll":{"2018":68.6,"2022":75.2,"2024":69.0},"oos":{"2018":4.9,"2022":3.6,"2024":3.3}},"Tamil Nadu":{"read":{"3":{"2018":10.2,"2022":4.8,"2024":12.0},"5":{"2018":40.7,"2022":25.2,"2024":35.6},"8":{"2018":73.2,"2022":63.0,"2024":64.2}},"arith":{"3":{"2018":26.0,"2022":11.2,"2024":27.7},"5":{"2018":25.4,"2022":14.9,"2024":20.8},"8":{"2018":50.2,"2022":44.4,"2024":40.0}},"enroll":{"2018":67.4,"2022":75.7,"2024":68.7},"oos":{"2018":2.3,"2022":1.9,"2024":1.8}},"Telangana":{"read":{"3":{"2018":18.0,"2022":5.1,"2024":6.2},"5":{"2018":43.7,"2022":31.7,"2024":31.6},"8":{"2018":69.0,"2022":61.8,"2024":56.4}},"arith":{"3":{"2018":34.3,"2022":28.5,"2024":30.9},"5":{"2018":27.1,"2022":22.7,"2024":25.2},"8":{"2018":48.3,"2022":44.6,"2024":41.1}},"enroll":{"2018":57.4,"2022":70.1,"2024":59.8},"oos":{"2018":5.1,"2022":2.5,"2024":2.5}},"Tripura":{"read":{"3":{"2018":25.6,"2022":20.3,"2024":20.9},"5":{"2018":45.0,"2022":46.7,"2024":40.7},"8":{"2018":68.3,"2022":66.4,"2024":68.8}},"arith":{"3":{"2018":34.8,"2022":31.6,"2024":33.2},"5":{"2018":19.2,"2022":17.2,"2024":22.0},"8":{"2018":30.7,"2022":43.8,"2024":39.4}},"enroll":{"2018":85.2,"2022":86.1,"2024":73.8},"oos":{"2018":4.9,"2022":4.6,"2024":3.4}},"Uttar Pradesh":{"read":{"3":{"2018":28.1,"2022":24.0,"2024":34.3},"5":{"2018":52.0,"2022":46.3,"2024":56.4},"8":{"2018":73.7,"2022":70.6,"2024":75.1}},"arith":{"3":{"2018":26.6,"2022":28.7,"2024":40.5},"5":{"2018":29.6,"2022":31.6,"2024":39.4},"8":{"2018":44.4,"2022":49.4,"2024":55.2}},"enroll":{"2018":44.3,"2022":59.6,"2024":49.1},"oos":{"2018":19.1,"2022":12.3,"2024":13.0}},"Uttarakhand":{"read":{"3":{"2018":34.5,"2022":27.8,"2024":39.4},"5":{"2018":64.3,"2022":53.6,"2024":63.9},"8":{"2018":83.8,"2022":82.2,"2024":82.2}},"arith":{"3":{"2018":32.3,"2022":23.6,"2024":36.0},"5":{"2018":37.5,"2022":30.6,"2024":39.8},"8":{"2018":48.6,"2022":44.4,"2024":52.5}},"enroll":{"2018":55.0,"2022":61.5,"2024":62.8},"oos":{"2018":6.9,"2022":3.8,"2024":4.3}},"West Bengal":{"read":{"3":{"2018":39.9,"2022":33.0,"2024":36.3},"5":{"2018":50.7,"2022":47.3,"2024":54.6},"8":{"2018":61.8,"2022":69.2,"2024":71.3}},"arith":{"3":{"2018":38.6,"2022":34.2,"2024":40.9},"5":{"2018":29.7,"2022":27.5,"2024":35.0},"8":{"2018":28.7,"2022":31.8,"2024":33.7}},"enroll":{"2018":88.1,"2022":92.2,"2024":89.6},"oos":{"2018":11.7,"2022":4.9,"2024":5.4}},"All India":{"read":{"3":{"2018":27.2,"2022":20.5,"2024":27.0},"5":{"2018":50.4,"2022":42.8,"2024":48.7},"8":{"2018":72.8,"2022":69.5,"2024":71.1}},"arith":{"3":{"2018":28.1,"2022":25.9,"2024":33.7},"5":{"2018":27.8,"2022":25.6,"2024":30.7},"8":{"2018":43.9,"2022":44.6,"2024":45.7}},"enroll":{"2018":65.6,"2022":72.9,"2024":66.8},"oos":{"2018":13.1,"2022":7.5,"2024":7.9}}}};
+window.ASER_EXTRA={"national":{"years":[2014,2016,2018,2022,2024],"read":{"3":{"2014":[17.2,37.8,23.6],"2016":[19.3,38.0,25.2],"2018":[20.9,40.6,27.3],"2022":[16.3,33.1,20.5],"2024":[23.4,35.5,27.1]},"5":{"2014":[42.2,62.6,48.0],"2016":[41.7,63.0,47.9],"2018":[44.2,65.1,50.5],"2022":[38.5,56.8,42.8],"2024":[44.8,59.3,48.8]},"8":{"2014":[71.5,82.4,74.7],"2016":[70.0,81.0,73.1],"2018":[69.0,82.9,73.0],"2022":[66.2,80.0,69.6],"2024":[67.5,80.0,71.1]}},"arith":{"3":{"2014":[17.2,43.4,25.4],"2016":[20.3,44.1,27.7],"2018":[20.9,43.5,28.2],"2022":[20.2,43.1,25.9],"2024":[27.6,47.5,33.7]},"5":{"2014":[20.7,39.3,26.1],"2016":[21.1,38.0,26.0],"2018":[22.7,39.8,27.9],"2022":[21.6,38.7,25.6],"2024":[26.5,41.8,30.7]},"8":{"2014":[40.0,54.2,44.2],"2016":[40.2,51.2,43.3],"2018":[40.0,54.2,44.1],"2022":[41.8,53.8,44.7],"2024":[41.9,55.8,45.8]}}},"ladder":{"read":{"1":[31.9,38.8,17.2,6.9,5.3],"2":[15.1,32.7,23.2,14.9,14.1],"3":[8.2,22.6,22.2,20.0,27.0],"4":[5.0,15.1,18.0,22.0,40.0],"5":[4.1,11.7,14.2,21.3,48.7],"6":[2.9,8.9,10.6,19.9,57.7],"7":[2.0,7.1,8.7,17.9,64.4],"8":[1.6,5.3,6.9,15.2,71.1]},"arith":{"1":[26.3,39.9,26.6,5.2,2.0],"2":[10.6,33.5,37.2,13.7,5.0],"3":[5.5,23.7,37.1,22.3,11.4],"4":[2.9,15.6,34.1,25.8,21.5],"5":[2.3,11.8,30.1,25.1,30.7],"6":[1.6,8.8,28.9,24.7,36.0],"7":[1.2,6.6,27.2,23.5,41.5],"8":[1.1,4.9,25.4,22.8,45.7]},"readRungs":["Can't read letters","Letter","Word","Std I text","Std II text"],"arithRungs":["Can't recognise 1\u20139","Numbers 1\u20139","Numbers 11\u201399","Subtraction","Division"]}};
 (function(){
   "use strict";
   var D=window.ASER_DATA, STATES=D.states, YEARS=D.years;
+  var X=window.ASER_EXTRA, NAT=X.national, LAD=X.ladder;
   var S={subject:"read",grade:"3",year:"2024",view:"rank",state:"Bihar"};
   var GLABEL={"3":"Std III","5":"Std V","8":"Std VIII"};
   var SUBLABEL={read:"read a Std II-level text",arith:"do grade-level arithmetic"};
@@ -188,14 +191,28 @@ window.ASER_DATA={"years":[2018,2022,2024],"states":["Andhra Pradesh","Arunachal
 
   // ── caption ──
   function renderCaption(){
+    var cap=document.getElementById("caption");
+    if(S.view==="ladder"){
+      var subj=S.subject==="read"?"reading":"arithmetic";
+      cap.innerHTML="<div class='q'>The "+subj+" skill ladder — where children actually are, grade by grade</div>"+
+        "<div class='sub'>All children (government + private) · Rural India · 2024 · each bar sums to 100%</div>"+
+        "<div class='allindia'>Read up the grades (Std I → VIII) to see how the "+(S.subject==="read"?"top rung (reads a Std II text)":"top rung (can divide)")+" fills in.</div>";
+      return;
+    }
+    if(S.view==="trend"&&S.state==="All India"){
+      cap.innerHTML="<div class='q'>National trend by school type — "+GLABEL[S.grade]+" children who "+taskPhrase()+"</div>"+
+        "<div class='sub'>All-India rural · 2014–2024 · government vs private vs all</div>"+
+        "<div class='allindia'>Private-school children start higher, but the gap and the pandemic dip both show up here.</div>";
+      return;
+    }
     var ai=val("All India",S.subject,S.grade,S.year);
     var prev=val("All India",S.subject,S.grade,2022);
     var d=(ai!=null&&prev!=null)?(ai-prev):null;
     var dtxt = d==null?"":(" <span class='"+(d>0.05?"up":d<-0.05?"down":"flat")+"'>"+(d>0?"▲ +":d<0?"▼ ":"")+d.toFixed(1)+" pts vs 2022</span>");
-    document.getElementById("caption").innerHTML =
-      "<div class='q'>Share of "+GLABEL[S.grade]+" children in government schools who "+taskPhrase()+"</div>"+
-      "<div class='sub'>Rural India · "+S.year+" · ASER assessment (tested one-on-one at home)</div>"+
-      "<div class='allindia'>All-India: <b>"+(ai!=null?ai.toFixed(1)+"%":"—")+"</b>"+dtxt+"</div>";
+    cap.innerHTML =
+      "<div class='q'>Share of "+GLABEL[S.grade]+" children who "+taskPhrase()+"</div>"+
+      "<div class='sub'>All children (government + private) · Rural India · "+(S.view==="trend"?"2018–2024":S.year)+" · tested one-on-one at home</div>"+
+      "<div class='allindia'>All-India "+S.year+": <b>"+(ai!=null?ai.toFixed(1)+"%":"—")+"</b>"+dtxt+"</div>";
   }
 
   // ── RANK view (horizontal bars) ──
@@ -230,22 +247,36 @@ window.ASER_DATA={"years":[2018,2022,2024],"states":["Andhra Pradesh","Arunachal
       '<span>▲▼ = change since 2022</span></div>';
   }
 
-  // ── TREND view (line, state vs All-India) ──
+  // ── TREND view (line) ──
   function renderTrend(){
     var st=S.state, W=760,H=340,padL=52,padR=120,padT=24,padB=40;
-    var series=[{name:st,color:css('--acc'),vals:YEARS.map(function(y){return val(st,S.subject,S.grade,y);})},
-                {name:"All India",color:css('--acc2'),vals:YEARS.map(function(y){return val("All India",S.subject,S.grade,y);})}];
+    var xyears, series;
+    if(st==="All India"){
+      // national by school type, 2014–2024
+      xyears=NAT.years;
+      var arr=NAT[S.subject][S.grade];
+      series=[
+        {name:"Government",color:css('--acc'),vals:xyears.map(function(y){return arr[String(y)][0];})},
+        {name:"Private",color:'#F59E0B',vals:xyears.map(function(y){return arr[String(y)][1];})},
+        {name:"All",color:css('--acc2'),vals:xyears.map(function(y){return arr[String(y)][2];})}
+      ];
+    } else {
+      xyears=YEARS;
+      series=[{name:st,color:css('--acc'),vals:YEARS.map(function(y){return val(st,S.subject,S.grade,y);})},
+              {name:"All India",color:css('--acc2'),vals:YEARS.map(function(y){return val("All India",S.subject,S.grade,y);})}];
+    }
     var innerW=W-padL-padR, innerH=H-padT-padB;
-    var xs=function(i){return padL+innerW*(i/(YEARS.length-1));};
+    var xs=function(i){return padL+innerW*(i/(xyears.length-1));};
     var ys=function(v){return padT+innerH*(1-v/100);};
     var svg=['<svg class="chart-svg" viewBox="0 0 '+W+' '+H+'" role="img" aria-label="Trend">'];
     for(var g=0;g<=100;g+=25){var y=ys(g);svg.push('<line x1="'+padL+'" y1="'+y+'" x2="'+(W-padR)+'" y2="'+y+'" stroke="'+css('--bd')+'" stroke-width="1"/>');
       svg.push('<text x="'+(padL-8)+'" y="'+(y+4)+'" text-anchor="end" font-family="Inter" font-size="10.5" fill="'+css('--faint')+'">'+g+'%</text>');}
-    YEARS.forEach(function(yr,i){svg.push('<text x="'+xs(i)+'" y="'+(H-14)+'" text-anchor="middle" font-family="Inter" font-size="12" font-weight="600" fill="'+css('--mut')+'">'+yr+'</text>');});
+    xyears.forEach(function(yr,i){svg.push('<text x="'+xs(i)+'" y="'+(H-14)+'" text-anchor="middle" font-family="Inter" font-size="12" font-weight="600" fill="'+css('--mut')+'">'+yr+'</text>');});
     series.forEach(function(se){
       var pts=se.vals.map(function(v,i){return v==null?null:[xs(i),ys(v)];});
       var dpath=pts.filter(Boolean).map(function(p,i){return (i?'L':'M')+p[0]+' '+p[1];}).join(' ');
-      svg.push('<path d="'+dpath+'" fill="none" stroke="'+se.color+'" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"'+(se.name==="All India"?' stroke-dasharray="5 4"':'')+'/>');
+      var dash=(se.name==="All India"||se.name==="All");
+      svg.push('<path d="'+dpath+'" fill="none" stroke="'+se.color+'" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"'+(dash?' stroke-dasharray="5 4"':'')+'/>');
       pts.forEach(function(p,i){if(!p)return;svg.push('<circle cx="'+p[0]+'" cy="'+p[1]+'" r="4.5" fill="'+se.color+'"/>');
         svg.push('<text x="'+p[0]+'" y="'+(p[1]-10)+'" text-anchor="middle" font-family="JetBrains Mono" font-size="10.5" font-weight="600" fill="'+se.color+'">'+se.vals[i].toFixed(1)+'</text>');});
       var last=pts[pts.length-1];
@@ -253,6 +284,29 @@ window.ASER_DATA={"years":[2018,2022,2024],"states":["Andhra Pradesh","Arunachal
     });
     svg.push('</svg>');
     document.getElementById("panel").innerHTML=svg.join("");
+  }
+
+  // ── SKILL LADDER view (stacked distribution by grade, 2024) ──
+  var RUNG_COLORS=['#EF4444','#F59E0B','#FBBF24','#38BDF8','#10B981'];
+  function renderLadder(){
+    var dist=LAD[S.subject], rungs=(S.subject==="read"?LAD.readRungs:LAD.arithRungs);
+    var grades=["1","2","3","4","5","6","7","8"], GROM=["I","II","III","IV","V","VI","VII","VIII"];
+    var W=760,padL=54,padR=16,top=10,rowH=34,gap=8,H=top+grades.length*rowH+8;
+    var innerW=W-padL-padR;
+    var svg=['<svg class="chart-svg" viewBox="0 0 '+W+' '+H+'" role="img" aria-label="Skill ladder distribution by grade">'];
+    grades.forEach(function(g,gi){
+      var y=top+gi*rowH, seg=dist[g], x=padL;
+      svg.push('<text x="'+(padL-10)+'" y="'+(y+rowH/2+3)+'" text-anchor="end" font-family="Inter" font-size="12.5" font-weight="700" fill="'+css('--ink')+'">Std '+GROM[gi]+'</text>');
+      seg.forEach(function(pct,ri){
+        var w=innerW*pct/100;
+        svg.push('<rect x="'+x.toFixed(1)+'" y="'+(y+4)+'" width="'+Math.max(0,w).toFixed(1)+'" height="'+(rowH-gap-4)+'" fill="'+RUNG_COLORS[ri]+'"><title>Std '+GROM[gi]+' · '+rungs[ri]+': '+pct.toFixed(1)+'%</title></rect>');
+        if(w>26)svg.push('<text x="'+(x+w/2).toFixed(1)+'" y="'+(y+rowH/2+3)+'" text-anchor="middle" font-family="JetBrains Mono" font-size="10.5" font-weight="600" fill="#fff">'+Math.round(pct)+'</text>');
+        x+=w;
+      });
+    });
+    svg.push('</svg>');
+    var leg='<div class="legend">'+rungs.map(function(r,i){return '<span><span class="dot" style="background:'+RUNG_COLORS[i]+'"></span>'+esc(r)+'</span>';}).join('')+'</div>';
+    document.getElementById("panel").innerHTML=svg.join("")+leg;
   }
 
   // ── TABLE view ──
@@ -276,6 +330,7 @@ window.ASER_DATA={"years":[2018,2022,2024],"states":["Andhra Pradesh","Arunachal
     renderCaption();
     if(S.view==="rank")renderRank();
     else if(S.view==="trend")renderTrend();
+    else if(S.view==="ladder")renderLadder();
     else renderTable();
   }
   // re-render on theme change (colours are theme-dependent)

--- a/aser.html
+++ b/aser.html
@@ -6,11 +6,11 @@
 <meta name="theme-color" content="#0F172A">
 <title>ASER Learning Explorer — foundational reading &amp; arithmetic across India | ImpactMojo</title>
 <meta name="description" content="Explore ASER (Annual Status of Education Report) foundational-learning data — the share of government-school children who can read a Std II text or do basic arithmetic — ranked and trended across Indian states, 2018–2024. Source: ASER Centre / Pratham.">
-<link rel="canonical" href="https://www.impactmojo.in/Labs/aser-learning-explorer.html">
+<link rel="canonical" href="https://www.impactmojo.in/aser.html">
 <meta property="og:title" content="ASER Learning Explorer — ImpactMojo">
 <meta property="og:description" content="Foundational reading &amp; arithmetic across Indian states, 2018–2024, from ASER data. Rank states, see trends, and read the skill gap. Source: ASER Centre / Pratham.">
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://www.impactmojo.in/Labs/aser-learning-explorer.html">
+<meta property="og:url" content="https://www.impactmojo.in/aser.html">
 <meta name="twitter:card" content="summary_large_image">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -91,7 +91,7 @@ table.data tr.ai td{font-weight:800;color:var(--acc);border-top:2px solid var(--
 
 <main class="wrap">
   <section class="hero">
-    <div class="eyebrow">Data Lab · Foundational Learning</div>
+    <div class="eyebrow">Showcase · Foundational Learning</div>
     <h1>ASER Learning Explorer</h1>
     <p>How many children in rural India can actually read and do basic arithmetic — and how it varies by state, grade and year. Drawn from the <b>Annual Status of Education Report (ASER)</b>, India's largest citizen-led survey of children's learning.</p>
     <div class="srcbadge">Source: <b>ASER 2024</b>, Table 15 · ASER Centre / Pratham</div>

--- a/catalog.html
+++ b/catalog.html
@@ -5,7 +5,7 @@
     |  Version: 3.1.0 - January 28, 2026                                            |
     |                                                                               |
     |  Complete catalog page with V3 design system matching index.html standards.   |
-    |  Features 70 courses (19 flagship + 51 foundational), 37 labs, 135 games, 11 premium tools, plus free tools — Game Library, Peer Review, certificate verification and a Partner API. |
+    |  Features 70 courses (19 flagship + 51 foundational), 36 labs, 135 games, 11 premium tools, plus free tools — Game Library, Peer Review, certificate verification and a Partner API. |
     |                                                                               |
     |  INCLUDED FEATURES (ALL Required Elements):                                   |
     |  [OK] Google Analytics (G-JRCMEB9TBW)                                            |
@@ -136,16 +136,16 @@ window.addEventListener('pageshow', function(event) {
 </script>
 
 <!-- SEO Meta Tags -->
-<meta name="description" content="Browse 19 flagship courses, 70 free courses, 37 interactive studios, and 135 educational games on MEAL, Theory of Change, Research Methods, Gender Studies, and more. ImpactMojo: Free development education for NGOs and impact teams across South Asia.">
+<meta name="description" content="Browse 19 flagship courses, 70 free courses, 36 interactive studios, and 135 educational games on MEAL, Theory of Change, Research Methods, Gender Studies, and more. ImpactMojo: Free development education for NGOs and impact teams across South Asia.">
 <meta property="og:title" content="Course Catalog | ImpactMojo">
-<meta property="og:description" content="Browse 19 flagship courses, 70 free courses, 37 interactive studios, and 135 educational games on MEAL, Theory of Change, Research Methods, Gender Studies, and more.">
+<meta property="og:description" content="Browse 19 flagship courses, 70 free courses, 36 interactive studios, and 135 educational games on MEAL, Theory of Change, Research Methods, Gender Studies, and more.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://www.impactmojo.in/catalog.html">
 <meta property="og:image" content="https://www.impactmojo.in/assets/images/og-card.png">
 <meta property="og:site_name" content="ImpactMojo">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Course Catalog | ImpactMojo">
-<meta name="twitter:description" content="Browse 19 flagship courses, 70 free courses, 37 interactive studios, and 135 educational games on MEAL, Theory of Change, Research Methods, Gender Studies, and more.">
+<meta name="twitter:description" content="Browse 19 flagship courses, 70 free courses, 36 interactive studios, and 135 educational games on MEAL, Theory of Change, Research Methods, Gender Studies, and more.">
 <meta name="twitter:image" content="https://www.impactmojo.in/assets/images/og-card.png">
 
 <title>Course Catalog | ImpactMojo</title>

--- a/data/counts.json
+++ b/data/counts.json
@@ -5,7 +5,7 @@
   "foundational-courses": 51,
   "games": 135,
   "game-simulations": 18,
-  "labs": 37,
+  "labs": 36,
   "reading-companions": 149,
   "deep-dives": 22,
   "handouts": 89,

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -15028,12 +15028,12 @@
     ]
   },
   {
-    "id": "lab-aser-learning-explorer",
-    "title": "ASER Learning Explorer",
+    "id": "showcase-aser-explorer",
+    "title": "ASER Explorer",
     "description": "Explore ASER foundational-learning data — the share of government-school children who can read a Std II text or do basic arithmetic — ranked and trended across Indian states, 2018–2024.",
-    "type": "lab",
-    "category": "Labs",
-    "url": "/Labs/aser-learning-explorer.html",
+    "type": "tool",
+    "category": "Showcase",
+    "url": "/aser.html",
     "tags": [
       "aser",
       "education",

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -15030,7 +15030,7 @@
   {
     "id": "showcase-aser-explorer",
     "title": "ASER Explorer",
-    "description": "Explore ASER foundational-learning data — the share of government-school children who can read a Std II text or do basic arithmetic — ranked and trended across Indian states, 2018–2024.",
+    "description": "Explore ASER foundational-learning data — the share of children who can read a Std II text or do basic arithmetic — ranked across Indian states, trended by school type 2014–2024, with a rung-by-rung skill ladder.",
     "type": "tool",
     "category": "Showcase",
     "url": "/aser.html",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,7 @@ What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](h
 
 ### For Learners
 
-- **ASER Learning Explorer** (`/Labs/aser-learning-explorer.html`) — a new interactive data studio built on India's Annual Status of Education Report (ASER). See what share of government-school children can read a Std II text or do basic arithmetic, ranked across every state, with trends from 2018 to 2024 and a comparison to the All-India average. Switch subject (reading / arithmetic), grade (Std III / V / VIII), year and view (state ranking, trend line, or full table). Source-linked to ASER Centre / Pratham.
+- **ASER Learning Explorer** (`/aser.html`) — a new interactive data product in the Showcase, built on India's Annual Status of Education Report (ASER). See what share of government-school children can read a Std II text or do basic arithmetic, ranked across every state, with trends from 2018 to 2024 and a comparison to the All-India average. Switch subject (reading / arithmetic), grade (Std III / V / VIII), year and view (state ranking, trend line, or full table). Source-linked to ASER Centre / Pratham.
 
 ## v10.146.0 — July 21, 2026 (New flagship: Social Movements & Protests)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,7 @@ What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](h
 
 ### For Learners
 
-- **ASER Learning Explorer** (`/aser.html`) — a new interactive data product in the Showcase, built on India's Annual Status of Education Report (ASER). See what share of government-school children can read a Std II text or do basic arithmetic, ranked across every state, with trends from 2018 to 2024 and a comparison to the All-India average. Switch subject (reading / arithmetic), grade (Std III / V / VIII), year and view (state ranking, trend line, or full table). Source-linked to ASER Centre / Pratham.
+- **ASER Explorer** (`/aser.html`) — a new interactive data product in the Showcase, built on India's Annual Status of Education Report (ASER). See what share of children can read a Std II text or do basic arithmetic: **rank** all 27 states, watch the **national trend by school type** (government vs private vs all, 2014–2024), and read the full **skill ladder** — the rung-by-rung distribution from "can't read letters" up to "reads a Std II text", grade by grade. Switch subject (reading / arithmetic), grade and year. Source-linked to ASER Centre / Pratham.
 
 ## v10.146.0 — July 21, 2026 (New flagship: Social Movements & Protests)
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,7 +6,7 @@ Common questions from educators, facilitators, and practitioners.
 
 ## Is ImpactMojo really free?
 
-Yes. All 19 flagship courses (13 modules each), 51 foundational courses, 135 learning games, 37 interactive studios, 89 handouts, the ImpactLex glossary (390+ terms), 200 Dev Case Studies, 500+ DevDiscourses papers, and interactive BookSummaries are completely free.
+Yes. All 19 flagship courses (13 modules each), 51 foundational courses, 135 learning games, 36 interactive studios, 89 handouts, the ImpactLex glossary (390+ terms), 200 Dev Case Studies, 500+ DevDiscourses papers, and interactive BookSummaries are completely free.
 
 There are paid tiers (Practitioner, Professional, and Organization) that unlock additional tools — things like advanced studio features, PDF/PNG export, AI-powered tools, and team dashboards. But the core learning experience is free and always will be.
 
@@ -104,7 +104,7 @@ Here is a straightforward comparison:
 |---------|----------------|------------------------|------------------------|-------------------------------|
 | All 70 courses | Yes | Yes | Yes | Yes |
 | 135 games | Yes | Yes | Yes | Yes |
-| 37 studios | Yes | Yes | Yes | Yes |
+| 36 studios | Yes | Yes | Yes | Yes |
 | 89 handouts | Yes | Yes | Yes | Yes |
 | ImpactLex, DevDiscourses, Case Studies | Yes | Yes | Yes | Yes |
 | Progress tracking and certificates | — | Yes | Yes | Yes |

--- a/docs/labs-guide.md
+++ b/docs/labs-guide.md
@@ -2,13 +2,13 @@
 
 ## What Are the ImpactMojo Studios?
 
-ImpactMojo offers **37 interactive studios** — hands-on workbenches where you build, design, and practice real development skills. Unlike courses (which teach concepts) or games (which simulate dynamics), studios produce **tangible outputs** — a Theory of Change diagram, a MEL plan, a policy brief — that you can export and use in your actual work.
+ImpactMojo offers **36 interactive studios** — hands-on workbenches where you build, design, and practice real development skills. Unlike courses (which teach concepts) or games (which simulate dynamics), studios produce **tangible outputs** — a Theory of Change diagram, a MEL plan, a policy brief — that you can export and use in your actual work.
 
 All studios are **free, browser-based, and require no login**.
 
 ---
 
-## The 37 Studios
+## The 36 Studios
 
 ### MEL & Research Studios
 

--- a/docs/platform-overview.md
+++ b/docs/platform-overview.md
@@ -77,7 +77,7 @@ Each game:
 
 ---
 
-## Interactive Studios (37 studios)
+## Interactive Studios (36 studios)
 
 Studios are browser-based workbenches where you build something. Unlike courses (where you read and reflect), studios are hands-on — you follow a guided workflow and produce a real output.
 
@@ -306,7 +306,7 @@ Switch languages from the platform interface. This makes ImpactMojo usable for t
 
 ## What's Free vs. Premium?
 
-The vast majority of ImpactMojo is **completely free** — this is a genuine commitment, not a marketing strategy. All 70 courses, 135 games, 37 studios, handouts, ImpactLex, case studies, DevDiscourses, and Dataverse are available at no cost.
+The vast majority of ImpactMojo is **completely free** — this is a genuine commitment, not a marketing strategy. All 70 courses, 135 games, 36 studios, handouts, ImpactLex, case studies, DevDiscourses, and Dataverse are available at no cost.
 
 Premium memberships (starting at ₹399/month) unlock additional tools, PDF/PNG export from studios, certificates, and priority access to coaching and workshops.
 

--- a/faq.html
+++ b/faq.html
@@ -1670,7 +1670,7 @@ body.dark-mode .badge-free, body.dark-mode .badge-status-live, body.dark-mode .s
       "name": "How much content is there in total?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "70 courses (19 flagship + 51 foundational), 37 interactive studios, a 135-game library, 149 reading companions, 22 deep dives, 89 handouts, a 321-source Dataverse, and the ImpactLex glossary of 490+ terms — almost all of it free."
+        "text": "70 courses (19 flagship + 51 foundational), 36 interactive studios, a 135-game library, 149 reading companions, 22 deep dives, 89 handouts, a 321-source Dataverse, and the ImpactLex glossary of 490+ terms — almost all of it free."
       }
     },
     {
@@ -1972,7 +1972,7 @@ body.dark-mode .badge-free, body.dark-mode .badge-status-live, body.dark-mode .s
                     <svg class="faq-toggle" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
                 </div>
                 <div class="faq-answer"><div class="faq-answer-content">
-                    70 courses (19 flagship + 51 foundational), 37 interactive studios, a 135-game library, 149 reading companions, 22 deep dives, 89 handouts, a 321-source Dataverse, the ImpactLex glossary (490+ terms) and more &mdash; almost all of it free. Browse it all in the <a href="/catalog.html">catalog</a>.
+                    70 courses (19 flagship + 51 foundational), 36 interactive studios, a 135-game library, 149 reading companions, 22 deep dives, 89 handouts, a 321-source Dataverse, the ImpactLex glossary (490+ terms) and more &mdash; almost all of it free. Browse it all in the <a href="/catalog.html">catalog</a>.
                 </div></div>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -677,6 +677,7 @@ window.addEventListener('click', function(e) {
     <li id="nav-marginalia"><a href='/specials/marginalia/' style='color: #BE185D; font-weight: 600;' class="nav-accent" data-dark-color="#EC4899"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Book"/></svg> Marginalia</a></li>
     <li id="nav-longview"><a href='/the-long-view.html' style='color: #6B3FA0; font-weight: 600;' class="nav-accent" data-dark-color="#764ba2"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Flare"/></svg> Long View</a></li>
     <li id="nav-nfhs"><a href='/nfhs.html' style='color: #0F766E; font-weight: 600;' class="nav-accent" data-dark-color="#14B8A6"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Map"/></svg> NFHS Explorer</a></li>
+    <li id="nav-aser"><a href='/aser.html' style='color: #0369A1; font-weight: 600;' class="nav-accent" data-dark-color="#38BDF8"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Map"/></svg> NFHS Explorer</a></li>
     <li id="nav-maps"><a href='/maps/' style='color: #6D28D9; font-weight: 600;' class="nav-accent" data-dark-color="#7C3AED"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Globe_detailed"/></svg> Maps <span style="background:#7C3AED;color:#fff;font-size:0.65rem;padding:0.1rem 0.35rem;border-radius:4px;margin-left:0.3rem;text-transform:uppercase;letter-spacing:0.5px;vertical-align:middle">New</span></a></li>
     <li id="nav-timelines"><a href='/timelines/' style='color: #0369A1; font-weight: 600;' class="nav-accent" data-dark-color="#0EA5E9"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Activity"/></svg> Timelines</a></li>
     <li id="nav-research-to-action"><a href='/research-to-action/' style='color: #C2410C; font-weight: 600;' class="nav-accent" data-dark-color="#F97316"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Album"/></svg> Posters</a></li>
@@ -931,7 +932,7 @@ window.addEventListener('authStateChanged', function(e) {
         <div class="v3-callout-arrow"></div>
         <div class="v3-callout-content">
             <div style="font-weight:700;font-size:0.98rem;line-height:1.5;margin-bottom:10px;">
-                <span data-i18n="benefits.content_lead">Everything free &mdash; 70 courses &middot; 135 games &middot; 37 studios &middot; 149 reading companions &amp; more</span>
+                <span data-i18n="benefits.content_lead">Everything free &mdash; 70 courses &middot; 135 games &middot; 36 studios &middot; 149 reading companions &amp; more</span>
                 <span style="display:block;font-weight:600;opacity:.75;font-size:0.86rem;margin-top:2px;" data-i18n="benefits.plus_account">&mdash; practitioner-built, and yours to keep:</span>
             </div>
             <span class="v3-benefit-item">
@@ -1121,7 +1122,7 @@ window.addEventListener('authStateChanged', function(e) {
       </a>
       <a class="tp-tile" href="/Labs/" style="--tc:#10B981">
         <span class="tp-ic"><svg viewBox="0 0 24 24"><path d="M2 12h4l3 8 4-16 3 8h6"/></svg></span>
-        <span class="tp-n">Studios <span class="tp-cnt tp-mono">37</span></span>
+        <span class="tp-n">Studios <span class="tp-cnt tp-mono">36</span></span>
         <span class="tp-d">Hands-on tools &mdash; build a Theory of Change, design a sample, and more.</span>
         <span class="tp-go">Open studios &rarr;</span>
       </a>
@@ -1223,6 +1224,7 @@ window.addEventListener('authStateChanged', function(e) {
       <a class="tp-scard" href="/specials/marginalia/" style="--sc:#EC4899"><span class="tp-n">Marginalia</span><span class="tp-d">Cartoon essays on development work.</span><span class="tp-go">View &rarr;</span></a>
       <a class="tp-scard" href="/the-long-view.html" style="--sc:#10B981"><span class="tp-n">Long View</span><span class="tp-d">31 honest data visualisations.</span><span class="tp-go">View &rarr;</span></a>
       <a class="tp-scard" href="/nfhs.html" style="--sc:#0d9488"><span class="tp-n">NFHS Explorer</span><span class="tp-d">Every Indian district, two health surveys, mapped.</span><span class="tp-go">View &rarr;</span></a>
+      <a class="tp-scard" href="/aser.html" style="--sc:#0EA5E9"><span class="tp-n">ASER Explorer</span><span class="tp-d">Can India's children read &amp; count? State by state, 2018&ndash;2024.</span><span class="tp-go">View &rarr;</span></a>
       <a class="tp-scard" href="/maps/" style="--sc:#7C3AED"><span class="tp-n">Maps</span><span class="tp-d">Interactive topic &amp; funding ecosystem maps.</span><span class="tp-go">View &rarr;</span></a>
     </div>
   </div>

--- a/js/tours.js
+++ b/js/tours.js
@@ -119,10 +119,10 @@
   // keep the "<number> <type>" phrasing when editing.
   var TOURS = {
     index: [
-      { intro: '<strong>Welcome to ImpactMojo!</strong><br>Development know-how for South Asia — 70 courses, 135 games and 37 studios, all free, built by practitioners. Here’s a quick lay of the land.' },
+      { intro: '<strong>Welcome to ImpactMojo!</strong><br>Development know-how for South Asia — 70 courses, 135 games and 36 studios, all free, built by practitioners. Here’s a quick lay of the land.' },
       { element: '#nav-learn', intro: '<strong>Learn</strong><br>The heart of the platform: 70 courses (19 flagship + 51 foundational), interactive studios, and practice packs.' },
       { element: '#nav-flagships', intro: '<strong>Flagship courses</strong><br>Semester-depth courses with progress tracking, self-assessments, and free certificates — MEL, development economics, gender studies, causal inference, and more.' },
-      { element: '#nav-labs', intro: '<strong>Studios</strong><br>37 studios where you build real artefacts — a Theory of Change, a LogFrame, a sampling plan, a survey instrument.' },
+      { element: '#nav-labs', intro: '<strong>Studios</strong><br>36 studios where you build real artefacts — a Theory of Change, a LogFrame, a sampling plan, a survey instrument.' },
       { element: '#nav-specials', intro: '<strong>Explore</strong><br>The 135-game library, 149 reading companions, 22 deep dives, citation-backed timelines, and daily practice dojos.' },
       { element: '#nav-libraries', intro: '<strong>Libraries &amp; data</strong><br>Reference collections: the Dataverse of data tools, the ImpactLex glossary, NudgeKit behaviour-change techniques, and Indian policy documents.' },
       { element: '.ims-nav-btn', intro: '<strong>Search everything</strong><br>Press <kbd>Ctrl</kbd>+<kbd>K</kbd> anywhere to search across every course, studio, game and companion.' },

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -741,7 +741,7 @@
   <url><loc>https://www.impactmojo.in/work-samples/05_wage_gap_visualisation.html</loc><lastmod>2026-07-12</lastmod></url>
   <url><loc>https://www.impactmojo.in/workshops.html</loc><lastmod>2026-07-19</lastmod></url>
     <url>
-        <loc>https://www.impactmojo.in/Labs/aser-learning-explorer.html</loc>
+        <loc>https://www.impactmojo.in/aser.html</loc>
         <lastmod>2026-07-26</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>

--- a/transparency.html
+++ b/transparency.html
@@ -724,7 +724,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
                     <div class="tier-price">Paid</div>
                     <ul class="tier-features">
                         <li>Everything in Explorer</li>
-                        <li>37 interactive studios</li>
+                        <li>36 interactive studios</li>
                         <li>Premium tools (ToC Workbench, MEL Studio, etc.)</li>
                         <li>Live case challenges</li>
                         <li>Certificates &amp; portfolio builder</li>


### PR DESCRIPTION
## What does this PR do?

Two things the user asked for: **(1) reclassify** the ASER Explorer as a *data product on the Showcase landing* (not a Lab), and **(2) finish the data** — correct a labelling error and add the two missing signature views.

### Reclassification
- Moves `/Labs/aser-learning-explorer.html` → `/aser.html` (mirroring the sibling **NFHS Explorer** at `/nfhs.html`).
- Adds an **ASER Explorer** card to the homepage Showcase strip and the Showcase nav menu; removes the Labs card.
- Reverts the studios count to 36 (`data/counts.json`; `check-counts.py` passes); reclassifies the search-index entry to `type: tool` / `category: Showcase`; updates the sitemap URL and eyebrow ("Showcase · Foundational Learning").

### Data correctness + new views
- **Label fix:** ASER Table 15's learning columns are **all children (government + private)**, not government-only — validated against Tables 1/2, whose All-India row matches Table 15's numbers on the **"All"** column, not "Govt" (e.g. Std III reading 2024: 27.0 ≈ 27.1, not 23.4). The tool is relabelled throughout.
- **National trend by school type** (new): government / private / all, 2014–2024, from Tables 1/2/5/6/8/9. Shown when "All India" is selected in the trend view.
- **Skill ladder** (new view): the rung-by-rung distribution by grade for 2024 (reading: can't-read-letters → letter → word → Std I → Std II text; arithmetic: can't-recognise-numbers → 1–9 → 11–99 → subtraction → division), from Tables 4/7. Each grade's bar sums to 100%.
- Every series validated against the report's own All-India figures and (for the ladder) 100% row totals.

Views now: **Rank states · Trend · Skill ladder · Table.** Still self-contained (data + charts inline), light/dark, mobile-friendly.

## Type of change

- [x] New feature or tool
- [x] Bug fix (corrected data label)

## Checklist

- [x] Rendered rank, trend (state + national-by-school-type), skill ladder, and dark mode in-browser; all data matches the ASER 2024 report tables
- [x] `check-counts.py` passes; search-index valid JSON; sitemap valid XML; mojibake guard passes
- [x] `/aser.html` renders at the new path; Showcase card + nav entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgDJcnAiEfc5NQL4DjbrJY)_