### PR TITLE
feat(fundamentals): the Power Cube and Who Counts, plus a language pass and two visual fixes

### DIFF
--- a/.pa11yci
+++ b/.pa11yci
@@ -28,6 +28,9 @@
     "http://localhost:8080/dojos.html",
     "http://localhost:8080/dataverse.html",
     "http://localhost:8080/handouts.html",
-    "http://localhost:8080/fundamentals/wheel.html"
+    "http://localhost:8080/fundamentals/wheel.html",
+    "http://localhost:8080/fundamentals/ladder.html",
+    "http://localhost:8080/fundamentals/power-cube.html",
+    "http://localhost:8080/fundamentals/who-counts.html"
   ]
 }

--- a/css/fundamentals.css
+++ b/css/fundamentals.css
@@ -352,7 +352,7 @@ details.ax[open] > summary { border-bottom: 1px solid var(--color-border); }
 .rung[aria-pressed="true"] { border-color: var(--rc); box-shadow: 0 0 0 2px var(--rc) inset; }
 .rung-n {
   flex: 0 0 auto; width: 34px; height: 34px; border-radius: 9px; background: var(--rc);
-  color: #fff; font-family: var(--font-mono); font-weight: 500; font-size: 0.95rem;
+  color: var(--ri, #fff); font-family: var(--font-mono); font-weight: 500; font-size: 0.95rem;
   display: flex; align-items: center; justify-content: center; align-self: center;
 }
 .rung-b { display: flex; flex-direction: column; gap: 0.15rem; min-width: 0; }
@@ -432,6 +432,6 @@ details.ax[open] > summary { border-bottom: 1px solid var(--color-border); }
 }
 .gap:hover { border-color: var(--gc); }
 .gap[aria-pressed="true"] { box-shadow: 0 0 0 2px var(--gc) inset; }
-.gap-k { display: inline-block; font-family: var(--font-mono); font-size: 0.66rem; letter-spacing: 1.4px; text-transform: uppercase; color: #fff; background: var(--gc); padding: 0.12rem 0.5rem; border-radius: 999px; margin-bottom: 0.35rem; }
+.gap-k { display: inline-block; font-family: var(--font-mono); font-size: 0.66rem; letter-spacing: 1.4px; text-transform: uppercase; color: var(--gi, #fff); background: var(--gc); padding: 0.12rem 0.5rem; border-radius: 999px; margin-bottom: 0.35rem; }
 .gap-n { display: block; font-family: var(--font-heading); font-weight: 800; font-size: 1.05rem; line-height: 1.25; }
 .gap-m { display: block; font-size: 0.88rem; color: var(--color-text-muted); margin-top: 0.15rem; }

--- a/css/fundamentals.css
+++ b/css/fundamentals.css
@@ -137,7 +137,10 @@ a { color: var(--color-link); }
 .seg.is-active { stroke: var(--color-text); stroke-width: 3; }
 .seg.is-focus { stroke: var(--color-accent-blue); stroke-width: 3.5; }
 .segw { transition: opacity 0.18s ease; }
-.wheel-dim .segw:not(.is-active) { opacity: 0.42; }
+/* Dim the fill, never the label. Fading the whole group took its text down
+   with it: dark labels at 42% opacity measured 2.28:1, below AA. Dimming the
+   path alone lightens the background behind the label, which improves it. */
+.wheel-dim .segw:not(.is-active) .seg { opacity: 0.34; }
 .seg.is-marked { stroke: #f59e0b; stroke-width: 3; }
 
 .hub { fill: var(--wheel-hub); }
@@ -261,6 +264,11 @@ details.ax[open] > summary { border-bottom: 1px solid var(--color-border); }
 /* segment labels drawn on the wheel face */
 .seg-label { font-family: var(--font-heading); font-weight: 700; letter-spacing: 0.2px; pointer-events: none; }
 .axis-label { font-size: 13.5px; }
+/* user units; rendered size = these x the viewBox scale. Sized per ring by
+   the arc available: outer 146 units at 30deg, middle 101, inner 55. */
+.seg-label.r-power  { font-size: 9px; }
+.seg-label.r-middle { font-size: 10px; }
+.seg-label.r-margin { font-size: 11.5px; }
 
 /* System mode: site-chrome.js removes data-theme entirely and lets the media
    query decide, so every [data-theme="dark"] component override needs a twin
@@ -361,3 +369,69 @@ details.ax[open] > summary { border-bottom: 1px solid var(--color-border); }
   .rung { padding: 0.8rem 0.85rem; gap: 0.7rem; }
   .rung-name { font-size: 0.98rem; }
 }
+
+/* ---------- live selection caption ---------- */
+.wheel-caption {
+  margin-top: 0.9rem; padding: 0.7rem 0.95rem; border-radius: 12px;
+  background: var(--color-bg-card); border: 1px solid var(--color-border);
+  display: flex; align-items: center; gap: 0.6rem; min-height: 52px;
+}
+.wheel-caption .cap-sw { width: 14px; height: 14px; border-radius: 4px; flex: 0 0 auto; }
+.wheel-caption .cap-t { font-family: var(--font-heading); font-weight: 800; font-size: 1.02rem; line-height: 1.2; }
+.wheel-caption .cap-s { display: block; font-family: var(--font-mono); font-size: 0.72rem; letter-spacing: 1.2px; text-transform: uppercase; color: var(--color-text-muted); }
+.wheel-caption.is-empty .cap-t { font-weight: 400; color: var(--color-text-muted); font-family: var(--font-body); font-size: 0.92rem; }
+
+/* ---------- the ladder, drawn as a ladder ---------- */
+.ladder { position: relative; }
+/* the rail the rungs sit on, coloured by band from citizen power down */
+.ladder::before {
+  content: ""; position: absolute; left: 27px; top: 6px; bottom: 6px; width: 4px; border-radius: 2px;
+  background: linear-gradient(to bottom, #166534 0%, #4d7c0f 30%, #b45309 42%, #d97706 66%, #9f1239 78%, #881337 100%);
+}
+.ladder-key { display: flex; justify-content: space-between; font-family: var(--font-mono); font-size: 0.68rem; letter-spacing: 1.4px; text-transform: uppercase; color: var(--color-text-muted); margin-bottom: 0.4rem; padding-left: 4px; }
+.rung { position: relative; z-index: 1; }
+.rung-n { border-radius: 50%; box-shadow: 0 0 0 4px var(--color-bg); }
+[data-theme="dark"] .rung-n { box-shadow: 0 0 0 4px var(--color-bg); }
+.band-head { padding-left: 56px; }
+
+/* ---------- Power cube ---------- */
+.dim + .dim { margin-top: 1.3rem; }
+.dim-h { margin-bottom: 0.5rem; }
+.dim-n { display: inline-block; font-family: var(--font-heading); font-weight: 800; font-size: 0.74rem; letter-spacing: 2px; text-transform: uppercase; color: #fff; background: var(--dc); padding: 0.2rem 0.6rem; border-radius: 6px; }
+.dim-q { display: block; margin-top: 0.3rem; font-size: 0.9rem; color: var(--color-text-muted); }
+.dim-cats { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+.cat {
+  display: inline-flex; align-items: center; gap: 0.5rem; flex: 1 1 auto;
+  font-family: var(--font-heading); font-weight: 700; font-size: 0.95rem;
+  background: var(--color-bg-card); color: var(--color-text);
+  border: 1px solid var(--color-border); border-radius: 12px;
+  padding: 0.75rem 1rem; min-height: 56px; cursor: pointer;
+}
+.cat:hover { border-color: var(--cc); }
+.cat[aria-pressed="true"] { background: var(--cc); border-color: var(--cc); color: var(--ci, #fff); }
+.cat-sw { width: 12px; height: 12px; border-radius: 3px; background: var(--cc); flex: 0 0 auto; }
+.cat[aria-pressed="true"] .cat-sw { background: var(--ci, #fff); }
+
+.case-wrap { overflow-x: auto; }
+.case-tbl { width: 100%; border-collapse: collapse; font-size: 0.9rem; min-width: 720px; }
+.case-tbl th, .case-tbl td { text-align: left; vertical-align: top; padding: 0.7rem 0.6rem; border-bottom: 1px solid var(--color-border); }
+.case-tbl thead th { font-family: var(--font-heading); font-size: 0.72rem; letter-spacing: 1.4px; text-transform: uppercase; color: var(--color-text-muted); }
+.case-tbl tbody th { font-family: var(--font-heading); font-weight: 800; width: 20%; }
+.case-tbl .cy { display: block; font-family: var(--font-mono); font-size: 0.72rem; font-weight: 400; color: var(--color-text-muted); }
+.case-tbl .cn { color: var(--color-text-muted); }
+.tag { display: inline-block; font-family: var(--font-heading); font-size: 0.74rem; font-weight: 700; background: var(--cc); padding: 0.15rem 0.5rem; border-radius: 999px; white-space: nowrap; }
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
+
+/* ---------- Who Counts ---------- */
+.gaps { display: grid; gap: 0.6rem; }
+.gap {
+  display: block; width: 100%; text-align: left; cursor: pointer;
+  background: var(--color-bg-card); border: 1px solid var(--color-border);
+  border-left: 5px solid var(--gc); border-radius: 12px;
+  padding: 0.85rem 1rem; min-height: 56px; font-family: var(--font-body); color: var(--color-text);
+}
+.gap:hover { border-color: var(--gc); }
+.gap[aria-pressed="true"] { box-shadow: 0 0 0 2px var(--gc) inset; }
+.gap-k { display: inline-block; font-family: var(--font-mono); font-size: 0.66rem; letter-spacing: 1.4px; text-transform: uppercase; color: #fff; background: var(--gc); padding: 0.12rem 0.5rem; border-radius: 999px; margin-bottom: 0.35rem; }
+.gap-n { display: block; font-family: var(--font-heading); font-weight: 800; font-size: 1.05rem; line-height: 1.25; }
+.gap-m { display: block; font-size: 0.88rem; color: var(--color-text-muted); margin-top: 0.15rem; }

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -15962,5 +15962,53 @@
     ],
     "type": "showcase",
     "category": "Showcase"
+  },
+  {
+    "id": "fundamentals-power-cube",
+    "title": "Fundamentals — The Power Cube, with Indian evidence",
+    "description": "John Gaventa's power cube made clickable: three dimensions and nine categories covering where a decision gets made (closed, invited or claimed spaces), at which level (local, national, global), and whether the power is visible, agenda-setting or working on what people accept as normal. Indian evidence for each category — the judicial collegium, internet shutdowns, gram sabhas, MGNREGA social audits, EIA hearings, the MKSS wage hearings, Narmada, the caste count frozen since 1931, untouchability and unpaid work — plus eight documented Indian cases plotted on all three dimensions at once.",
+    "url": "/fundamentals/power-cube.html",
+    "tags": [
+      "power cube",
+      "gaventa",
+      "ids",
+      "power analysis",
+      "lukes",
+      "spaces of power",
+      "invited space",
+      "claimed space",
+      "closed space",
+      "invisible power",
+      "hidden power",
+      "advocacy",
+      "governance",
+      "india"
+    ],
+    "type": "showcase",
+    "category": "Showcase"
+  },
+  {
+    "id": "fundamentals-who-counts",
+    "title": "Fundamentals — Who Counts: what India does not measure",
+    "description": "The other side of India's data infrastructure. Eight gaps in official statistics, sorted by kind: never asked (sexual orientation, skin tone and appearance), counted badly (disability at 2.2% against a global estimate near 16%, medically certified cause of death at 22.3%), and frozen (caste beyond SC and ST since 1931, internal migration since 2011, unpaid care work measured once in 2019, no official poverty line since 2011-12). Each gap names the instrument checked, what the gap costs, and the closest available proxy.",
+    "url": "/fundamentals/who-counts.html",
+    "tags": [
+      "missing data",
+      "official statistics",
+      "census",
+      "nss",
+      "time use survey",
+      "disability undercount",
+      "caste census",
+      "cause of death",
+      "poverty line",
+      "migration",
+      "unpaid care work",
+      "data gaps",
+      "measurement",
+      "india"
+    ],
+    "type": "showcase",
+    "category": "Showcase"
   }
 ]

--- a/fundamentals/ladder.html
+++ b/fundamentals/ladder.html
@@ -79,14 +79,16 @@
   <div class="hero-inner">
     <span class="eyebrow">Fundamentals</span>
     <h1>Who actually decides<br><span class="accent">when you say you consulted</span></h1>
-    <p>Sherry Arnstein&rsquo;s ladder of citizen participation, made clickable. Eight rungs, from decisions a community genuinely controls down to consultations held after the decision. Open any rung to see the Indian law, scheme or judgment that puts a real practice on it, with the source and year given.</p>
-    <p>Every rung also says what its placement leaves unsettled.</p>
+    <p>Sherry Arnstein&rsquo;s ladder of citizen participation, made clickable. Eight rungs, from decisions a community controls outright down to consultations held after the decision. Open any rung for the Indian law, scheme or judgment that puts a real practice on it, with the source and year given.</p>
+    <p>Each rung also says what its placement leaves unsettled.</p>
     <nav class="series-nav" aria-label="Fundamentals series">
       <a href="/fundamentals/">All Fundamentals</a>
       <a href="/fundamentals/wheel.html">The Wheel of Power</a>
       <a href="/fundamentals/ladder.html" aria-current="page">The Ladder of Participation</a>
+      <a href="/fundamentals/power-cube.html">The Power Cube</a>
+      <a href="/fundamentals/who-counts.html">Who Counts</a>
     </nav>
-    <p class="hero-credit">The ladder is not ours. It is <b>Sherry R. Arnstein&rsquo;s</b>, from &ldquo;A Ladder of Citizen Participation&rdquo;, <i>Journal of the American Institute of Planners</i> 35(4), July 1969. ImpactMojo added the Indian evidence. <a href="#credits">Full credits &darr;</a></p>
+    <p class="hero-credit">The ladder belongs to <b>Sherry R. Arnstein</b>, from &ldquo;A Ladder of Citizen Participation&rdquo;, <i>Journal of the American Institute of Planners</i> 35(4), July 1969. ImpactMojo added the Indian evidence. <a href="#credits">Full credits &darr;</a></p>
   </div>
 </section>
 
@@ -95,19 +97,19 @@
   <div class="wrap">
     <div class="section-head">
       <span class="kicker">How to read it</span>
-      <h2>The question is not whether people took part. It is what they got to decide.</h2>
-      <p>Arnstein&rsquo;s argument was that &ldquo;participation&rdquo; describes eight quite different things, and that the word is most often used for the ones that transfer no power at all. The rungs sort them by a single test: what could the citizen actually change?</p>
+      <h2>Eight things get called participation. Only three move any power.</h2>
+      <p>Arnstein&rsquo;s argument was that the word covers eight quite different arrangements, and gets used most often for the ones that transfer nothing. Her rungs sort them by one test: what could the citizen actually change?</p>
     </div>
     <div class="ring-key">
       <div class="rk rk-power"><b><span class="dot"></span>Rungs 6&ndash;8 &middot; Citizen power</b><span>People hold authority. The state has to negotiate, or is bound by what the community decides.</span></div>
       <div class="rk rk-middle"><b><span class="dot"></span>Rungs 3&ndash;5 &middot; Tokenism</b><span>People are informed, asked, or seated on a committee. Nothing obliges anyone to act on it.</span></div>
-      <div class="rk rk-margin"><b><span class="dot"></span>Rungs 1&ndash;2 &middot; Non-participation</b><span>The exercise substitutes for taking part rather than enabling it.</span></div>
+      <div class="rk rk-margin"><b><span class="dot"></span>Rungs 1&ndash;2 &middot; Non-participation</b><span>The exercise stands in for taking part.</span></div>
     </div>
     <div class="notice">
-      <h3>Where the ladder itself is contested</h3>
-      <p><b>Higher is not always the goal.</b> Arnstein wrote a ladder, and a ladder implies you should climb. Practitioners have argued since that some decisions genuinely warrant consultation and no more, and that &ldquo;citizen control&rdquo; can be a way for the state to hand over a duty it is meant to discharge.</p>
-      <p><b>It has one axis.</b> The ladder measures how much power moved. It does not ask which citizens, so a rung can be climbed by the people in a village who already hold power there. Read it alongside <a href="/fundamentals/wheel.html">the Wheel of Power &amp; Powerlessness</a>, which asks the second question.</p>
-      <p><b>Rungs are not fixed by scheme.</b> The same programme sits on different rungs in different districts. What is placed here is the design, not the delivery.</p>
+      <h3>Where the ladder is contested</h3>
+      <p>A ladder implies you should climb it. Practitioners have argued since 1969 that some decisions warrant consultation and no more, and that handing a community full control can be a way for the state to shed a duty it should be discharging.</p>
+      <p>The ladder also has one axis. It measures how much power moved, never which citizens received it, so a village can climb a rung on the strength of the people who already ran it. <a href="/fundamentals/wheel.html">The Wheel of Power &amp; Powerlessness</a> asks that second question.</p>
+      <p>And a scheme does not sit on one rung everywhere. The same programme lands differently by district. What is placed here is the design rather than the delivery.</p>
     </div>
   </div>
 </section>
@@ -152,7 +154,7 @@
     </div>
     <div class="notice">
       <h3>Using this in a workshop</h3>
-      <p>The ladder works best against a real programme rather than in the abstract. Ask the group to place their own project on a rung, privately, then defend the placement. The argument that follows is the exercise.</p>
+      <p>The ladder works better against a real programme than in the abstract. Ask the group to place their own project on a rung privately, then defend the placement to each other.</p>
       <p>If you reproduce the ladder, credit Arnstein. If you reproduce this evidence, credit ImpactMojo and check the figures against their sources first.</p>
     </div>
   </div>

--- a/fundamentals/power-cube.html
+++ b/fundamentals/power-cube.html
@@ -16,20 +16,20 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <!-- SEO Meta Tags -->
-<meta name="description" content="Fundamentals — the frameworks development work runs on, made interactive and backed by Indian evidence. The Wheel of Power &amp; Powerlessness and Arnstein's Ladder of Citizen Participation, each with the survey, statute or judgment behind every position, and an honest account of what the evidence leaves unsettled.">
+<meta name="description" content="John Gaventa&#39;s power cube, made clickable: spaces, levels and forms of power, with the Indian evidence for each of the nine categories and eight documented Indian cases plotted on all three dimensions.">
 <meta name="keywords" content="wheel of power and privilege, Indian wheel of power and powerlessness, intersectionality India, caste gender disability data, positionality, NFHS-5, PLFS, Census 2011, The Listeners Collective, ImpactMojo">
-<meta property="og:title" content="Fundamentals | ImpactMojo">
-<meta property="og:description" content="The frameworks development work runs on, made interactive and backed by Indian evidence.">
+<meta property="og:title" content="Fundamentals | The Power Cube">
+<meta property="og:description" content="Spaces, levels and forms of power, with the Indian evidence for each and eight cases plotted across all three.">
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://www.impactmojo.in/fundamentals/">
+<meta property="og:url" content="https://www.impactmojo.in/fundamentals/power-cube.html">
 <meta property="og:image" content="https://www.impactmojo.in/assets/images/og-card.png">
 <meta property="og:site_name" content="ImpactMojo">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Fundamentals | ImpactMojo">
-<meta name="twitter:description" content="The frameworks development work runs on, made interactive and backed by Indian evidence.">
+<meta name="twitter:title" content="Fundamentals | The Power Cube">
+<meta name="twitter:description" content="Spaces, levels and forms of power, with the Indian evidence for each and eight cases plotted across all three.">
 <meta name="twitter:image" content="https://www.impactmojo.in/assets/images/og-card.png">
 
-<title>Fundamentals | The frameworks development work runs on, with Indian evidence</title>
+<title>Fundamentals | The Power Cube, with Indian evidence</title>
 
 <!-- Favicons -->
 <link href="/assets/images/favicon.png" rel="icon" type="image/png">
@@ -77,52 +77,86 @@
 <section class="hero">
   <div class="hero-inner">
     <span class="eyebrow">Fundamentals</span>
-    <h1>The frameworks the sector runs on,<br><span class="accent">checked against the evidence</span></h1>
-    <p>Development work leans on a small number of diagrams. They get drawn on whiteboards, put into proposals and taught in workshops, mostly without anyone checking what the Indian evidence behind them says.</p>
-    <p>Fundamentals takes one framework at a time, makes it interactive, and attaches the Indian evidence to every position in it. Two rules hold across the series. Nothing goes in without a named source and a year. And every position says what the evidence does not settle.</p>
+    <h1>A seat at the table<br><span class="accent">is not the same as power</span></h1>
+    <p>John Gaventa&rsquo;s power cube, made clickable. Three dimensions, nine categories: where a decision gets made, at which level, and whether the power involved is visible at all. Open any category for the Indian evidence, with the source and year given.</p>
+    <p>Eight documented Indian cases are plotted on all three dimensions at once, further down.</p>
+    <nav class="series-nav" aria-label="Fundamentals series">
+      <a href="/fundamentals/">All Fundamentals</a>
+      <a href="/fundamentals/wheel.html">The Wheel of Power</a>
+      <a href="/fundamentals/ladder.html">The Ladder of Participation</a>
+      <a href="/fundamentals/power-cube.html" aria-current="page">The Power Cube</a>
+      <a href="/fundamentals/who-counts.html">Who Counts</a>
+    </nav>
+    <p class="hero-credit">The cube belongs to <b>John Gaventa</b>, from &ldquo;Finding the Spaces for Change: A Power Analysis&rdquo;, <i>IDS Bulletin</i> 37(6), 2006, building on Steven Lukes. ImpactMojo added the Indian evidence. <a href="#credits">Full credits &darr;</a></p>
   </div>
 </section>
 
-<section class="wrap">
+<section class="band">
+  <div class="wrap">
+    <div class="section-head">
+      <span class="kicker">How to read it</span>
+      <h2>Three questions, asked together</h2>
+      <p>Gaventa&rsquo;s argument is that the three dimensions only work read as a set. A seat in an invited local space counts for little when the decision was taken at another level, in a form nobody can see. Answering one question and stopping is how power analysis goes wrong.</p>
+    </div>
+    <div class="ring-key">
+      <div class="rk rk-power"><b><span class="dot"></span>Spaces</b><span>Closed, invited, or claimed. Who set the table, and on whose terms.</span></div>
+      <div class="rk rk-middle"><b><span class="dot"></span>Levels</b><span>Local, national, global. Where the binding decision actually sits.</span></div>
+      <div class="rk rk-margin"><b><span class="dot"></span>Forms</b><span>Visible, hidden, invisible. Whether you can observe the power at work.</span></div>
+    </div>
+    <div class="notice">
+      <h3>What the cube cannot do</h3>
+      <p>The bottom face is the hardest to evidence. Invisible power is a claim about what people have internalised, and the figures on this page are consistent with that reading without proving it. A norm someone accepts and a constraint they cannot escape look identical in survey data.</p>
+      <p>Hidden power has the same problem in a milder form. The disciplined version names a specific issue kept off the table and who gains from its absence. The undisciplined version explains everything and predicts nothing.</p>
+      <p>The cube also says nothing about who you are. It maps how power operates, not who it operates on. <a href="/fundamentals/wheel.html">The Wheel</a> covers that, and <a href="/fundamentals/ladder.html">the Ladder</a> covers how much of it moved.</p>
+    </div>
+  </div>
+</section>
+
+<section class="wrap" id="cube-section">
   <div class="section-head">
-    <span class="kicker">In the series</span>
-    <h2>Four so far</h2>
-    <p>Each framework belongs to someone else and is credited in full on its own page. ImpactMojo supplies the evidence layer underneath.</p>
+    <span class="kicker">The map</span>
+    <h2>Nine categories, each with its evidence</h2>
+    <p>Tap any category. Every one has its own shareable link.</p>
   </div>
-
-  <div class="credits">
-    <div class="credit-card">
-      <h3><a href="/fundamentals/wheel.html">The Wheel of Power &amp; Powerlessness &rarr;</a></h3>
-      <p>Twelve axes along which Indian society sorts people, three bands on each, and 113 sourced statistics, statutes and judgments behind the 36 positions. Asks <b>who holds power</b>.</p>
-      <p class="who-line">Wheel by The Listeners Collective, Bengaluru &middot; adapting Sylvia Duckworth</p>
-    </div>
-    <div class="credit-card">
-      <h3><a href="/fundamentals/ladder.html">The Ladder of Citizen Participation &rarr;</a></h3>
-      <p>Eight rungs from manipulation to citizen control, with the Indian law, scheme or judgment that puts a real practice on each. Asks <b>what people actually got to decide</b>.</p>
-      <p class="who-line">Ladder by Sherry R. Arnstein, 1969</p>
-    </div>
-    <div class="credit-card">
-      <h3><a href="/fundamentals/power-cube.html">The Power Cube &rarr;</a></h3>
-      <p>Spaces, levels and forms of power, with the Indian evidence for each of nine categories and eight cases plotted on all three at once. Asks <b>how power is being exercised</b>.</p>
-      <p class="who-line">Cube by John Gaventa, IDS, 2006</p>
-    </div>
-    <div class="credit-card">
-      <h3><a href="/fundamentals/who-counts.html">Who Counts &rarr;</a></h3>
-      <p>Eight gaps in India&rsquo;s official data, what each one costs, and the nearest substitute. Asks <b>who the state does not see</b>.</p>
-      <p class="who-line">ImpactMojo &middot; the one framework in the series that is our own</p>
-    </div>
+  <div class="wheel-layout">
+    <div class="wheel-stage"><div id="cube"></div></div>
+    <div class="panel" id="panel" role="region" aria-live="polite" aria-label="Evidence for the selected category"></div>
   </div>
+</section>
 
-  <div class="notice">
-    <h3>How a position earns its place</h3>
-    <p>Every entry in the series has to be backed by a national statistical source, a statute or constitutional provision, or a reported judgment. Where a figure cannot be sourced to a named publication and year, it is not on the page.</p>
-    <p>That leaves gaps, and the pages show them rather than filling them with plausible numbers. India collects no data on sexual orientation. It records disability at 2.2% of the population against a global estimate nearer 16%. It has not enumerated caste beyond SC and ST since 1931. Where a placement rests on a pattern rather than a statistic, the entry says so.</p>
-    <p>Corrections are wanted. If a figure here is stale, misattributed or misread, <a href="/contact.html">tell us</a> or open an issue on <a href="https://github.com/ImpactMojo/ImpactMojo" target="_blank" rel="noopener">GitHub</a>.</p>
+<section class="band">
+  <div class="wrap">
+    <div class="section-head">
+      <span class="kicker">Plotted</span>
+      <h2>Eight Indian cases, on all three dimensions</h2>
+      <p>The same case reads differently on each face, which is the point of using a cube rather than a list.</p>
+    </div>
+    <div class="case-wrap" id="cases" tabindex="0" role="region" aria-label="Indian cases plotted on the three dimensions of the power cube (scrollable)"></div>
   </div>
+</section>
 
-  <div class="notice">
-    <h3>Read alongside</h3>
-    <p><a href="/explorers.html">The Data Room</a> holds twelve interactive explorers built on India&rsquo;s official surveys &mdash; what the country does measure. <a href="/the-long-view.html">The Long View</a> is the data-visualisation studio. The <a href="/101-courses/inequality-basics.html">Inequality Basics</a> course covers the concepts these frameworks assume.</p>
+<section class="band" id="credits">
+  <div class="wrap">
+    <div class="section-head">
+      <span class="kicker">Credit where it is owed</span>
+      <h2>Whose cube this is</h2>
+    </div>
+    <div class="credits">
+      <div class="credit-card">
+        <h3>Finding the Spaces for Change</h3>
+        <p><b>John Gaventa</b>, Institute of Development Studies. The three dimensions, the nine categories and the argument that they must be read together are his.</p>
+        <p class="who-line"><i>IDS Bulletin</i> 37(6), 2006 &middot; teaching resources at powercube.net, run by IDS</p>
+      </div>
+      <div class="credit-card">
+        <h3>What it builds on</h3>
+        <p><b>Steven Lukes</b>, <i>Power: A Radical View</i> (1974), for the three dimensions of power, and <b>Lisa VeneKlasen and Valerie Miller</b> (2002) for the visible, hidden and invisible formulation.</p>
+      </div>
+      <div class="credit-card">
+        <h3>What ImpactMojo added</h3>
+        <p>The interactive cube, 23 pieces of Indian evidence across the nine categories, and eight documented Indian cases plotted on all three dimensions, each with a named source and year.</p>
+        <p class="who-line">ImpactMojo, 2026 &middot; content CC BY-NC-ND 4.0 &middot; code MIT</p>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -162,7 +196,7 @@
     </div>
   </div>
   <div class="footer-bottom">
-    <p>&copy; 2026 ImpactMojo. Code: MIT | Content: CC BY-NC-ND 4.0 &middot; Frameworks &copy; their respective authors, credited on each page; statistics &copy; their respective sources, cited on the page.</p>
+    <p>&copy; 2026 ImpactMojo. Code: MIT | Content: CC BY-NC-ND 4.0 &middot; The Power Cube &copy; John Gaventa / IDS, 2006; statistics &copy; their respective sources, cited on the page.</p>
   </div>
 </footer>
 
@@ -206,7 +240,14 @@
 </script>
 
 <!-- ===== The wheel ===== -->
-
+<script src="/js/cube-data.js"></script>
+<script src="/js/cube.js"></script>
+<script>
+(function(){
+  function go(){ if (window.FCube) window.FCube.init(); }
+  if (document.readyState !== 'loading') go(); else document.addEventListener('DOMContentLoaded', go);
+})();
+</script>
 
 <!-- ===== Translation ===== -->
 <script src="/js/translate-sarvam.js" defer></script>

--- a/fundamentals/wheel.html
+++ b/fundamentals/wheel.html
@@ -85,6 +85,8 @@
       <a href="/fundamentals/">All Fundamentals</a>
       <a href="/fundamentals/wheel.html" aria-current="page">The Wheel of Power</a>
       <a href="/fundamentals/ladder.html">The Ladder of Participation</a>
+      <a href="/fundamentals/power-cube.html">The Power Cube</a>
+      <a href="/fundamentals/who-counts.html">Who Counts</a>
     </nav>
     <p class="hero-credit">The wheel is not ours. It was built in 2022&ndash;23 by <a href="https://thelistenerscollective.org/indian-wheel-of-power-powerlessness/" target="_blank" rel="noopener">The Listeners Collective</a>, Bengaluru, adapting Sylvia Duckworth&rsquo;s Wheel of Power/Privilege. ImpactMojo added the evidence behind each position. <a href="#credits">Full credits &darr;</a></p>
   </div>
@@ -126,6 +128,8 @@
       <div class="wheel-frame" id="wheelFrame">
         <svg id="wheel" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 760"></svg>
       </div>
+      <div class="wheel-caption is-empty" id="wheelCaption" aria-live="polite"></div>
+
       <div class="picker">
         <span class="picker-label" id="axisChipsLabel">Axis</span>
         <div class="chips" id="axisChips" role="group" aria-labelledby="axisChipsLabel"></div>

--- a/fundamentals/who-counts.html
+++ b/fundamentals/who-counts.html
@@ -16,20 +16,20 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <!-- SEO Meta Tags -->
-<meta name="description" content="Fundamentals — the frameworks development work runs on, made interactive and backed by Indian evidence. The Wheel of Power &amp; Powerlessness and Arnstein's Ladder of Citizen Participation, each with the survey, statute or judgment behind every position, and an honest account of what the evidence leaves unsettled.">
+<meta name="description" content="The other side of India&#39;s data. Eight gaps in official statistics — never asked, counted badly, or frozen — with the evidence that each gap exists, what it costs, and the closest available substitute.">
 <meta name="keywords" content="wheel of power and privilege, Indian wheel of power and powerlessness, intersectionality India, caste gender disability data, positionality, NFHS-5, PLFS, Census 2011, The Listeners Collective, ImpactMojo">
-<meta property="og:title" content="Fundamentals | ImpactMojo">
-<meta property="og:description" content="The frameworks development work runs on, made interactive and backed by Indian evidence.">
+<meta property="og:title" content="Fundamentals | Who Counts">
+<meta property="og:description" content="Eight gaps in Indian official data, what each costs, and the nearest substitute.">
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://www.impactmojo.in/fundamentals/">
+<meta property="og:url" content="https://www.impactmojo.in/fundamentals/who-counts.html">
 <meta property="og:image" content="https://www.impactmojo.in/assets/images/og-card.png">
 <meta property="og:site_name" content="ImpactMojo">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Fundamentals | ImpactMojo">
-<meta name="twitter:description" content="The frameworks development work runs on, made interactive and backed by Indian evidence.">
+<meta name="twitter:title" content="Fundamentals | Who Counts">
+<meta name="twitter:description" content="Eight gaps in Indian official data, what each costs, and the nearest substitute.">
 <meta name="twitter:image" content="https://www.impactmojo.in/assets/images/og-card.png">
 
-<title>Fundamentals | The frameworks development work runs on, with Indian evidence</title>
+<title>Fundamentals | Who Counts — what India does not measure</title>
 
 <!-- Favicons -->
 <link href="/assets/images/favicon.png" rel="icon" type="image/png">
@@ -77,52 +77,73 @@
 <section class="hero">
   <div class="hero-inner">
     <span class="eyebrow">Fundamentals</span>
-    <h1>The frameworks the sector runs on,<br><span class="accent">checked against the evidence</span></h1>
-    <p>Development work leans on a small number of diagrams. They get drawn on whiteboards, put into proposals and taught in workshops, mostly without anyone checking what the Indian evidence behind them says.</p>
-    <p>Fundamentals takes one framework at a time, makes it interactive, and attaches the Indian evidence to every position in it. Two rules hold across the series. Nothing goes in without a named source and a year. And every position says what the evidence does not settle.</p>
+    <h1>What India does not measure,<br><span class="accent">and what that costs</span></h1>
+    <p>India runs some of the largest household surveys in the world. This page is about the other side of them. Eight things the country does not count, counts far below what independent estimates find, or counted once and has not counted since.</p>
+    <p>Each gap opens the evidence that it exists, what follows from it, and the closest substitute anyone has.</p>
+    <nav class="series-nav" aria-label="Fundamentals series">
+      <a href="/fundamentals/">All Fundamentals</a>
+      <a href="/fundamentals/wheel.html">The Wheel of Power</a>
+      <a href="/fundamentals/ladder.html">The Ladder of Participation</a>
+      <a href="/fundamentals/power-cube.html">The Power Cube</a>
+      <a href="/fundamentals/who-counts.html" aria-current="page">Who Counts</a>
+    </nav>
+    <p class="hero-credit">For what India does measure, and measures well, see <a href="/explorers.html">The Data Room</a> &mdash; twelve interactive explorers built on the official surveys. This page is its opposite number.</p>
   </div>
 </section>
 
-<section class="wrap">
+<section class="band">
+  <div class="wrap">
+    <div class="section-head">
+      <span class="kicker">How to read it</span>
+      <h2>Three ways a population goes missing</h2>
+      <p>Not every gap is the same kind of gap, and the remedy differs. One needs a question added to an instrument. One needs the instrument believed. One needs the survey run again.</p>
+    </div>
+    <div class="ring-key">
+      <div class="rk rk-power"><b><span class="dot"></span>Never asked</b><span>No national instrument collects it. There is nothing to correct, only something to add.</span></div>
+      <div class="rk rk-middle"><b><span class="dot"></span>Counted, badly</b><span>An official figure exists and sits far below what independent estimates find.</span></div>
+      <div class="rk rk-margin"><b><span class="dot"></span>Frozen</b><span>It was counted once. The number still circulates and the year keeps receding.</span></div>
+    </div>
+    <div class="notice">
+      <h3>Why this page exists</h3>
+      <p>Building <a href="/fundamentals/wheel.html">the Wheel of Power</a> meant sourcing 113 statistics, and the same holes kept appearing. Some axes had rich data and some had none, and the pattern of which was which was not random.</p>
+      <p>An absence is harder to cite than a presence, so the rule for this page is the same as the rest of the series. Every claim that something is not measured names the instrument checked and the year it was checked.</p>
+    </div>
+  </div>
+</section>
+
+<section class="wrap" id="gaps-section">
   <div class="section-head">
-    <span class="kicker">In the series</span>
-    <h2>Four so far</h2>
-    <p>Each framework belongs to someone else and is credited in full on its own page. ImpactMojo supplies the evidence layer underneath.</p>
+    <span class="kicker">The map</span>
+    <h2>Eight gaps</h2>
+    <p>Tap any gap. Every one has its own shareable link.</p>
   </div>
-
-  <div class="credits">
-    <div class="credit-card">
-      <h3><a href="/fundamentals/wheel.html">The Wheel of Power &amp; Powerlessness &rarr;</a></h3>
-      <p>Twelve axes along which Indian society sorts people, three bands on each, and 113 sourced statistics, statutes and judgments behind the 36 positions. Asks <b>who holds power</b>.</p>
-      <p class="who-line">Wheel by The Listeners Collective, Bengaluru &middot; adapting Sylvia Duckworth</p>
-    </div>
-    <div class="credit-card">
-      <h3><a href="/fundamentals/ladder.html">The Ladder of Citizen Participation &rarr;</a></h3>
-      <p>Eight rungs from manipulation to citizen control, with the Indian law, scheme or judgment that puts a real practice on each. Asks <b>what people actually got to decide</b>.</p>
-      <p class="who-line">Ladder by Sherry R. Arnstein, 1969</p>
-    </div>
-    <div class="credit-card">
-      <h3><a href="/fundamentals/power-cube.html">The Power Cube &rarr;</a></h3>
-      <p>Spaces, levels and forms of power, with the Indian evidence for each of nine categories and eight cases plotted on all three at once. Asks <b>how power is being exercised</b>.</p>
-      <p class="who-line">Cube by John Gaventa, IDS, 2006</p>
-    </div>
-    <div class="credit-card">
-      <h3><a href="/fundamentals/who-counts.html">Who Counts &rarr;</a></h3>
-      <p>Eight gaps in India&rsquo;s official data, what each one costs, and the nearest substitute. Asks <b>who the state does not see</b>.</p>
-      <p class="who-line">ImpactMojo &middot; the one framework in the series that is our own</p>
-    </div>
+  <div class="wheel-layout">
+    <div class="wheel-stage"><div class="gaps" id="gaps"></div></div>
+    <div class="panel" id="panel" role="region" aria-live="polite" aria-label="Detail for the selected gap"></div>
   </div>
+</section>
 
-  <div class="notice">
-    <h3>How a position earns its place</h3>
-    <p>Every entry in the series has to be backed by a national statistical source, a statute or constitutional provision, or a reported judgment. Where a figure cannot be sourced to a named publication and year, it is not on the page.</p>
-    <p>That leaves gaps, and the pages show them rather than filling them with plausible numbers. India collects no data on sexual orientation. It records disability at 2.2% of the population against a global estimate nearer 16%. It has not enumerated caste beyond SC and ST since 1931. Where a placement rests on a pattern rather than a statistic, the entry says so.</p>
-    <p>Corrections are wanted. If a figure here is stale, misattributed or misread, <a href="/contact.html">tell us</a> or open an issue on <a href="https://github.com/ImpactMojo/ImpactMojo" target="_blank" rel="noopener">GitHub</a>.</p>
-  </div>
-
-  <div class="notice">
-    <h3>Read alongside</h3>
-    <p><a href="/explorers.html">The Data Room</a> holds twelve interactive explorers built on India&rsquo;s official surveys &mdash; what the country does measure. <a href="/the-long-view.html">The Long View</a> is the data-visualisation studio. The <a href="/101-courses/inequality-basics.html">Inequality Basics</a> course covers the concepts these frameworks assume.</p>
+<section class="band" id="credits">
+  <div class="wrap">
+    <div class="section-head">
+      <span class="kicker">Sources</span>
+      <h2>Where this comes from</h2>
+    </div>
+    <div class="credits">
+      <div class="credit-card">
+        <h3>This one is ours</h3>
+        <p>Unlike the rest of the series there is no outside author to credit. The framing is ImpactMojo&rsquo;s, which also means it carries no external authority: treat it as an argument, and check the sources.</p>
+        <p class="who-line">ImpactMojo, 2026 &middot; content CC BY-NC-ND 4.0 &middot; code MIT</p>
+      </div>
+      <div class="credit-card">
+        <h3>Sources drawn on</h3>
+        <p>Census of India (2011, 1931) &middot; NSS 76th Round (2018) &middot; Time Use Survey (2019) &middot; Medical Certification of Cause of Death, ORGI (2020, 2022) &middot; Household Consumption Expenditure Survey (2022&ndash;23) &middot; WHO (2022) &middot; Bihar Caste-based Survey (2023) &middot; Indra Sawhney (1992) &middot; ASCI (2014) &middot; Union of India submission to the Supreme Court (2018).</p>
+      </div>
+      <div class="credit-card">
+        <h3>Read alongside</h3>
+        <p><a href="/explorers.html">The Data Room</a> for the twelve official surveys India does run, and <a href="/dataverse.html">Dataverse</a> for the wider catalogue of datasets and tools.</p>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -162,7 +183,7 @@
     </div>
   </div>
   <div class="footer-bottom">
-    <p>&copy; 2026 ImpactMojo. Code: MIT | Content: CC BY-NC-ND 4.0 &middot; Frameworks &copy; their respective authors, credited on each page; statistics &copy; their respective sources, cited on the page.</p>
+    <p>&copy; 2026 ImpactMojo. Code: MIT | Content: CC BY-NC-ND 4.0 &middot; Analysis &copy; ImpactMojo; statistics &copy; their respective sources, cited on the page.</p>
   </div>
 </footer>
 
@@ -206,7 +227,14 @@
 </script>
 
 <!-- ===== The wheel ===== -->
-
+<script src="/js/whocounts-data.js"></script>
+<script src="/js/whocounts.js"></script>
+<script>
+(function(){
+  function go(){ if (window.FWhoCounts) window.FWhoCounts.init(); }
+  if (document.readyState !== 'loading') go(); else document.addEventListener('DOMContentLoaded', go);
+})();
+</script>
 
 <!-- ===== Translation ===== -->
 <script src="/js/translate-sarvam.js" defer></script>

--- a/js/cube-data.js
+++ b/js/cube-data.js
@@ -1,0 +1,136 @@
+/* =============================================================================
+   ImpactMojo — Fundamentals: the Power Cube
+   -----------------------------------------------------------------------------
+   The cube is John Gaventa's, from "Finding the Spaces for Change: A Power
+   Analysis", IDS Bulletin 37(6), 2006. The three dimensions and their nine
+   categories are his, building on Steven Lukes' three dimensions of power
+   (1974) and on VeneKlasen and Miller's forms of power (2002). The teaching
+   resource lives at powercube.net, run by IDS.
+
+   ImpactMojo adds the Indian evidence: for each category, and for a set of
+   documented Indian cases plotted on all three dimensions at once.
+   ============================================================================= */
+
+window.CUBE = (function () {
+  "use strict";
+
+  var dims = [
+    {
+      id: "space", name: "Spaces", color: "#7c3aed",
+      question: "Where does the decision get made, and who set the table?",
+      cats: [
+        { id: "closed", name: "Closed", color: "#4c1d95",
+          gaventa: "Decisions are made by a set of actors behind closed doors, without any pretence of broadening the boundaries of who is involved.",
+          evidence: [
+            { stat: "Collegium", detail: "Judges of the Supreme Court and High Courts are selected by a collegium of senior judges. There is no application, no published criteria and no external participation. The 99th Amendment tried to replace it and was struck down in 2015.", source: "Supreme Court Advocates-on-Record Association v. Union of India", year: "2015" },
+            { stat: "116", detail: "internet shutdown orders in one year, the sixth year running that India led the world. Orders are issued under the Telegraph Act by an executive officer and are frequently not published.", source: "Access Now, #KeepItOn", year: "2023" },
+            { stat: "Ordinances", detail: "Union and state governments legislate by ordinance between sessions under Articles 123 and 213, which produces binding law with no debate and no hearing.", source: "Constitution of India", year: "1950" }
+          ],
+          complication: "A closed space is not always illegitimate. Judicial independence is a reason to keep some decisions away from popular pressure, and the collegium's defenders make exactly that argument. The cube asks who is inside the room, not whether the room should exist."
+        },
+        { id: "invited", name: "Invited", color: "#7c3aed",
+          gaventa: "People are invited to participate by authorities, whether by government, supranational agencies or NGOs. The invitation, and its terms, come from the powerholder.",
+          evidence: [
+            { stat: "2.6 lakh", detail: "gram panchayats hold gram sabha meetings that state law requires, with quorum and notice rules. The agenda, timing and follow-up are set by the administration.", source: "Ministry of Panchayati Raj", year: "2024" },
+            { stat: "§17", detail: "MGNREGA requires the gram sabha to conduct social audits of every work in its jurisdiction, with records read aloud in public.", source: "Mahatma Gandhi National Rural Employment Guarantee Act", year: "2005" },
+            { stat: "2006", detail: "EIA public hearings give affected people a recorded chance to object before a project is cleared, on a notice period and format the regulator sets.", source: "Environment Impact Assessment Notification", year: "2006" }
+          ],
+          complication: "Invited spaces are where most participatory practice happens, and the invitation is also the limit. Gaventa's point is that entering one can legitimise a decision without changing it, which is why the cube asks people to look at the other two spaces before judging how much a seat is worth."
+        },
+        { id: "claimed", name: "Claimed", color: "#a78bfa",
+          gaventa: "Spaces claimed by less powerful actors from or against the powerholders, or created more autonomously by them: social movements, community associations, places people come together on their own terms.",
+          evidence: [
+            { stat: "1990s", detail: "The Mazdoor Kisan Shakti Sangathan's public hearings in rural Rajasthan, where wage records were read aloud against what people were actually paid, ran with no statutory basis at all. The Right to Information Act followed a decade later.", source: "MKSS; Right to Information Act 2005", year: "1990s" },
+            { stat: "1985", detail: "The Narmada Bachao Andolan organised against the Sardar Sarovar dam outside any official process, and forced the first World Bank independent review of a project it was funding.", source: "Morse Commission, World Bank", year: "1992" },
+            { stat: "2012", detail: "Protests after the Delhi gang rape produced the Justice Verma Committee, which took 80,000 public submissions in 29 days, and then the Criminal Law (Amendment) Act.", source: "Justice J.S. Verma Committee Report; Criminal Law (Amendment) Act", year: "2013" }
+          ],
+          complication: "Claimed spaces are the ones that most often change the rules, and they are also the least durable. Each of these three was absorbed into official process afterwards, which is a victory and a domestication at the same time."
+        }
+      ]
+    },
+    {
+      id: "level", name: "Levels", color: "#0f766e",
+      question: "At which level is the decision actually taken?",
+      cats: [
+        { id: "local", name: "Local", color: "#134e4a",
+          gaventa: "The level closest to where people live, where participation is most often invited and where the decisions available may already have been bounded from above.",
+          evidence: [
+            { stat: "29", detail: "subjects are listed in the Eleventh Schedule for devolution to panchayats. How many a state actually devolves, with funds and staff attached, is the state's choice.", source: "Constitution (73rd Amendment) Act", year: "1992" },
+            { stat: "Untied", detail: "Finance Commission grants reach panchayats directly, but most local budgets remain tied to centrally designed schemes, which sets the menu before the gram sabha meets.", source: "Fifteenth Finance Commission", year: "2021-26" }
+          ],
+          complication: "Local is where participation is easiest to organise and where the least tends to be at stake. A gram sabha with real authority over a scheme it did not design, cannot alter and does not fund is participating at one level in a decision taken at another."
+        },
+        { id: "national", name: "National", color: "#0f766e",
+          gaventa: "The level at which most binding law and budget is set, and where formal representation substitutes for direct participation.",
+          evidence: [
+            { stat: "16%", detail: "of Bills introduced in the 17th Lok Sabha were referred to a parliamentary committee, against 71% in the 15th. Pre-legislative consultation policy exists but is not binding.", source: "PRS Legislative Research", year: "2019-24" },
+            { stat: "4.4% / 13.6%", detail: "of the 18th Lok Sabha are Muslim and women respectively, against 14.2% and roughly half of the population.", source: "Election Commission of India; Census 2011", year: "2024" }
+          ],
+          complication: "The cube's national level is where the wheel's axes bite hardest. Who sits in the room is itself patterned by caste, religion and gender, so a national space can be formally open and demographically closed at once."
+        },
+        { id: "global", name: "Global", color: "#14b8a6",
+          gaventa: "The level of treaties, lenders and standard-setters, where decisions with domestic force are taken in rooms no domestic citizen can enter.",
+          evidence: [
+            { stat: "WTO", detail: "India's public stockholding for food security, which underpins the PDS, has been contested at the WTO since 2013 and runs under an interim peace clause rather than a settled rule.", source: "WTO Bali Ministerial Decision", year: "2013" },
+            { stat: "TRIPS", detail: "India's patent law, including the Section 3(d) bar on evergreening upheld in the Novartis case, is written inside the space TRIPS leaves.", source: "Novartis AG v. Union of India", year: "2013" }
+          ],
+          complication: "Global decisions are the hardest to hold anyone accountable for, and also the ones where Indian negotiators have sometimes had more room than the framing suggests. Section 3(d) exists because that room was used."
+        }
+      ]
+    },
+    {
+      id: "form", name: "Forms", color: "#b45309",
+      question: "How is the power being exercised, and can you see it?",
+      cats: [
+        { id: "visible", name: "Visible", color: "#78350f",
+          gaventa: "Observable decision-making: the formal rules, structures, authorities and procedures. Who makes the law, and who sits where.",
+          evidence: [
+            { stat: "Statute", detail: "Reservation in legislatures, education and public employment for SCs, STs and OBCs is written into the Constitution and is contested in the open, in Parliament and in court.", source: "Constitution of India, Arts. 15, 16, 330, 332", year: "1950 onward" },
+            { stat: "Published", detail: "Budgets, Bills, judgments and gazette notifications are all published. Visible power is the layer India documents best, which is why most evidence on this page describes it.", source: "Parliament of India; eGazette", year: "current" }
+          ],
+          complication: "Visible power is the easiest to study and the easiest to overestimate. A law can be entirely public and still be irrelevant to what happens, which is what the other two forms are for."
+        },
+        { id: "hidden", name: "Hidden", color: "#b45309",
+          gaventa: "Power exercised by setting the agenda: keeping certain issues and certain people away from the table, so that the decision never comes up for a decision.",
+          evidence: [
+            { stat: "1931", detail: "No Indian census has enumerated caste beyond SC and ST since 1931. Without a count there is no denominator, and a claim for proportional share cannot be argued in the terms policy uses.", source: "Census of India", year: "1931" },
+            { stat: "Para 3", detail: "The 1950 Presidential Order bars Dalit Christians and Dalit Muslims from SC status. The Ranganath Misra Commission recommended removing the religious bar in 2007 and it has not been removed.", source: "Constitution (Scheduled Castes) Order; Ranganath Misra Commission", year: "1950, 2007" },
+            { stat: "22.3%", detail: "of registered deaths in India carry a medically certified cause. What kills four in five Indians does not enter the record that health budgets are argued from.", source: "Medical Certification of Cause of Death, ORGI", year: "2022" }
+          ],
+          complication: "Hidden power is inferred rather than observed, which makes it the easiest claim to overreach on. The disciplined version names the specific issue kept off the table, and who benefits from its absence, rather than asserting a general conspiracy."
+        },
+        { id: "invisible", name: "Invisible", color: "#f59e0b",
+          gaventa: "Power that shapes meaning and what people accept as normal, so that an arrangement is not experienced as a decision at all and grievance does not form.",
+          evidence: [
+            { stat: "~27%", detail: "of surveyed households said someone in the household practises untouchability. It persists as ordinary domestic conduct rather than as a policy anyone defends.", source: "India Human Development Survey-II", year: "2011-12" },
+            { stat: "~95%", detail: "of Indian marriages are within caste. Endogamy at that rate is maintained by preference and family expectation, not by any rule that could be repealed.", source: "India Human Development Survey-II", year: "2011-12" },
+            { stat: "299 vs 97", detail: "minutes a day of unpaid domestic work by women and men. The allocation is treated as a fact of life rather than as a distribution anyone chose, and no national account records it.", source: "Time Use Survey, NSO", year: "2019" }
+          ],
+          complication: "Invisible power is the level at which the cube is most useful and least testable. These three figures show a pattern consistent with internalised norms, and they cannot by themselves distinguish a norm someone accepts from a constraint they cannot escape."
+        }
+      ]
+    }
+  ];
+
+  /* Documented Indian cases, plotted on all three dimensions at once. */
+  var cases = [
+    { name: "MKSS wage hearings, Rajasthan", space: "claimed", level: "local", form: "hidden",
+      note: "Muster rolls read aloud against what people were actually paid. A claimed local space used to drag hidden power into view; the practice became statutory as the RTI Act a decade later.", year: "1990s" },
+    { name: "Right to Information Act", space: "invited", level: "national", form: "hidden",
+      note: "Turned an activist practice into a national entitlement, and converted a claimed space into an invited one. Its work is against hidden power: it makes the file available.", year: "2005" },
+    { name: "MGNREGA social audit", space: "invited", level: "local", form: "visible",
+      note: "The state invites the gram sabha to audit the state, on a schedule the state sets. Visible power made contestable in the village where the work happened.", year: "2005" },
+    { name: "Niyamgiri gram sabha referendum", space: "invited", level: "local", form: "visible",
+      note: "The Supreme Court created an invited local space and made its output binding. Twelve assemblies were convened and all twelve refused the mine.", year: "2013" },
+    { name: "Narmada Bachao Andolan", space: "claimed", level: "global", form: "visible",
+      note: "A claimed space that reached the global level, forcing the first independent review of a World Bank-funded project.", year: "1985 onward" },
+    { name: "Judicial collegium", space: "closed", level: "national", form: "hidden",
+      note: "Selection of judges by judges, with no application and no published criteria. Parliament's attempt to open it was struck down in 2015.", year: "1993 onward" },
+    { name: "Caste not counted since 1931", space: "closed", level: "national", form: "hidden",
+      note: "An absence rather than an act. Keeping the count off the table keeps the claim it would support out of policy argument.", year: "1931 onward" },
+    { name: "Untouchability in the household", space: "closed", level: "local", form: "invisible",
+      note: "No decision is taken and no rule is cited. Roughly a quarter of surveyed households reported the practice, sustained as ordinary conduct.", year: "2011-12" }
+  ];
+
+  return { dims: dims, cases: cases };
+})();

--- a/js/cube.js
+++ b/js/cube.js
@@ -15,16 +15,23 @@ window.FCube = (function () {
       return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
     });
   }
-  /* White on the lighter category colours measures ~2.1-2.7:1, below AA, so the
-     ink is chosen per colour rather than fixed. */
+  /* Pick the ink that actually contrasts better, rather than guessing a
+     luminance cutoff. A fixed threshold picked white on #d97706 (3.19:1);
+     comparing the two ratios is self-correcting for any future colour. */
   function ink(hex) {
-    var h = hex.replace("#", "");
-    var c = [0, 2, 4].map(function (i) {
-      var v = parseInt(h.slice(i, i + 2), 16) / 255;
-      return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
-    });
-    var L = 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2];
-    return L > 0.32 ? "#1a1420" : "#ffffff";
+    function lum(h) {
+      h = h.replace("#", "");
+      var c = [0, 2, 4].map(function (i) {
+        var v = parseInt(h.slice(i, i + 2), 16) / 255;
+        return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+      });
+      return 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2];
+    }
+    function ratio(a, b) {
+      var x = lum(a), y = lum(b), hi = Math.max(x, y), lo = Math.min(x, y);
+      return (hi + 0.05) / (lo + 0.05);
+    }
+    return ratio("#1a1420", hex) > ratio("#ffffff", hex) ? "#1a1420" : "#ffffff";
   }
 
   function find(id) {

--- a/js/cube.js
+++ b/js/cube.js
@@ -1,0 +1,140 @@
+/* =============================================================================
+   ImpactMojo — Fundamentals: the Power Cube (Gaventa, 2006)
+   Nine categories across three dimensions, rendered as buttons, plus a case
+   table plotting documented Indian examples on all three at once.
+   Depends on /js/cube-data.js.
+   ============================================================================= */
+
+window.FCube = (function () {
+  "use strict";
+  var D = window.CUBE;
+  var state = { cat: null };
+
+  function esc(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    });
+  }
+  /* White on the lighter category colours measures ~2.1-2.7:1, below AA, so the
+     ink is chosen per colour rather than fixed. */
+  function ink(hex) {
+    var h = hex.replace("#", "");
+    var c = [0, 2, 4].map(function (i) {
+      var v = parseInt(h.slice(i, i + 2), 16) / 255;
+      return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+    });
+    var L = 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2];
+    return L > 0.32 ? "#1a1420" : "#ffffff";
+  }
+
+  function find(id) {
+    for (var i = 0; i < D.dims.length; i++) {
+      var c = D.dims[i].cats.filter(function (x) { return x.id === id; })[0];
+      if (c) return { dim: D.dims[i], cat: c };
+    }
+    return null;
+  }
+
+  function build() {
+    var box = document.getElementById("cube");
+    if (!box) return;
+    box.innerHTML = D.dims.map(function (d) {
+      return '<div class="dim">' +
+        '<div class="dim-h"><span class="dim-n" style="--dc:' + esc(d.color) + '">' + esc(d.name) + '</span>' +
+        '<span class="dim-q">' + esc(d.question) + '</span></div>' +
+        '<div class="dim-cats">' + d.cats.map(function (c) {
+          return '<button type="button" class="cat" data-cat="' + esc(c.id) + '" aria-pressed="false" style="--cc:' + esc(c.color) + ';--ci:' + ink(c.color) + '">' +
+                 '<span class="cat-sw"></span>' + esc(c.name) + '</button>';
+        }).join("") + '</div></div>';
+    }).join("");
+    box.querySelectorAll("[data-cat]").forEach(function (b) {
+      b.addEventListener("click", function () { select(b.getAttribute("data-cat")); });
+    });
+  }
+
+  function buildCases() {
+    var box = document.getElementById("cases");
+    if (!box) return;
+    box.innerHTML =
+      '<table class="case-tbl"><caption class="sr-only">Indian cases plotted on the three dimensions of the power cube</caption>' +
+      '<thead><tr><th scope="col">Case</th><th scope="col">Space</th><th scope="col">Level</th><th scope="col">Form</th><th scope="col">What it shows</th></tr></thead><tbody>' +
+      D.cases.map(function (c) {
+        return '<tr><th scope="row">' + esc(c.name) + ' <span class="cy">' + esc(c.year) + '</span></th>' +
+          ['space', 'level', 'form'].map(function (k) {
+            var f = find(c[k]);
+            var col = f ? f.cat.color : '#666666';
+            return '<td><span class="tag" style="--cc:' + esc(col) + ';color:' + ink(col) + '">' + esc(f ? f.cat.name : c[k]) + '</span></td>';
+          }).join("") +
+          '<td class="cn">' + esc(c.note) + '</td></tr>';
+      }).join("") + '</tbody></table>';
+  }
+
+  function select(id, opts) {
+    opts = opts || {};
+    var f = find(id);
+    if (!f) return;
+    state.cat = id;
+    document.querySelectorAll("#cube .cat").forEach(function (b) {
+      b.setAttribute("aria-pressed", String(b.getAttribute("data-cat") === id));
+    });
+    var c = f.cat, h = [];
+    h.push('<div class="panel-axis"><span class="swatch" style="background:' + esc(c.color) + '"></span>' + esc(f.dim.name) + '</div>');
+    h.push('<h3>' + esc(c.name) + '</h3>');
+    h.push('<blockquote class="arnstein">' + esc(c.gaventa) + '<cite>Gaventa&rsquo;s category, paraphrased from the 2006 paper</cite></blockquote>');
+    h.push('<ul class="ev-list">');
+    c.evidence.forEach(function (e) {
+      h.push('<li class="ev"><div class="fig">' + esc(e.stat) + '</div><div class="txt">' + esc(e.detail) +
+             '<span class="src">' + esc(e.source) + ', ' + esc(e.year) + '</span></div></li>');
+    });
+    h.push('</ul>');
+    h.push('<div class="caveat"><b>What this does not settle</b><p>' + esc(c.complication) + '</p></div>');
+    h.push('<div class="panel-nav"><button class="btn-ghost" data-nav="next">Next category</button>' +
+           '<button class="btn-ghost" data-nav="clear">Clear</button></div>');
+    var p = document.getElementById("panel");
+    p.innerHTML = h.join("");
+    p.querySelectorAll("[data-nav]").forEach(function (b) {
+      b.addEventListener("click", function () { nav(b.getAttribute("data-nav")); });
+    });
+    if (!opts.silent) history.replaceState(null, "", "#" + id);
+  }
+
+  function allIds() {
+    return D.dims.reduce(function (a, d) { return a.concat(d.cats.map(function (c) { return c.id; })); }, []);
+  }
+
+  function nav(dir) {
+    if (dir === "clear") {
+      state.cat = null;
+      document.querySelectorAll("#cube .cat").forEach(function (b) { b.setAttribute("aria-pressed", "false"); });
+      renderEmpty();
+      history.replaceState(null, "", location.pathname);
+      return;
+    }
+    var ids = allIds(), i = ids.indexOf(state.cat);
+    select(ids[(i + 1) % ids.length]);
+  }
+
+  function renderEmpty() {
+    document.getElementById("panel").innerHTML =
+      '<div class="panel-empty"><h3>Pick a category</h3>' +
+      '<p>Nine categories across three dimensions. Each opens Gaventa&rsquo;s definition and the Indian evidence for it, with a note on what the evidence does not settle.</p>' +
+      '<ol><li><b>Spaces</b> ask where the decision gets made and who set the table.</li>' +
+      '<li><b>Levels</b> ask whether that is local, national or global.</li>' +
+      '<li><b>Forms</b> ask whether the power is visible, agenda-setting, or working on what people accept as normal.</li></ol>' +
+      '<p>Gaventa&rsquo;s argument is that the three have to be read together. A seat in an invited local space is worth little if the decision was taken at another level, in another form.</p></div>';
+  }
+
+  function fromHash() {
+    var id = (location.hash || "").replace("#", "");
+    if (id && find(id)) { select(id, { silent: true }); return true; }
+    return false;
+  }
+
+  function init() {
+    if (!D || !D.dims) return;
+    build(); buildCases();
+    if (!fromHash()) renderEmpty();
+    window.addEventListener("hashchange", fromHash);
+  }
+  return { init: init, select: select };
+})();

--- a/js/fundamentals-wheel.js
+++ b/js/fundamentals-wheel.js
@@ -120,8 +120,7 @@ window.FWheel = (function () {
         var id = "arc-" + axis.id + "-" + ring;
         defs.appendChild(el("path", { id: id, d: textArc(a0, a1, rMid) }));
         var t = el("text", {
-          class: "seg-label",
-          "font-size": ring === "power" ? 7.6 : 8.4,
+          class: "seg-label r-" + ring,
           fill: readableOn(fill),
           "pointer-events": "none"
         });
@@ -182,6 +181,7 @@ window.FWheel = (function () {
     }
     document.getElementById("wheelFrame").classList.add("wheel-dim");
     syncPickers();
+    setCaption(axis, ring);
     renderPanel(axis, ring);
     if (!opts.silent) history.replaceState(null, "", "#" + axisId + "/" + ring);
   }
@@ -191,6 +191,7 @@ window.FWheel = (function () {
     document.querySelectorAll("#wheel .seg, #wheel .segw").forEach(function (s) { s.classList.remove("is-active"); });
     document.getElementById("wheelFrame").classList.remove("wheel-dim");
     syncPickers();
+    setCaption(null, null);
     renderEmpty();
     history.replaceState(null, "", location.pathname);
   }
@@ -311,6 +312,47 @@ window.FWheel = (function () {
     document.getElementById("clearMarks").addEventListener("click", function () {
       state.marks = {}; saveMarks(); paintMarks(); renderMarks();
     });
+  }
+
+  /* Labels are sized per ring by the arc that ring has, but the longest string
+     in a ring can still overrun its 30-degree slice and spill onto the page
+     background. Measure each one against its own arc and shrink only those
+     that overflow, so a future label change cannot reintroduce it. */
+  function fitLabels() {
+    document.querySelectorAll("#wheel .seg-label").forEach(function (t) {
+      var tp = t.querySelector("textPath");
+      if (!tp) return;
+      var href = tp.getAttribute("href") || tp.getAttributeNS("http://www.w3.org/1999/xlink", "href");
+      var arc = href && document.querySelector("#wheel " + href);
+      if (!arc || !arc.getTotalLength) return;
+      var avail = arc.getTotalLength() * 0.92;
+      var size = parseFloat(getComputedStyle(t).fontSize) || 9;
+      for (var i = 0; i < 12; i++) {
+        var len = 0;
+        try { len = t.getComputedTextLength(); } catch (e) { return; }
+        if (!len || len <= avail || size <= 6.5) break;
+        size = Math.max(6.5, size * Math.max(0.86, avail / len));
+        t.setAttribute("font-size", size.toFixed(2));
+      }
+    });
+  }
+
+  /* ------------------------------------------------------------- caption */
+  /* Below 760px the segment labels would render at about 4px, so they are
+     hidden and this carries the selection at real text size instead. It is
+     useful at every width, which is why it is not itself behind a query. */
+  function setCaption(axis, ring) {
+    var box = document.getElementById("wheelCaption");
+    if (!box) return;
+    if (!axis) {
+      box.className = "wheel-caption is-empty";
+      box.innerHTML = '<span class="cap-t">Nothing selected yet. Pick a band on the wheel, or use the buttons below.</span>';
+      return;
+    }
+    box.className = "wheel-caption";
+    box.innerHTML = '<span class="cap-sw" style="background:' + esc(axis.color) + '"></span>' +
+      '<span><span class="cap-s">' + esc(axis.name) + ' &middot; ' + esc(D.RING_LABEL[ring]) + '</span>' +
+      '<span class="cap-t">' + esc(axis.rings[ring].short) + '</span></span>';
   }
 
   /* --------------------------------------------------------------- pickers */
@@ -439,7 +481,9 @@ window.FWheel = (function () {
   function init() {
     if (!D || !D.axes) return;
     buildWheel();
+    fitLabels();
     buildPickers();
+    setCaption(null, null);
     buildIndex();
     loadMarks();
     paintMarks();

--- a/js/ladder-data.js
+++ b/js/ladder-data.js
@@ -16,22 +16,22 @@ window.LADDER = (function () {
   "use strict";
 
   var BANDS = {
-    power:   { label: "Citizen power",   note: "Citizens hold decision-making authority, not just a hearing." },
-    token:   { label: "Tokenism",        note: "Citizens are heard, but nothing obliges anyone to act on what they say." },
-    nonpart: { label: "Non-participation", note: "The purpose is not to let people take part. It is to substitute for taking part." }
+    power:   { label: "Citizen power",   note: "Citizens hold decision-making authority." },
+    token:   { label: "Tokenism",        note: "Citizens are heard. Nothing obliges anyone to act on what they say." },
+    nonpart: { label: "Non-participation", note: "The exercise stands in for taking part." }
   };
 
   var rungs = [
     {
       n: 8, id: "citizen-control", name: "Citizen control", band: "power", color: "#166534",
-      arnstein: "Participants govern a programme outright, with full charge of policy and management and no intermediaries between them and the source of funds.",
+      arnstein: "Participants govern the programme outright, with full charge of policy and management and no intermediaries between them and the source of funds.",
       india: "Village assemblies make a decision the state is legally bound to accept.",
       evidence: [
         { stat: "2013", detail: "The Supreme Court held that the gram sabhas of Niyamgiri, not the state government, would decide whether bauxite mining could proceed on their hills. Twelve village assemblies were convened and all twelve refused. The environment ministry cancelled the clearance in January 2014.", source: "Orissa Mining Corporation v. Ministry of Environment & Forests", year: "2013" },
         { stat: "§3(1)(i)", detail: "The Forest Rights Act gives the gram sabha the right to protect, regenerate and manage community forest resources. It is the strongest transfer of control to a village assembly anywhere in Indian statute.", source: "Scheduled Tribes and Other Traditional Forest Dwellers (Recognition of Forest Rights) Act", year: "2006" },
         { stat: "1996", detail: "PESA extends gram sabha authority across Fifth Schedule areas, including a mandatory consultation before land acquisition and ownership of minor forest produce.", source: "Panchayats (Extension to the Scheduled Areas) Act", year: "1996" }
       ],
-      complication: "This rung is far better established in law than in practice. Rights and Resources Initiative assessed in 2015 that forest-dwelling communities hold legal title to under 5% of the land they customarily use, and states had rejected an average of 54% of the claims decided since 2008. Niyamgiri itself is narrower than it looks: the state selected 12 villages to vote out of 112 in the affected area."
+      complication: "The law here runs well ahead of the practice. Rights and Resources Initiative assessed in 2015 that forest-dwelling communities hold legal title to under 5% of the land they customarily use, and states had rejected an average of 54% of the claims decided since 2008. Niyamgiri was also narrower than it looks: the state picked 12 villages to vote, out of 112 in the affected area."
     },
     {
       n: 7, id: "delegated-power", name: "Delegated power", band: "power", color: "#15803d",
@@ -42,7 +42,7 @@ window.LADDER = (function () {
         { stat: "35–40%", detail: "of Kerala's annual state plan budget was devolved to local governments in the first years of the People's Plan Campaign, with gram sabhas and development seminars setting local priorities.", source: "People's Plan Campaign, Government of Kerala", year: "1996 onward" },
         { stat: "1/3 → 1/2", detail: "of panchayat seats reserved for women by the 73rd Amendment, raised to half by more than twenty states. India has more elected women in local government than any other country.", source: "Constitution (73rd Amendment) Act; Ministry of Panchayati Raj", year: "1992 onward" }
       ],
-      complication: "Devolution is a state subject, so the rung a panchayat actually stands on varies by state. Most devolved functions without the funds or the staff to discharge them, which leaves an elected body with authority on paper and a budget it does not control. Kerala is the exception cited so often precisely because it is exceptional."
+      complication: "Devolution is a state subject, so the rung a panchayat stands on varies by state. Most devolved functions without the funds or the staff to discharge them, leaving an elected body with authority on paper and a budget it does not control. Kerala gets cited constantly because few states went as far."
     },
     {
       n: 6, id: "partnership", name: "Partnership", band: "power", color: "#4d7c0f",
@@ -52,7 +52,7 @@ window.LADDER = (function () {
         { stat: "1990", detail: "The Joint Forest Management circular invited village committees to co-manage degraded forest in return for a share of the produce.", source: "Ministry of Environment & Forests circular", year: "1990" },
         { stat: "106,482", detail: "JFM committees across 28 states were managing about 22 million hectares of forest by 2006, involving roughly 14.5 million families.", source: "Ministry of Environment & Forests / Forest Survey of India", year: "2006" }
       ],
-      complication: "A partnership one party can dissolve is not quite a partnership. JFM committees are created by executive circular rather than statute, and the forest department retains the power to wind one up. That is the difference between rung 6 and rung 8, and it is why the Forest Rights Act was argued for as a statutory replacement rather than an extension."
+      complication: "JFM committees are created by executive circular rather than statute, and the forest department can wind one up. A partnership that one side can dissolve sits below rung 8 for that reason, and it is why the Forest Rights Act was argued for as a statutory replacement."
     },
     {
       n: 5, id: "placation", name: "Placation", band: "token", color: "#b45309",
@@ -62,7 +62,7 @@ window.LADDER = (function () {
         { stat: "75%", detail: "of a School Management Committee must be parents and guardians under the Right to Education Act, and the committee is to monitor the school and prepare its development plan.", source: "Right of Children to Free and Compulsory Education Act, §21", year: "2009" },
         { stat: "Advisory", detail: "In most states the SMC's development plan is a recommendation. The committee has no authority over teacher deployment, transfers or the school budget, which are the decisions that determine whether the school works.", source: "RTE §21–22 and state rules", year: "2009 onward" }
       ],
-      complication: "Placation is the hardest rung to identify from the outside, because it looks exactly like partnership on an organisation chart. The test Arnstein proposed is simple: count who can be outvoted, and check whether the body's output binds anyone."
+      complication: "On an organisation chart this rung looks the same as partnership, which makes it hard to spot from outside. Arnstein's test: count who can be outvoted, then check whether the body's output binds anyone."
     },
     {
       n: 4, id: "consultation", name: "Consultation", band: "token", color: "#c2410c",
@@ -73,7 +73,7 @@ window.LADDER = (function () {
         { stat: "30 → 20", detail: "days of public notice for those hearings, as proposed in the 2020 draft EIA notification. The proposal drew over 1.7 million public responses and was not finalised.", source: "Draft EIA Notification 2020, Ministry of Environment", year: "2020" },
         { stat: "Quorum", detail: "Gram sabha meetings require quorum and notice under state panchayat Acts. Where either fails, the meeting is still commonly recorded as held.", source: "State Panchayati Raj Acts", year: "various" }
       ],
-      complication: "Consultation is not automatically a failure. For a technical decision with one defensible answer it may be the right rung, and pretending otherwise wastes everyone's time. It becomes tokenism when it is used for a decision that genuinely has alternatives, and the alternatives were closed before the hearing."
+      complication: "Consultation suits a technical decision with one defensible answer, and treating it as failure there wastes everyone's time. It becomes tokenism when the decision had real alternatives and those were closed before the hearing."
     },
     {
       n: 3, id: "informing", name: "Informing", band: "token", color: "#d97706",
@@ -83,7 +83,7 @@ window.LADDER = (function () {
         { stat: "§4(1)(b)", detail: "The Right to Information Act requires every public authority to publish 17 categories of information on its own initiative, without anyone having to ask.", source: "Right to Information Act", year: "2005" },
         { stat: "Muster rolls", detail: "MGNREGA requires job cards, muster rolls and payment records to be publicly displayed and read out at social audits, making the paper trail contestable in the village where the work happened.", source: "Mahatma Gandhi National Rural Employment Guarantee Act, §17", year: "2005" }
       ],
-      complication: "Arnstein put informing on the tokenism band, and for one-way disclosure that is right. But India's version is unusual: MGNREGA's social audit gives the information a return channel, which pushes it towards the rungs above. Disclosure plus a forum to contest it is a different thing from disclosure alone."
+      complication: "Arnstein placed informing on the tokenism band, which fits one-way disclosure. India's version sits awkwardly there: MGNREGA's social audit gives the information a return channel, and disclosure with a forum to contest it behaves more like the rungs above."
     },
     {
       n: 2, id: "therapy", name: "Therapy", band: "nonpart", color: "#9f1239",
@@ -92,16 +92,16 @@ window.LADDER = (function () {
       evidence: [
         { stat: "Pattern", detail: "Behaviour-change campaigns that frame a shortfall as attitude while the underlying access gap persists. No Indian statistic isolates this rung; it is identified by what a programme's theory of change blames, so it is described here rather than counted.", source: "Characterisation, not a measurement", year: "2026" }
       ],
-      complication: "This is the rung most likely to be misapplied by a critic. Behaviour genuinely matters for some outcomes, and calling every demand-side programme 'therapy' is lazy. The distinction Arnstein drew is whether the citizen is being engaged as a person with a grievance, or as a problem to be treated."
+      complication: "Critics reach for this rung too readily. Behaviour does matter for some outcomes, and calling every demand-side programme therapy is lazy. Arnstein's distinction was whether the citizen is engaged as a person with a grievance or as a problem to be treated."
     },
     {
       n: 1, id: "manipulation", name: "Manipulation", band: "nonpart", color: "#881337",
       arnstein: "People are placed on advisory bodies for the purpose of engineering their support. Participation becomes a public relations exercise for a decision already taken.",
       india: "The consultation is held because the file requires one.",
       evidence: [
-        { stat: "Sequence", detail: "The signature of this rung is order: the hearing follows the decision rather than preceding it, and the record of consultation is produced to satisfy a procedural requirement. Identified by sequence, not by a statistic.", source: "Characterisation, not a measurement", year: "2026" }
+        { stat: "Sequence", detail: "What marks this rung is order. The hearing follows the decision rather than preceding it, and the record exists to satisfy a procedural requirement. Identified by sequence, not by a statistic.", source: "Characterisation, not a measurement", year: "2026" }
       ],
-      complication: "Arnstein's bottom rung is an accusation, and it should be made with evidence about a specific decision rather than as a general posture. The useful question is narrow and answerable: what could this consultation have changed, and was that still open when it was held?"
+      complication: "The bottom rung is an accusation, so it needs evidence about a specific decision rather than a general posture. The answerable question is narrow: what could this consultation have changed, and was that still open when it was held?"
     }
   ];
 

--- a/js/ladder.js
+++ b/js/ladder.js
@@ -14,6 +14,25 @@ window.FLadder = (function () {
       return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
     });
   }
+  /* Pick the ink that actually contrasts better, rather than guessing a
+     luminance cutoff. A fixed threshold picked white on #d97706 (3.19:1);
+     comparing the two ratios is self-correcting for any future colour. */
+  function ink(hex) {
+    function lum(h) {
+      h = h.replace("#", "");
+      var c = [0, 2, 4].map(function (i) {
+        var v = parseInt(h.slice(i, i + 2), 16) / 255;
+        return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+      });
+      return 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2];
+    }
+    function ratio(a, b) {
+      var x = lum(a), y = lum(b), hi = Math.max(x, y), lo = Math.min(x, y);
+      return (hi + 0.05) / (lo + 0.05);
+    }
+    return ratio("#1a1420", hex) > ratio("#ffffff", hex) ? "#1a1420" : "#ffffff";
+  }
+
   function byId(id) { return D.rungs.filter(function (r) { return r.id === id; })[0]; }
 
   function buildLadder() {
@@ -28,7 +47,7 @@ window.FLadder = (function () {
       }
       html.push(
         '<button type="button" class="rung b-' + r.band + '" data-rung="' + esc(r.id) + '" aria-pressed="false" ' +
-          'style="--rc:' + esc(r.color) + '">' +
+          'style="--rc:' + esc(r.color) + ';--ri:' + ink(r.color) + '">' +
           '<span class="rung-n">' + r.n + '</span>' +
           '<span class="rung-b"><span class="rung-name">' + esc(r.name) + '</span>' +
           '<span class="rung-say">' + esc(r.india) + '</span></span>' +

--- a/js/ladder.js
+++ b/js/ladder.js
@@ -34,7 +34,7 @@ window.FLadder = (function () {
           '<span class="rung-say">' + esc(r.india) + '</span></span>' +
         '</button>');
     });
-    box.innerHTML = html.join("");
+    box.innerHTML = '<div class="ladder-key"><span>&uarr; more power</span><span>less power &darr;</span></div>' + html.join("");
     box.querySelectorAll("[data-rung]").forEach(function (b) {
       b.addEventListener("click", function () { select(b.getAttribute("data-rung")); });
     });

--- a/js/whocounts-data.js
+++ b/js/whocounts-data.js
@@ -1,0 +1,107 @@
+/* =============================================================================
+   ImpactMojo — Fundamentals: Who Counts
+   -----------------------------------------------------------------------------
+   The Data Room (/explorers.html) covers what India measures. This covers the
+   other side: what it does not, why, and what follows from the gap. Unlike the
+   rest of the series this framework is ImpactMojo's own, so there is no outside
+   author to credit — only the sources for each gap.
+
+   Same rule as the rest of the series: every entry names a source and a year.
+   ============================================================================= */
+
+window.WHOCOUNTS = (function () {
+  "use strict";
+
+  var KINDS = {
+    never:   { label: "Never asked",     note: "No national instrument collects it at all." },
+    under:   { label: "Counted, badly",  note: "An official figure exists and is far below what independent estimates find." },
+    frozen:  { label: "Frozen",          note: "It was counted once and has not been counted since." }
+  };
+
+  var gaps = [
+    {
+      id: "orientation", name: "Sexual orientation", kind: "never", color: "#7c3aed",
+      missing: "No national survey asks who anyone is attracted to, or whether they are in a same-sex relationship.",
+      evidence: [
+        { stat: "Zero", detail: "The Census, NFHS and PLFS carry no question on sexual orientation. The absence is complete rather than partial.", source: "Review of Census, NFHS-5 and PLFS instruments", year: "2026" },
+        { stat: "~25 lakh", detail: "the government's own estimate of LGBT Indians, given to the Supreme Court and derived from 2012 figures. It is the only official number and it rests on nothing that was collected for the purpose.", source: "Union of India submission to the Supreme Court", year: "2018" }
+      ],
+      cost: "Every claim about health, employment or violence for this population has to be argued from small non-random studies. A ministry can decline a scheme on the ground that the need is not established, and be technically correct.",
+      proxy: "None at national scale. Community-led surveys exist and are neither representative nor comparable across states."
+    },
+    {
+      id: "caste", name: "Caste beyond SC and ST", kind: "frozen", color: "#b45309",
+      missing: "The Census enumerates Scheduled Castes and Scheduled Tribes. It has not enumerated other castes since 1931.",
+      evidence: [
+        { stat: "1931", detail: "the last Census to count caste in full. Every OBC entitlement since has been argued from estimates, commission findings and sample surveys rather than an enumeration.", source: "Census of India", year: "1931" },
+        { stat: "63%", detail: "OBC and EBC share of Bihar's population in the state's own 2023 survey. No national figure exists to place beside it.", source: "Bihar Caste-based Survey", year: "2023" },
+        { stat: "27%", detail: "OBC reservation in central posts and institutions, upheld in 1992, still rests on a population share nobody has measured nationally.", source: "Indra Sawhney v. Union of India", year: "1992" }
+      ],
+      cost: "Proportionality is the language Indian reservation policy argues in, and for the largest reserved category the denominator is missing. Both sides of every OBC dispute cite estimates.",
+      proxy: "NSS and NFHS record a self-reported caste category, which gives shares but not the jati-level detail policy questions turn on."
+    },
+    {
+      id: "disability", name: "Disability", kind: "under", color: "#0369a1",
+      missing: "India records disability at a fraction of the rate found everywhere else, and most people it does record hold no certificate.",
+      evidence: [
+        { stat: "2.2%", detail: "of the population, in both the Census and the NSS 76th Round, measured independently and agreeing with each other.", source: "Census of India; NSS 76th Round", year: "2011, 2018" },
+        { stat: "~16%", detail: "global prevalence estimated by the WHO. The gap between the two implies roughly 150 million people India does not record as disabled.", source: "WHO Global Report on Health Equity for Persons with Disabilities", year: "2022" },
+        { stat: "28.8%", detail: "of persons with disabilities hold a disability certificate. Reservation, pension, concessions and standing under the RPwD Act all require one.", source: "NSS 76th Round", year: "2018" }
+      ],
+      cost: "Budgets, quotas and accessibility obligations are all sized against 2.2%. Seven in ten of those counted cannot claim what the count entitles them to.",
+      proxy: "NFHS-5 added disability questions, which is why prevalence estimates from it run higher than the Census. The instrument, not the population, is what changed."
+    },
+    {
+      id: "unpaid", name: "Unpaid care and domestic work", kind: "frozen", color: "#be185d",
+      missing: "India measured how its households spend time once, in 2019, and does not carry the result into any national account.",
+      evidence: [
+        { stat: "299 vs 97", detail: "minutes a day of unpaid domestic work by women and by men, from the only full Time Use Survey India has run.", source: "Time Use Survey, NSO", year: "2019" },
+        { stat: "Excluded", detail: "None of it enters GDP. The System of National Accounts places unpaid household services outside the production boundary, and India follows that convention.", source: "System of National Accounts", year: "2008" }
+      ],
+      cost: "The single largest block of work done in India is invisible to the measure that decides whether the economy grew. Policy on childcare, elder care and women's employment argues without it.",
+      proxy: "The 2019 survey remains usable and is now several years old. A second round would make it a series rather than a snapshot."
+    },
+    {
+      id: "death", name: "What Indians die of", kind: "under", color: "#7f1d1d",
+      missing: "Deaths are registered. The cause is medically certified for a small minority of them.",
+      evidence: [
+        { stat: "22.3%", detail: "of registered deaths carried a medically certified cause. For roughly four in five deaths, the cause is not recorded in the system health policy is argued from.", source: "Medical Certification of Cause of Death, ORGI", year: "2022" },
+        { stat: "100% to <7%", detail: "the range of certification rates across states, from Goa and Manipur at the top to Bihar, Jharkhand and Madhya Pradesh at the bottom.", source: "Medical Certification of Cause of Death, ORGI", year: "2020" }
+      ],
+      cost: "Disease burden estimates for India are largely modelled rather than counted, and the states with the weakest certification are the ones whose burden most needs to be known.",
+      proxy: "The Million Death Study used verbal autopsy on a large sample and remains the main evidence for cause of death outside the certified minority."
+    },
+    {
+      id: "migration", name: "Where people moved", kind: "frozen", color: "#4d7c0f",
+      missing: "The only full picture of internal migration is from a Census taken in 2011.",
+      evidence: [
+        { stat: "45.6 crore", detail: "internal migrants counted, about 37% of the population, in the last Census India completed.", source: "Census of India", year: "2011" },
+        { stat: "2021", detail: "The Census due in 2021 was postponed. Nothing has replaced it as a source for district-level migration.", source: "Registrar General of India", year: "2021 onward" }
+      ],
+      cost: "The 2020 lockdown found the state without a current count of who was where. Entitlements are tied to place of registration, which is precisely what migration breaks.",
+      proxy: "PLFS added a migration module in 2020-21, and e-Shram has registered over 30 crore unorganised workers. Neither reproduces the Census's district-to-district detail."
+    },
+    {
+      id: "poverty", name: "How many are poor", kind: "frozen", color: "#166534",
+      missing: "India has published no official poverty line, and no official poverty count, for more than a decade.",
+      evidence: [
+        { stat: "2011-12", detail: "the last consumption survey used for an official poverty estimate. The 2017-18 round was not released.", source: "NSSO; Ministry of Statistics", year: "2011-12, 2019" },
+        { stat: "11 years", detail: "between that survey and the Household Consumption Expenditure Survey of 2022-23, which was published without an accompanying official poverty line.", source: "Household Consumption Expenditure Survey", year: "2022-23" }
+      ],
+      cost: "Every poverty claim about India in the intervening years, in either direction, rests on a researcher's own line rather than the state's.",
+      proxy: "The NITI Aayog National MPI counts deprivation across twelve indicators rather than income, which answers a different question and is not a substitute."
+    },
+    {
+      id: "appearance", name: "Skin tone and appearance", kind: "never", color: "#9d174d",
+      missing: "No Indian official survey records skin tone, body size, or discrimination based on either.",
+      evidence: [
+        { stat: "Zero", detail: "national instruments collect it. Evidence on colourism in hiring or marriage comes from audit studies and market data rather than from statistics.", source: "Review of NSO and Census instruments", year: "2026" },
+        { stat: "2014", detail: "ASCI guidelines bar advertising that portrays darker skin as a barrier to success, which is a regulator conceding the pattern exists without anyone measuring it.", source: "Advertising Standards Council of India", year: "2014" }
+      ],
+      cost: "A form of sorting that people describe constantly cannot be entered into any equality argument that requires numbers.",
+      proxy: "None. This is the widest gap on the page between what is documented in daily life and what is documented at all."
+    }
+  ];
+
+  return { gaps: gaps, KINDS: KINDS };
+})();

--- a/js/whocounts.js
+++ b/js/whocounts.js
@@ -1,0 +1,98 @@
+/* =============================================================================
+   ImpactMojo — Fundamentals: Who Counts
+   Eight gaps in Indian official data, as buttons plus a detail panel.
+   Depends on /js/whocounts-data.js.
+   ============================================================================= */
+
+window.FWhoCounts = (function () {
+  "use strict";
+  var D = window.WHOCOUNTS;
+  var state = { gap: null };
+
+  function esc(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    });
+  }
+  function byId(id) { return D.gaps.filter(function (g) { return g.id === id; })[0]; }
+
+  function build() {
+    var box = document.getElementById("gaps");
+    if (!box) return;
+    box.innerHTML = D.gaps.map(function (g) {
+      return '<button type="button" class="gap" data-gap="' + esc(g.id) + '" aria-pressed="false" style="--gc:' + esc(g.color) + '">' +
+        '<span class="gap-k">' + esc(D.KINDS[g.kind].label) + '</span>' +
+        '<span class="gap-n">' + esc(g.name) + '</span>' +
+        '<span class="gap-m">' + esc(g.missing) + '</span></button>';
+    }).join("");
+    box.querySelectorAll("[data-gap]").forEach(function (b) {
+      b.addEventListener("click", function () { select(b.getAttribute("data-gap")); });
+    });
+  }
+
+  function select(id, opts) {
+    opts = opts || {};
+    var g = byId(id);
+    if (!g) return;
+    state.gap = id;
+    document.querySelectorAll("#gaps .gap").forEach(function (b) {
+      b.setAttribute("aria-pressed", String(b.getAttribute("data-gap") === id));
+    });
+    var h = [];
+    h.push('<div class="panel-axis"><span class="swatch" style="background:' + esc(g.color) + '"></span>' + esc(D.KINDS[g.kind].label) + '</div>');
+    h.push('<h3>' + esc(g.name) + '</h3>');
+    h.push('<p class="who"><b>What is missing:</b> ' + esc(g.missing) + '</p>');
+    h.push('<ul class="ev-list">');
+    g.evidence.forEach(function (e) {
+      h.push('<li class="ev"><div class="fig">' + esc(e.stat) + '</div><div class="txt">' + esc(e.detail) +
+             '<span class="src">' + esc(e.source) + ', ' + esc(e.year) + '</span></div></li>');
+    });
+    h.push('</ul>');
+    h.push('<div class="caveat"><b>What the gap costs</b><p>' + esc(g.cost) + '</p></div>');
+    h.push('<div class="caveat"><b>Closest available proxy</b><p>' + esc(g.proxy) + '</p></div>');
+    h.push('<div class="panel-nav"><button class="btn-ghost" data-nav="next">Next gap</button>' +
+           '<button class="btn-ghost" data-nav="clear">Clear</button></div>');
+    var p = document.getElementById("panel");
+    p.innerHTML = h.join("");
+    p.querySelectorAll("[data-nav]").forEach(function (b) {
+      b.addEventListener("click", function () { nav(b.getAttribute("data-nav")); });
+    });
+    if (!opts.silent) history.replaceState(null, "", "#" + id);
+  }
+
+  function nav(dir) {
+    if (dir === "clear") {
+      state.gap = null;
+      document.querySelectorAll("#gaps .gap").forEach(function (b) { b.setAttribute("aria-pressed", "false"); });
+      renderEmpty();
+      history.replaceState(null, "", location.pathname);
+      return;
+    }
+    var ids = D.gaps.map(function (g) { return g.id; });
+    select(ids[(ids.indexOf(state.gap) + 1) % ids.length]);
+  }
+
+  function renderEmpty() {
+    document.getElementById("panel").innerHTML =
+      '<div class="panel-empty"><h3>Pick a gap</h3>' +
+      '<p>Each opens what is missing, the evidence that it is missing, what the gap costs, and the closest available substitute.</p>' +
+      '<ol><li><b>Never asked</b> means no national instrument collects it at all.</li>' +
+      '<li><b>Counted, badly</b> means an official figure exists well below what independent estimates find.</li>' +
+      '<li><b>Frozen</b> means it was counted once and has not been counted since.</li></ol>' +
+      '<p>For what India does measure, and measures well, see <a href="/explorers.html">The Data Room</a>.</p></div>';
+  }
+
+  function fromHash() {
+    var id = (location.hash || "").replace("#", "");
+    if (id && byId(id)) { select(id, { silent: true }); return true; }
+    return false;
+  }
+
+  function init() {
+    if (!D || !D.gaps) return;
+    build();
+    if (!fromHash()) renderEmpty();
+    window.addEventListener("hashchange", fromHash);
+  }
+  return { init: init, select: select };
+})();

--- a/js/whocounts.js
+++ b/js/whocounts.js
@@ -14,13 +14,32 @@ window.FWhoCounts = (function () {
       return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
     });
   }
+  /* Pick the ink that actually contrasts better, rather than guessing a
+     luminance cutoff. A fixed threshold picked white on #d97706 (3.19:1);
+     comparing the two ratios is self-correcting for any future colour. */
+  function ink(hex) {
+    function lum(h) {
+      h = h.replace("#", "");
+      var c = [0, 2, 4].map(function (i) {
+        var v = parseInt(h.slice(i, i + 2), 16) / 255;
+        return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+      });
+      return 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2];
+    }
+    function ratio(a, b) {
+      var x = lum(a), y = lum(b), hi = Math.max(x, y), lo = Math.min(x, y);
+      return (hi + 0.05) / (lo + 0.05);
+    }
+    return ratio("#1a1420", hex) > ratio("#ffffff", hex) ? "#1a1420" : "#ffffff";
+  }
+
   function byId(id) { return D.gaps.filter(function (g) { return g.id === id; })[0]; }
 
   function build() {
     var box = document.getElementById("gaps");
     if (!box) return;
     box.innerHTML = D.gaps.map(function (g) {
-      return '<button type="button" class="gap" data-gap="' + esc(g.id) + '" aria-pressed="false" style="--gc:' + esc(g.color) + '">' +
+      return '<button type="button" class="gap" data-gap="' + esc(g.id) + '" aria-pressed="false" style="--gc:' + esc(g.color) + ';--gi:' + ink(g.color) + '">' +
         '<span class="gap-k">' + esc(D.KINDS[g.kind].label) + '</span>' +
         '<span class="gap-n">' + esc(g.name) + '</span>' +
         '<span class="gap-m">' + esc(g.missing) + '</span></button>';

--- a/scripts/mobile/audit.py
+++ b/scripts/mobile/audit.py
@@ -22,7 +22,7 @@ DEFAULT = [
  'index.html','catalog.html','premium.html','about.html','blog.html','dojos.html',
  'handouts.html','dataverse.html','faq.html','contact.html','game-library.html',
  'workshops.html','testimonials.html','login.html','signup.html','account.html',
- 'upgrade.html','portfolio.html','coaching.html','sitemap.html','fundamentals/wheel.html','fundamentals/index.html',
+ 'upgrade.html','portfolio.html','coaching.html','sitemap.html','fundamentals/wheel.html','fundamentals/index.html','fundamentals/ladder.html','fundamentals/power-cube.html','fundamentals/who-counts.html',
  '101-courses/index.html','101-courses/decks.html',
  'courses/causal/index.html','courses/mel/index.html','courses/gender/index.html',
  'BookSummaries/index.html','specials/marginalia/index.html',

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -731,6 +731,8 @@
   <url><loc>https://www.impactmojo.in/fundamentals/</loc><lastmod>2026-08-19</lastmod></url>
   <url><loc>https://www.impactmojo.in/fundamentals/wheel.html</loc><lastmod>2026-08-19</lastmod></url>
   <url><loc>https://www.impactmojo.in/fundamentals/ladder.html</loc><lastmod>2026-08-19</lastmod></url>
+  <url><loc>https://www.impactmojo.in/fundamentals/power-cube.html</loc><lastmod>2026-08-19</lastmod></url>
+  <url><loc>https://www.impactmojo.in/fundamentals/who-counts.html</loc><lastmod>2026-08-19</lastmod></url>
   <url><loc>https://www.impactmojo.in/the-long-view.html</loc><lastmod>2026-07-19</lastmod></url>
   <url><loc>https://www.impactmojo.in/nfhs.html</loc><lastmod>2026-07-21</lastmod></url>
   <url><loc>https://www.impactmojo.in/the-long-view/chart.html</loc><lastmod>2026-07-12</lastmod></url>

--- a/tests/axe-accessibility.js
+++ b/tests/axe-accessibility.js
@@ -34,6 +34,9 @@ const PAGES = [
   'courses/mel/index.html',
   'fundamentals/wheel.html',
   'fundamentals/index.html',
+  'fundamentals/ladder.html',
+  'fundamentals/power-cube.html',
+  'fundamentals/who-counts.html',
 ];
 
 // axe-core impact levels: minor, moderate, serious, critical


### PR DESCRIPTION
Completes the series at four pages, and fixes three things reported on the two already shipped.

## New pages

**[The Power Cube](https://www.impactmojo.in/fundamentals/power-cube.html)** — John Gaventa's, from "Finding the Spaces for Change: A Power Analysis", *IDS Bulletin* 37(6), 2006, building on Lukes (1974) and VeneKlasen &amp; Miller (2002). Nine categories across spaces, levels and forms, with **23 pieces of Indian evidence**: the judicial collegium and the 99th Amendment struck down in 2015, internet shutdowns, gram sabhas and MGNREGA social audits, EIA hearings, the MKSS wage hearings that preceded the RTI Act, Narmada and the Morse Commission, WTO public stockholding, *Novartis* and Section 3(d), the caste count frozen since 1931, untouchability at ~27% of surveyed households. **Eight documented cases are plotted on all three dimensions at once**, because the same case reads differently on each face.

**[Who Counts](https://www.impactmojo.in/fundamentals/who-counts.html)** — the one framework in the series that is ours, and the page says so, since that means it carries no external authority. Deliberately the **inverse of `/explorers.html`** rather than a second catalogue of it. Eight gaps, sorted by kind:

| Kind | Examples |
|---|---|
| **Never asked** | sexual orientation; skin tone and appearance |
| **Counted, badly** | disability at 2.2% against a global ~16%; cause of death certified for **22.3%** of registered deaths |
| **Frozen** | caste since 1931; migration since 2011; unpaid work measured once in 2019; no official poverty line since 2011&ndash;12 |

Each names the instrument checked, what the gap costs, and the nearest proxy.

## Language

Owner reported the same AI register in the new pages, correctly — I had reproduced constructions removed from the wheel a few hours earlier. Rewrote the ladder data and both pages against explicit rules: no "X is not Y, it is Z" reveals, no epigram closing a paragraph, no triads of bolded parallel lead-ins, no commentary on the page's own virtue. The wheel's own *"It is not a score / not additive / not fixed"* triad had already been replaced once; the ladder had grown its own.

## Two visual fixes

**The ladder was a stack of cards, not a ladder.** It now has a rail running from citizen power down to non-participation, numbered nodes sitting on it, and an up/down power key.

**Hiding the wheel's labels below 760px removed information rather than solving the problem.** Labels are now sized per ring by the arc each has, auto-shrunk if any overruns, and a live caption under the wheel carries the selection at real text size at every width — which is what a phone gets in place of labels that would render at 4px.

| | Before | After |
|---|---|---|
| Desktop segment label | 7.0px | **9.6px** |
| Phone | labels hidden, nothing in their place | **live caption at full text size** |

## Accessibility found while building

1. **Dimming unselected wheel segments faded their labels too**, measuring **2.28:1**. The dim now applies to the fill only, which lightens the ground behind the label and improves it. Only visible with something selected — earlier audits never tested that state.
2. **The cube's case-table tags used white on three lighter category colours** (2.14&ndash;2.72:1). Ink is now chosen per colour by luminance.
3. **The case table is a horizontally scrollable region with no keyboard access** — the same defect I reported on `index.html`'s trust strip in #937, this time in my own code. Fixed with `tabindex` and an accessible name.

## Type of change

- [x] New content (course, case study, translation)
- [x] New feature or tool
- [x] Accessibility improvement
- [x] Bug fix (broken link, layout, JS error)

## Checklist

- [x] Tested on desktop browser &mdash; 1440px; all 9 cube categories and 8 gaps open; 23 + 18 evidence rows; 8 case rows
- [x] Tested on mobile browser &mdash; 390px with touch; gap targets 110px; no overflow
- [x] No console errors
- [x] Links are working &mdash; internal-link guard **PASS across 846 pages**

### Also verified

- axe &rarr; **0 violations at every impact level** on all five pages at 390px and 1440px, **including with a selection active**
- `check-counts.py` &rarr; PASS · `check-mojibake.py` &rarr; PASS · `sitemap.xml` valid
- Wired into the hub, series nav on every page, `search-index.json`, `sitemap.xml`, and all three CI page lists (`axe`, `.pa11yci`, `scripts/mobile/audit.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01199dCmAgzMN1Z1d8qj2UfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01199dCmAgzMN1Z1d8qj2UfN)_