### PR TITLE
Changelog: record v10.191.0 (four new Long View chart forms)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to ImpactMojo are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.191.0] - 2026-08-15
+
+### Added
+
+- **Four new chart forms in The Long View** (`js/longview-charts.js`, `the-long-view.html`), taking the Data Wing from 31 to 35 charts. All hand-coded SVG in the existing engine — no charting library, theme-aware (redraw on `data-theme` mutation), `prefers-reduced-motion` aware.
+  - `sankeyHub()` → **`c-rupee`**, the Union Budget 2025–26 drawn through a single hub node: 8 receipts narrow into ₹1, 9 spending heads fan out, ribbon thickness in paise so both sides balance at 100. Source: "Budget at a Glance".
+  - `dotDensity()` → **`c-poor-dots`**, a dot-density tile map of multidimensional poverty, one dot per 10 lakh poor people, rejection-sampled inside each state's hexagon. Placement uses a mulberry32 PRNG seeded from the state code (`rng()`/`seedOf()`), so the scatter is identical on every redraw — `Math.random()` would have reshuffled the dots on each theme switch. 206 dots ≈ 20.6 crore, against NITI Aayog's ~20.9 crore national figure.
+  - `dorling()` → **`c-seats`**, a Dorling cartogram of population per Lok Sabha seat: circles sized by Census 2011 population, coloured on a 16.7–27.4 lakh ramp, relaxed apart from hand-placed geographic anchors over 260 iterations with anchor springs and viewport clamping. Anchors are normalised to the data extents so the layout fills the frame.
+  - `tilegram()` → **`c-tilegram`**, a 121-hexagon tilegram of India (1 hex = 1 crore, Census 2011). State outlines are derived from hex adjacency — an edge is stroked only where the neighbour across it belongs to a different state — rather than hand-drawn; group labels snap to the tile nearest each state's centroid, since the raw centroid often falls in the gutter between hexes. Hex size is fitted to the frame from the grid's col/row span.
+  - Shared helpers extracted for the map forms: `rng()`, `seedOf()`, `hexAt()`, `hexPts()`, `inHex()`, `lerpCol()`.
+- Wired into `ORDER` and `DETAILS` (so `/the-long-view/chart.html?c=…` and its prev/next navigation work), the page's "Where the numbers come from" list, `data/search-index.json` (new tags: sankey, alluvial, cartogram, tilegram, dot density, hex map, union budget, lok sabha, representation), `docs/long-view-guide.md` and `docs/changelog.md`.
+
+### Notes
+
+- The three new map forms are deliberately placed next to the existing hex cartogram (`c-states`): same country, four different decisions about what a map encodes — rate vs count vs magnitude vs units. The guide frames them as a sequence.
+- Verified in Chromium at 1280px and 390px in both themes: all four charts fit their `viewBox`, all 206 dots assert inside their own hexagon, 42/42 page SVGs render non-empty, `ORDER`↔`DETAILS` are in bijection, no horizontal overflow, no JS errors. CI: 14 success + 1 neutral (Netlify informational).
+
 ## [10.162.0] - 2026-07-29
 
 ### Fixed


### PR DESCRIPTION
## What does this PR do?

Records the v10.191.0 release in the root `CHANGELOG.md`, which had gone stale at v10.162 while `docs/changelog.md` carried on to v10.191.

The entry covers what the user-facing changelog deliberately leaves out — the renderers added (`sankeyHub`, `dotDensity`, `dorling`, `tilegram`) and the two implementation decisions a future maintainer would otherwise have to rediscover:

- dot placement is seeded per state, because the page redraws every chart on theme switch and `Math.random()` would reshuffle the scatter each time;
- tilegram state outlines are derived from hex adjacency rather than hand-drawn, and labels snap to the nearest tile because a raw centroid often lands in the gutter between hexes.

**Scope note.** The root file has always been a sporadic "notable changes" log rather than a mirror of the user-facing one — it already skips 10.84–10.132 and 10.145–10.160 — so this backfills the current release only rather than reconstructing 28 versions of history that were never recorded in this format. Happy to do a full backfill from `docs/changelog.md` if that's wanted; it just isn't what the file's own history implies.

Documentation only — no code, content or data files touched.

## Type of change

- [ ] Bug fix (broken link, layout, JS error)
- [ ] New content (course, case study, translation)
- [ ] New feature or tool
- [ ] Accessibility improvement
- [ ] Performance improvement
- [x] Documentation update

## Checklist

- [x] Tested on desktop browser
- [x] Tested on mobile browser
- [x] No console errors
- [x] Links are working

Not a rendered-page change, so browser testing is not meaningful here. Repo guards run locally: `check-counts.py`, `check-mojibake.py` and `check-internal-links.py` all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyaQFJuJdgDoBA8mi3rxAu

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyaQFJuJdgDoBA8mi3rxAu)_