### PR TITLE
style(fundamentals): finish the language pass on the copy outside the page

### DIFF
--- a/data/search-index.json
+++ b/data/search-index.json
@@ -15910,7 +15910,7 @@
   {
     "id": "fundamentals",
     "title": "Fundamentals — The Indian Wheel of Power & Powerlessness, with the evidence",
-    "description": "A clickable map of who sits close to power in India and who is pushed to the rim. Twelve axes of difference — caste, gender, sexual orientation, religion, economic position, education, body and appearance, neurodiversity and ability, language, age, geography and citizenship, relationship status — with three bands each, and 113 sourced Indian statistics, statutes and judgments behind the 36 placements: NFHS-5, PLFS, Census 2011, NSS 76th Round, NCRB, AISHE, ASER, the Time Use Survey, the National MPI, the World Inequality Lab and more. Each axis also carries an honest note on what the evidence does not settle. The wheel itself is by The Listeners Collective, adapting Sylvia Duckworth's Wheel of Power/Privilege.",
+    "description": "An interactive Indian Wheel of Power and Powerlessness. Twelve axes sort people in Indian society: caste, gender, sexual orientation, religion, economic position, education, body and appearance, neurodiversity and ability, language, age, geography and citizenship, and relationship status. Each has three bands, and behind the 36 positions sit 113 sourced statistics, statutes and judgments from NFHS-5, PLFS, Census 2011, the NSS 76th Round, NCRB, AISHE, ASER, the Time Use Survey, the National MPI and the World Inequality Lab, each with its source and year. Every axis also says what the evidence leaves unsettled. The wheel is by The Listeners Collective, adapting Sylvia Duckworth's Wheel of Power/Privilege.",
     "url": "/fundamentals.html",
     "tags": [
       "wheel of power",

--- a/fundamentals.html
+++ b/fundamentals.html
@@ -16,17 +16,17 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <!-- SEO Meta Tags -->
-<meta name="description" content="Fundamentals — a clickable Indian Wheel of Power &amp; Powerlessness. Twelve axes, 36 bands, and the Indian evidence behind each placement: NFHS-5, PLFS, Census, NCRB, AISHE, NSS and the judgments. Built on the wheel by The Listeners Collective.">
+<meta name="description" content="An interactive Indian Wheel of Power &amp; Powerlessness. Twelve axes, 36 bands, and the Indian evidence behind each position, drawn from NFHS-5, PLFS, Census 2011, NCRB, AISHE and the NSS. The wheel is by The Listeners Collective.">
 <meta name="keywords" content="wheel of power and privilege, Indian wheel of power and powerlessness, intersectionality India, caste gender disability data, positionality, NFHS-5, PLFS, Census 2011, The Listeners Collective, ImpactMojo">
 <meta property="og:title" content="Fundamentals | The Indian Wheel of Power &amp; Powerlessness, with the evidence">
-<meta property="og:description" content="A clickable map of who sits close to power in India and who is pushed to the rim — with the survey, the law and the year behind every placement.">
+<meta property="og:description" content="Twelve axes, 36 bands, and the survey, statute or judgment behind each position, with its source and year.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://www.impactmojo.in/fundamentals.html">
 <meta property="og:image" content="https://www.impactmojo.in/assets/images/og-card.png">
 <meta property="og:site_name" content="ImpactMojo">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Fundamentals | The Indian Wheel of Power &amp; Powerlessness">
-<meta name="twitter:description" content="Twelve axes, 36 bands, and the Indian data behind each one. Adapted with credit from The Listeners Collective.">
+<meta name="twitter:description" content="Twelve axes, 36 bands, and the Indian data behind each one. Wheel by The Listeners Collective.">
 <meta name="twitter:image" content="https://www.impactmojo.in/assets/images/og-card.png">
 
 <title>Fundamentals | The Indian Wheel of Power &amp; Powerlessness, with the evidence</title>

--- a/index.html
+++ b/index.html
@@ -1248,7 +1248,7 @@ window.addEventListener('authStateChanged', function(e) {
       <a class="tp-scard" href="/law-guides/" style="--sc:#1A6B5A"><span class="tp-n">Law Guides</span><span class="tp-d">Indian laws for the social sector, in plain English.</span><span class="tp-go">View &rarr;</span></a>
       <a class="tp-scard" href="/specials/marginalia/" style="--sc:#EC4899"><span class="tp-n">Marginalia</span><span class="tp-d">Cartoon essays on development work.</span><span class="tp-go">View &rarr;</span></a>
       <a class="tp-scard" href="/the-long-view.html" style="--sc:#10B981"><span class="tp-n">Long View</span><span class="tp-d">31 honest data visualisations.</span><span class="tp-go">View &rarr;</span></a>
-      <a class="tp-scard" href="/fundamentals.html" style="--sc:#B45309"><span class="tp-n">Fundamentals</span><span class="tp-d">The Indian Wheel of Power &amp; Powerlessness, clickable &mdash; with the evidence behind every placement.</span><span class="tp-go">Open the wheel &rarr;</span></a>
+      <a class="tp-scard" href="/fundamentals.html" style="--sc:#B45309"><span class="tp-n">Fundamentals</span><span class="tp-d">The Indian Wheel of Power &amp; Powerlessness, with the evidence behind all 36 positions.</span><span class="tp-go">Open the wheel &rarr;</span></a>
       <a class="tp-scard" href="/maps/" style="--sc:#7C3AED"><span class="tp-n">Maps</span><span class="tp-d">Interactive topic &amp; funding ecosystem maps.</span><span class="tp-go">View &rarr;</span></a>
     </div>
   </div>


### PR DESCRIPTION
## What does this PR do?

Follow-up to #935. The prose rewrite in that PR covered the page body but missed the strings that live outside it and are just as visible: the homepage card, the meta / Open Graph / Twitter descriptions, and the search-index entry. Those were written before the language pass and still carried the tells the rest of the page had shed.

| Where | Before | After |
|---|---|---|
| Homepage card | "clickable &mdash; with the evidence behind every placement" | "with the evidence behind all 36 positions" |
| `<meta description>` | "Fundamentals &mdash; a clickable Indian Wheel&hellip;" | "An interactive Indian Wheel&hellip; drawn from NFHS-5, PLFS, Census 2011, NCRB, AISHE and the NSS" |
| `og:description` | "a clickable map of who sits close to power in India and who is pushed to the rim &mdash; with the survey, the law and the year behind every placement" | "Twelve axes, 36 bands, and the survey, statute or judgment behind each position, with its source and year" |
| `twitter:description` | "Adapted with credit from The Listeners Collective" | "Wheel by The Listeners Collective" |
| `search-index.json` | one em-dash-spanned list of all twelve axes; "an honest note on what the evidence does not settle" | broken into a sentence; "says what the evidence leaves unsettled" |

Copy only. No figure, source, link, placement or markup structure changed.

## Type of change

- [x] Documentation update

## Checklist

- [x] Tested on desktop browser
- [x] Tested on mobile browser &mdash; unchanged markup, no layout surface touched
- [x] No console errors
- [x] Links are working

### Also verified

- `scripts/check-counts.py` &rarr; PASS
- `scripts/check-mojibake.py` &rarr; PASS
- `data/search-index.json` valid JSON

### Note on the parent PR

#935 merged with one check, **Mobile overflow audit (390px)**, stuck `in_progress` for 25+ minutes rather than failing. Its logs 404'd, meaning it died before running any test body (the job does a `playwright install --with-deps chromium`). The same job with `fundamentals.html` already in its page list had passed in 3.5 minutes on the immediately preceding commit, and the audit's exact predicate was re-run locally at 390px with a 2x device scale factor on the final code &mdash; `scrollWidth` 390 against `innerWidth` 390, matching `index.html`'s baseline. Production was verified afterwards with `scripts/verify-deploy.py` (PASS) plus a live spot-check of the page and its three assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01199dCmAgzMN1Z1d8qj2UfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01199dCmAgzMN1Z1d8qj2UfN)_