### PR TITLE
Data currency: flag superseded survey rounds on four explorers

### DIFF
--- a/dataverse-india.html
+++ b/dataverse-india.html
@@ -367,7 +367,7 @@ body { padding-top: 56px; }
         <table class="budget-table">
             <thead><tr><th>Type</th><th>Strength</th><th>Watch out for</th></tr></thead>
             <tbody>
-                <tr><td><strong>Census</strong> (e.g. Census of India)</td><td>Covers everyone — supports the finest geographic detail.</td><td>Infrequent (decennial) and slow; India's last full count was 2011.</td></tr>
+                <tr><td><strong>Census</strong> (e.g. Census of India)</td><td>Covers everyone — supports the finest geographic detail.</td><td>Infrequent (decennial) and slow; India's last full count was 2011 — Census 2027, the first conducted digitally and the first to enumerate caste since 1931, is underway: house-listing ran from 1 April 2026, population enumeration follows in February 2027.</td></tr>
                 <tr><td><strong>Sample survey</strong> (NFHS, PLFS, NSS)</td><td>Rich detail, regular, scientifically representative <em>at its design level</em>.</td><td>Sampling error grows as you slice finer; not reliable below its design level.</td></tr>
                 <tr><td><strong>Administrative / MIS</strong> (HMIS, U-DISE+)</td><td>Near-complete coverage, high frequency, cheap.</td><td>Reflects what the <em>system records</em> — reporting gaps, incentives to over/under-report.</td></tr>
             </tbody>
@@ -486,9 +486,9 @@ function applyTheme(theme) {
 var DATASETS = [
     { id:'census', name:'Census of India', abbr:'CENSUS', agency:'Office of the Registrar General & Census Commissioner (RGI)', cats:['Demographics'],
       what:'A complete headcount of population, households and housing — the backbone of every sampling frame and per-capita denominator in the country.',
-      unit:'Individual / household', geo:'Down to village & urban ward', freq:'Decennial', latest:'2011 (2021 round postponed)', access:'free', url:'https://censusindia.gov.in',
+      unit:'Individual / household', geo:'Down to village & urban ward', freq:'Decennial', latest:'2011 (Census 2027 underway: house-listing Apr–Sep 2026, population enumeration Feb 2027)', access:'free', url:'https://censusindia.gov.in',
       good:'Fine-grained population, literacy, migration, housing and amenities; building sampling frames and denominators.',
-      caveat:'The last full count is 2011 — increasingly dated. The 2021 Census was repeatedly delayed. Caste beyond SC/ST is not enumerated.' },
+      caveat:'The last full count is still 2011 — increasingly dated. Census 2027 is notified and underway (house-listing from April 2026, population enumeration February 2027) and will enumerate caste for the first time since 1931 — but no new data is published yet.' },
     { id:'plfs', name:'Periodic Labour Force Survey', abbr:'PLFS', agency:'National Statistical Office (NSO), MoSPI', cats:['Employment'],
       what:'India’s official employment and unemployment survey — labour-force participation, worker status, wages, informality.',
       unit:'Individual / household', geo:'State (annual); urban quarterly', freq:'Annual + quarterly (urban)', latest:'Annual rounds from 2017-18 onward', access:'free', url:'https://mospi.gov.in',
@@ -506,9 +506,9 @@ var DATASETS = [
       caveat:'Each round is a different subject and sample — check the specific schedule. Microdata needs some processing skill.' },
     { id:'nfhs', name:'National Family Health Survey', abbr:'NFHS', agency:'IIPS for MoHFW (DHS programme)', cats:['Health'],
       what:'India’s flagship health, nutrition and population survey — fertility, mortality, immunisation, anthropometry (stunting/wasting), anaemia, women’s status, and more.',
-      unit:'Individual / household', geo:'District-representative', freq:'Roughly every 5–6 years', latest:'NFHS-5 (2019-21)', access:'free', url:'https://rchiips.org/nfhs/',
+      unit:'Individual / household', geo:'District-representative', freq:'Roughly every 5–6 years', latest:'NFHS-6 (2023-24, released May 2026)', access:'free', url:'https://rchiips.org/nfhs/',
       good:'District-level health & nutrition indicators, gender and empowerment measures, biomarkers — the go-to for health outcomes.',
-      caveat:'Reference period is pre/mid-pandemic for NFHS-5. Cross-round comparability needs care where questions changed.' },
+      caveat:'NFHS-6 (fielded 2023-24) was released on 29 May 2026, superseding NFHS-5 (2019-21) as the latest round. Cross-round comparability needs care where questions changed.' },
     { id:'aser', name:'Annual Status of Education Report', abbr:'ASER', agency:'Pratham / ASER Centre (citizen-led)', cats:['Education'],
       what:'A household-based survey of whether rural children can actually read and do basic arithmetic — learning outcomes, not just enrolment.',
       unit:'Child (age 3–16)', geo:'Rural district', freq:'Annual (with themed years)', latest:'Recent annual rounds', access:'free', url:'https://asercentre.org',

--- a/nas.html
+++ b/nas.html
@@ -108,6 +108,13 @@ table.data tr.ai td{font-weight:800;color:var(--acc);border-top:2px solid var(--
     <div class="srcbadge">Source: <b>National Achievement Survey 2021</b> · NCERT / Ministry of Education</div>
   </section>
 
+  <div class="note">
+
+    <b>Newer data available.</b> NCERT's assessment body PARAKH ran a successor survey, "PARAKH Rashtriya Sarvekshan 2024," on 4 December 2024, with results published from July 2025. It tests Classes 3, 6 and 9 — not 3, 5, 8 and 10 — under a different framework, so it is not a direct continuation of NAS 2021. This page has not yet been rebuilt on that newer survey.
+
+  </div>
+
+
   <section class="about">
     <h2>What is NAS — and why it matters</h2>
     <p>Once every few years, NCERT tests a huge sample of <b>government and government-aided school</b> children — <b>3.4 million students in 2021</b> — on what the curriculum says they should have learned by Class 3, 5, 8 and 10. The score is the <b>average percentage of questions answered correctly</b>. It is the official, curriculum-referenced counterpart to ASER's simpler "can they read a Std II text" test — and the two tell a consistent, sobering story: performance <b>falls sharply as children move up the grades</b>, from about 60% correct in Class 3 to the mid-30s by Class 10. NAS is the number education departments are held to.</p>

--- a/nfhs.html
+++ b/nfhs.html
@@ -329,6 +329,11 @@ table.nf-table tbody tr:hover{ background:var(--nf-hover); }
       </ul>
     </section>
 
+    <div class="nf-howto" role="note">
+      <h2>▸ Newer data available</h2>
+      <p style="margin:0;color:var(--nf-ink-soft);font-size:.9rem">The Health Ministry released <b>NFHS-6</b> (fielded 2023-24) on 29 May 2026, superseding NFHS-5 as the latest round — this explorer still shows the NFHS-4 → NFHS-5 comparison and has not yet been rebuilt on NFHS-6 district data.</p>
+    </div>
+
     <div class="nf-howto">
       <h2>▸ How to read this map</h2>
       <ul>

--- a/plfs.html
+++ b/plfs.html
@@ -125,6 +125,13 @@ table.data tr.ai td{font-weight:800;color:var(--acc);border-top:2px solid var(--
     <div class="srcbadge">Source: <b>PLFS 2023-24</b> (annual, usual status) · MoSPI</div>
   </section>
 
+  <div class="note">
+
+    <b>Newer data available.</b> MoSPI released the PLFS Annual Report for calendar year 2025 (Jan–Dec 2025) in March 2026 — the first under a redesigned, larger sample (about 2.7 lakh households) and a switch from the July–June to a January–December cycle. Because of that methodology break the new figures are not a simple continuation of the 2017-18 to 2023-24 series shown below; this page has not yet been rebuilt on the 2025 dataset.
+
+  </div>
+
+
   <section class="about">
     <h2>What is PLFS — and why it matters</h2>
     <p>The <b>Periodic Labour Force Survey</b> is how India officially counts who is working, looking for work, or out of the labour force. Its three headline numbers: <b>LFPR</b> (the share of people working or seeking work), <b>WPR</b> (the share actually employed), and the <b>unemployment rate</b> (the share of the labour force without work). The single biggest fact it reveals is the <b>gender gap</b>: barely two in five Indian women are in the labour force, against nearly four in five men — one of the widest such gaps in the world. But the gap is closing fast, and PLFS is where you can watch it happen.</p>

--- a/udise.html
+++ b/udise.html
@@ -122,6 +122,13 @@ table.data tr.ai td{font-weight:800;color:var(--acc);border-top:2px solid var(--
     <div class="srcbadge">Source: <b>UDISE+ 2024-25</b> · Ministry of Education (DoSEL)</div>
   </section>
 
+  <div class="note">
+
+    <b>Newer data available.</b> The Ministry of Education released the <b>UDISE+ 2025-26</b> report on 7 July 2026 (teacher counts, pupil-teacher ratios and dropout rates all updated) — this explorer still shows the 2021-22 → 2024-25 dataset and has not yet been rebuilt on the 2025-26 figures.
+
+  </div>
+
+
   <section class="about">
     <h2>What is UDISE+ — and why it matters</h2>
     <p>Every year, every recognised school in India files a return on its pupils, teachers and facilities. Compiled by the Ministry of Education, <b>UDISE+</b> (Unified District Information System for Education Plus) is the resulting census — the ground truth on what a school actually <em>has</em>. Learning outcomes (ASER, NAS) tell you whether children can read; UDISE+ tells you whether the classroom had a toilet, a teacher, a working light. The gap between the two is where a lot of education policy lives — and a working girls' toilet or a real pupil-teacher ratio often explains an outcome better than any slogan.</p>


### PR DESCRIPTION
## What does this PR do?

Adds honest "newer data available" notices to four data explorers whose underlying surveys have been superseded, plus currency updates to the Dataverse India source table.

This is the `fact-check-20260801` routine's work — **but every claim was checked against primary sources before publishing, not taken on trust.** An unverified staleness notice is its own accuracy problem, and the verification earned its keep: the routine had a factual error.

## Verified claims

| Page | Claim | Source |
|---|---|---|
| `nas.html` | PARAKH Rashtriya Sarvekshan 2024 replaced NAS — run 4 Dec 2024, results from July 2025, Classes **3/6/9** not 3/5/8/10 | [PIB](https://www.pib.gov.in/PressReleaseIframePage.aspx?PRID=2080272) |
| `nfhs.html` | NFHS-6 (fielded 2023-24) released **29 May 2026**, superseding NFHS-5 | [PIB](https://www.pib.gov.in/PressReleasePage.aspx?PRID=2266600&reg=3&lang=1), [IIPS](https://www.nfhsiips.in/nfhsuser/nfhs6.php) |
| `plfs.html` | PLFS Annual Report CY2025 released March 2026 — first under a redesigned ~2.7 lakh household sample and the July–June → Jan–Dec cycle switch | [MoSPI press note](``https://www.mospi.gov.in/uploads/latestReleases/latest_release_1774607827733_3e8964a9-268b-4cc9-ad65-cfc8a9e32f08_Press_note_AR_PLFS_2025_23032025_V2.1_26032026_final.pdf),`` [PIB](https://www.pib.gov.in/PressReleasePage.aspx?PRID=2128662) |
| `udise.html` | UDISE+ 2025-26 released **7 July 2026** | [PIB](https://www.pib.gov.in/PressReleasePage.aspx?PRID=2282141&reg=48&lang=2) |
| `dataverse-india.html` | Census 2027 — digital, self-enumeration, caste enumerated first time since 1931; house-listing from 1 Apr 2026 | [PIB](https://www.pib.gov.in/PressReleasePage.aspx?lang=1&PRID=2246847&reg=3), [PMO](https://www.pmindia.gov.in/en/news_updates/cabinet-approves-scheme-of-conduct-of-census-of-india-2027/) |

## The error verification caught

The routine's draft placed Census 2027 population enumeration in **"Mar 2027"**. It is **February 2027** — house-listing ran 1 April–30 September 2026, population enumeration follows in February 2027. Corrected here, along with tightened dates throughout (exact release days rather than months where the source gives one).

## The other half of each claim

A staleness notice makes two assertions — that newer data exists, *and* that this page doesn't use it. I checked the second against the pages themselves rather than assuming:

- `nas.html` does present NAS 2021 for Classes 3, 5, 8 and 10 ✅
- `nfhs.html` references only NFHS-4 and NFHS-5 ✅
- `plfs.html` runs 2017-18 through 2023-24 ✅
- `udise.html` goes up to 2024-25 ✅

## Verification

Rendered all five pages at **390px**: notices present, **zero horizontal overflow**, no JS errors. counts, mojibake and internal-link guards PASS.

## Note on tone

These say the explorer *hasn't been rebuilt yet* rather than implying the data shown is wrong — the figures remain accurate for the round they describe. That matches the "don't represent what didn't exist yet" principle already recorded in the project's memory.

## Type of change

- [ ] Bug fix (broken link, layout, JS error)
- [x] New content (course, case study, translation)
- [ ] New feature or tool
- [ ] Accessibility improvement
- [ ] Performance improvement
- [ ] Documentation update

## Checklist

- [x] Tested on desktop browser
- [x] Tested on mobile browser
- [x] No console errors
- [x] Links are working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyaQFJuJdgDoBA8mi3rxAu

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyaQFJuJdgDoBA8mi3rxAu)_