### PR TITLE
Homepage: neaten the green benefits callout box

### DIFF
--- a/index.html
+++ b/index.html
@@ -928,10 +928,10 @@ window.addEventListener('authStateChanged', function(e) {
     </div>
     
     <!-- Speech Bubble Callout pointing to Sign Up benefits -->
-    <div class="v3-benefits-callout">
+    <div class="v3-benefits-callout" style="transform:none;animation:none;max-width:860px;">
         <div class="v3-callout-arrow"></div>
         <div class="v3-callout-content">
-            <div style="font-weight:700;font-size:0.98rem;line-height:1.5;margin-bottom:10px;">
+            <div style="font-weight:700;font-size:0.98rem;line-height:1.5;margin-bottom:10px;max-width:none;">
                 <span data-i18n="benefits.content_lead">Everything free &mdash; 70 courses &middot; 135 games &middot; 36 studios &middot; 163 reading companions &amp; more</span>
                 <span style="display:block;font-weight:600;opacity:.75;font-size:0.86rem;margin-top:2px;" data-i18n="benefits.plus_account">&mdash; practitioner-built, and yours to keep:</span>
             </div>


### PR DESCRIPTION
The "Everything free" callout under the hero buttons was tilted (`rotate(1deg)` + wobble animation) and narrow (`max-width` + a `60ch` cap on the intro), which made the text look wonky and orphaned "& more" onto its own line.

Fix (inline overrides on the element, robust across the minified CSS's media-query cascade): straighten it (`transform:none; animation:none`), widen to `860px`, and remove the intro line's `60ch` cap — so "Everything free — 70 courses · 135 games · 36 studios · 163 reading companions & more" reads on one clean line. Rendered/QA'd at 1440px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgDJcnAiEfc5NQL4DjbrJY)_