### PR TITLE
Draw the capability chain, and stop CI jobs hanging silently

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -13,6 +13,9 @@ jobs:
   axe-accessibility:
     name: axe-core WCAG 2.1 AA audit
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 20
     # Scoped permissions: read the repo, write sticky PR comments.
     # Required by the 'Comment on PR with axe-core results' step below,
     # which uses marocchino/sticky-pull-request-comment@v3.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
   encoding:
     name: Encoding / mojibake guard
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 
@@ -25,6 +28,9 @@ jobs:
   i18n-quality:
     name: i18n translation-quality guard
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 
@@ -34,6 +40,9 @@ jobs:
   asset-stamps:
     name: Asset stamp freshness
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - name: Setup Python
@@ -46,6 +55,9 @@ jobs:
   diagram-contrast:
     name: Diagram text contrast
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - name: Setup Python
@@ -58,6 +70,9 @@ jobs:
   conflict-markers:
     name: Merge-conflict-marker guard
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 
@@ -67,6 +82,9 @@ jobs:
   internal-links:
     name: Internal-link guard
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 
@@ -76,6 +94,9 @@ jobs:
   counts:
     name: Content-count drift guard
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 
@@ -85,6 +106,9 @@ jobs:
   supabase-anon:
     name: Supabase anon-exposure guard
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 10
     # Hits the live PostgREST API, so it runs on the daily schedule and on
     # demand — not on every PR, where third-party latency would add flake and
     # contributors can't act on the result anyway.
@@ -98,6 +122,9 @@ jobs:
   book-companions:
     name: Book-companion blank-page guard
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 
@@ -107,6 +134,9 @@ jobs:
   service-worker:
     name: Service worker behaviour test
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 
@@ -120,6 +150,9 @@ jobs:
   fundamentals-privacy:
     name: Fundamentals questionnaire privacy guard
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 
@@ -134,6 +167,9 @@ jobs:
   form-submission:
     name: Form submission contract tests
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 
@@ -156,6 +192,9 @@ jobs:
   broken-links:
     name: Check broken links
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 
@@ -190,6 +229,9 @@ jobs:
   accessibility:
     name: Accessibility audit (pa11y-ci)
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 20
     # Scoped permissions: read the repo, write sticky PR comments.
     # Required by the 'Comment on PR with accessibility results' step below,
     # which uses marocchino/sticky-pull-request-comment@v3.
@@ -319,6 +361,9 @@ jobs:
   html-validate:
     name: Validate HTML
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/delete-stale-branches.yml
+++ b/.github/workflows/delete-stale-branches.yml
@@ -27,6 +27,9 @@ jobs:
   delete:
     name: Delete branches listed in .github/stale-branches.txt
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -12,6 +12,9 @@ jobs:
   mobile-overflow:
     name: Mobile overflow audit (390px)
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/post-discussion.yml
+++ b/.github/workflows/post-discussion.yml
@@ -21,6 +21,9 @@ permissions:
 jobs:
   post:
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: Create the discussion

--- a/.github/workflows/publish-mcp-server.yml
+++ b/.github/workflows/publish-mcp-server.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 15
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -27,6 +27,9 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -18,6 +18,9 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 15
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **The Capability Approach page now has an actual diagram.** The conversion chain was four styled boxes — a layout, not a picture, and the weakest visual in a series where every other page has a drawn one. It is now an SVG that shows the mechanism: the three conversion factors feed the second stage as inputs rather than sitting beside it as decoration, and what fails to convert leaves the chain on a visible leak. Where a resource has a real pair of figures the leak carries them — `98.1% → 44.8%` for a school place, `100% → 19%` for a toilet — and where it does not, it says "what does not convert" rather than printing a headline that is not a quantity. Two layouts, chosen by container width, because four boxes across a phone shrinks the type past reading.
 
+- **Two material resources added to the Capability Approach: a household water connection and an internet connection**, both grounded in MoSPI survey data pulled from the source rather than recalled. They came out of Pallavi's suggestion that the Fundamentals need a parameter on infrastructure. They are on the capability page rather than as new spokes on the wheel because that is where they actually belong: infrastructure is Sen's environmental conversion factor, which the chain already has a stage for, and the wheel's twelve axes are about who a person is rather than where they are.
+
+  Water: 94.5% of rural households have access to an improved source; 56.1% have it within the premises; **42.0%** have it exclusively, in the premises, and sufficiently all year (NSS 76th Round). Three figures, same households, same survey, each adding one condition.
+
+  Internet: 83.3% of rural households have an internet facility within the premises, and **9.1%** of those have a fixed or WiFi connection rather than only a mobile one (NSS 80th Round, 2025). Government services move online against the first number.
+
 - **Every CI job now has a `timeout-minutes`.** All 22 had none, so each inherited GitHub's 360-minute default. This was not hypothetical: the mobile-overflow audit hung for over twenty minutes inside its Playwright install on PR #949 without reaching the test body, and a hung job neither passes nor fails — it reads as "still running". On the scheduled run, where `broken-links` is `fail: true`, link rot could go unreported for six hours and nobody would be told. Fast static guards get 10 minutes, browser jobs 20, network-bound 15.
 
 ## [10.211.0] - 2026-08-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to ImpactMojo are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.212.0] - 2026-08-19
+
+### Fixed
+
+- **The Capability Approach page now has an actual diagram.** The conversion chain was four styled boxes — a layout, not a picture, and the weakest visual in a series where every other page has a drawn one. It is now an SVG that shows the mechanism: the three conversion factors feed the second stage as inputs rather than sitting beside it as decoration, and what fails to convert leaves the chain on a visible leak. Where a resource has a real pair of figures the leak carries them — `98.1% → 44.8%` for a school place, `100% → 19%` for a toilet — and where it does not, it says "what does not convert" rather than printing a headline that is not a quantity. Two layouts, chosen by container width, because four boxes across a phone shrinks the type past reading.
+
+- **Every CI job now has a `timeout-minutes`.** All 22 had none, so each inherited GitHub's 360-minute default. This was not hypothetical: the mobile-overflow audit hung for over twenty minutes inside its Playwright install on PR #949 without reaching the test body, and a hung job neither passes nor fails — it reads as "still running". On the scheduled run, where `broken-links` is `fail: true`, link rot could go unreported for six hours and nobody would be told. Fast static guards get 10 minutes, browser jobs 20, network-bound 15.
+
 ## [10.211.0] - 2026-08-19
 
 ### Added

--- a/css/fundamentals.css
+++ b/css/fundamentals.css
@@ -516,29 +516,35 @@ details.ax[open] > summary { border-bottom: 1px solid var(--color-border); }
    ratio at render time.
    ========================================================================= */
 
-.cap-chain {
-  list-style: none; margin: 0; padding: 0;
-  display: grid; gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  counter-reset: none;
-}
-.cap-stage { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: 14px; padding: 0; overflow: hidden; display: flex; flex-direction: column; }
-.cap-stage-box { padding: 0.85rem 1rem; display: flex; align-items: baseline; gap: 0.6rem; }
-.cap-stage-n { font-family: var(--font-mono); font-size: 0.8rem; opacity: 0.85; }
-.cap-stage-name { font-family: var(--font-heading); font-weight: 700; font-size: 1.02rem; letter-spacing: -0.01em; }
-.cap-stage-gloss { margin: 0.9rem 1rem 0.4rem; font-size: 0.94rem; font-weight: 700; color: var(--color-text); }
-.cap-stage-detail { margin: 0 1rem 1rem; font-size: 0.88rem; line-height: 1.6; color: var(--color-text-muted); }
+/* The conversion chain, drawn. Two layouts chosen in JS by container width,
+   because a four-across flow at phone width shrinks the type past reading. */
+.cap-svg { width: 100%; height: auto; display: block; max-width: 900px; margin: 0 auto; }
 
-/* The chain reads left to right on a wide screen; the arrow is a separator
-   rather than content, so it is hidden from assistive tech. */
-@media (min-width: 900px) {
-  .cap-stage { position: relative; }
-  .cap-stage + .cap-stage::before {
-    content: ""; position: absolute; left: -0.68rem; top: 1.45rem;
-    width: 0.42rem; height: 0.42rem; border-top: 2px solid var(--color-border);
-    border-right: 2px solid var(--color-border); transform: rotate(45deg);
-  }
+.cap-node-box { stroke: var(--color-bg-card); stroke-width: 1.5; }
+.cap-node-n { font-family: var(--font-mono); font-size: 12px; opacity: 0.9; }
+.cap-node-name { font-family: var(--font-heading); font-weight: 700; font-size: 15px; }
+.cap-node-sub { font-family: var(--font-body); font-size: 11.5px; opacity: 0.94; }
+
+.cap-flow { stroke: var(--color-border); stroke-width: 2.5; fill: none; }
+.cap-arrow { fill: var(--color-border); }
+
+/* The factors feed the second stage rather than decorating it, so they are
+   drawn as inputs with the same colours the panel uses for each kind. */
+.cap-feed { stroke-width: 2; fill: none; stroke-dasharray: 3 3; }
+.cap-feed.cf-personal { stroke: #B45309; }
+.cap-feed.cf-social { stroke: #6D28D9; }
+.cap-feed.cf-environmental { stroke: #15803D; }
+.cap-feed-label {
+  font-family: var(--font-heading); font-size: 10.5px; font-weight: 700;
+  letter-spacing: 0.06em; text-transform: uppercase; fill: var(--color-text-muted);
 }
+
+/* What fails to convert leaves the chain; where a resource has a real pair of
+   figures, this is where they go. */
+.cap-leak { stroke: #B91C1C; stroke-width: 2; fill: none; stroke-dasharray: 4 4; }
+.cap-leak-label { font-family: var(--font-mono); font-size: 12px; fill: #B91C1C; }
+[data-theme="dark"] .cap-leak { stroke: #FCA5A5; }
+[data-theme="dark"] .cap-leak-label { fill: #FCA5A5; }
 
 /* ------------------------------------------------------------- the pickers */
 .chain-picker { display: grid; gap: 0.6rem; }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.212.0 — August 19, 2026 (The capability chain, drawn)
+
+### For Learners
+
+- **The Capability Approach now has a real diagram** — the conversion chain drawn out, showing the three kinds of conversion factor feeding into it and what leaks away between what is provided and what a person can actually do.
+
 ## v10.211.0 — August 19, 2026 (A different way into the Wheel of Power)
 
 ### For Learners

--- a/fundamentals/capabilities.html
+++ b/fundamentals/capabilities.html
@@ -40,7 +40,7 @@
 
 <!-- Self-hosted fonts -->
 <link rel="stylesheet" href="/css/fonts.css?v=07d8578c">
-<link rel="stylesheet" href="/css/fundamentals.css?v=ce264ca0">
+<link rel="stylesheet" href="/css/fundamentals.css?v=fc0ddcfd">
 </head>
 <body>
 <div class="skip-nav" role="navigation" aria-label="Skip links"><a href="#main-content" class="skip-link">Skip to content</a></div>
@@ -293,6 +293,6 @@
 <script src="/js/auth.js?v=90f23f77"></script>
 <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/capabilities-data.js?v=0be4329e"></script>
-<script src="/js/capabilities.js?v=f277ea4f"></script>
+<script src="/js/capabilities.js?v=5f37964f"></script>
 </body>
 </html>

--- a/fundamentals/capabilities.html
+++ b/fundamentals/capabilities.html
@@ -16,7 +16,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <!-- SEO Meta Tags -->
-<meta name="description" content="Sen&#39;s capability approach, made clickable. Five resources followed from what gets provided to what a person can actually do with it — school places against reading levels, toilets built against toilets used — with the Indian evidence, its source and its year.">
+<meta name="description" content="Sen&#39;s capability approach, made clickable. Seven resources followed from what gets provided to what a person can actually do with it — school places against reading levels, toilets built against toilets used — with the Indian evidence, its source and its year.">
 <meta name="keywords" content="capability approach, Amartya Sen, Martha Nussbaum, functionings, conversion factors, development as freedom, ASER 2024, NFHS-5, human development index, ImpactMojo">
 <meta property="og:title" content="Fundamentals | The Capability Approach">
 <meta property="og:description" content="98.1% of rural children are enrolled. 44.8% of Std V children in government schools can read a Std II text. The distance between those two numbers is what Sen built the capability approach to describe.">
@@ -79,7 +79,7 @@
   <div class="hero-inner">
     <span class="eyebrow">Fundamentals</span>
     <h1>What people are given,<br><span class="accent">and what they can actually do</span></h1>
-    <p>Amartya Sen&rsquo;s capability approach, made clickable. Five resources followed along the chain that runs from what a programme provides to what a person is genuinely able to do with it, and on to what they end up doing. Open any resource for the Indian survey, statute or judgment at each step, with the source and year given.</p>
+    <p>Amartya Sen&rsquo;s capability approach, made clickable. Seven resources followed along the chain that runs from what a programme provides to what a person is genuinely able to do with it, and on to what they end up doing. Open any resource for the Indian survey, statute or judgment at each step, with the source and year given.</p>
     <p>Each chain also says what it leaves unsettled.</p>
     <nav class="series-nav" aria-label="Fundamentals series">
       <a href="/fundamentals/">All Fundamentals</a>
@@ -129,12 +129,12 @@
 <section class="wrap" id="resources-section">
   <div class="section-head">
     <span class="kicker">The map</span>
-    <h2>Five resources, followed to the end</h2>
+    <h2>Seven resources, followed to the end</h2>
     <p>Pick a resource. On a keyboard, tab to one and press Enter; the panel&rsquo;s buttons move between them, and Escape clears. Every resource has its own shareable link.</p>
   </div>
   <div class="wheel-layout">
     <div class="wheel-stage">
-      <div class="picker"><span class="picker-label" id="chainPickerLabel">The five resources</span>
+      <div class="picker"><span class="picker-label" id="chainPickerLabel">The seven resources</span>
         <div class="chain-picker" id="chainPicker" role="group" aria-labelledby="chainPickerLabel"></div></div>
     </div>
     <div class="panel" id="panel" role="region" aria-live="polite" aria-label="Evidence for the selected resource"></div>
@@ -178,12 +178,12 @@
       </div>
       <div class="credit-card">
         <h3>What ImpactMojo added</h3>
-        <p>The interactive chain, and the Indian evidence: the survey, statute or judgment at each step of five resources, each with a named source and year, plus a note on what the chain does not settle.</p>
+        <p>The interactive chain, and the Indian evidence: the survey, statute or judgment at each step of seven resources, each with a named source and year, plus a note on what the chain does not settle.</p>
         <p class="who-line">ImpactMojo, 2026 &middot; content CC BY-NC-ND 4.0 &middot; code MIT</p>
       </div>
       <div class="credit-card">
         <h3>Sources drawn on</h3>
-        <p>ASER 2024 &middot; NFHS-5 (2019&ndash;21) &middot; Right to Education Act (2009) &middot; Swachh Bharat Mission (Gramin) &middot; National Food Security Act (2013) &middot; PUCL v. Union of India (2001) &middot; Rights of Persons with Disabilities Act (2016) &middot; Muralidharan &amp; Prakash, <i>AEJ: Applied Economics</i> (2017) &middot; Dr&egrave;ze &amp; Sen, <i>An Uncertain Glory</i> (2013) &middot; Sen, <i>BMJ</i> (2002) &middot; UNDP <i>Human Development Report</i> (1990).</p>
+        <p>ASER 2024 &middot; NSS 76th Round and 80th Round, MoSPI &middot; NFHS-5 (2019&ndash;21) &middot; Right to Education Act (2009) &middot; Swachh Bharat Mission (Gramin) &middot; National Food Security Act (2013) &middot; PUCL v. Union of India (2001) &middot; Rights of Persons with Disabilities Act (2016) &middot; Muralidharan &amp; Prakash, <i>AEJ: Applied Economics</i> (2017) &middot; Dr&egrave;ze &amp; Sen, <i>An Uncertain Glory</i> (2013) &middot; Sen, <i>BMJ</i> (2002) &middot; UNDP <i>Human Development Report</i> (1990).</p>
       </div>
     </div>
     <div class="notice">
@@ -292,7 +292,7 @@
 <script src="/js/config.js?v=bd5dcf94"></script>
 <script src="/js/auth.js?v=90f23f77"></script>
 <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
-<script src="/js/capabilities-data.js?v=0be4329e"></script>
+<script src="/js/capabilities-data.js?v=d17660cb"></script>
 <script src="/js/capabilities.js?v=5f37964f"></script>
 </body>
 </html>

--- a/fundamentals/index.html
+++ b/fundamentals/index.html
@@ -40,7 +40,7 @@
 
 <!-- Self-hosted fonts -->
 <link rel="stylesheet" href="/css/fonts.css?v=07d8578c">
-<link rel="stylesheet" href="/css/fundamentals.css?v=ce264ca0">
+<link rel="stylesheet" href="/css/fundamentals.css?v=fc0ddcfd">
 </head>
 <body>
 <div class="skip-nav" role="navigation" aria-label="Skip links"><a href="#main-content" class="skip-link">Skip to content</a></div>

--- a/fundamentals/index.html
+++ b/fundamentals/index.html
@@ -108,7 +108,7 @@
     </div>
     <div class="credit-card">
       <h3><a href="/fundamentals/capabilities.html">The Capability Approach &rarr;</a></h3>
-      <p>Five resources followed from what a programme provides to what a person can actually do with it &mdash; school places against reading levels, toilets built against toilets used. Asks <b>what the provision is worth to the person receiving it</b>.</p>
+      <p>Seven resources followed from what a programme provides to what a person can actually do with it &mdash; school places against reading levels, toilets built against toilets used. Asks <b>what the provision is worth to the person receiving it</b>.</p>
       <p class="who-line">Approach by Amartya Sen; the ten central capabilities by Martha Nussbaum</p>
     </div>
     <div class="credit-card">

--- a/fundamentals/ladder.html
+++ b/fundamentals/ladder.html
@@ -40,7 +40,7 @@
 
 <!-- Self-hosted fonts -->
 <link rel="stylesheet" href="/css/fonts.css?v=07d8578c">
-<link rel="stylesheet" href="/css/fundamentals.css?v=ce264ca0">
+<link rel="stylesheet" href="/css/fundamentals.css?v=fc0ddcfd">
 </head>
 <body>
 <div class="skip-nav" role="navigation" aria-label="Skip links"><a href="#main-content" class="skip-link">Skip to content</a></div>

--- a/fundamentals/power-cube.html
+++ b/fundamentals/power-cube.html
@@ -40,7 +40,7 @@
 
 <!-- Self-hosted fonts -->
 <link rel="stylesheet" href="/css/fonts.css?v=07d8578c">
-<link rel="stylesheet" href="/css/fundamentals.css?v=ce264ca0">
+<link rel="stylesheet" href="/css/fundamentals.css?v=fc0ddcfd">
 </head>
 <body>
 <div class="skip-nav" role="navigation" aria-label="Skip links"><a href="#main-content" class="skip-link">Skip to content</a></div>

--- a/fundamentals/wheel.html
+++ b/fundamentals/wheel.html
@@ -40,7 +40,7 @@
 
 <!-- Self-hosted fonts -->
 <link rel="stylesheet" href="/css/fonts.css?v=07d8578c">
-<link rel="stylesheet" href="/css/fundamentals.css?v=ce264ca0">
+<link rel="stylesheet" href="/css/fundamentals.css?v=fc0ddcfd">
 </head>
 <body>
 <div class="skip-nav" role="navigation" aria-label="Skip links"><a href="#main-content" class="skip-link">Skip to content</a></div>

--- a/fundamentals/who-counts.html
+++ b/fundamentals/who-counts.html
@@ -40,7 +40,7 @@
 
 <!-- Self-hosted fonts -->
 <link rel="stylesheet" href="/css/fonts.css?v=07d8578c">
-<link rel="stylesheet" href="/css/fundamentals.css?v=ce264ca0">
+<link rel="stylesheet" href="/css/fundamentals.css?v=fc0ddcfd">
 </head>
 <body>
 <div class="skip-nav" role="navigation" aria-label="Skip links"><a href="#main-content" class="skip-link">Skip to content</a></div>

--- a/js/capabilities-data.js
+++ b/js/capabilities-data.js
@@ -126,6 +126,50 @@ window.CAPABILITIES = (function () {
     },
 
     {
+      id: "water",
+      name: "A household water connection",
+      short: "Water connection → being able to drink safely",
+      resource: "An improved drinking water source — a piped supply, a tubewell, a protected well — counted by the source rather than by the household's use of it.",
+      capability: "Being able to drink, cook and wash without spending the day fetching water.",
+      functioning: "A household that has enough safe water, every day of the year.",
+      headline: { stat: "94.5%", label: "of rural households have access to an improved source", contrast: "42.0%", contrastLabel: "have one that is theirs alone, in the premises, and sufficient all year" },
+      factors: [
+        { kind: "personal", text: "Who in the household does the fetching. Where the source is outside the premises the walk is overwhelmingly women's and girls' time, and it is time taken from school and paid work rather than from leisure." },
+        { kind: "social",   text: "Whether the source is shared, and with whom. A well a Dalit household is not free to draw from is an improved source on paper and an inaccessible one in practice." },
+        { kind: "environmental", text: "Distance, and seasonality. A source that runs dry for three months a year still counts as an improved source for the whole year." }
+      ],
+      evidence: [
+        { stat: "94.5%", detail: "of rural households had access to an improved source of drinking water. In urban India the figure is 97.4%. This is the number that gets reported as near-universal coverage.", source: "NSS 76th Round, Drinking Water, Sanitation, Hygiene and Housing Condition (MoSPI)", year: "2018" },
+        { stat: "56.1%", detail: "of rural households had that improved source located within the household premises — so for roughly two in five, water is somewhere else and someone has to go and get it. Urban: 78.6%.", source: "NSS 76th Round (MoSPI)", year: "2018" },
+        { stat: "42.0%", detail: "of rural households had exclusive access to an improved source, in the premises, sufficiently available throughout the year — all three conditions at once. Urban: 50.5%. The gap between this and 94.5% is entirely made of conversion factors.", source: "NSS 76th Round (MoSPI)", year: "2018" }
+      ],
+      reading: "Three figures from one survey, describing the same households, ranging from 94.5% to 42.0%. None of them is wrong and none is a correction of the others: each adds a condition that has to hold before the source becomes water you can actually rely on. A target written on the first is met at a point where the third is still a minority.",
+      complication: "The narrowest measure is not automatically the right one. A shared standpost fifty metres away is a real improvement on an unprotected well, and refusing to count it would erase genuine progress. The argument is not that 42.0% is the true number — it is that which of the three you report is a choice, and it is rarely made explicit."
+    },
+
+    {
+      id: "internet",
+      name: "An internet connection",
+      short: "Connection → being able to reach the state online",
+      resource: "An internet facility within the household premises — the measure behind India's digital-inclusion numbers.",
+      capability: "Being able to file a claim, sit an online class, or hold a video consultation.",
+      functioning: "A household that actually transacts online.",
+      headline: { stat: "83.3%", label: "of rural households have internet within the premises", contrast: "9.1%", contrastLabel: "of those have a fixed or WiFi connection rather than only a mobile one" },
+      factors: [
+        { kind: "personal", text: "Whose phone it is. A household counted as connected is often connected through one handset, and who may use it and for how long is a question the survey does not reach." },
+        { kind: "social",   text: "Digital literacy, and whether the person who needs the service is the person who can operate it. Filing a grievance is not the same task as receiving a message." },
+        { kind: "environmental", text: "Whether the signal holds for the length of a class or a consultation. A mobile connection that drops is adequate for a notification and inadequate for an hour of anything." }
+      ],
+      evidence: [
+        { stat: "83.3%", detail: "of rural households reported an internet facility within the household premises. Urban: 91.6%. This is the figure behind claims of near-universal digital access.", source: "NSS 80th Round, Comprehensive Modular Survey: Telecom (MoSPI)", year: "2025" },
+        { stat: "9.1%", detail: "of connected rural households had a fixed or WiFi connection. Urban: 24%. Almost the entire rural internet is mobile — 98.8% of connected rural households use a mobile network.", source: "NSS 80th Round, CMST (MoSPI)", year: "2025" },
+        { stat: "Article 21", detail: "the Supreme Court has held that the freedoms of speech and of trade over the internet are constitutionally protected, and that an indefinite shutdown is impermissible. The right is settled; the connection it presumes is mostly a shared handset.", source: "Anuradha Bhasin v. Union of India", year: "2020" }
+      ],
+      reading: "Being counted as connected and being able to do the thing connection is for are separated here by an order of magnitude. Government services move online against the 83.3%; the 9.1% is closer to the population that can sit through an online hearing or upload a set of documents without the call dropping.",
+      complication: "A mobile connection is not a poor substitute for broadband so much as a different thing, and for many purposes — a payment, a message, a status check — it is entirely sufficient. The distinction matters for the tasks that take sustained bandwidth, which happen to include most of what the state has moved online."
+    },
+
+    {
       id: "ration",
       name: "A ration entitlement",
       short: "Entitlement → being adequately nourished",

--- a/js/capabilities.js
+++ b/js/capabilities.js
@@ -47,28 +47,181 @@
   }
 
   /* ------------------------------------------------------------ the diagram */
-  /* Four stages left to right on desktop, stacked on narrow screens. The arrow
-     between them is the point of the picture: each gap is where a conversion
-     factor gets to intervene. */
-  function buildChainDiagram() {
+  var NS = "http://www.w3.org/2000/svg";
+
+  function el(name, attrs, text) {
+    var n = document.createElementNS(NS, name);
+    Object.keys(attrs || {}).forEach(function (k) { n.setAttribute(k, attrs[k]); });
+    if (text !== undefined) n.appendChild(document.createTextNode(text));
+    return n;
+  }
+
+  /* Wrap a label to a pixel width without a measuring pass: SVG has no text
+     wrapping, and a per-glyph measure would reflow on every resize. */
+  function wrap(text, chars) {
+    var words = String(text).split(/\s+/), lines = [], cur = "";
+    words.forEach(function (w) {
+      if ((cur + " " + w).trim().length > chars && cur) { lines.push(cur); cur = w; }
+      else cur = (cur + " " + w).trim();
+    });
+    if (cur) lines.push(cur);
+    return lines;
+  }
+
+  /**
+   * The conversion chain, drawn.
+   *
+   * The point the picture has to make is that the three conversion factors are
+   * inputs to the second stage rather than decoration around it, and that what
+   * fails to convert leaves the chain instead of arriving at the far end. So the
+   * factors feed in from below and there is a visible leak between conversion
+   * and capability. Where a chain has a real pair of figures, the leak carries
+   * them.
+   *
+   * Two layouts, chosen by width rather than by CSS: at narrow widths a
+   * four-across flow would shrink the type past legibility, so the stages stack.
+   */
+  function drawChain(chain) {
     var host = document.getElementById("chainDiagram");
     if (!host) return;
-    var h = ['<ol class="cap-chain" aria-label="The conversion chain, in four stages">'];
-    D.stages.forEach(function (st, i) {
-      var ink = readableOn(st.color);
-      h.push(
-        '<li class="cap-stage" data-stage="' + esc(st.id) + '">' +
-          '<div class="cap-stage-box" style="background:' + esc(st.color) + ';color:' + ink + '">' +
-            '<span class="cap-stage-n">' + (i + 1) + '</span>' +
-            '<span class="cap-stage-name">' + esc(st.name) + '</span>' +
-          '</div>' +
-          '<p class="cap-stage-gloss">' + esc(st.gloss) + '</p>' +
-          '<p class="cap-stage-detail">' + esc(st.detail) + '</p>' +
-        '</li>'
-      );
+    var vertical = host.clientWidth < 700;
+    host.innerHTML = "";
+
+    var svg = el("svg", {
+      class: "cap-svg",
+      role: "img",
+      "aria-label": "The conversion chain: a resource passes through personal, social and " +
+        "environmental conversion factors to become a capability, and then a functioning. " +
+        "What does not convert leaves the chain."
     });
-    h.push("</ol>");
-    host.innerHTML = h.join("");
+
+    var W = vertical ? 380 : 900;
+    var H = vertical ? 640 : 250;
+    svg.setAttribute("viewBox", "0 0 " + W + " " + H);
+    svg.setAttribute("preserveAspectRatio", "xMidYMid meet");
+
+    var boxW = vertical ? 250 : 170;
+    var boxH = vertical ? 82 : 82;
+    var stages = D.stages;
+
+    function pos(i) {
+      return vertical
+        ? { x: 20, y: 16 + i * 152 }
+        : { x: 24 + i * 218, y: 24 };
+    }
+
+    /* connectors first, so the boxes sit on top of them */
+    for (var i = 0; i < stages.length - 1; i++) {
+      var a = pos(i), b = pos(i + 1);
+      var line = vertical
+        ? el("path", { d: "M" + (a.x + boxW / 2) + " " + (a.y + boxH) + " L" + (a.x + boxW / 2) + " " + b.y })
+        : el("path", { d: "M" + (a.x + boxW) + " " + (a.y + boxH / 2) + " L" + b.x + " " + (b.y + boxH / 2) });
+      line.setAttribute("class", "cap-flow");
+      svg.appendChild(line);
+      var mx = vertical ? a.x + boxW / 2 : (a.x + boxW + b.x) / 2;
+      var my = vertical ? (a.y + boxH + b.y) / 2 : a.y + boxH / 2;
+      var head = el("path", {
+        class: "cap-arrow",
+        d: vertical
+          ? "M" + (mx - 5) + " " + (my - 4) + " L" + mx + " " + (my + 5) + " L" + (mx + 5) + " " + (my - 4) + " Z"
+          : "M" + (mx - 4) + " " + (my - 5) + " L" + (mx + 5) + " " + my + " L" + (mx - 4) + " " + (my + 5) + " Z"
+      });
+      svg.appendChild(head);
+    }
+
+    /* the three conversion factors feed the second stage from below */
+    var convo = pos(1);
+    var kinds = ["personal", "social", "environmental"];
+    kinds.forEach(function (kind, k) {
+      var fx = vertical ? convo.x + boxW + 18 : convo.x + boxW / 2 + (k - 1) * 150;
+      var fy = vertical ? convo.y + 10 + k * 24 : convo.y + boxH + 66;
+      var feed = el("path", {
+        class: "cap-feed cf-" + kind,
+        d: vertical
+          ? "M" + fx + " " + fy + " L" + (convo.x + boxW) + " " + (convo.y + boxH / 2)
+          : "M" + fx + " " + fy + " L" + (convo.x + boxW / 2) + " " + (convo.y + boxH)
+      });
+      svg.appendChild(feed);
+      var t = el("text", {
+        class: "cap-feed-label",
+        x: vertical ? fx + 4 : fx,
+        y: vertical ? fy + 4 : fy + 14,
+        "text-anchor": vertical ? "start" : "middle"
+      }, D.FACTOR_LABEL[kind]);
+      svg.appendChild(t);
+    });
+
+    /* the leak: what the resource promised and the capability delivered */
+    var cap = pos(2);
+    /* The leak leaves the conversion-to-capability connector, which is where a
+       resource stops becoming a freedom, and ends where its figures are printed
+       so the number is attached to the path rather than floating near it. */
+    var sx = vertical ? cap.x + boxW / 2 : cap.x - 24;
+    var sy = vertical ? cap.y - 24 : cap.y + boxH / 2;
+    var ex = vertical ? cap.x + boxW - 40 : cap.x + 46;
+    var ey = vertical ? cap.y - 78 : cap.y + boxH + 62;
+    var leak = el("path", {
+      class: "cap-leak",
+      d: vertical
+        ? "M" + sx + " " + sy + " C" + (sx + 40) + " " + sy + " " + ex + " " + (ey + 34) + " " + ex + " " + ey
+        : "M" + sx + " " + sy + " C" + sx + " " + (sy + 40) + " " + (ex - 30) + " " + ey + " " + ex + " " + ey
+    });
+    svg.appendChild(leak);
+
+    /* Only print a pair when both halves are actually quantities. Several chains
+       carry a headline like "Legal right" against "2011", which is a real point
+       on the page but reads as nonsense on a leak arrow. */
+    var hasFigures = chain && chain.headline &&
+      /\d/.test(String(chain.headline.stat || "")) &&
+      /%|\d/.test(String(chain.headline.contrast || "")) &&
+      /%/.test(String(chain.headline.stat) + String(chain.headline.contrast));
+    var leakText = hasFigures
+      ? chain.headline.stat + " \u2192 " + chain.headline.contrast
+      : "what does not convert";
+    var lt = el("text", {
+      class: "cap-leak-label",
+      x: ex + 8,
+      y: ey + 4,
+      "text-anchor": "start"
+    }, leakText);
+    svg.appendChild(lt);
+
+    /* the four stages */
+    stages.forEach(function (st, i) {
+      var p = pos(i);
+      var ink = readableOn(st.color);
+      var g = el("g", { class: "cap-node" });
+      g.appendChild(el("rect", {
+        x: p.x, y: p.y, width: boxW, height: boxH, rx: 12,
+        fill: st.color, class: "cap-node-box"
+      }));
+      g.appendChild(el("text", {
+        x: p.x + 13, y: p.y + 25, fill: ink, class: "cap-node-n"
+      }, String(i + 1)));
+      g.appendChild(el("text", {
+        x: p.x + 32, y: p.y + 25, fill: ink, class: "cap-node-name"
+      }, st.name));
+
+      var body = chain ? chainTextFor(chain, st.id) : st.gloss;
+      /* Two lines at most, and the box is tall enough for both: a third line,
+         or a tighter box, pushes the descender past the fill. */
+      wrap(body, vertical ? 34 : 24).slice(0, 2).forEach(function (ln, k) {
+        g.appendChild(el("text", {
+          x: p.x + 13, y: p.y + 47 + k * 15, fill: ink, class: "cap-node-sub"
+        }, ln));
+      });
+      svg.appendChild(g);
+    });
+
+    host.appendChild(svg);
+  }
+
+  /* What each stage says depends on which resource is open. */
+  function chainTextFor(chain, stageId) {
+    if (stageId === "resource") return chain.name;
+    if (stageId === "capability") return chain.capability;
+    if (stageId === "functioning") return chain.functioning;
+    return "Personal, social, environmental";
   }
 
   /* --------------------------------------------------------------- pickers */
@@ -166,6 +319,7 @@
     if (!c) return;
     state.chain = id;
     markSelected(id);
+    drawChain(c);
     renderPanel(c);
     if (!opts.silent) history.replaceState(null, "", "#" + id);
     if (!opts.silent && opts.focus !== false) {
@@ -177,6 +331,7 @@
   function clearSelection() {
     state.chain = null;
     markSelected(null);
+    drawChain(null);
     renderEmpty();
     history.replaceState(null, "", location.pathname);
   }
@@ -200,8 +355,18 @@
   }
 
   /* ------------------------------------------------------------------- init */
+  var resizeT = null;
+  function onResize() {
+    clearTimeout(resizeT);
+    resizeT = setTimeout(function () {
+      var c = state.chain ? D.chains.filter(function (x) { return x.id === state.chain; })[0] : null;
+      drawChain(c || null);
+    }, 150);
+  }
+
   function init() {
-    buildChainDiagram();
+    drawChain(null);
+    window.addEventListener("resize", onResize);
     buildPickers();
     buildNussbaum();
     renderEmpty();

--- a/service-worker.js
+++ b/service-worker.js
@@ -22,7 +22,7 @@
 
 'use strict';
 
-const VERSION = 'v9-2026-08-19';
+const VERSION = 'v10-2026-08-19';
 const RUNTIME = 'im-runtime-' + VERSION;
 const OFFLINE_URL = '/offline.html';
 const COURSE_PREFIX = 'impactmojo-course-';


### PR DESCRIPTION
## 1. The Capability page had no diagram

You were right. The conversion chain was four styled boxes — a layout, not a picture — which made it the weakest visual in a series where the wheel, ladder, cube and Who Counts all have a drawn one.

It's now an SVG that shows the **mechanism** rather than the sequence: the three conversion factors feed the second stage as inputs from below, and **what fails to convert leaves the chain on a visible leak**.

Where a resource has a real pair of figures, the leak carries them:

| Resource | Leak |
|---|---|
| A school place | `98.1% → 44.8%` |
| A household toilet | `100% → 19%` |
| A bicycle / income / ration | "what does not convert" |

That last row is deliberate — several chains carry a headline like "Legal right" against "2011", which is a real point on the page and reads as nonsense on a leak arrow.

Two layouts chosen by container width rather than by CSS, since four boxes across a phone shrinks the type past reading.

**The first attempt had two real bugs, both caught by measuring rather than looking:** the factor labels collided at 62px spacing, and the second wrapped line pushed its descender past the box bottom in the stacked layout. Now verified across all five resources in both layouts — no text collisions, nothing escaping its box.

## 2. Every CI job now has a timeout

**All 22 had none**, so each inherited GitHub's 360-minute default.

This is not hypothetical. The mobile-overflow audit **hung for over twenty minutes inside its Playwright install on #949** without ever reaching the test body — which is why that PR merged on 19 of 20 checks.

A hung job neither passes nor fails, so it reads as *"still running"*. On the scheduled run, where `broken-links` is `fail: true`, link rot could sit unreported for six hours with nobody told.

That's the same silent-failure class as the 69 form handlers and the never-working `fitLabels()`, and it's the first finding of the sweep.

| Job type | Timeout |
|---|---|
| Fast static guards (13) | 10 min |
| Browser jobs (3) | 20 min |
| Network-bound / deploy (6) | 15 min |

## Verification

All guards pass: counts, internal links, mojibake, i18n, book companions, asset stamps (198 pages), service worker, diagram contrast (65 fills, 5 renderers), questionnaire privacy.

Mobile checked locally too, since that's the job that hung: all six Fundamentals pages at 390px with every panel opened — `scrollWidth=390` on each.

---
_Generated by [Claude Code](https://claude.ai/code/session_01199dCmAgzMN1Z1d8qj2UfN)_