### PR TITLE
Studios: build-first pass across 7 course-like studios

### DIFF
--- a/Labs/conflict-sensitive-lab.html
+++ b/Labs/conflict-sensitive-lab.html
@@ -362,17 +362,17 @@ body { padding-top: 56px; }
     <div class="progress-bar"><div class="progress-bar-fill" id="progressFill"></div></div>
 
     <div class="tabs" id="tabs">
-        <button class="tab-btn active" onclick="switchTab(0)"><span class="tab-num">1</span> Conflict Sensitivity</button>
-        <button class="tab-btn" onclick="switchTab(1)"><span class="tab-num">2</span> Conflict Analysis</button>
-        <button class="tab-btn" onclick="switchTab(2)"><span class="tab-num">3</span> Do No Harm</button>
-        <button class="tab-btn" onclick="switchTab(3)"><span class="tab-num">4</span> Peacebuilding M&amp;E</button>
-        <button class="tab-btn" onclick="switchTab(4)"><span class="tab-num">5</span> Adaptive Management</button>
-        <button class="tab-btn" onclick="switchTab(5)"><span class="tab-num">6</span> Case Study</button>
-        <button class="tab-btn" onclick="switchTab(6)"><span class="tab-num">7</span> Done</button>
+        <button class="tab-btn active" data-target="0" onclick="switchTab(0)"><span class="tab-num">1</span> Case Study</button>
+        <button class="tab-btn" data-target="1" onclick="switchTab(1)"><span class="tab-num">2</span> Conflict Sensitivity</button>
+        <button class="tab-btn" data-target="2" onclick="switchTab(2)"><span class="tab-num">3</span> Conflict Analysis</button>
+        <button class="tab-btn" data-target="3" onclick="switchTab(3)"><span class="tab-num">4</span> Do No Harm</button>
+        <button class="tab-btn" data-target="4" onclick="switchTab(4)"><span class="tab-num">5</span> Peacebuilding M&amp;E</button>
+        <button class="tab-btn" data-target="5" onclick="switchTab(5)"><span class="tab-num">6</span> Adaptive Management</button>
+        <button class="tab-btn" data-target="6" onclick="switchTab(6)"><span class="tab-num">7</span> Done</button>
     </div>
 
     <!-- ===== TAB 1: Understanding Conflict Sensitivity ===== -->
-    <div class="tab-panel active" data-panel="0">
+    <div class="tab-panel" data-panel="1">
         <h2 class="section-title">Understanding Conflict Sensitivity</h2>
         <p class="section-desc">Conflict sensitivity means understanding how your intervention interacts with the conflict context — and designing to minimise harm and maximise peace.</p>
 
@@ -432,12 +432,12 @@ body { padding-top: 56px; }
 
         <div class="nav-row">
             <span></span>
-            <button class="btn btn-primary" onclick="switchTab(1)">Next: Conflict Analysis &rarr;</button>
+            <button class="btn btn-primary" onclick="switchTab(2)">Next: Conflict Analysis &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 2: Conflict Analysis ===== -->
-    <div class="tab-panel" data-panel="1">
+    <div class="tab-panel" data-panel="2">
         <h2 class="section-title">Conflict Analysis</h2>
         <p class="section-desc">Before designing any intervention, understand the conflict landscape. Who are the actors? What are their interests? What are the drivers?</p>
 
@@ -507,13 +507,13 @@ body { padding-top: 56px; }
         <div id="analysisFeedback"></div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(0)">&larr; Back</button>
-            <button class="btn btn-primary" onclick="switchTab(2)" id="q2next" disabled>Next: Do No Harm &rarr;</button>
+            <button class="btn" onclick="switchTab(1)">&larr; Back</button>
+            <button class="btn btn-primary" onclick="switchTab(3)" id="q2next" disabled>Next: Do No Harm &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 3: Do No Harm in Practice ===== -->
-    <div class="tab-panel" data-panel="2">
+    <div class="tab-panel" data-panel="3">
         <h2 class="section-title">Do No Harm in Practice</h2>
         <p class="section-desc">Even well-intentioned programmes can worsen conflict. Work through these teaching scenarios and choose the most conflict-sensitive response.</p>
 
@@ -541,13 +541,13 @@ body { padding-top: 56px; }
         <div id="scenarioFeedback"></div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(1)">&larr; Back</button>
-            <button class="btn btn-primary" onclick="switchTab(3)" id="q3next" disabled>Next: Peacebuilding M&amp;E &rarr;</button>
+            <button class="btn" onclick="switchTab(2)">&larr; Back</button>
+            <button class="btn btn-primary" onclick="switchTab(4)" id="q3next" disabled>Next: Peacebuilding M&amp;E &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 4: Peacebuilding M&E ===== -->
-    <div class="tab-panel" data-panel="3">
+    <div class="tab-panel" data-panel="4">
         <h2 class="section-title">Peacebuilding Monitoring &amp; Evaluation</h2>
         <p class="section-desc">Measuring peace is harder than measuring outputs — but it is essential for learning and accountability.</p>
 
@@ -602,13 +602,13 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(2)">&larr; Back</button>
-            <button class="btn btn-primary" onclick="switchTab(4)" id="q4next" disabled>Next: Adaptive Management &rarr;</button>
+            <button class="btn" onclick="switchTab(3)">&larr; Back</button>
+            <button class="btn btn-primary" onclick="switchTab(5)" id="q4next" disabled>Next: Adaptive Management &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 5: Adaptive Management ===== -->
-    <div class="tab-panel" data-panel="4">
+    <div class="tab-panel" data-panel="5">
         <h2 class="section-title">Adaptive Management in Conflict Contexts</h2>
         <p class="section-desc">Conflict contexts change rapidly. Your programme must sense, adapt, and respond — sometimes in hours, not months.</p>
 
@@ -634,13 +634,13 @@ body { padding-top: 56px; }
         <div id="adaptFeedback"></div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(3)">&larr; Back</button>
-            <button class="btn btn-primary" onclick="switchTab(5)" id="q5next" disabled>Next: Case Study &rarr;</button>
+            <button class="btn" onclick="switchTab(4)">&larr; Back</button>
+            <button class="btn btn-primary" onclick="switchTab(0)" id="q5next" disabled>Next: Case Study &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 6: Case Study ===== -->
-    <div class="tab-panel" data-panel="5">
+    <div class="tab-panel active" data-panel="0">
         <h2 class="section-title">Case Study: Designing a Conflict-Sensitive Programme</h2>
         <p class="section-desc">Put it together. Design a conflict-sensitive education programme for a mixed-community district with a history of violence.</p>
 
@@ -667,7 +667,7 @@ body { padding-top: 56px; }
         <div id="designFeedback"></div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(4)">&larr; Back</button>
+            <button class="btn" onclick="switchTab(5)">&larr; Back</button>
             <button class="btn btn-primary" onclick="switchTab(6)" id="q6next" disabled>Finish Studio &rarr;</button>
         </div>
     </div>
@@ -706,7 +706,7 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(5)">&larr; Review</button>
+            <button class="btn" onclick="switchTab(0)">&larr; Review</button>
             <button class="btn" onclick="window.print()">Print / save as PDF</button>
         </div>
     </div>
@@ -787,7 +787,7 @@ body { padding-top: 56px; }
         document.querySelector('.tab-panel[data-panel="' + idx + '"]').classList.add('active');
 
         const btns = document.querySelectorAll('.tab-btn');
-        btns.forEach((b, i) => {
+        btns.forEach((b, i) => { i = parseInt(b.getAttribute('data-target'),10);
             b.classList.toggle('active', i === idx);
             if (i < idx) b.classList.add('completed');
         });

--- a/Labs/data-feminism-lab.html
+++ b/Labs/data-feminism-lab.html
@@ -353,17 +353,17 @@ body { padding-top: 56px; }
     <div class="progress-bar"><div class="progress-bar-fill" id="progressFill"></div></div>
 
     <div class="tabs" id="tabs">
-        <button class="tab-btn active" onclick="switchTab(0)"><span class="tab-num">1</span> Why Data Feminism</button>
-        <button class="tab-btn" onclick="switchTab(1)"><span class="tab-num">2</span> Intersectionality</button>
-        <button class="tab-btn" onclick="switchTab(2)"><span class="tab-num">3</span> Spotting Bias</button>
-        <button class="tab-btn" onclick="switchTab(3)"><span class="tab-num">4</span> Visualizing</button>
-        <button class="tab-btn" onclick="switchTab(4)"><span class="tab-num">5</span> Data Justice</button>
-        <button class="tab-btn" onclick="switchTab(5)"><span class="tab-num">6</span> Case Study</button>
-        <button class="tab-btn" onclick="switchTab(6)"><span class="tab-num">7</span> Done</button>
+        <button class="tab-btn active" data-target="0" onclick="switchTab(0)"><span class="tab-num">1</span> Case Study</button>
+        <button class="tab-btn" data-target="1" onclick="switchTab(1)"><span class="tab-num">2</span> Why Data Feminism</button>
+        <button class="tab-btn" data-target="2" onclick="switchTab(2)"><span class="tab-num">3</span> Intersectionality</button>
+        <button class="tab-btn" data-target="3" onclick="switchTab(3)"><span class="tab-num">4</span> Spotting Bias</button>
+        <button class="tab-btn" data-target="4" onclick="switchTab(4)"><span class="tab-num">5</span> Visualizing</button>
+        <button class="tab-btn" data-target="5" onclick="switchTab(5)"><span class="tab-num">6</span> Data Justice</button>
+        <button class="tab-btn" data-target="6" onclick="switchTab(6)"><span class="tab-num">7</span> Done</button>
     </div>
 
     <!-- ===== TAB 1: Why Data Feminism ===== -->
-    <div class="tab-panel active" data-panel="0">
+    <div class="tab-panel" data-panel="1">
         <h2 class="section-title">Why Data Feminism?</h2>
         <p class="section-desc">Data is not neutral. It reflects who collected it, who was counted, who was left out, and what questions were asked. Data feminism asks: <em>Whose data? Who benefits? Who is harmed?</em></p>
 
@@ -399,12 +399,12 @@ body { padding-top: 56px; }
 
         <div class="nav-row">
             <span></span>
-            <button class="btn btn-primary" onclick="switchTab(1)">Next: Intersectionality &rarr;</button>
+            <button class="btn btn-primary" onclick="switchTab(2)">Next: Intersectionality &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 2: Intersectionality ===== -->
-    <div class="tab-panel" data-panel="1">
+    <div class="tab-panel" data-panel="2">
         <h2 class="section-title">Intersectionality in Data</h2>
         <p class="section-desc">Intersectionality (Kimberlé Crenshaw, 1989) means that gender, caste, class, religion, and disability don't operate independently — they <strong>intersect</strong> to create distinct experiences of privilege and oppression.</p>
 
@@ -440,13 +440,13 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(0)">&larr; Back</button>
-            <button class="btn btn-primary" id="next-1" onclick="switchTab(2)" disabled>Next: Spotting Bias &rarr;</button>
+            <button class="btn" onclick="switchTab(1)">&larr; Back</button>
+            <button class="btn btn-primary" id="next-1" onclick="switchTab(3)" disabled>Next: Spotting Bias &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 3: Spotting Bias ===== -->
-    <div class="tab-panel" data-panel="2">
+    <div class="tab-panel" data-panel="3">
         <h2 class="section-title">Spotting Bias in Data Collection &amp; Analysis</h2>
         <p class="section-desc">Bias enters data at every stage: who asks, who answers, what's asked, what's recorded, what's analysed, and what's published.</p>
 
@@ -467,13 +467,13 @@ body { padding-top: 56px; }
         <div class="feedback" id="fb-bias"></div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(1)">&larr; Back</button>
-            <button class="btn btn-primary" id="next-2" onclick="switchTab(3)" disabled>Next: Visualizing &rarr;</button>
+            <button class="btn" onclick="switchTab(2)">&larr; Back</button>
+            <button class="btn btn-primary" id="next-2" onclick="switchTab(4)" disabled>Next: Visualizing &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 4: Visualizing ===== -->
-    <div class="tab-panel" data-panel="3">
+    <div class="tab-panel" data-panel="4">
         <h2 class="section-title">Visualizing Data Intersectionally</h2>
         <p class="section-desc">How you visualize data shapes what people see. A single bar can hide as much as it reveals.</p>
 
@@ -516,13 +516,13 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(2)">&larr; Back</button>
-            <button class="btn btn-primary" id="next-3" onclick="switchTab(4)" disabled>Next: Data Justice &rarr;</button>
+            <button class="btn" onclick="switchTab(3)">&larr; Back</button>
+            <button class="btn btn-primary" id="next-3" onclick="switchTab(5)" disabled>Next: Data Justice &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 5: Data Justice ===== -->
-    <div class="tab-panel" data-panel="4">
+    <div class="tab-panel" data-panel="5">
         <h2 class="section-title">Data Justice in Action</h2>
         <p class="section-desc">Data feminism is not just critique — it's practice. Here's how to apply it in your own work.</p>
 
@@ -543,13 +543,13 @@ body { padding-top: 56px; }
         <div class="feedback" id="fb-justice"></div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(3)">&larr; Back</button>
-            <button class="btn btn-primary" id="next-4" onclick="switchTab(5)" disabled>Next: Case Study &rarr;</button>
+            <button class="btn" onclick="switchTab(4)">&larr; Back</button>
+            <button class="btn btn-primary" id="next-4" onclick="switchTab(0)" disabled>Next: Case Study &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 6: Case Study ===== -->
-    <div class="tab-panel" data-panel="5">
+    <div class="tab-panel active" data-panel="0">
         <h2 class="section-title">Case Study: Re-analyzing a "Successful" Program</h2>
         <p class="section-desc">An NGO reports: "Our water program increased household water access from 45% to 78% in 20 villages." Let's re-analyse this through a data-feminism lens.</p>
 
@@ -585,7 +585,7 @@ body { padding-top: 56px; }
         <div class="feedback" id="fb-case"></div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(4)">&larr; Back</button>
+            <button class="btn" onclick="switchTab(5)">&larr; Back</button>
             <button class="btn btn-primary" id="next-5" onclick="switchTab(6)" disabled>Finish Studio &rarr;</button>
         </div>
     </div>
@@ -621,7 +621,7 @@ body { padding-top: 56px; }
         <p class="body-text" style="text-align:center; margin-top:1rem;">Read further: <em>Data Feminism</em> by Catherine D'Ignazio &amp; Lauren F. Klein (MIT Press, open access) &middot; <em>Invisible Women</em> by Caroline Criado Perez.</p>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(5)">&larr; Review</button>
+            <button class="btn" onclick="switchTab(0)">&larr; Review</button>
             <button class="btn" onclick="window.print()">Print / save as PDF</button>
         </div>
     </div>
@@ -700,11 +700,11 @@ var TOTAL_TABS = 7;
 var visited = { 0: true };
 function switchTab(idx) {
     visited[idx] = true;
-    document.querySelectorAll('.tab-btn').forEach(function(b, i) {
+    document.querySelectorAll('.tab-btn').forEach(function(b, i) { i = parseInt(b.getAttribute('data-target'),10);
         b.classList.toggle('active', i === idx);
         b.classList.toggle('completed', i < idx || (visited[i] && i !== idx));
     });
-    document.querySelectorAll('.tab-panel').forEach(function(p, i) { p.classList.toggle('active', i === idx); });
+    document.querySelectorAll('.tab-panel').forEach(function(p, i) { i = parseInt(p.getAttribute('data-panel'),10); p.classList.toggle('active', i === idx); });
     document.getElementById('progressFill').style.width = ((idx + 1) / TOTAL_TABS * 100) + '%';
     window.scrollTo({ top: 0, behavior: 'smooth' });
     if (idx === 1) renderIntersectionQuiz();

--- a/Labs/ethics-research-lab.html
+++ b/Labs/ethics-research-lab.html
@@ -381,17 +381,17 @@ body { padding-top: 56px; }
     <div class="progress-bar"><div class="progress-bar-fill" id="progressFill"></div></div>
 
     <div class="tabs" id="tabs">
-        <button class="tab-btn active" onclick="switchTab(0)"><span class="tab-num">1</span> Why Ethics</button>
-        <button class="tab-btn" onclick="switchTab(1)"><span class="tab-num">2</span> Informed Consent</button>
-        <button class="tab-btn" onclick="switchTab(2)"><span class="tab-num">3</span> Field Dilemmas</button>
-        <button class="tab-btn" onclick="switchTab(3)"><span class="tab-num">4</span> Data Privacy</button>
-        <button class="tab-btn" onclick="switchTab(4)"><span class="tab-num">5</span> Positionality</button>
-        <button class="tab-btn" onclick="switchTab(5)"><span class="tab-num">6</span> Ethics Review</button>
-        <button class="tab-btn" onclick="switchTab(6)"><span class="tab-num">7</span> Done</button>
+        <button class="tab-btn active" data-target="0" onclick="switchTab(0)"><span class="tab-num">1</span> Informed Consent</button>
+        <button class="tab-btn" data-target="1" onclick="switchTab(1)"><span class="tab-num">2</span> Why Ethics</button>
+        <button class="tab-btn" data-target="2" onclick="switchTab(2)"><span class="tab-num">3</span> Field Dilemmas</button>
+        <button class="tab-btn" data-target="3" onclick="switchTab(3)"><span class="tab-num">4</span> Data Privacy</button>
+        <button class="tab-btn" data-target="4" onclick="switchTab(4)"><span class="tab-num">5</span> Positionality</button>
+        <button class="tab-btn" data-target="5" onclick="switchTab(5)"><span class="tab-num">6</span> Ethics Review</button>
+        <button class="tab-btn" data-target="6" onclick="switchTab(6)"><span class="tab-num">7</span> Done</button>
     </div>
 
     <!-- ===== TAB 1: Why Ethics ===== -->
-    <div class="tab-panel active" data-panel="0">
+    <div class="tab-panel" data-panel="1">
         <h2 class="section-title">Why Ethics Matters in Development Research</h2>
         <p class="section-desc">Research ethics is not a checkbox. It is about respecting the dignity, autonomy, and safety of the people who make your work possible.</p>
 
@@ -446,12 +446,12 @@ body { padding-top: 56px; }
 
         <div class="nav-row">
             <span></span>
-            <button class="btn btn-primary" onclick="switchTab(1)">Next: Informed Consent &rarr;</button>
+            <button class="btn btn-primary" onclick="switchTab(0)">Next: Informed Consent &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 2: Informed Consent ===== -->
-    <div class="tab-panel" data-panel="1">
+    <div class="tab-panel active" data-panel="0">
         <h2 class="section-title">Informed Consent — Beyond the Signature</h2>
         <p class="section-desc">Informed consent is not a form. It is a <strong>process</strong> of communication that ensures participants understand what they are agreeing to and can refuse without penalty.</p>
 
@@ -485,7 +485,7 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(0)">&larr; Back</button>
+            <button class="btn" onclick="switchTab(1)">&larr; Back</button>
             <button class="btn btn-primary" id="q2next" onclick="switchTab(2)" disabled>Next: Field Dilemmas &rarr;</button>
         </div>
     </div>
@@ -518,7 +518,7 @@ body { padding-top: 56px; }
         <div class="feedback" id="dilemmaFeedback"></div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(1)">&larr; Back</button>
+            <button class="btn" onclick="switchTab(0)">&larr; Back</button>
             <button class="btn btn-primary" id="q3next" onclick="switchTab(3)" disabled>Next: Data Privacy &rarr;</button>
         </div>
     </div>
@@ -807,11 +807,11 @@ var TOTAL_TABS = 7;
 var visited = { 0: true };
 function switchTab(idx) {
     visited[idx] = true;
-    document.querySelectorAll('.tab-btn').forEach(function(b, i) {
+    document.querySelectorAll('.tab-btn').forEach(function(b, i) { i = parseInt(b.getAttribute('data-target'),10);
         b.classList.toggle('active', i === idx);
         b.classList.toggle('completed', i < idx || (visited[i] && i !== idx));
     });
-    document.querySelectorAll('.tab-panel').forEach(function(p, i) { p.classList.toggle('active', i === idx); });
+    document.querySelectorAll('.tab-panel').forEach(function(p, i) { i = parseInt(p.getAttribute('data-panel'),10); p.classList.toggle('active', i === idx); });
     document.getElementById('progressFill').style.width = ((idx + 1) / TOTAL_TABS * 100) + '%';
     window.scrollTo({ top: 0, behavior: 'smooth' });
     if (idx === 1) renderConsentQuiz();

--- a/Labs/participatory-methods-lab.html
+++ b/Labs/participatory-methods-lab.html
@@ -327,17 +327,17 @@ body { padding-top: 56px; }
     <div class="progress-bar"><div class="progress-bar-fill" id="progressFill"></div></div>
 
     <div class="tabs" id="tabs">
-        <button class="tab-btn active" onclick="switchTab(0)"><span class="tab-num">1</span> Why Participatory?</button>
-        <button class="tab-btn" onclick="switchTab(1)"><span class="tab-num">2</span> PRA Toolkit</button>
-        <button class="tab-btn" onclick="switchTab(2)"><span class="tab-num">3</span> Focus Groups</button>
-        <button class="tab-btn" onclick="switchTab(3)"><span class="tab-num">4</span> Community Mapping</button>
-        <button class="tab-btn" onclick="switchTab(4)"><span class="tab-num">5</span> Participatory M&amp;E</button>
-        <button class="tab-btn" onclick="switchTab(5)"><span class="tab-num">6</span> Ethics &amp; Power</button>
-        <button class="tab-btn" onclick="switchTab(6)"><span class="tab-num">7</span> Done</button>
+        <button class="tab-btn active" data-target="0" onclick="switchTab(0)"><span class="tab-num">1</span> Community Mapping</button>
+        <button class="tab-btn" data-target="1" onclick="switchTab(1)"><span class="tab-num">2</span> Why Participatory?</button>
+        <button class="tab-btn" data-target="2" onclick="switchTab(2)"><span class="tab-num">3</span> PRA Toolkit</button>
+        <button class="tab-btn" data-target="3" onclick="switchTab(3)"><span class="tab-num">4</span> Focus Groups</button>
+        <button class="tab-btn" data-target="4" onclick="switchTab(4)"><span class="tab-num">5</span> Participatory M&amp;E</button>
+        <button class="tab-btn" data-target="5" onclick="switchTab(5)"><span class="tab-num">6</span> Ethics &amp; Power</button>
+        <button class="tab-btn" data-target="6" onclick="switchTab(6)"><span class="tab-num">7</span> Done</button>
     </div>
 
     <!-- ===== TAB 1: Why Participatory? ===== -->
-    <div class="tab-panel active" data-panel="0">
+    <div class="tab-panel" data-panel="1">
         <h2 class="section-title">Why Participatory Methods Matter</h2>
         <p class="section-desc">Participatory methods shift power from extractive research to collaborative inquiry — and they usually produce better, more actionable data.</p>
 
@@ -397,12 +397,12 @@ body { padding-top: 56px; }
 
         <div class="nav-row">
             <span></span>
-            <button class="btn btn-primary" onclick="switchTab(1)">Next: PRA Toolkit &rarr;</button>
+            <button class="btn btn-primary" onclick="switchTab(2)">Next: PRA Toolkit &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 2: PRA Toolkit ===== -->
-    <div class="tab-panel" data-panel="1">
+    <div class="tab-panel" data-panel="2">
         <h2 class="section-title">The Participatory Rural Appraisal Toolkit</h2>
         <p class="section-desc">A family of visual, ground-based methods that hand analysis over to the community. Click any method to select it as you build your own toolkit.</p>
 
@@ -467,13 +467,13 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(0)">&larr; Back</button>
-            <button class="btn btn-primary" onclick="switchTab(2)">Next: Focus Groups &rarr;</button>
+            <button class="btn" onclick="switchTab(1)">&larr; Back</button>
+            <button class="btn btn-primary" onclick="switchTab(3)">Next: Focus Groups &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 3: Focus Groups ===== -->
-    <div class="tab-panel" data-panel="2">
+    <div class="tab-panel" data-panel="3">
         <h2 class="section-title">Facilitating Focus Group Discussions</h2>
         <p class="section-desc">An FGD is a structured conversation where participants interact with each other — not a group interview where everyone answers the facilitator in turn.</p>
 
@@ -540,13 +540,13 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(1)">&larr; Back</button>
-            <button class="btn btn-primary" onclick="switchTab(3)">Next: Community Mapping &rarr;</button>
+            <button class="btn" onclick="switchTab(2)">&larr; Back</button>
+            <button class="btn btn-primary" onclick="switchTab(0)">Next: Community Mapping &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 4: Community Mapping ===== -->
-    <div class="tab-panel" data-panel="3">
+    <div class="tab-panel active" data-panel="0">
         <h2 class="section-title">Community Mapping for Development</h2>
         <p class="section-desc">Maps are not neutral. Who draws the map controls what is visible. Community mapping makes the invisible visible.</p>
 
@@ -629,7 +629,7 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(2)">&larr; Back</button>
+            <button class="btn" onclick="switchTab(3)">&larr; Back</button>
             <button class="btn btn-primary" onclick="switchTab(4)">Next: Participatory M&amp;E &rarr;</button>
         </div>
     </div>
@@ -703,7 +703,7 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(3)">&larr; Back</button>
+            <button class="btn" onclick="switchTab(0)">&larr; Back</button>
             <button class="btn btn-primary" onclick="switchTab(5)">Next: Ethics &amp; Power &rarr;</button>
         </div>
     </div>
@@ -878,11 +878,11 @@ var TOTAL_TABS = 7;
 var visited = { 0: true };
 function switchTab(idx) {
     visited[idx] = true;
-    document.querySelectorAll('.tab-btn').forEach(function(b, i) {
+    document.querySelectorAll('.tab-btn').forEach(function(b, i) { i = parseInt(b.getAttribute('data-target'),10);
         b.classList.toggle('active', i === idx);
         b.classList.toggle('completed', i < idx || (visited[i] && i !== idx));
     });
-    document.querySelectorAll('.tab-panel').forEach(function(p, i) { p.classList.toggle('active', i === idx); });
+    document.querySelectorAll('.tab-panel').forEach(function(p, i) { i = parseInt(p.getAttribute('data-panel'),10); p.classList.toggle('active', i === idx); });
     document.getElementById('progressFill').style.width = ((idx + 1) / TOTAL_TABS * 100) + '%';
     window.scrollTo({ top: 0, behavior: 'smooth' });
 }

--- a/Labs/policy-brief-lab.html
+++ b/Labs/policy-brief-lab.html
@@ -355,17 +355,17 @@ body { padding-top: 56px; }
     <div class="progress-bar"><div class="progress-bar-fill" id="progressFill"></div></div>
 
     <div class="tabs" id="tabs">
-        <button class="tab-btn active" onclick="switchTab(0)"><span class="tab-num">1</span> What Is a Brief?</button>
-        <button class="tab-btn" onclick="switchTab(1)"><span class="tab-num">2</span> Know Your Audience</button>
-        <button class="tab-btn" onclick="switchTab(2)"><span class="tab-num">3</span> Executive Summary</button>
-        <button class="tab-btn" onclick="switchTab(3)"><span class="tab-num">4</span> Evidence</button>
-        <button class="tab-btn" onclick="switchTab(4)"><span class="tab-num">5</span> Recommendations</button>
-        <button class="tab-btn" onclick="switchTab(5)"><span class="tab-num">6</span> Full Brief</button>
-        <button class="tab-btn" onclick="switchTab(6)"><span class="tab-num">7</span> Done</button>
+        <button class="tab-btn active" data-target="0" onclick="switchTab(0)"><span class="tab-num">1</span> Full Brief</button>
+        <button class="tab-btn" data-target="1" onclick="switchTab(1)"><span class="tab-num">2</span> What Is a Brief?</button>
+        <button class="tab-btn" data-target="2" onclick="switchTab(2)"><span class="tab-num">3</span> Know Your Audience</button>
+        <button class="tab-btn" data-target="3" onclick="switchTab(3)"><span class="tab-num">4</span> Executive Summary</button>
+        <button class="tab-btn" data-target="4" onclick="switchTab(4)"><span class="tab-num">5</span> Evidence</button>
+        <button class="tab-btn" data-target="5" onclick="switchTab(5)"><span class="tab-num">6</span> Recommendations</button>
+        <button class="tab-btn" data-target="6" onclick="switchTab(6)"><span class="tab-num">7</span> Done</button>
     </div>
 
     <!-- ===== TAB 1: What Is a Policy Brief? ===== -->
-    <div class="tab-panel active" data-panel="0">
+    <div class="tab-panel" data-panel="1">
         <h2 class="section-title">What Is a Policy Brief?</h2>
         <p class="section-desc">A policy brief is not a research paper shrunk down. It is a <strong>decision-making tool</strong> for busy people who need to act on evidence — fast.</p>
 
@@ -437,12 +437,12 @@ body { padding-top: 56px; }
 
         <div class="nav-row">
             <span></span>
-            <button class="btn btn-primary" onclick="switchTab(1)">Next: Know Your Audience &rarr;</button>
+            <button class="btn btn-primary" onclick="switchTab(2)">Next: Know Your Audience &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 2: Know Your Audience ===== -->
-    <div class="tab-panel" data-panel="1">
+    <div class="tab-panel" data-panel="2">
         <h2 class="section-title">Know Your Audience</h2>
         <p class="section-desc">The same evidence needs different framing for a minister, a joint secretary, a journalist, and a civil-society advocate.</p>
 
@@ -471,13 +471,13 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(0)">&larr; Back</button>
-            <button class="btn btn-primary" id="q2next" onclick="switchTab(2)" disabled>Next: Executive Summary &rarr;</button>
+            <button class="btn" onclick="switchTab(1)">&larr; Back</button>
+            <button class="btn btn-primary" id="q2next" onclick="switchTab(3)" disabled>Next: Executive Summary &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 3: Executive Summary ===== -->
-    <div class="tab-panel" data-panel="2">
+    <div class="tab-panel" data-panel="3">
         <h2 class="section-title">The Executive Summary &mdash; The Only Part Everyone Reads</h2>
         <p class="section-desc">Most readers stop after the executive summary. If you get this right, the rest is a bonus.</p>
 
@@ -500,13 +500,13 @@ body { padding-top: 56px; }
         <div class="info-box warning" style="margin-top:1.5rem;"><strong>Context:</strong> Denial of welfare because of Aadhaar authentication failures (biometric mismatches, seeding errors) is a documented concern raised by researchers and audits in several Indian states. Ground your own brief in a verifiable source before you circulate it.</div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(1)">&larr; Back</button>
-            <button class="btn btn-primary" id="q3next" onclick="switchTab(3)" disabled>Next: Evidence &rarr;</button>
+            <button class="btn" onclick="switchTab(2)">&larr; Back</button>
+            <button class="btn btn-primary" id="q3next" onclick="switchTab(4)" disabled>Next: Evidence &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 4: Evidence ===== -->
-    <div class="tab-panel" data-panel="3">
+    <div class="tab-panel" data-panel="4">
         <h2 class="section-title">Presenting Evidence That Persuades</h2>
         <p class="section-desc">Data in a brief is not about comprehensiveness. It is about <strong>precision</strong> &mdash; the right number, at the right time, for the right argument.</p>
 
@@ -538,13 +538,13 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(2)">&larr; Back</button>
-            <button class="btn btn-primary" id="q4next" onclick="switchTab(4)" disabled>Next: Recommendations &rarr;</button>
+            <button class="btn" onclick="switchTab(3)">&larr; Back</button>
+            <button class="btn btn-primary" id="q4next" onclick="switchTab(5)" disabled>Next: Recommendations &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 5: Recommendations ===== -->
-    <div class="tab-panel" data-panel="4">
+    <div class="tab-panel" data-panel="5">
         <h2 class="section-title">Recommendations That Get Implemented</h2>
         <p class="section-desc">Weak recommendations kill good briefs. Strong ones are specific, actionable, and assigned to someone.</p>
 
@@ -578,13 +578,13 @@ body { padding-top: 56px; }
         <div class="feedback" id="recFeedback"></div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(3)">&larr; Back</button>
-            <button class="btn btn-primary" id="q5next" onclick="switchTab(5)" disabled>Next: Full Brief &rarr;</button>
+            <button class="btn" onclick="switchTab(4)">&larr; Back</button>
+            <button class="btn btn-primary" id="q5next" onclick="switchTab(0)" disabled>Next: Full Brief &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 6: Full Brief ===== -->
-    <div class="tab-panel" data-panel="5">
+    <div class="tab-panel active" data-panel="0">
         <h2 class="section-title">Write a Complete Policy Brief</h2>
         <p class="section-desc">Put it all together. Draft a short brief on a real South Asian issue.</p>
 
@@ -627,7 +627,7 @@ body { padding-top: 56px; }
         <div class="feedback" id="briefFeedback"></div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(4)">&larr; Back</button>
+            <button class="btn" onclick="switchTab(5)">&larr; Back</button>
             <button class="btn btn-primary" id="q6next" onclick="switchTab(6)" disabled>Finish Studio &rarr;</button>
         </div>
     </div>
@@ -662,7 +662,7 @@ body { padding-top: 56px; }
         <div class="info-box" style="margin-top:1.5rem;">Resource: the Overseas Development Institute (ODI) publishes widely used policy-brief templates and writing guides. Practice by writing a 2-pager on your own current project.</div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(5)">&larr; Review</button>
+            <button class="btn" onclick="switchTab(0)">&larr; Review</button>
             <button class="btn" onclick="window.print()">Print / save as PDF</button>
         </div>
     </div>
@@ -741,11 +741,11 @@ var TOTAL_TABS = 7;
 var visited = { 0: true };
 function switchTab(idx) {
     visited[idx] = true;
-    document.querySelectorAll('.tab-btn').forEach(function(b, i) {
+    document.querySelectorAll('.tab-btn').forEach(function(b, i) { i = parseInt(b.getAttribute('data-target'),10);
         b.classList.toggle('active', i === idx);
         b.classList.toggle('completed', i < idx || (visited[i] && i !== idx));
     });
-    document.querySelectorAll('.tab-panel').forEach(function(p, i) { p.classList.toggle('active', i === idx); });
+    document.querySelectorAll('.tab-panel').forEach(function(p, i) { i = parseInt(p.getAttribute('data-panel'),10); p.classList.toggle('active', i === idx); });
     document.getElementById('progressFill').style.width = ((idx + 1) / TOTAL_TABS * 100) + '%';
     window.scrollTo({ top: 0, behavior: 'smooth' });
     if (idx === 1) renderAudienceQuiz();

--- a/Labs/systems-thinking-lab.html
+++ b/Labs/systems-thinking-lab.html
@@ -379,18 +379,18 @@ body { padding-top: 56px; }
     <div class="progress-bar"><div class="progress-bar-fill" id="progressFill"></div></div>
 
     <div class="tabs" id="tabs">
-        <button class="tab-btn active" onclick="switchTab(0)"><span class="tab-num">1</span> Why Systems Thinking</button>
-        <button class="tab-btn" onclick="switchTab(1)"><span class="tab-num">2</span> Iceberg Model</button>
-        <button class="tab-btn" onclick="switchTab(2)"><span class="tab-num">3</span> Causal Loops</button>
-        <button class="tab-btn" onclick="switchTab(3)"><span class="tab-num">4</span> Feedback Loops</button>
-        <button class="tab-btn" onclick="switchTab(4)"><span class="tab-num">5</span> Leverage Points</button>
-        <button class="tab-btn" onclick="switchTab(5)"><span class="tab-num">6</span> Complexity M&amp;E</button>
-        <button class="tab-btn" onclick="switchTab(6)"><span class="tab-num">7</span> Intervention Design</button>
-        <button class="tab-btn" onclick="switchTab(7)"><span class="tab-num">8</span> Done</button>
+        <button class="tab-btn active" data-target="0" onclick="switchTab(0)"><span class="tab-num">1</span> Intervention Design</button>
+        <button class="tab-btn" data-target="1" onclick="switchTab(1)"><span class="tab-num">2</span> Why Systems Thinking</button>
+        <button class="tab-btn" data-target="2" onclick="switchTab(2)"><span class="tab-num">3</span> Iceberg Model</button>
+        <button class="tab-btn" data-target="3" onclick="switchTab(3)"><span class="tab-num">4</span> Causal Loops</button>
+        <button class="tab-btn" data-target="4" onclick="switchTab(4)"><span class="tab-num">5</span> Feedback Loops</button>
+        <button class="tab-btn" data-target="5" onclick="switchTab(5)"><span class="tab-num">6</span> Leverage Points</button>
+        <button class="tab-btn" data-target="6" onclick="switchTab(6)"><span class="tab-num">7</span> Complexity M&amp;E</button>
+        <button class="tab-btn" data-target="7" onclick="switchTab(7)"><span class="tab-num">8</span> Done</button>
     </div>
 
     <!-- ===== TAB 1: Why Systems Thinking ===== -->
-    <div class="tab-panel active" data-panel="0">
+    <div class="tab-panel" data-panel="1">
         <h2 class="section-title">Why Systems Thinking?</h2>
         <p class="section-desc">Most development problems are not merely complicated — they are <strong>complex</strong>. Telling the difference is the first skill of a systems practitioner.</p>
 
@@ -436,12 +436,12 @@ body { padding-top: 56px; }
 
         <div class="nav-row">
             <span></span>
-            <button class="btn btn-primary" onclick="switchTab(1)">Next: Iceberg Model &rarr;</button>
+            <button class="btn btn-primary" onclick="switchTab(2)">Next: Iceberg Model &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 2: Iceberg Model ===== -->
-    <div class="tab-panel" data-panel="1">
+    <div class="tab-panel" data-panel="2">
         <h2 class="section-title">The Iceberg Model</h2>
         <p class="section-desc">A single event is only the tip. The iceberg model — a staple of systems thinking (Senge, Meadows and the wider system-dynamics tradition) — pushes you below the waterline to the structures and beliefs that keep producing the event.</p>
 
@@ -495,13 +495,13 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(0)">&larr; Back</button>
-            <button class="btn btn-primary" onclick="switchTab(2)">Next: Causal Loops &rarr;</button>
+            <button class="btn" onclick="switchTab(1)">&larr; Back</button>
+            <button class="btn btn-primary" onclick="switchTab(3)">Next: Causal Loops &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 3: Causal Loop Diagrams ===== -->
-    <div class="tab-panel" data-panel="2">
+    <div class="tab-panel" data-panel="3">
         <h2 class="section-title">Causal Loop Diagrams</h2>
         <p class="section-desc">A Causal Loop Diagram (CLD) shows how variables influence each other — revealing the feedback loops that linear analysis misses.</p>
 
@@ -554,13 +554,13 @@ body { padding-top: 56px; }
         <div id="cldFeedback"></div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(1)">&larr; Back</button>
-            <button class="btn btn-primary" onclick="switchTab(3)" id="q3next" disabled>Next: Feedback Loops &rarr;</button>
+            <button class="btn" onclick="switchTab(2)">&larr; Back</button>
+            <button class="btn btn-primary" onclick="switchTab(4)" id="q3next" disabled>Next: Feedback Loops &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 4: Feedback Loops ===== -->
-    <div class="tab-panel" data-panel="3">
+    <div class="tab-panel" data-panel="4">
         <h2 class="section-title">Identifying Feedback Loops</h2>
         <p class="section-desc">Feedback loops are the engines of system behaviour. In Peter Senge's terms (<em>The Fifth Discipline</em>, 1990), <strong>reinforcing</strong> loops amplify change while <strong>balancing</strong> loops seek equilibrium — and delays make cause and effect hard to connect.</p>
 
@@ -590,13 +590,13 @@ body { padding-top: 56px; }
         <div id="loopFeedback"></div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(2)">&larr; Back</button>
-            <button class="btn btn-primary" onclick="switchTab(4)" id="q4next" disabled>Next: Leverage Points &rarr;</button>
+            <button class="btn" onclick="switchTab(3)">&larr; Back</button>
+            <button class="btn btn-primary" onclick="switchTab(5)" id="q4next" disabled>Next: Leverage Points &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 5: Leverage Points ===== -->
-    <div class="tab-panel" data-panel="4">
+    <div class="tab-panel" data-panel="5">
         <h2 class="section-title">Finding Leverage Points</h2>
         <p class="section-desc">Donella Meadows' <strong>twelve leverage points</strong> ("Places to Intervene in a System," 1997/1999) rank where to intervene by depth of effect. Some changes are easy but weak; others are hard but transformative.</p>
 
@@ -638,13 +638,13 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(3)">&larr; Back</button>
-            <button class="btn btn-primary" onclick="switchTab(5)" id="q5next" disabled>Next: Complexity M&amp;E &rarr;</button>
+            <button class="btn" onclick="switchTab(4)">&larr; Back</button>
+            <button class="btn btn-primary" onclick="switchTab(6)" id="q5next" disabled>Next: Complexity M&amp;E &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 6: Complexity-Aware M&E ===== -->
-    <div class="tab-panel" data-panel="5">
+    <div class="tab-panel" data-panel="6">
         <h2 class="section-title">Complexity-Aware Monitoring &amp; Evaluation</h2>
         <p class="section-desc">Traditional M&amp;E assumes linear causality (inputs &rarr; outputs &rarr; outcomes). Complex systems need approaches that expect emergence and prize learning.</p>
 
@@ -688,13 +688,13 @@ body { padding-top: 56px; }
         <div id="meFeedback"></div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(4)">&larr; Back</button>
-            <button class="btn btn-primary" onclick="switchTab(6)" id="q6next" disabled>Next: Intervention Design &rarr;</button>
+            <button class="btn" onclick="switchTab(5)">&larr; Back</button>
+            <button class="btn btn-primary" onclick="switchTab(0)" id="q6next" disabled>Next: Intervention Design &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 7: Intervention Design ===== -->
-    <div class="tab-panel" data-panel="6">
+    <div class="tab-panel active" data-panel="0">
         <h2 class="section-title">Designing Systems Interventions</h2>
         <p class="section-desc">In complex systems the best interventions are often small, adaptive and designed to learn — not large, fixed and designed to control. This is the spirit of adaptive management and "Doing Development Differently."</p>
 
@@ -716,7 +716,7 @@ body { padding-top: 56px; }
         <div id="designFeedback"></div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(5)">&larr; Back</button>
+            <button class="btn" onclick="switchTab(6)">&larr; Back</button>
             <button class="btn btn-primary" onclick="switchTab(7)" id="q7next" disabled>Finish Studio &rarr;</button>
         </div>
     </div>
@@ -754,7 +754,7 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(6)">&larr; Review</button>
+            <button class="btn" onclick="switchTab(0)">&larr; Review</button>
             <button class="btn" onclick="window.print()">Print / save as PDF</button>
         </div>
     </div>
@@ -834,11 +834,11 @@ var visited = { 0: true };
 var rendered = {};
 function switchTab(idx) {
     visited[idx] = true;
-    document.querySelectorAll('.tab-btn').forEach(function(b, i) {
+    document.querySelectorAll('.tab-btn').forEach(function(b, i) { i = parseInt(b.getAttribute('data-target'),10);
         b.classList.toggle('active', i === idx);
         b.classList.toggle('completed', i < idx || (visited[i] && i !== idx));
     });
-    document.querySelectorAll('.tab-panel').forEach(function(p, i) { p.classList.toggle('active', i === idx); });
+    document.querySelectorAll('.tab-panel').forEach(function(p, i) { i = parseInt(p.getAttribute('data-panel'),10); p.classList.toggle('active', i === idx); });
     document.getElementById('progressFill').style.width = ((idx + 1) / TOTAL_TABS * 100) + '%';
     renderTab(idx);
     window.scrollTo({ top: 0, behavior: 'smooth' });

--- a/Labs/urban-boundaries-lab.html
+++ b/Labs/urban-boundaries-lab.html
@@ -285,14 +285,14 @@ body { padding-top: 56px; }
     </div>
 
     <div class="tabs" id="tabs">
-        <button class="tab-btn active" onclick="switchTab(0)"><span class="tab-num">1</span> The Problem</button>
-        <button class="tab-btn" onclick="switchTab(1)"><span class="tab-num">2</span> India's Undercount</button>
-        <button class="tab-btn" onclick="switchTab(2)"><span class="tab-num">3</span> Redraw with Satellites</button>
-        <button class="tab-btn" onclick="switchTab(3)"><span class="tab-num">4</span> Why It Matters</button>
+        <button class="tab-btn active" data-target="0" onclick="switchTab(0)"><span class="tab-num">1</span> Redraw with Satellites</button>
+        <button class="tab-btn" data-target="1" onclick="switchTab(1)"><span class="tab-num">2</span> The Problem</button>
+        <button class="tab-btn" data-target="2" onclick="switchTab(2)"><span class="tab-num">3</span> India's Undercount</button>
+        <button class="tab-btn" data-target="3" onclick="switchTab(3)"><span class="tab-num">4</span> Why It Matters</button>
     </div>
 
     <!-- ===== TAB 1: THE PROBLEM ===== -->
-    <div class="tab-panel active" data-panel="0">
+    <div class="tab-panel" data-panel="1">
         <h2 class="section-title">The administrative city vs the economic city</h2>
         <p class="section-desc">Economists define a city by <strong>agglomeration</strong> — a contiguous patch of built-up density where people and firms benefit from being close together. Administrations define it by whatever line was last drawn in a gazette. The two rarely match. Toggle the map to see the gap.</p>
 
@@ -362,12 +362,12 @@ body { padding-top: 56px; }
 
         <div class="nav-row">
             <span></span>
-            <button class="btn btn-primary" onclick="switchTab(1)">Next: India's Undercount &rarr;</button>
+            <button class="btn btn-primary" onclick="switchTab(2)">Next: India's Undercount &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 2: INDIA'S UNDERCOUNT ===== -->
-    <div class="tab-panel" data-panel="1">
+    <div class="tab-panel" data-panel="2">
         <h2 class="section-title">How India undercounts its own cities</h2>
         <p class="section-desc">India's Census uses a strict, decades-old rule to decide what counts as "urban". Many places that are city-like in every practical sense stay classified as rural — so the official urbanisation rate is almost certainly an undercount.</p>
 
@@ -400,13 +400,13 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(0)">&larr; Back</button>
-            <button class="btn btn-primary" onclick="switchTab(2)">Next: Redraw with Satellites &rarr;</button>
+            <button class="btn" onclick="switchTab(1)">&larr; Back</button>
+            <button class="btn btn-primary" onclick="switchTab(0)">Next: Redraw with Satellites &rarr;</button>
         </div>
     </div>
 
     <!-- ===== TAB 3: REDRAW WITH SATELLITES ===== -->
-    <div class="tab-panel" data-panel="2">
+    <div class="tab-panel active" data-panel="0">
         <h2 class="section-title">Redrawing the city from space</h2>
         <p class="section-desc">Instead of trusting an administrative line, you can build a boundary from what the land actually looks like. The approach behind Development Data Studio's Global Urban Boundaries combines three satellite-derived signals and asks: does this small grid cell look urban?</p>
 
@@ -452,7 +452,7 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(1)">&larr; Back</button>
+            <button class="btn" onclick="switchTab(2)">&larr; Back</button>
             <button class="btn btn-primary" onclick="switchTab(3)">Next: Why It Matters &rarr;</button>
         </div>
     </div>
@@ -542,7 +542,7 @@ body { padding-top: 56px; }
         </div>
 
         <div class="nav-row">
-            <button class="btn" onclick="switchTab(2)">&larr; Back</button>
+            <button class="btn" onclick="switchTab(0)">&larr; Back</button>
             <button class="btn" onclick="window.print()">Print / save as PDF</button>
         </div>
     </div>
@@ -618,8 +618,8 @@ function applyTheme(theme) {
 
 /* ===== TABS ===== */
 function switchTab(idx) {
-    document.querySelectorAll('.tab-btn').forEach(function(b, i) { b.classList.toggle('active', i === idx); });
-    document.querySelectorAll('.tab-panel').forEach(function(p, i) { p.classList.toggle('active', i === idx); });
+    document.querySelectorAll('.tab-btn').forEach(function(b, i) { i = parseInt(b.getAttribute('data-target'),10); b.classList.toggle('active', i === idx); });
+    document.querySelectorAll('.tab-panel').forEach(function(p, i) { i = parseInt(p.getAttribute('data-panel'),10); p.classList.toggle('active', i === idx); });
     window.scrollTo({ top: 0, behavior: 'smooth' });
 }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,20 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.174.0 — July 30, 2026 (Studios: build-first pass across the course-like ones)
+
+### Changed
+
+- **Seven more Interactive Studios now open on the build**, not an explainer — the same "Build is tab 1" treatment piloted on DPI, applied where the audit found studios leading with concept tabs:
+  - **Systems Thinking** → opens on *Designing Systems Interventions*
+  - **Policy Brief** → opens on *Write a Complete Policy Brief*
+  - **Conflict-Sensitive Programming** → opens on *Designing a Conflict-Sensitive Programme*
+  - **Ethics in Research** → opens on *building an informed-consent form*
+  - **Participatory Methods** → opens on *Community Mapping*
+  - **Data Feminism** → opens on the *re-analysis case study*
+  - **Urban Boundaries** → opens on *Redraw with Satellites*
+- In each, the make-something tab is now tab 1 with the concept tabs following as reference, and tab-switching resolves panels by a stable id so navigation stays intact. **NVC** and **Sampling Design** already opened on their builders and were left as-is.
+
 ## v10.173.0 — July 30, 2026 (DPI studio: Build is now literally tab 1)
 
 ### Changed

--- a/scripts/reorder-studio.py
+++ b/scripts/reorder-studio.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Reorder a studio's tabs so the BUILD tab is tab 1 (build-first).
+
+Reuses the DPI approach: make switchTab resolve by data-panel/data-target
+(not DOM order) via a minimal `i = <data-attr>` rebind injected into the two
+existing forEach loops, then reorder the tab BUTTONS, renumber data-panel,
+and remap nav switchTab() targets. Panels stay physically in place.
+
+Usage: reorder-studio.py <file> <build_old_idx> [--keep-last N]
+  build_old_idx : the current data-panel index of the build/make tab
+  --keep-last N : old index of a wrap-up tab (e.g. Done) to keep last
+"""
+import re, sys
+
+def main():
+    f=sys.argv[1]; build=int(sys.argv[2])
+    keep_last=None
+    if "--keep-last" in sys.argv:
+        keep_last=int(sys.argv[sys.argv.index("--keep-last")+1])
+    s=open(f,encoding="utf-8").read()
+
+    # discover tab buttons in order -> (label_html, old_idx)
+    btn_re=re.compile(r'<button[^>]*class="tab-btn[^"]*"[^>]*onclick="switchTab\((\d+)\)"[^>]*>(.*?)</button>', re.S)
+    btns=[(int(m.group(1)), m.group(2)) for m in btn_re.finditer(s)]
+    N=len(btns)
+    if N<2: sys.exit("no tab buttons found")
+    old_order=[b[0] for b in btns]
+    label={i:re.sub(r'<span class="tab-num">.*?</span>\s*','',lab,flags=re.S).strip() for i,lab in btns}
+
+    # new order: build first, then the rest in original order, keep_last last
+    rest=[i for i in old_order if i!=build and i!=keep_last]
+    new_order=[build]+rest+([keep_last] if keep_last is not None else [])
+    assert sorted(new_order)==sorted(old_order), (new_order, old_order)
+    o2n={old:new for new,old in enumerate(new_order)}   # old idx -> new idx
+
+    # 1) make button matching data-driven via a minimal i-rebind (both fn and arrow forms)
+    before=s
+    for pat in (r"(querySelectorAll\('\.tab-btn'\)[.\s\S]{0,40}?\.forEach\(function\(b,\s*i\)\s*\{)",
+                r"(querySelectorAll\('\.tab-btn'\)[.\s\S]{0,40}?\.forEach\(\(b,\s*i\)\s*=>\s*\{)",
+                r"(\bbtns\.forEach\(\(b,\s*i\)\s*=>\s*\{)",
+                r"(\bbtns\.forEach\(function\(b,\s*i\)\s*\{)"):
+        s2=re.sub(pat, r"\1 i = parseInt(b.getAttribute('data-target'),10);", s, count=1)
+        if s2!=s: s=s2; break
+    btn_ok = s!=before
+    # panel matching: inject rebind if it iterates panels by index; skip if it already
+    # selects panels by [data-panel="..."] (already data-driven)
+    already_panel = "tab-panel[data-panel=" in s
+    if not already_panel:
+        for pat in (r"(querySelectorAll\('\.tab-panel'\)\.forEach\(function\(p,\s*i\)\s*\{)",
+                    r"(querySelectorAll\('\.tab-panel'\)\.forEach\(\(p,\s*i\)\s*=>\s*\{)"):
+            s2=re.sub(pat, r"\1 i = parseInt(p.getAttribute('data-panel'),10);", s, count=1)
+            if s2!=s: s=s2; break
+    if not btn_ok and not already_panel:
+        sys.exit("ERROR: could not make switchTab data-driven (shape differs) — handle manually")
+
+    # 2) rebuild the tab buttons block in NEW order (tab-num, switchTab, data-target, active on build)
+    tabs_block=re.search(r'(<div class="tabs"[^>]*>)(.*?)(</div>)', s, re.S)
+    head,_,tail=tabs_block.group(1),tabs_block.group(2),tabs_block.group(3)
+    new_btns=[]
+    for new_idx,old_idx in enumerate(new_order):
+        lab=label[old_idx]
+        active=" active" if new_idx==0 else ""
+        new_btns.append(f'        <button class="tab-btn{active}" data-target="{new_idx}" onclick="switchTab({new_idx})"><span class="tab-num">{new_idx+1}</span> {lab}</button>')
+    s=s[:tabs_block.start()]+head+"\n"+"\n".join(new_btns)+"\n    "+tail+s[tabs_block.end():]
+
+    # 3) renumber data-panel via o2n (simultaneous)
+    s=re.sub(r'data-panel="(\d+)"', lambda m:f'data-panel="{o2n[int(m.group(1))]}"', s)
+
+    # 4) set active class on the build panel, remove from others
+    def panel_active(m):
+        cls=m.group(1); dp=int(m.group(2))
+        cls=re.sub(r'\s*active','',cls)
+        if dp==0: cls=cls+" active"
+        return f'class="{cls.strip()}" data-panel="{dp}"'
+    s=re.sub(r'class="(tab-panel[^"]*)"\s+data-panel="(\d+)"', panel_active, s)
+
+    # 5) remap nav-row switchTab() calls (buttons NOT in the tabs bar) via o2n
+    #    (the tabs bar buttons were rebuilt with explicit new indices already)
+    tabs_now=re.search(r'<div class="tabs"[^>]*>.*?</div>', s, re.S).span()
+    def remap_nav(m):
+        start=m.start()
+        if tabs_now[0]<=start<tabs_now[1]: return m.group(0)   # skip the tab bar
+        return f'switchTab({o2n[int(m.group(1))]})'
+    s=re.sub(r'switchTab\((\d+)\)', remap_nav, s)
+
+    open(f,"w",encoding="utf-8").write(s)
+    print(f"OK {f}: build '{label[build]}' -> tab 1. new order:",
+          [label[i][:22] for i in new_order])
+
+if __name__=="__main__":
+    main()


### PR DESCRIPTION
Completes the "make the studios lead with building" pass from Vandana's feedback, rolling the DPI pattern to the rest.

**Seven studios now open on the build** (make-something tab = tab 1; concept tabs demoted to reference):
| Studio | Now opens on |
|---|---|
| Systems Thinking | Designing Systems Interventions |
| Policy Brief | Write a Complete Policy Brief |
| Conflict-Sensitive | Designing a Conflict-Sensitive Programme |
| Ethics in Research | Build an informed-consent form |
| Participatory Methods | Community Mapping |
| Data Feminism | Re-analysis case study |
| Urban Boundaries | Redraw with Satellites |

**Mechanism** (`scripts/reorder-studio.py`, reusable): `switchTab` resolves panels by a stable `data-panel`/`data-target` id — injected as a one-line `i` rebind into each studio's existing `forEach`, so **panels stay physically in place** (no risky block moves). Tab buttons reordered, `data-panel` renumbered, Next/Back remapped to the new build-first order.

**Verified per studio:** buttons `0..N-1`, exactly one active tab + panel (the build), all nav targets in range; `check-mojibake.py` PASS. Each spot-rendered to confirm it opens on the build.

**Left unchanged (honest):** **NVC** (already opens on the OFNR Builder) and **Sampling Design** (already a design wizard). **toc** (a ToC *lesson* — no build step to promote) and **teacher-evidence** (an evidence-*explorer*, not a build studio) would need real content work, not reordering — flagged rather than force-fitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgDJcnAiEfc5NQL4DjbrJY)_