### PR TITLE
Nav: "Updated" badges on Field Radio + Libraries

### DIFF
--- a/index.html
+++ b/index.html
@@ -732,13 +732,13 @@ window.addEventListener('click', function(e) {
 </li>
 
 <!-- Libraries Link -->
-<li id="nav-libraries"><a href='/libraries'><span data-i18n="nav.libraries">Libraries</span> <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Library_books"/></svg></a></li>
+<li id="nav-libraries"><a href='/libraries'><span data-i18n="nav.libraries">Libraries</span> <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Library_books"/></svg> <span style="background:#D97706;color:#fff;font-size:0.6rem;padding:0.08rem 0.32rem;border-radius:4px;margin-left:0.15rem;text-transform:uppercase;letter-spacing:0.5px;vertical-align:middle;font-weight:700">Updated</span></a></li>
 
 <!-- Blog Link -->
 <li id="nav-blog"><a href='/blog'><span data-i18n="nav.blog">Blog</span> <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Article"/></svg></a></li>
 
 <!-- Field Radio Link -->
-<li id="nav-fieldradio"><a href='/field-radio'><span data-i18n="nav.fieldradio">Field Radio</span> <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Album"/></svg></a></li>
+<li id="nav-fieldradio"><a href='/field-radio'><span data-i18n="nav.fieldradio">Field Radio</span> <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Album"/></svg> <span style="background:#D97706;color:#fff;font-size:0.6rem;padding:0.08rem 0.32rem;border-radius:4px;margin-left:0.15rem;text-transform:uppercase;letter-spacing:0.5px;vertical-align:middle;font-weight:700">Updated</span></a></li>
 
 <!-- Mobile Auth Buttons (inside nav-links so they appear in the fixed mobile menu overlay) -->
 <li class="mobile-auth-section" id="mobileAuthSection">


### PR DESCRIPTION
Adds an amber **"Updated"** badge (distinct from the purple/green **"New"** badges) to two nav items whose content was just refreshed:
- **Field Radio** — new audio + video clips (17 total).
- **Libraries** — 14 new Reading Companions.

Two-line change to `index.html`, mirroring the existing badge span pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgDJcnAiEfc5NQL4DjbrJY)_