### PR TITLE
DPI studio: physically reorder tabs so Build is tab 1

### DIFF
--- a/Labs/dpi-lab.html
+++ b/Labs/dpi-lab.html
@@ -341,18 +341,18 @@ body { padding-top: 56px; }
 
     <div class="progress-bar"><div class="progress-bar-fill" id="progressFill"></div></div>
 
-    <div class="tabs" id="tabs">
-        <button class="tab-btn" onclick="switchTab(0)"><span class="tab-num">1</span> What is DPI?</button>
-        <button class="tab-btn" onclick="switchTab(1)"><span class="tab-num">2</span> India's DPI Stack</button>
-        <button class="tab-btn" onclick="switchTab(2)"><span class="tab-num">3</span> Aadhaar Deep Dive</button>
-        <button class="tab-btn" onclick="switchTab(3)"><span class="tab-num">4</span> UPI &amp; Payments</button>
-        <button class="tab-btn" onclick="switchTab(4)"><span class="tab-num">5</span> Governance &amp; Risks</button>
-        <button class="tab-btn active" onclick="switchTab(5)"><span class="tab-num">▶</span> Build a programme</button>
-        <button class="tab-btn" onclick="switchTab(6)"><span class="tab-num">7</span> Done</button>
+        <div class="tabs" id="tabs">
+        <button class="tab-btn active" data-target="0" onclick="switchTab(0)"><span class="tab-num">1</span> Build a programme</button>
+        <button class="tab-btn" data-target="1" onclick="switchTab(1)"><span class="tab-num">2</span> What is DPI?</button>
+        <button class="tab-btn" data-target="2" onclick="switchTab(2)"><span class="tab-num">3</span> India's DPI Stack</button>
+        <button class="tab-btn" data-target="3" onclick="switchTab(3)"><span class="tab-num">4</span> Aadhaar Deep Dive</button>
+        <button class="tab-btn" data-target="4" onclick="switchTab(4)"><span class="tab-num">5</span> UPI &amp; Payments</button>
+        <button class="tab-btn" data-target="5" onclick="switchTab(5)"><span class="tab-num">6</span> Governance &amp; Risks</button>
+        <button class="tab-btn" data-target="6" onclick="switchTab(6)"><span class="tab-num">7</span> Done</button>
     </div>
 
     <!-- ===== TAB 1: What is DPI? ===== -->
-    <div class="tab-panel" data-panel="0">
+    <div class="tab-panel" data-panel="1">
         <h2 class="section-title">What is Digital Public Infrastructure?</h2>
         <p class="section-desc">DPI is the set of digital building blocks — identity, payments, data exchange, consent — that governments provide as public goods, enabling private innovation and public service delivery at scale.</p>
 
@@ -413,12 +413,12 @@ body { padding-top: 56px; }
 
         <div class="nav-row">
             <span></span>
-            <button class="btn btn-primary" onclick="switchTab(1)">Next: India's DPI Stack &rarr;</button>
+            <button class="btn btn-primary" onclick="switchTab(2)">Next: India's DPI Stack &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 2: India's DPI Stack ===== -->
-    <div class="tab-panel" data-panel="1">
+    <div class="tab-panel" data-panel="2">
         <h2 class="section-title">India's DPI Stack in Detail</h2>
         <p class="section-desc">The "India Stack" is now studied and adapted worldwide, often with support from bodies like UNDP and the World Bank. Tap each block to select it and note the current scale.</p>
 
@@ -507,13 +507,13 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(0)">&larr; Back</button>
-            <button class="btn btn-primary" onclick="switchTab(2)">Next: Aadhaar Deep Dive &rarr;</button>
+            <button class="btn" onclick="switchTab(1)">&larr; Back</button>
+            <button class="btn btn-primary" onclick="switchTab(3)">Next: Aadhaar Deep Dive &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 3: Aadhaar Deep Dive ===== -->
-    <div class="tab-panel" data-panel="2">
+    <div class="tab-panel" data-panel="3">
         <h2 class="section-title">Aadhaar &mdash; Promise, Peril, and Practice</h2>
         <p class="section-desc">Aadhaar is the world's largest biometric ID system and the foundation of India's DPI. For practitioners it is impossible to ignore — and it carries real ethical and operational trade-offs.</p>
 
@@ -584,13 +584,13 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(1)">&larr; Back</button>
-            <button class="btn btn-primary" onclick="switchTab(3)">Next: UPI &amp; Payments &rarr;</button>
+            <button class="btn" onclick="switchTab(2)">&larr; Back</button>
+            <button class="btn btn-primary" onclick="switchTab(4)">Next: UPI &amp; Payments &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 4: UPI & Payments ===== -->
-    <div class="tab-panel" data-panel="3">
+    <div class="tab-panel" data-panel="4">
         <h2 class="section-title">UPI and the Payments Revolution</h2>
         <p class="section-desc">UPI is the payments rail that most visibly changed everyday transactions in India — and the backbone of many DBT-based schemes.</p>
 
@@ -662,13 +662,13 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(2)">&larr; Back</button>
-            <button class="btn btn-primary" onclick="switchTab(4)">Next: Governance &amp; Risks &rarr;</button>
+            <button class="btn" onclick="switchTab(3)">&larr; Back</button>
+            <button class="btn btn-primary" onclick="switchTab(5)">Next: Governance &amp; Risks &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 5: Governance & Risks ===== -->
-    <div class="tab-panel" data-panel="4">
+    <div class="tab-panel" data-panel="5">
         <h2 class="section-title">Governance, Privacy, and the DPDP Act</h2>
         <p class="section-desc">India's Digital Personal Data Protection (DPDP) Act, 2023 is its first comprehensive data-protection law. It governs how organisations — public and private — collect and process personal data. Tap each provision to select it.</p>
 
@@ -731,13 +731,13 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(3)">&larr; Back</button>
-            <button class="btn btn-primary" onclick="switchTab(5)">Next: DPI for Development &rarr;</button>
+            <button class="btn" onclick="switchTab(4)">&larr; Back</button>
+            <button class="btn btn-primary" onclick="switchTab(6)">Finish Studio &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 6: DPI for Development ===== -->
-    <div class="tab-panel active" data-panel="5">
+    <div class="tab-panel active" data-panel="0">
         <h2 class="section-title">Build: design a DPI-enabled programme</h2>
         <p class="section-desc"><strong>Start here.</strong> You'll design a programme layer by layer — identity, eligibility, payment, monitoring — mapping each to India's digital rails, always with a fallback for whoever the system might exclude. Work through the model below, then design your own. New to a term (Aadhaar, DBT, DPDP)? The reference tabs above break each one down.</p>
 
@@ -801,7 +801,7 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(0)">New here? Learn the rails &rarr;</button>
+            <button class="btn" onclick="switchTab(1)">New here? Learn the rails &rarr;</button>
             <button class="btn btn-primary" onclick="switchTab(6)">Finish Studio &rarr;</button>
         </div>
     </div>
@@ -837,7 +837,7 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(5)">&larr; Review</button>
+            <button class="btn" onclick="switchTab(0)">&larr; Review</button>
             <button class="btn" onclick="window.print()">Print / save as PDF</button>
         </div>
     </div>
@@ -916,11 +916,14 @@ var TOTAL_TABS = 7;
 var visited = { 0: true };
 function switchTab(idx) {
     visited[idx] = true;
-    document.querySelectorAll('.tab-btn').forEach(function(b, i) {
-        b.classList.toggle('active', i === idx);
-        b.classList.toggle('completed', i < idx || (visited[i] && i !== idx));
+    document.querySelectorAll('.tab-btn').forEach(function(b) {
+        var t = parseInt(b.getAttribute('data-target'), 10);
+        b.classList.toggle('active', t === idx);
+        b.classList.toggle('completed', !!visited[t] && t !== idx);
     });
-    document.querySelectorAll('.tab-panel').forEach(function(p, i) { p.classList.toggle('active', i === idx); });
+    document.querySelectorAll('.tab-panel').forEach(function(p) {
+        p.classList.toggle('active', parseInt(p.getAttribute('data-panel'), 10) === idx);
+    });
     document.getElementById('progressFill').style.width = ((idx + 1) / TOTAL_TABS * 100) + '%';
     window.scrollTo({ top: 0, behavior: 'smooth' });
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.173.0 — July 30, 2026 (DPI studio: Build is now literally tab 1)
+
+### Changed
+
+- **Digital Public Infrastructure studio** — the tab bar is now physically reordered so **"Build a programme" is tab 1**, with the concept tabs (What is DPI, Aadhaar, UPI, Governance) following as steps 2–6 and Done last. Tab switching was rewritten to resolve panels by a stable id rather than DOM position, and the Next/Back flow now reads build-first end to end (Build → learn the rails → … → Done).
+
 ## v10.172.0 — July 30, 2026 (DPI studio reframed build-first — pilot)
 
 ### Changed


### PR DESCRIPTION
Follow-up to the build-first pilot — you asked to go further and make **Build literally tab 1** in the bar, not just the default-open tab.

**What changed**
- The tab bar is now **1 Build a programme · 2 What is DPI? · 3 India's DPI Stack · 4 Aadhaar Deep Dive · 5 UPI & Payments · 6 Governance & Risks · 7 Done**.
- `switchTab()` was rewritten to resolve panels/buttons by a **stable `data-panel`/`data-target` id** instead of DOM position. This lets the Build panel keep its physical place in the 1000-line file (no risky block move) while being **indexed 0** — so it's the first, active tab.
- The **Next/Back flow is rewired build-first end to end**: Build → "learn the rails" → What is DPI → Stack → Aadhaar → UPI → Governance → Finish → Done.

**Verification:** exactly one active tab/panel (Build); all 12 nav-row targets resolve to valid panels; rendered check shows the bar leads with "1 Build a programme" (active) and the page opens on the build. `check-mojibake.py` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgDJcnAiEfc5NQL4DjbrJY)_