### PR TITLE
Nav "updated" dots + About "What We Offer" refresh

### DIFF
--- a/about.html
+++ b/about.html
@@ -2084,16 +2084,36 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
             
             <div class="stats-grid">
                 <div class="stat-card">
-                    <div class="stat-number">69</div>
+                    <div class="stat-number">70</div>
                     <div class="stat-label">Courses</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-number">163</div>
+                    <div class="stat-label">Reading Companions</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-number">135</div>
+                    <div class="stat-label">Educational Games</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-number">89</div>
+                    <div class="stat-label">Handouts</div>
                 </div>
                 <div class="stat-card">
                     <div class="stat-number">36</div>
                     <div class="stat-label">Interactive Studios</div>
                 </div>
                 <div class="stat-card">
-                    <div class="stat-number">135</div>
-                    <div class="stat-label">Educational Games</div>
+                    <div class="stat-number">22</div>
+                    <div class="stat-label">Deep Dives</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-number">8</div>
+                    <div class="stat-label">Data Explorers</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-number">6</div>
+                    <div class="stat-label">Law Guides</div>
                 </div>
                 <div class="stat-card">
                     <div class="stat-number">13</div>

--- a/data/counts.json
+++ b/data/counts.json
@@ -7,6 +7,7 @@
     "game-simulations": 18,
     "labs": 36,
     "reading-companions": 163,
+    "data-explorers": 8,
     "deep-dives": 22,
     "handouts": 89,
     "timelines": 6,

--- a/index.html
+++ b/index.html
@@ -732,13 +732,13 @@ window.addEventListener('click', function(e) {
 </li>
 
 <!-- Libraries Link -->
-<li id="nav-libraries"><a href='/libraries'><span data-i18n="nav.libraries">Libraries</span> <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Library_books"/></svg></a></li>
+<li id="nav-libraries"><a href='/libraries'><span data-i18n="nav.libraries">Libraries</span> <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Library_books"/></svg><span title="Recently updated" aria-label="Recently updated" style="display:inline-block;width:6px;height:6px;border-radius:50%;background:#D97706;margin-left:4px;vertical-align:middle"></span></a></li>
 
 <!-- Blog Link -->
 <li id="nav-blog"><a href='/blog'><span data-i18n="nav.blog">Blog</span> <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Article"/></svg></a></li>
 
 <!-- Field Radio Link -->
-<li id="nav-fieldradio"><a href='/field-radio'><span data-i18n="nav.fieldradio">Field Radio</span> <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Album"/></svg></a></li>
+<li id="nav-fieldradio"><a href='/field-radio'><span data-i18n="nav.fieldradio">Field Radio</span> <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="v3-inline-icon"><use href="#si_Album"/></svg><span title="Recently updated" aria-label="Recently updated" style="display:inline-block;width:6px;height:6px;border-radius:50%;background:#D97706;margin-left:4px;vertical-align:middle"></span></a></li>
 
 <!-- Mobile Auth Buttons (inside nav-links so they appear in the fixed mobile menu overlay) -->
 <li class="mobile-auth-section" id="mobileAuthSection">


### PR DESCRIPTION
Two consistency fixes:

**Nav "recently updated" indicator (non-breaking).** Replaces the text badges (which wrapped the nav) with subtle amber dots on *Field Radio* and *Libraries*. Tested single-line at 1280px (the width the badges broke); the 1180px wrap is the nav's pre-existing breakpoint, present with or without the dots.

**About "What We Offer" refresh.** The stats grid was stale/incomplete:
- Corrected course count 69 → 70 (canonical).
- Added the newer content types: 163 Reading Companions, 89 Handouts, 22 Deep Dives, 8 Data Explorers, 6 Law Guides.
- `data/counts.json` now tracks `data-explorers: 8`.

Guards: mojibake PASS, counts PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgDJcnAiEfc5NQL4DjbrJY)_