### PR TITLE
Challenge submissions: optional feedback email with Reply-To

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to ImpactMojo are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.162.0] - 2026-07-29
+
+### Fixed
+
+- **Challenge submissions had no reply path**: the `challenge-submission` Netlify form captured no contact field, so notification emails couldn't be answered. Added an optional email input to the submit section (`challenges.html` + `js/challenges.js`) — validated loosely, remembered in `localStorage` (`im-challenge-email`), pre-filled from the Supabase session for signed-in users, and sent as the `email` field so Netlify sets it as the notification's Reply-To. Site-wide form audit: all 19 other Netlify form types already collect email; the only remaining email-less form is the deliberately anonymous `chatbot-feedback` widget.
+
 ## [10.161.0] - 2026-07-29
 
 ### Added

--- a/challenges.html
+++ b/challenges.html
@@ -462,6 +462,17 @@ body.dark-mode .ch-group-advanced h2, [data-theme="dark"] .ch-group-advanced h2 
 
 .ch-char-count { font-size: 0.75rem; color: var(--text-muted); text-align: right; margin-top: -0.75rem; margin-bottom: 0.75rem; }
 
+.ch-email-label { display: block; font-size: 0.85rem; color: var(--text-secondary); margin-bottom: 0.35rem; }
+.ch-email-label span { color: var(--text-muted); }
+.ch-email-input {
+    width: 100%; max-width: 420px; padding: 0.6rem 0.85rem; border-radius: 8px;
+    border: 1px solid var(--border-color); background: var(--primary-bg);
+    color: var(--text-primary); font-family: 'Inter', sans-serif; font-size: 0.85rem;
+    margin-bottom: 1rem;
+}
+.ch-email-input:focus { outline: none; border-color: var(--accent-color); }
+.ch-email-input::placeholder { color: var(--text-muted); }
+
 .ch-submit-actions { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
 
 .ch-btn {
@@ -932,6 +943,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
     <input name="challenge_track">
     <input name="challenge_difficulty">
     <textarea name="submission_text"></textarea>
+    <input type="email" name="email">
     <input name="submitted_at">
 </form>
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.162.0 — July 29, 2026 (Challenge submissions: optional feedback email)
+
+### For Learners
+
+- **Get feedback on your challenge responses** — when you submit a Live Case Challenge you can now leave your email (optional) so we can reply with personal feedback. Signed-in learners get the field pre-filled automatically; leave it blank to stay anonymous as before.
+
 ## v10.161.0 — July 29, 2026 (New: Law Guides — Indian laws for the social sector)
 
 ### For Learners

--- a/js/challenges.js
+++ b/js/challenges.js
@@ -299,6 +299,8 @@
                     // can fill it in directly — but only when there is no saved draft to preserve.
                     '<textarea class="ch-textarea" id="challengeResponse" placeholder="Write your response here...">' + escapeHTML(draft || ch.submissionTemplate || '') + '</textarea>' +
                     '<div class="ch-char-count"><span id="charCount">' + ((draft || ch.submissionTemplate || '').length) + '</span> characters (min 200)</div>' +
+                    '<label class="ch-email-label" for="challengeEmail">Want feedback on your response? Leave an email <span>(optional — we only use it to reply)</span></label>' +
+                    '<input type="email" class="ch-email-input" id="challengeEmail" placeholder="you@example.org" autocomplete="email" value="' + escapeHTML(getSavedEmail()) + '">' +
                     '<div class="ch-submit-actions">' +
                         '<button class="ch-btn ch-btn-primary" id="submitChallengeBtn" onclick="window._challengeSubmit(\'' + ch.id + '\')">' +
                             '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/></svg> Submit Response' +
@@ -346,6 +348,17 @@
 
         overlay.classList.add('open');
         document.body.style.overflow = 'hidden';
+
+        // Prefill the optional feedback email from the signed-in account
+        // (only when the field is empty — never overwrite a typed/saved value)
+        if (!isSubmitted) {
+            (async function () {
+                var input = document.getElementById('challengeEmail');
+                if (!input || input.value) return;
+                var user = await getUser();
+                if (user && user.email && input && !input.value) input.value = user.email;
+            })();
+        }
 
         // Cloud read-back: show that the submission is recorded to the account
         if (isSubmitted) {
@@ -396,6 +409,11 @@
 
     // ---- Submit ----
     var NETLIFY_FORM_NAME = 'challenge-submission';
+    var EMAIL_STORAGE_KEY = 'im-challenge-email';
+
+    function getSavedEmail() {
+        try { return localStorage.getItem(EMAIL_STORAGE_KEY) || ''; } catch (e) { return ''; }
+    }
 
     function submitChallenge(challengeId) {
         var textarea = document.getElementById('challengeResponse');
@@ -405,6 +423,16 @@
         if (text.length < 200) {
             alert('Please write at least 200 characters before submitting.');
             return;
+        }
+
+        var emailInput = document.getElementById('challengeEmail');
+        var email = emailInput ? emailInput.value.trim() : '';
+        if (email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+            alert('That email address doesn\'t look right — fix it or leave the field empty.');
+            return;
+        }
+        if (email) {
+            try { localStorage.setItem(EMAIL_STORAGE_KEY, email); } catch (e) { /* private mode */ }
         }
 
         var ch = challenges.find(function (c) { return c.id === challengeId; });
@@ -434,6 +462,9 @@
         formData.append('challenge_track', ch ? ch.trackLabel : '');
         formData.append('challenge_difficulty', ch ? ch.difficulty : '');
         formData.append('submission_text', text);
+        // Netlify sets the notification's Reply-To from a field named "email",
+        // so replies from the inbox reach the submitter directly.
+        formData.append('email', email);
         formData.append('submitted_at', new Date().toISOString());
 
         fetch('/', {


### PR DESCRIPTION
## What

Fixes the no-reply-path problem on Live Case Challenge submissions: the `challenge-submission` Netlify form captured no contact field, so the notification email you receive couldn't be answered.

- Adds an **optional** email input to the challenge submit section: *"Want feedback on your response? Leave an email (optional — we only use it to reply)"*
- Pre-filled automatically from the signed-in Supabase session (never overwrites a typed value); remembered in `localStorage` for repeat submissions; loosely validated (reject malformed, allow empty)
- Sent as the `email` field, which Netlify uses as the notification's **Reply-To** — so replying from the inbox reaches the submitter directly
- Anonymous submission still works exactly as before if the field is left blank

## Site-wide audit

Checked every `data-netlify` form on the site (70 files, 20 distinct form types): all 19 other form types already collect an email. The only remaining email-less form is the deliberately anonymous `chatbot-feedback` widget on the homepage — left as is.

## Verification

- `node --check js/challenges.js` — parses
- `check-mojibake.py`, `check-counts.py` — PASS
- Changelogs updated (`docs/changelog.md` For Learners + `CHANGELOG.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QSym5L43F2ueonJFDpoa4Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSym5L43F2ueonJFDpoa4Z)_