### PR TITLE
Dataverse: add Indian Open Maps (geospatial)

### DIFF
--- a/data/dataverse.json
+++ b/data/dataverse.json
@@ -2,8 +2,8 @@
   "meta": {
     "title": "ImpactMojo Dataverse",
     "version": "1.0",
-    "totalItems": 321,
-    "lastUpdated": "2026-07-16"
+    "totalItems": 322,
+    "lastUpdated": "2026-07-30"
   },
   "categories": [
     {
@@ -2521,6 +2521,24 @@
             "satellite",
             "remote-sensing",
             "thematic-maps"
+          ],
+          "free": true
+        },
+        {
+          "id": "indian-open-maps",
+          "name": "Indian Open Maps",
+          "description": "Free, open geospatial data for India — vector layers (administrative boundaries, roads, buildings) and raster data (topographic maps, satellite imagery), downloadable for GIS and mapping work.",
+          "type": "dataset",
+          "status": "live",
+          "url": "https://indianopenmaps.com/",
+          "source": "Indian Open Maps (community)",
+          "tags": [
+            "india",
+            "geospatial",
+            "boundaries",
+            "maps",
+            "satellite",
+            "gis"
           ],
           "free": true
         },

--- a/dataverse.html
+++ b/dataverse.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>ImpactMojo Dataverse | Curated Tools & Data for Social Impact</title>
-<meta name="description" content="ImpactMojo Dataverse: A curated catalog of 321 tools, datasets, APIs, and platforms for social impact, development economics, and policy research.">
+<meta name="description" content="ImpactMojo Dataverse: A curated catalog of 322 tools, datasets, APIs, and platforms for social impact, development economics, and policy research.">
 <link rel="icon" href="assets/images/favicon.png" type="image/png">
 <link rel="stylesheet" href="/css/fonts.css">
 <link rel="stylesheet" href="/css/impact-bold.css">
@@ -1632,7 +1632,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
     <section class="hero ib-hero">
         <h1 class="hero-title">ImpactMojo Dataverse</h1>
         <p class="hero-subtitle">Curated Tools & Data for Social Impact</p>
-        <p class="hero-desc">Discover 321 datasets, APIs, tools, platforms, and MCP servers for development economics, policy research, and social impact work.</p>
+        <p class="hero-desc">Discover 322 datasets, APIs, tools, platforms, and MCP servers for development economics, policy research, and social impact work.</p>
     </section>
 
     <!-- Featured: Indian Data Navigator -->

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.175.0 — July 30, 2026 (Dataverse: added Indian Open Maps)
+
+### For Learners
+
+- **Indian Open Maps** added to the Dataverse (Geospatial & Mapping) — free, open geospatial data for India: vector layers (administrative boundaries, roads, buildings) and raster (topographic maps, satellite imagery), for GIS and mapping work. Brings the catalogue to 322 sources.
+
 ## v10.174.0 — July 30, 2026 (Studios: build-first pass across the course-like ones)
 
 ### Changed


### PR DESCRIPTION
Adds **[Indian Open Maps](https://indianopenmaps.com/)** to the Dataverse, in **Geospatial & Mapping**.

Free, open geospatial data for India — vector layers (administrative boundaries, roads, buildings) and raster (topographic maps, satellite imagery), downloadable for GIS/mapping work. Distinct from Bhuvan (ISRO's official geoportal) — this is a complementary community open-data source.

- `data/dataverse.json`: new `geospatial` item (`type: dataset`, `free: true`), `meta.totalItems` **321 → 322**, `lastUpdated` bumped.
- `dataverse.html`: two hardcoded totals **321 → 322** (the page's stat counters already compute from the JSON, so they update automatically).
- Changelog v10.175.0.

Verified: `dataverse.json` valid JSON · `check-counts.py` PASS · `check-mojibake.py` PASS · not a duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgDJcnAiEfc5NQL4DjbrJY)_