### PR TITLE
fix(fundamentals): make the wheel usable on a phone

### DIFF
--- a/css/fundamentals.css
+++ b/css/fundamentals.css
@@ -123,7 +123,7 @@ a { color: var(--color-link); }
 
 /* ---------- Wheel layout ---------- */
 .wheel-layout { display: grid; grid-template-columns: 1fr; gap: 2rem; align-items: start; }
-@media (min-width: 1000px) { .wheel-layout { grid-template-columns: minmax(0, 1.05fr) minmax(340px, 0.95fr); } }
+@media (min-width: 1000px) { .wheel-layout { grid-template-columns: minmax(0, 1.2fr) minmax(340px, 0.8fr); } }
 
 .wheel-stage { position: sticky; top: 60px; }
 @media (max-width: 999px) { .wheel-stage { position: static; } }
@@ -260,6 +260,7 @@ details.ax[open] > summary { border-bottom: 1px solid var(--color-border); }
 
 /* segment labels drawn on the wheel face */
 .seg-label { font-family: var(--font-heading); font-weight: 700; letter-spacing: 0.2px; pointer-events: none; }
+.axis-label { font-size: 13.5px; }
 
 /* System mode: site-chrome.js removes data-theme entirely and lets the media
    query decide, so every [data-theme="dark"] component override needs a twin
@@ -272,4 +273,39 @@ details.ax[open] > summary { border-bottom: 1px solid var(--color-border); }
   :root:not([data-theme="light"]) .ring-pos.r-middle { background: rgba(251,146,60,0.16); color: #fdba74; }
   :root:not([data-theme="light"]) .ring-pos.r-margin { background: rgba(214,180,131,0.18); color: #e7cfa8; }
   :root:not([data-theme="light"]) .ev .fig { color: #c9b8ff; }
+}
+
+/* ---------- Axis / band picker ----------
+   The wheel's inner segments are ~30px across on a 390px phone and its labels
+   render at ~3px, so the wheel alone is not a usable control at that size.
+   These chips drive the same selection with 44px+ targets at every width. */
+.picker { margin-top: 1rem; }
+.picker + .picker { margin-top: 0.6rem; }
+.picker-label { display: block; font-family: var(--font-mono); font-size: 0.68rem; letter-spacing: 1.6px; text-transform: uppercase; color: var(--color-text-muted); margin-bottom: 0.4rem; }
+.chips { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.chip {
+  font-family: var(--font-heading); font-size: 0.82rem; font-weight: 700;
+  background: var(--color-bg-card); color: var(--color-text);
+  border: 1px solid var(--color-border); border-radius: 999px;
+  padding: 0.5rem 0.85rem; cursor: pointer; min-height: 44px;
+  display: inline-flex; align-items: center; gap: 0.4rem; line-height: 1.1;
+}
+.chip:hover { border-color: var(--color-link); color: var(--color-link); }
+.chip[aria-pressed="true"] { background: var(--color-text); border-color: var(--color-text); color: var(--color-bg-card); }
+.chip .sw { width: 10px; height: 10px; border-radius: 3px; flex: 0 0 auto; }
+.chip[aria-pressed="true"] .sw { outline: 2px solid var(--color-bg-card); outline-offset: 1px; }
+.ring-chips .chip { flex: 1 1 auto; justify-content: center; text-align: center; }
+
+/* ---------- Mobile: the wheel becomes a display, the chips are the control ---------- */
+@media (max-width: 760px) {
+  .wrap { padding-left: 0.9rem; padding-right: 0.9rem; }
+  .wheel-frame { padding: 0.3rem; border-radius: 14px; }
+  /* at this scale these render at ~3px and ~5px — noise, not information */
+  .seg-label { display: none; }
+  .axis-label { display: none; }
+  .hub-label { font-size: 26px; }
+  .chip { font-size: 0.86rem; padding: 0.55rem 0.9rem; }
+}
+@media (max-width: 420px) {
+  .wrap { padding-left: 0.6rem; padding-right: 0.6rem; }
 }

--- a/fundamentals.html
+++ b/fundamentals.html
@@ -113,7 +113,7 @@
   <div class="section-head">
     <span class="kicker">The map</span>
     <h2>Thirty-six bands, each with its evidence</h2>
-    <p>Click or tap any band. On a keyboard, tab into the wheel and use the arrow keys: left and right move between axes, up and down move between bands, Enter opens one. Every selection has its own link you can share.</p>
+    <p>Tap a band on the wheel, or use the Axis and Band buttons underneath. They do the same thing, and the buttons are easier to hit on a phone. On a keyboard: tab in, arrow keys to move, Enter to open. Every selection has its own shareable link.</p>
   </div>
 
   <div class="wheel-layout">
@@ -121,6 +121,15 @@
       <div class="wheel-frame" id="wheelFrame">
         <svg id="wheel" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 760"></svg>
       </div>
+      <div class="picker">
+        <span class="picker-label" id="axisChipsLabel">Axis</span>
+        <div class="chips" id="axisChips" role="group" aria-labelledby="axisChipsLabel"></div>
+      </div>
+      <div class="picker">
+        <span class="picker-label" id="ringChipsLabel">Band</span>
+        <div class="chips ring-chips" id="ringChips" role="group" aria-labelledby="ringChipsLabel"></div>
+      </div>
+
       <div class="wheel-tools">
         <button class="btn-ghost" id="markToggle" aria-pressed="false">Mark where you sit</button>
         <button class="btn-ghost" id="resetView">Reset view</button>

--- a/js/fundamentals-wheel.js
+++ b/js/fundamentals-wheel.js
@@ -181,6 +181,7 @@ window.FWheel = (function () {
       if (opts.focus || hadFocus) node.focus();
     }
     document.getElementById("wheelFrame").classList.add("wheel-dim");
+    syncPickers();
     renderPanel(axis, ring);
     if (!opts.silent) history.replaceState(null, "", "#" + axisId + "/" + ring);
   }
@@ -189,6 +190,7 @@ window.FWheel = (function () {
     state.axis = state.ring = null;
     document.querySelectorAll("#wheel .seg, #wheel .segw").forEach(function (s) { s.classList.remove("is-active"); });
     document.getElementById("wheelFrame").classList.remove("wheel-dim");
+    syncPickers();
     renderEmpty();
     history.replaceState(null, "", location.pathname);
   }
@@ -311,6 +313,46 @@ window.FWheel = (function () {
     });
   }
 
+  /* --------------------------------------------------------------- pickers */
+  /* On a 390px phone the inner segments are ~30px across and their labels
+     render at ~3px, so the wheel cannot be the only control. These chips
+     select the same 36 bands with 44px targets at any width. */
+  function buildPickers() {
+    var ax = document.getElementById("axisChips");
+    var rg = document.getElementById("ringChips");
+    if (!ax || !rg) return;
+
+    ax.innerHTML = D.axes.map(function (a) {
+      return '<button type="button" class="chip" data-axis="' + esc(a.id) + '" aria-pressed="false">' +
+             '<span class="sw" style="background:' + esc(a.color) + '"></span>' + esc(a.name) + '</button>';
+    }).join("");
+
+    rg.innerHTML = D.RING_ORDER.map(function (r) {
+      return '<button type="button" class="chip" data-ring="' + r + '" aria-pressed="false">' +
+             esc(D.RING_LABEL[r]) + '</button>';
+    }).join("");
+
+    ax.querySelectorAll("[data-axis]").forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        select(btn.getAttribute("data-axis"), state.ring || "margin");
+      });
+    });
+    rg.querySelectorAll("[data-ring]").forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        select(state.axis || D.axes[0].id, btn.getAttribute("data-ring"));
+      });
+    });
+  }
+
+  function syncPickers() {
+    document.querySelectorAll("#axisChips [data-axis]").forEach(function (b) {
+      b.setAttribute("aria-pressed", String(b.getAttribute("data-axis") === state.axis));
+    });
+    document.querySelectorAll("#ringChips [data-ring]").forEach(function (b) {
+      b.setAttribute("aria-pressed", String(b.getAttribute("data-ring") === state.ring));
+    });
+  }
+
   /* ----------------------------------------------------------- text index */
   function buildIndex() {
     var box = document.getElementById("axisIndex");
@@ -397,6 +439,7 @@ window.FWheel = (function () {
   function init() {
     if (!D || !D.axes) return;
     buildWheel();
+    buildPickers();
     buildIndex();
     loadMarks();
     paintMarks();

--- a/js/site-chrome.js
+++ b/js/site-chrome.js
@@ -159,8 +159,8 @@
       '<div class="im-sc-right">' +
         '<button class="im-sc-btn im-sc-search" type="button" aria-label="Search the site">' + I.search + '<span class="im-sc-label">Search</span></button>' +
         '<button class="im-sc-btn im-sc-lang" type="button" aria-label="Language">' + I.globe + '<span class="im-sc-label">Language</span></button>' +
-        '<a class="im-sc-btn im-sc-prem" href="' + SITE + '/premium.html">' + I.star + '<span class="im-sc-label">Premium</span></a>' +
-        '<a class="im-sc-btn" href="' + SITE + '/about.html">' + I.info + '<span class="im-sc-label">About</span></a>' +
+        '<a class="im-sc-btn im-sc-prem" href="' + SITE + '/premium.html" aria-label="Premium">' + I.star + '<span class="im-sc-label">Premium</span></a>' +
+        '<a class="im-sc-btn" href="' + SITE + '/about.html" aria-label="About">' + I.info + '<span class="im-sc-label">About</span></a>' +
         '<div class="im-sc-theme" role="group" aria-label="Theme">' +
           '<button class="im-sc-tbtn" data-m="system" title="System" aria-label="System theme">' + I.sys + '</button>' +
           '<button class="im-sc-tbtn" data-m="light" title="Light" aria-label="Light theme">' + I.sun + '</button>' +


### PR DESCRIPTION
## What does this PR do?

Owner reported the wheel was hard to click and asked whether the page was mobile-optimised. Measured first — it was not:

| | 390px phone | 1400px desktop |
|---|---|---|
| Segment labels rendered at | **3.1&ndash;3.5px** | 5.5&ndash;6.1px |
| Axis labels | 5.2px | 9.0px |
| Inner-band tap target (bbox) | **30.5px** | 53.4px |
| Wheel width | 314 of 390px | 550px |

SVG text scales with the viewBox, so the labels shrank with the wheel. At 3px they were noise rather than information, and the inner ring was close to untappable — the bbox overstates it, since a curved wedge fills well under half its bounding box.

### Changes

| | Before | After |
|---|---|---|
| Wheel width @390px | 314px | **359px** |
| Wheel width @360px | 284px | **329px** |
| Wheel width @desktop | 550px | **632px** |
| Inner tap target @390px | 30.5px | **34.9px** |
| Outer tap target @390px | 46.8px | **53.5px** |
| Desktop label size | 5.5&ndash;6.1px | **~7.0px** |

- **Segment and axis labels hidden below 760px.** At that scale they cannot be made legible without overflowing their 30&deg; arc, so the wheel becomes a position display and the text carries the content.
- **New Axis / Band picker** — 12 axis chips and 3 band chips, 44px minimum height, driving the same `select()` as the wheel and staying in sync with it (`aria-pressed`, deep links, keyboard nav). This is the real answer to "hard to click": all 36 bands are now reachable without precision at any width, and it is what replaces the hidden labels on mobile.

## Also fixed: a sitewide a11y bug, pre-existing and unrelated to this page

`js/site-chrome.js` renders the **Premium** and **About** topbar links icon-only at narrow widths, and neither carried an `aria-label` — so both had **no accessible name on every page of the site at phone width**. axe scores this *serious*.

CI never caught it because the axe audit runs at desktop width, where the text labels are visible. Two `aria-label` attributes fix it everywhere. Verified identical on untouched `main` before changing it, so this PR is not the cause.

## Type of change

- [x] Bug fix (broken link, layout, JS error)
- [x] Accessibility improvement

## Checklist

- [x] Tested on desktop browser &mdash; 1400px, wheel 632px, labels legible
- [x] Tested on mobile browser &mdash; 390px and 360px with touch; chip taps drive selection, wheel taps still work, no horizontal overflow
- [x] No console errors
- [x] Links are working

### Also verified

- axe &rarr; **0 violations at every impact level** on `fundamentals.html` at both 390px and 1400px (was 1 serious at 390px before the site-chrome fix)
- `scripts/check-counts.py` &rarr; PASS · `scripts/check-mojibake.py` &rarr; PASS

## Reported, not fixed

`index.html` carries a pre-existing serious `scrollable-region-focusable` violation at 390px on `.practitioner-trust-strip` — a horizontally scrollable region with no keyboard access. Confirmed identical on untouched `main`, and unrelated to the Showcase strip this session touched. Not fixed here; it needs a `tabindex="0"` plus an accessible name on that container, which is a homepage change rather than a Fundamentals one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01199dCmAgzMN1Z1d8qj2UfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01199dCmAgzMN1Z1d8qj2UfN)_