### PR TITLE
feat(fundamentals): give every page a real diagram, on one shared grammar

### DIFF
--- a/css/fundamentals.css
+++ b/css/fundamentals.css
@@ -435,3 +435,64 @@ details.ax[open] > summary { border-bottom: 1px solid var(--color-border); }
 .gap-k { display: inline-block; font-family: var(--font-mono); font-size: 0.66rem; letter-spacing: 1.4px; text-transform: uppercase; color: var(--gi, #fff); background: var(--gc); padding: 0.12rem 0.5rem; border-radius: 999px; margin-bottom: 0.35rem; }
 .gap-n { display: block; font-family: var(--font-heading); font-weight: 800; font-size: 1.05rem; line-height: 1.25; }
 .gap-m { display: block; font-size: 0.88rem; color: var(--color-text-muted); margin-top: 0.15rem; }
+
+/* =============================================================================
+   Shared diagram grammar: every Fundamentals page has one clickable, labelled
+   diagram, a live caption under it, and the evidence panel beside it.
+   ============================================================================= */
+
+/* ---------- Ladder: two side rails with rungs spanning between them ---------- */
+.ladder { position: relative; padding: 0 34px; }
+.ladder::before, .ladder::after {
+  content: ""; position: absolute; top: 26px; bottom: 6px; width: 10px; border-radius: 5px;
+  background: linear-gradient(to bottom, #166534 0%, #4d7c0f 30%, #b45309 46%, #d97706 66%, #9f1239 80%, #881337 100%);
+}
+.ladder::before { left: 6px; }
+.ladder::after { right: 6px; }
+.rung { border-left-width: 1px; border-radius: 8px; }
+.rung::before, .rung::after {
+  content: ""; position: absolute; top: 50%; width: 34px; height: 6px; margin-top: -3px;
+  background: var(--rc); opacity: 0.55;
+}
+.rung::before { left: -34px; }
+.rung::after { right: -34px; }
+.rung[aria-pressed="true"]::before, .rung[aria-pressed="true"]::after { opacity: 1; height: 8px; margin-top: -4px; }
+.band-head { padding-left: 4px; }
+.ladder-key { padding: 0 0 0.2rem; }
+
+/* ---------- Cube ---------- */
+.cube-frame { background: var(--wheel-plate); border: 1px solid var(--color-border); border-radius: 20px; padding: 0.6rem; }
+#cubeSvg { width: 100%; height: auto; display: block; }
+.slice { cursor: pointer; stroke: var(--wheel-stroke); stroke-width: 1.5; transition: opacity 0.15s ease; }
+.slice:hover { filter: brightness(1.12); }
+.has-sel .slice:not(.is-on) { opacity: 0.3; }
+.slice.is-on { stroke: var(--color-text); stroke-width: 3; }
+.cube-edge { stroke: var(--color-text); stroke-width: 1.6; fill: none; opacity: 0.55; pointer-events: none; }
+.leader { stroke: var(--color-text-muted); stroke-width: 1; pointer-events: none; }
+.slice-label { font-family: var(--font-heading); font-weight: 700; font-size: 13px; fill: var(--color-text); pointer-events: none; }
+.slice-label.is-on { font-weight: 800; }
+.face-title { font-family: var(--font-heading); font-weight: 800; font-size: 12px; letter-spacing: 2px; pointer-events: none; }
+
+/* ---------- Who Counts matrix ---------- */
+.mx { display: grid; gap: 6px; }
+.mx-row { display: grid; grid-template-columns: minmax(120px, 1.1fr) repeat(3, minmax(120px, 1fr)); gap: 6px; }
+.mx-corner { display: flex; flex-direction: column; justify-content: flex-end; font-family: var(--font-mono); font-size: 0.64rem; letter-spacing: 1px; text-transform: uppercase; color: var(--color-text-muted); padding: 0.3rem; }
+.mx-ch, .mx-rh { background: var(--color-bg-sunk); border-radius: 10px; padding: 0.6rem 0.7rem; }
+.mx-ch b, .mx-rh b { display: block; font-family: var(--font-heading); font-size: 0.86rem; }
+.mx-ch span, .mx-rh span { display: block; font-size: 0.76rem; color: var(--color-text-muted); margin-top: 0.15rem; }
+.mx-cell { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: 10px; padding: 0.45rem; display: flex; flex-direction: column; gap: 0.4rem; justify-content: center; min-height: 64px; }
+.mx-cell.is-empty { background: transparent; border-style: dashed; }
+.mx-none { text-align: center; color: var(--color-text-muted); font-family: var(--font-mono); }
+.mx-tile {
+  width: 100%; text-align: left; cursor: pointer; min-height: 44px;
+  font-family: var(--font-heading); font-weight: 700; font-size: 0.84rem; line-height: 1.2;
+  background: var(--gc); color: var(--gi, #fff); border: 2px solid transparent; border-radius: 8px; padding: 0.5rem 0.6rem;
+}
+.mx-tile[aria-pressed="true"] { border-color: var(--color-text); }
+@media (max-width: 760px) {
+  .mx-row { grid-template-columns: 1fr; }
+  .mx-corner { display: none; }
+  .mx-rh { margin-top: 0.5rem; }
+  .mx-cell.is-empty { display: none; }
+  .mx-ch { position: relative; }
+}

--- a/fundamentals/ladder.html
+++ b/fundamentals/ladder.html
@@ -124,6 +124,7 @@
   <div class="wheel-layout">
     <div class="wheel-stage">
       <div class="ladder" id="ladder"></div>
+      <div class="wheel-caption is-empty" id="rungCaption" aria-live="polite"></div>
     </div>
     <div class="panel" id="panel" role="region" aria-live="polite" aria-label="Evidence for the selected rung"></div>
   </div>

--- a/fundamentals/power-cube.html
+++ b/fundamentals/power-cube.html
@@ -116,10 +116,15 @@
   <div class="section-head">
     <span class="kicker">The map</span>
     <h2>Nine categories, each with its evidence</h2>
-    <p>Tap any category. Every one has its own shareable link.</p>
+    <p>Tap a slice of the cube, or use the buttons under it. Every category has its own shareable link.</p>
   </div>
   <div class="wheel-layout">
-    <div class="wheel-stage"><div id="cube"></div></div>
+    <div class="wheel-stage">
+      <div class="cube-frame"><svg id="cubeSvg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 620 470"></svg></div>
+      <div class="wheel-caption is-empty" id="cubeCaption" aria-live="polite"></div>
+      <div class="picker"><span class="picker-label" id="cubeChipsLabel">Or pick a category</span>
+        <div id="cube" role="group" aria-labelledby="cubeChipsLabel"></div></div>
+    </div>
     <div class="panel" id="panel" role="region" aria-live="polite" aria-label="Evidence for the selected category"></div>
   </div>
 </section>

--- a/fundamentals/who-counts.html
+++ b/fundamentals/who-counts.html
@@ -114,11 +114,16 @@
 <section class="wrap" id="gaps-section">
   <div class="section-head">
     <span class="kicker">The map</span>
-    <h2>Eight gaps</h2>
-    <p>Tap any gap. Every one has its own shareable link.</p>
+    <h2>Eight gaps, and where the empty cells are</h2>
+    <p>The matrix sets what is being measured against how the measurement fails. Tap a tile, or use the list under it. Every gap has its own shareable link.</p>
   </div>
   <div class="wheel-layout">
-    <div class="wheel-stage"><div class="gaps" id="gaps"></div></div>
+    <div class="wheel-stage">
+      <div id="matrix"></div>
+      <div class="wheel-caption is-empty" id="gapCaption" aria-live="polite"></div>
+      <div class="picker"><span class="picker-label" id="gapListLabel">All eight, as a list</span>
+        <div class="gaps" id="gaps" role="group" aria-labelledby="gapListLabel"></div></div>
+    </div>
     <div class="panel" id="panel" role="region" aria-live="polite" aria-label="Detail for the selected gap"></div>
   </div>
 </section>

--- a/js/cube.js
+++ b/js/cube.js
@@ -42,6 +42,113 @@ window.FCube = (function () {
     return null;
   }
 
+  /* ---------------------------------------------------------------- diagram */
+  /* An isometric cube: three visible faces, each sliced into the three values
+     of one dimension. Nine clickable slices, labelled outside the solid with
+     leader lines so no text sits on a slanted face. */
+  var NS = "http://www.w3.org/2000/svg";
+  var CX = 310, CY = 240, S = 125;
+  var T  = [CX, CY - S], R = [CX + S, CY - S / 2], BO = [CX, CY],
+      L  = [CX - S, CY - S / 2], BL = [CX - S, CY + S / 2],
+      BR = [CX + S, CY + S / 2], BOT = [CX, CY + S];
+
+  function lerp(a, b, t) { return [a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t]; }
+  function pts(a) { return a.map(function (p) { return p[0].toFixed(1) + "," + p[1].toFixed(1); }).join(" "); }
+  function el(n, at, txt) {
+    var e = document.createElementNS(NS, n);
+    for (var k in at) if (at.hasOwnProperty(k)) e.setAttribute(k, at[k]);
+    if (txt != null) e.textContent = txt;
+    return e;
+  }
+
+  /* face: [a,b,c,d]; slices run between edge a-b and edge d-c.
+     labelEdge: which side the leader comes off — "ad" or "bc". */
+  var FACES = {
+    level: { quad: [T, R, BO, L],   labelEdge: "ad", dx: -14, dy: -3, anchor: "end",   title: [150, 96,  "end"] },
+    space: { quad: [L, BO, BOT, BL], labelEdge: "ad", dx: -16, dy: 4,  anchor: "end",   title: [150, 340, "end"] },
+    form:  { quad: [R, BO, BOT, BR], labelEdge: "ad", dx: 16,  dy: 4,  anchor: "start", title: [470, 340, "start"] }
+  };
+
+  function drawCube() {
+    var svg = document.getElementById("cubeSvg");
+    if (!svg) return;
+    svg.setAttribute("viewBox", "0 0 620 470");
+    svg.setAttribute("role", "group");
+    svg.setAttribute("aria-label", "Power cube: three faces, each sliced into the three values of one dimension. Select a slice to read its evidence.");
+    svg.innerHTML = "";
+
+    D.dims.forEach(function (dim) {
+      var F = FACES[dim.id];
+      if (!F) return;
+      var a = F.quad[0], b = F.quad[1], c = F.quad[2], d = F.quad[3];
+      var g = el("g", { "data-face": dim.id });
+
+      dim.cats.forEach(function (cat, i) {
+        var t0 = i / 3, t1 = (i + 1) / 3;
+        var p1 = lerp(a, d, t0), p2 = lerp(b, c, t0), p3 = lerp(b, c, t1), p4 = lerp(a, d, t1);
+        g.appendChild(el("polygon", {
+          points: pts([p1, p2, p3, p4]), fill: cat.color, class: "slice",
+          role: "button", tabindex: "-1", "data-cat": cat.id,
+          "aria-label": dim.name + ": " + cat.name
+        }));
+        /* leader line and label, outside the solid */
+        var mid = lerp(lerp(a, d, t0), lerp(a, d, t1), 0.5);
+        var lx = mid[0] + F.dx, ly = mid[1] + F.dy;
+        g.appendChild(el("line", { x1: mid[0], y1: mid[1], x2: lx, y2: ly, class: "leader" }));
+        g.appendChild(el("text", {
+          x: lx + (F.anchor === "end" ? -4 : 4), y: ly + 4,
+          "text-anchor": F.anchor, class: "slice-label", "data-cat": cat.id
+        }, cat.name));
+      });
+
+      svg.appendChild(g);
+      svg.appendChild(el("text", {
+        x: F.title[0], y: F.title[1], "text-anchor": F.title[2], class: "face-title", fill: dim.color
+      }, dim.name.toUpperCase()));
+    });
+
+    /* the solid's own edges, drawn over the slices */
+    [[T, R], [R, BO], [BO, L], [L, T], [L, BL], [BL, BOT], [BOT, BR], [BR, R], [BO, BOT]]
+      .forEach(function (e) {
+        svg.appendChild(el("line", { x1: e[0][0], y1: e[0][1], x2: e[1][0], y2: e[1][1], class: "cube-edge" }));
+      });
+
+    svg.querySelectorAll(".slice").forEach(function (n) {
+      n.addEventListener("click", function () { select(n.getAttribute("data-cat")); });
+      n.addEventListener("keydown", function (e) {
+        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); select(n.getAttribute("data-cat")); }
+      });
+    });
+    var first = svg.querySelector(".slice");
+    if (first) first.setAttribute("tabindex", "0");
+  }
+
+  function paintCube() {
+    var svg = document.getElementById("cubeSvg");
+    if (!svg) return;
+    svg.classList.toggle("has-sel", !!state.cat);
+    svg.querySelectorAll(".slice").forEach(function (n) {
+      n.classList.toggle("is-on", n.getAttribute("data-cat") === state.cat);
+    });
+    svg.querySelectorAll(".slice-label").forEach(function (n) {
+      n.classList.toggle("is-on", n.getAttribute("data-cat") === state.cat);
+    });
+  }
+
+  function setCaption() {
+    var box = document.getElementById("cubeCaption");
+    if (!box) return;
+    if (!state.cat) {
+      box.className = "wheel-caption is-empty";
+      box.innerHTML = '<span class="cap-t">Nothing selected yet. Pick a slice of the cube, or use the buttons below.</span>';
+      return;
+    }
+    var f = find(state.cat);
+    box.className = "wheel-caption";
+    box.innerHTML = '<span class="cap-sw" style="background:' + esc(f.cat.color) + '"></span>' +
+      '<span><span class="cap-s">' + esc(f.dim.name) + '</span><span class="cap-t">' + esc(f.cat.name) + '</span></span>';
+  }
+
   function build() {
     var box = document.getElementById("cube");
     if (!box) return;
@@ -84,6 +191,7 @@ window.FCube = (function () {
     document.querySelectorAll("#cube .cat").forEach(function (b) {
       b.setAttribute("aria-pressed", String(b.getAttribute("data-cat") === id));
     });
+    paintCube(); setCaption();
     var c = f.cat, h = [];
     h.push('<div class="panel-axis"><span class="swatch" style="background:' + esc(c.color) + '"></span>' + esc(f.dim.name) + '</div>');
     h.push('<h3>' + esc(c.name) + '</h3>');
@@ -113,6 +221,7 @@ window.FCube = (function () {
     if (dir === "clear") {
       state.cat = null;
       document.querySelectorAll("#cube .cat").forEach(function (b) { b.setAttribute("aria-pressed", "false"); });
+      paintCube(); setCaption();
       renderEmpty();
       history.replaceState(null, "", location.pathname);
       return;
@@ -139,7 +248,7 @@ window.FCube = (function () {
 
   function init() {
     if (!D || !D.dims) return;
-    build(); buildCases();
+    drawCube(); build(); buildCases(); setCaption();
     if (!fromHash()) renderEmpty();
     window.addEventListener("hashchange", fromHash);
   }

--- a/js/ladder.js
+++ b/js/ladder.js
@@ -35,6 +35,21 @@ window.FLadder = (function () {
 
   function byId(id) { return D.rungs.filter(function (r) { return r.id === id; })[0]; }
 
+  function setCaption() {
+    var box = document.getElementById("rungCaption");
+    if (!box) return;
+    if (!state.rung) {
+      box.className = "wheel-caption is-empty";
+      box.innerHTML = '<span class="cap-t">Nothing selected yet. Pick a rung of the ladder.</span>';
+      return;
+    }
+    var r = byId(state.rung);
+    box.className = "wheel-caption";
+    box.innerHTML = '<span class="cap-sw" style="background:' + esc(r.color) + '"></span>' +
+      '<span><span class="cap-s">Rung ' + r.n + ' &middot; ' + esc(D.BANDS[r.band].label) + '</span>' +
+      '<span class="cap-t">' + esc(r.name) + '</span></span>';
+  }
+
   function buildLadder() {
     var box = document.getElementById("ladder");
     if (!box) return;
@@ -67,6 +82,7 @@ window.FLadder = (function () {
     document.querySelectorAll("#ladder .rung").forEach(function (b) {
       b.setAttribute("aria-pressed", String(b.getAttribute("data-rung") === id));
     });
+    setCaption();
     renderPanel(r);
     if (!opts.silent) history.replaceState(null, "", "#" + id);
   }
@@ -99,6 +115,7 @@ window.FLadder = (function () {
     if (dir === "clear") {
       state.rung = null;
       document.querySelectorAll("#ladder .rung").forEach(function (b) { b.setAttribute("aria-pressed", "false"); });
+      setCaption();
       renderEmpty();
       history.replaceState(null, "", location.pathname);
       return;
@@ -130,6 +147,7 @@ window.FLadder = (function () {
   function init() {
     if (!D || !D.rungs) return;
     buildLadder();
+    setCaption();
     if (!fromHash()) renderEmpty();
     window.addEventListener("hashchange", fromHash);
   }

--- a/js/whocounts-data.js
+++ b/js/whocounts-data.js
@@ -12,6 +12,12 @@
 window.WHOCOUNTS = (function () {
   "use strict";
 
+  var ABOUT = {
+    identity:  { label: "Who you are",   note: "Attributes a person carries." },
+    condition: { label: "How you live",  note: "Circumstances that change." },
+    outcome:   { label: "What happens",  note: "Results the state records." }
+  };
+
   var KINDS = {
     never:   { label: "Never asked",     note: "No national instrument collects it at all." },
     under:   { label: "Counted, badly",  note: "An official figure exists and is far below what independent estimates find." },
@@ -20,7 +26,7 @@ window.WHOCOUNTS = (function () {
 
   var gaps = [
     {
-      id: "orientation", name: "Sexual orientation", kind: "never", color: "#7c3aed",
+      id: "orientation", name: "Sexual orientation", kind: "never", about: "identity", color: "#7c3aed",
       missing: "No national survey asks who anyone is attracted to, or whether they are in a same-sex relationship.",
       evidence: [
         { stat: "Zero", detail: "The Census, NFHS and PLFS carry no question on sexual orientation. The absence is complete rather than partial.", source: "Review of Census, NFHS-5 and PLFS instruments", year: "2026" },
@@ -30,7 +36,7 @@ window.WHOCOUNTS = (function () {
       proxy: "None at national scale. Community-led surveys exist and are neither representative nor comparable across states."
     },
     {
-      id: "caste", name: "Caste beyond SC and ST", kind: "frozen", color: "#b45309",
+      id: "caste", name: "Caste beyond SC and ST", kind: "frozen", about: "identity", color: "#b45309",
       missing: "The Census enumerates Scheduled Castes and Scheduled Tribes. It has not enumerated other castes since 1931.",
       evidence: [
         { stat: "1931", detail: "the last Census to count caste in full. Every OBC entitlement since has been argued from estimates, commission findings and sample surveys rather than an enumeration.", source: "Census of India", year: "1931" },
@@ -41,7 +47,7 @@ window.WHOCOUNTS = (function () {
       proxy: "NSS and NFHS record a self-reported caste category, which gives shares but not the jati-level detail policy questions turn on."
     },
     {
-      id: "disability", name: "Disability", kind: "under", color: "#0369a1",
+      id: "disability", name: "Disability", kind: "under", about: "identity", color: "#0369a1",
       missing: "India records disability at a fraction of the rate found everywhere else, and most people it does record hold no certificate.",
       evidence: [
         { stat: "2.2%", detail: "of the population, in both the Census and the NSS 76th Round, measured independently and agreeing with each other.", source: "Census of India; NSS 76th Round", year: "2011, 2018" },
@@ -52,7 +58,7 @@ window.WHOCOUNTS = (function () {
       proxy: "NFHS-5 added disability questions, which is why prevalence estimates from it run higher than the Census. The instrument, not the population, is what changed."
     },
     {
-      id: "unpaid", name: "Unpaid care and domestic work", kind: "frozen", color: "#be185d",
+      id: "unpaid", name: "Unpaid care and domestic work", kind: "frozen", about: "condition", color: "#be185d",
       missing: "India measured how its households spend time once, in 2019, and does not carry the result into any national account.",
       evidence: [
         { stat: "299 vs 97", detail: "minutes a day of unpaid domestic work by women and by men, from the only full Time Use Survey India has run.", source: "Time Use Survey, NSO", year: "2019" },
@@ -62,7 +68,7 @@ window.WHOCOUNTS = (function () {
       proxy: "The 2019 survey remains usable and is now several years old. A second round would make it a series rather than a snapshot."
     },
     {
-      id: "death", name: "What Indians die of", kind: "under", color: "#7f1d1d",
+      id: "death", name: "What Indians die of", kind: "under", about: "outcome", color: "#7f1d1d",
       missing: "Deaths are registered. The cause is medically certified for a small minority of them.",
       evidence: [
         { stat: "22.3%", detail: "of registered deaths carried a medically certified cause. For roughly four in five deaths, the cause is not recorded in the system health policy is argued from.", source: "Medical Certification of Cause of Death, ORGI", year: "2022" },
@@ -72,7 +78,7 @@ window.WHOCOUNTS = (function () {
       proxy: "The Million Death Study used verbal autopsy on a large sample and remains the main evidence for cause of death outside the certified minority."
     },
     {
-      id: "migration", name: "Where people moved", kind: "frozen", color: "#4d7c0f",
+      id: "migration", name: "Where people moved", kind: "frozen", about: "condition", color: "#4d7c0f",
       missing: "The only full picture of internal migration is from a Census taken in 2011.",
       evidence: [
         { stat: "45.6 crore", detail: "internal migrants counted, about 37% of the population, in the last Census India completed.", source: "Census of India", year: "2011" },
@@ -82,7 +88,7 @@ window.WHOCOUNTS = (function () {
       proxy: "PLFS added a migration module in 2020-21, and e-Shram has registered over 30 crore unorganised workers. Neither reproduces the Census's district-to-district detail."
     },
     {
-      id: "poverty", name: "How many are poor", kind: "frozen", color: "#166534",
+      id: "poverty", name: "How many are poor", kind: "frozen", about: "condition", color: "#166534",
       missing: "India has published no official poverty line, and no official poverty count, for more than a decade.",
       evidence: [
         { stat: "2011-12", detail: "the last consumption survey used for an official poverty estimate. The 2017-18 round was not released.", source: "NSSO; Ministry of Statistics", year: "2011-12, 2019" },
@@ -92,7 +98,7 @@ window.WHOCOUNTS = (function () {
       proxy: "The NITI Aayog National MPI counts deprivation across twelve indicators rather than income, which answers a different question and is not a substitute."
     },
     {
-      id: "appearance", name: "Skin tone and appearance", kind: "never", color: "#9d174d",
+      id: "appearance", name: "Skin tone and appearance", kind: "never", about: "identity", color: "#9d174d",
       missing: "No Indian official survey records skin tone, body size, or discrimination based on either.",
       evidence: [
         { stat: "Zero", detail: "national instruments collect it. Evidence on colourism in hiring or marriage comes from audit studies and market data rather than from statistics.", source: "Review of NSO and Census instruments", year: "2026" },
@@ -103,5 +109,5 @@ window.WHOCOUNTS = (function () {
     }
   ];
 
-  return { gaps: gaps, KINDS: KINDS };
+  return { gaps: gaps, KINDS: KINDS, ABOUT: ABOUT };
 })();

--- a/js/whocounts.js
+++ b/js/whocounts.js
@@ -35,6 +35,59 @@ window.FWhoCounts = (function () {
 
   function byId(id) { return D.gaps.filter(function (g) { return g.id === id; })[0]; }
 
+  /* ---------------------------------------------------------------- diagram */
+  /* A 3x3 matrix: what is being measured against how the measurement fails.
+     The empty cells carry the argument - identity gaps cluster under "never
+     asked", and every "how you live" gap is frozen rather than missing. */
+  function drawMatrix() {
+    var box = document.getElementById("matrix");
+    if (!box) return;
+    var rows = ["identity", "condition", "outcome"];
+    var cols = ["never", "under", "frozen"];
+    var h = ['<div class="mx" role="table" aria-label="Gaps in Indian official data, by what is measured and how the measurement fails">'];
+    h.push('<div class="mx-row mx-head" role="row"><div class="mx-corner" role="columnheader"><span>what</span><span>how it fails</span></div>');
+    cols.forEach(function (c) {
+      h.push('<div class="mx-ch" role="columnheader"><b>' + esc(D.KINDS[c].label) + '</b><span>' + esc(D.KINDS[c].note) + '</span></div>');
+    });
+    h.push('</div>');
+    rows.forEach(function (r) {
+      h.push('<div class="mx-row" role="row"><div class="mx-rh" role="rowheader"><b>' + esc(D.ABOUT[r].label) + '</b><span>' + esc(D.ABOUT[r].note) + '</span></div>');
+      cols.forEach(function (c) {
+        var here = D.gaps.filter(function (g) { return g.about === r && g.kind === c; });
+        h.push('<div class="mx-cell' + (here.length ? '' : ' is-empty') + '" role="cell">');
+        if (!here.length) h.push('<span class="mx-none" aria-label="no gap of this kind">&mdash;</span>');
+        here.forEach(function (g) {
+          h.push('<button type="button" class="mx-tile" data-gap="' + esc(g.id) + '" aria-pressed="false" style="--gc:' + esc(g.color) + ';--gi:' + ink(g.color) + '">' + esc(g.name) + '</button>');
+        });
+        h.push('</div>');
+      });
+      h.push('</div>');
+    });
+    h.push('</div>');
+    box.innerHTML = h.join("");
+    box.querySelectorAll("[data-gap]").forEach(function (b) {
+      b.addEventListener("click", function () { select(b.getAttribute("data-gap")); });
+    });
+  }
+
+  function paint() {
+    document.querySelectorAll("#matrix .mx-tile, #gaps .gap").forEach(function (b) {
+      b.setAttribute("aria-pressed", String(b.getAttribute("data-gap") === state.gap));
+    });
+    var box = document.getElementById("gapCaption");
+    if (!box) return;
+    if (!state.gap) {
+      box.className = "wheel-caption is-empty";
+      box.innerHTML = '<span class="cap-t">Nothing selected yet. Pick a tile in the matrix, or a gap from the list below.</span>';
+      return;
+    }
+    var g = byId(state.gap);
+    box.className = "wheel-caption";
+    box.innerHTML = '<span class="cap-sw" style="background:' + esc(g.color) + '"></span>' +
+      '<span><span class="cap-s">' + esc(D.ABOUT[g.about].label) + ' &middot; ' + esc(D.KINDS[g.kind].label) + '</span>' +
+      '<span class="cap-t">' + esc(g.name) + '</span></span>';
+  }
+
   function build() {
     var box = document.getElementById("gaps");
     if (!box) return;
@@ -54,9 +107,7 @@ window.FWhoCounts = (function () {
     var g = byId(id);
     if (!g) return;
     state.gap = id;
-    document.querySelectorAll("#gaps .gap").forEach(function (b) {
-      b.setAttribute("aria-pressed", String(b.getAttribute("data-gap") === id));
-    });
+    paint();
     var h = [];
     h.push('<div class="panel-axis"><span class="swatch" style="background:' + esc(g.color) + '"></span>' + esc(D.KINDS[g.kind].label) + '</div>');
     h.push('<h3>' + esc(g.name) + '</h3>');
@@ -82,7 +133,7 @@ window.FWhoCounts = (function () {
   function nav(dir) {
     if (dir === "clear") {
       state.gap = null;
-      document.querySelectorAll("#gaps .gap").forEach(function (b) { b.setAttribute("aria-pressed", "false"); });
+      paint();
       renderEmpty();
       history.replaceState(null, "", location.pathname);
       return;
@@ -109,7 +160,7 @@ window.FWhoCounts = (function () {
 
   function init() {
     if (!D || !D.gaps) return;
-    build();
+    drawMatrix(); build(); paint();
     if (!fromHash()) renderEmpty();
     window.addEventListener("hashchange", fromHash);
   }


### PR DESCRIPTION
Owner asked whether the ladder has a ladder, the cube a cube, and Who Counts a matrix. Honest answer was **no** — only the wheel had a diagram. The ladder had a rail with cards beside it; the cube and Who Counts were styled buttons.

Every page now carries the same four parts:

1. **one clickable labelled diagram**
2. **a live caption** under it, naming the current selection at real text size
3. **a list or chip fallback** for narrow screens and keyboard users
4. **the evidence panel** beside it

| Page | Before | After |
|---|---|---|
| Wheel | SVG wheel ✅ | unchanged |
| Ladder | one rail, cards floating beside it | **two side rails with rungs spanning between them**, connector stubs into each rail |
| Power Cube | three rows of buttons | **an actual isometric cube** — three faces, nine clickable slices |
| Who Counts | a list of cards | **a 3×3 matrix** |

### The cube

Three visible faces, each sliced into the three values of one dimension. Labels sit **outside the solid on leader lines**, so no text lies on a slanted face — which also keeps them horizontal and legible. The solid's own edges are drawn over the slices so it reads as one object rather than nine polygons.

### The matrix earns its place

It makes an argument the list could not. Adding a second axis — **what is being measured** (who you are / how you live / what happens) against **how the measurement fails** (never asked / counted badly / frozen) — produces this:

| | Never asked | Counted, badly | Frozen |
|---|---|---|---|
| **Who you are** | sexual orientation, skin tone | disability | caste |
| **How you live** | — | — | unpaid work, migration, poverty |
| **What happens** | — | cause of death | — |

Every "how you live" gap is **frozen** rather than missing, and four cells are empty. The empty cells are the finding, so they are drawn rather than omitted.

The second axis is real data, not decoration: an `about` field was added to each gap and **the cross-tab was checked before drawing anything**.

## Type of change

- [x] New feature or tool
- [x] Accessibility improvement

## Checklist

- [x] Tested on desktop browser &mdash; 1440px; 9 cube slices, 8 matrix tiles in 9 cells, 8 rungs
- [x] Tested on mobile browser &mdash; 390px with touch; matrix collapses to one column, empty cells hidden, no overflow
- [x] No console errors
- [x] Links are working &mdash; internal-link guard **PASS across 846 pages**

### Also verified

- axe &rarr; **0 violations at every impact level** on all five pages at 390px and 1440px, **with a selection active**
- pa11y &rarr; passes all three interactive pages
- `check-counts.py` &rarr; PASS · `check-mojibake.py` &rarr; PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01199dCmAgzMN1Z1d8qj2UfN

---
_Generated by [Claude Code](https://claude.ai/code/session_01199dCmAgzMN1Z1d8qj2UfN)_