### PR TITLE
A seventh Fundamental: the Sustainable Livelihoods Framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to ImpactMojo are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.216.0] - 2026-08-19
+
+### Added
+
+- **Fundamentals: The Sustainable Livelihoods Framework** (`/fundamentals/livelihoods.html`) — the seventh framework. DFID's *Sustainable Livelihoods Guidance Sheets* (1999), formalising Chambers and Conway's argument (IDS Discussion Paper 296, 1992) and given its analytical shape by Scoones (IDS Working Paper 72, 1998). All three are credited.
+
+  **Its own diagram form: the asset pentagon, drawn eight times.** The framework's claim is that the shape matters more than the total, so the page leads with small multiples — all eight livelihoods to the same scale, side by side — and shows the selected one at size beside its detail. A single chart would have hidden the argument. Each case carries a vulnerability context split into shocks, trends and seasonality, and a note on the structures and processes that decide what its assets are worth.
+
+  The eight: a marginal farmer, a landless labourer, a large landholder (as the contrast case), a forest-dwelling household, a pastoralist, a small-scale marine fisher, a seasonal migrant worker and a home-based worker.
+
+  **20 sourced evidence entries**, most of them new to the site, from the NSS 77th Round:
+
+  - An average agricultural household earns **₹4,063 a month from wages against ₹3,058 from crop production** — total ₹8,337, of which farming is under half. The households agriculture defines earn more from selling labour than from farming.
+  - **70.4%** of agricultural households possess one hectare or less; **0.37%** possess more than ten.
+  - For households under 0.01 ha, **50.3%** of outstanding credit is owed to professional moneylenders and 13.5% to commercial banks. For households over 10 ha those figures are 5.2% and **55.8%**. Land is what buys access to the banking system, which is the sharpest statement of the framework's central claim available in Indian data.
+  - Wage income falls as landholding rises — ₹5,400 a month for ST households with almost no land, ₹2,081 for those with over ten hectares.
+
+  Plus the Forest Rights Act 2006 (ss. 3(1)(c), 3(1)(d) and 3(1)(e), the last recognising transhumant grazing and nomadic communities specifically), *Orissa Mining Corporation v MoEF* (2013), MGNREGA, the Inter-State Migrant Workmen Act 1979, ONORC, and the state Marine Fishing Regulation Acts.
+
+  The page states where the framework is contested: that five neutral-sounding capitals can be drawn for a landlord and for the labourer on that land without showing that one is the reason for the other; that treating credit as an asset is a category error at distress rates, which this page's own evidence demonstrates; and that a pentagon is a stock rather than a direction, so an accumulating and a liquidating household look identical.
+
+### Changed — guards
+
+- `scripts/check-diagram-contrast.py` gains the new renderer and an `AXIS_LABELS` section. The pentagon names each axis beside the chart, on the page ground rather than on any fill — **all five capital colours fail AA on the dark ground**, the same trap the gender-needs quadrant labels fell into a version earlier. They take theme-aware inks, checked against both grounds.
+
+### Fixed
+
+- Two label-clipping bugs in the pentagon, caught by measuring rather than by looking: `FINANCIAL` and `SOCIAL` sit at the widest points of a pentagon and are the two longest words, so a square viewBox clipped both. The labelled chart is now wider than it is tall.
+
 ## [10.215.0] - 2026-08-19
 
 ### Added

--- a/css/fundamentals.css
+++ b/css/fundamentals.css
@@ -784,3 +784,92 @@ details.ax[open] > summary { border-bottom: 1px solid var(--color-border); }
 [data-theme="dark"] .qn-strategic { fill: #C4B5FD; }
 [data-theme="dark"] .qn-both      { fill: #6EE7B7; }
 [data-theme="dark"] .qn-neither   { fill: #FCD34D; }
+
+/* ===========================================================================
+   The Sustainable Livelihoods Framework — the asset pentagon
+   ---------------------------------------------------------------------------
+   Eight small pentagons and one large one. The small multiples exist because
+   the framework's claim is that the shape matters more than the total, and a
+   single chart cannot make that claim visible.
+   =========================================================================== */
+
+.lv-layout { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr); gap: 2rem; align-items: start; }
+#assetPentagon { display: flex; justify-content: center; }
+.lv-pent { display: block; width: 100%; height: auto; max-width: 400px; font-family: var(--font-body); }
+.lv-grid { fill: none; stroke: var(--color-border); stroke-width: 1; }
+.lv-spoke { stroke: var(--color-border); stroke-width: 1; }
+.lv-shape { fill: var(--color-link); fill-opacity: 0.16; stroke: var(--color-link); stroke-width: 2; }
+.lv-node { stroke: var(--color-bg-card); stroke-width: 1.5; }
+.lv-axis { font-family: var(--font-mono); font-size: 11px; letter-spacing: 1px; text-transform: uppercase; font-weight: 700; }
+.lv-val { font-family: var(--font-mono); font-size: 13px; font-weight: 700; }
+
+/* The axis labels print on the page ground, not on the capital's own fill, so
+   they need their own ink per theme. Every one of the five failed AA on the
+   dark ground when it inherited the capital colour — the same trap the
+   gender-needs quadrant labels fell into. Checked by
+   scripts/check-diagram-contrast.py. */
+.lv-ax-human     { fill: #B45309; }
+.lv-ax-social    { fill: #6D28D9; }
+.lv-ax-natural   { fill: #15803D; }
+.lv-ax-physical  { fill: #0369A1; }
+.lv-ax-financial { fill: #BE185D; }
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .lv-ax-human     { fill: #FCD34D; }
+  :root:not([data-theme="light"]) .lv-ax-social    { fill: #C4B5FD; }
+  :root:not([data-theme="light"]) .lv-ax-natural   { fill: #6EE7B7; }
+  :root:not([data-theme="light"]) .lv-ax-physical  { fill: #7DD3FC; }
+  :root:not([data-theme="light"]) .lv-ax-financial { fill: #F9A8D4; }
+}
+[data-theme="dark"] .lv-ax-human     { fill: #FCD34D; }
+[data-theme="dark"] .lv-ax-social    { fill: #C4B5FD; }
+[data-theme="dark"] .lv-ax-natural   { fill: #6EE7B7; }
+[data-theme="dark"] .lv-ax-physical  { fill: #7DD3FC; }
+[data-theme="dark"] .lv-ax-financial { fill: #F9A8D4; }
+
+/* small multiples */
+#assetGrid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 0.9rem; }
+.lv-thumb {
+  display: flex; flex-direction: column; align-items: center; gap: 0.4rem;
+  cursor: pointer; background: var(--color-bg-card); color: var(--color-text);
+  border: 1px solid var(--color-border); border-radius: 14px;
+  padding: 0.7rem 0.6rem 0.8rem; font-family: var(--font-body);
+  transition: border-color 0.15s, background 0.15s;
+}
+.lv-thumb:hover { border-color: var(--color-link); }
+.lv-thumb.is-on { border-color: var(--color-link); background: var(--color-bg-sunk); }
+.lv-thumb .lv-pent { max-width: 120px; }
+.lv-thumb b { display: block; font-family: var(--font-heading); font-size: 0.9rem; text-align: center; line-height: 1.3; }
+.lv-thumb span span { display: block; font-size: 0.78rem; color: var(--color-text-muted); text-align: center; line-height: 1.4; margin-top: 0.15rem; }
+
+/* the capital key */
+#capitalKey { display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: 1rem; margin-top: 1.4rem; }
+.lv-key { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: 14px; padding: 0.9rem 1rem; }
+.lv-key b { font-family: var(--font-heading); margin-left: 0.45rem; }
+.lv-key-sw {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 24px; height: 24px; border-radius: 7px; vertical-align: middle;
+  font-family: var(--font-mono); font-size: 0.8rem; font-weight: 700;
+}
+.lv-key p { margin: 0.5rem 0 0; font-size: 0.9rem; line-height: 1.5; }
+.lv-key-d { color: var(--color-text-muted); font-size: 0.86rem !important; }
+
+/* the panel */
+.lv-head h3 { font-family: var(--font-heading); font-size: 1.35rem; margin: 0 0 0.2rem; }
+.lv-head p { margin: 0; color: var(--color-text-muted); font-family: var(--font-mono); font-size: 0.82rem; }
+#livePanel h4 {
+  font-family: var(--font-mono); font-size: 0.74rem; letter-spacing: 1.6px;
+  text-transform: uppercase; color: var(--color-text-muted); margin: 1.2rem 0 0.4rem;
+}
+.lv-ctx { margin: 0; font-size: 0.92rem; }
+.lv-ctx dt { font-family: var(--font-mono); font-size: 0.74rem; letter-spacing: 1.2px; text-transform: uppercase; color: var(--color-text-muted); margin-top: 0.6rem; }
+.lv-ctx dd { margin: 0.15rem 0 0; line-height: 1.55; }
+.lv-comp { color: var(--color-text-muted); }
+.lv-ev { list-style: none; padding: 0; margin: 0; }
+.lv-ev li { border-top: 1px solid var(--color-border); padding: 0.7rem 0; font-size: 0.92rem; line-height: 1.55; }
+.lv-ev li:first-child { border-top: none; }
+.lv-src { display: block; font-family: var(--font-mono); font-size: 0.76rem; color: var(--color-text-muted); margin-top: 0.3rem; }
+
+@media (max-width: 860px) {
+  .lv-layout { grid-template-columns: 1fr; }
+}

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -18,6 +18,28 @@
     ]
   },
   {
+    "id": "FUND002",
+    "title": "The Sustainable Livelihoods Framework",
+    "description": "DFID's Sustainable Livelihoods Framework, made clickable. Eight Indian livelihoods drawn as asset pentagons across human, social, natural, physical and financial capital — a marginal farmer, a landless labourer, a large landholder, a forest-dwelling household, a pastoralist, a marine fisher, a seasonal migrant and a home-based worker — shown together so the shapes can be compared, each with its vulnerability context and the survey or statute behind every corner.",
+    "type": "fundamental",
+    "category": "Frameworks",
+    "url": "/fundamentals/livelihoods.html",
+    "tags": [
+      "sustainable livelihoods",
+      "DFID",
+      "Robert Chambers",
+      "Ian Scoones",
+      "asset pentagon",
+      "five capitals",
+      "vulnerability context",
+      "India",
+      "NSS 77th Round",
+      "landless labour",
+      "Forest Rights Act",
+      "pastoralists"
+    ]
+  },
+  {
     "id": "FUND001",
     "title": "Practical and Strategic Gender Needs",
     "description": "Caroline Moser's distinction between practical gender needs and strategic gender interests, made clickable. Twelve Indian interventions plotted by how much material burden each lifts off a woman's day and how far it moves the division of labour, assets or authority — from Ujjwala and Jal Jeevan to the 73rd Amendment and the Hindu Succession (Amendment) Act — each with the survey, statute or judgment behind its position.",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,14 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.216.0 — August 19, 2026 (A seventh Fundamentals map: sustainable livelihoods)
+
+### For Learners
+
+- **The Sustainable Livelihoods Framework** — the seventh framework in the series. Eight Indian livelihoods drawn as asset pentagons across the five capitals, and shown together so the shapes can be compared: a landless labourer's collapses on the natural axis, a large landholder's is nearly full, a home-based worker's is the smallest on the page. Open any one for the shocks and trends it sits inside, the structures that decide what its assets are actually worth, and the evidence for every corner.
+
+  The finding the page is built around: an average Indian agricultural household earns **₹4,063 a month from wages and ₹3,058 from crop production**. The households that farming defines earn more from selling their labour than from farming.
+
 ## v10.215.0 — August 19, 2026 (A sixth Fundamentals map: gender needs)
 
 ### For Learners

--- a/fundamentals/capabilities.html
+++ b/fundamentals/capabilities.html
@@ -40,7 +40,7 @@
 
 <!-- Self-hosted fonts -->
 <link rel="stylesheet" href="/css/fonts.css?v=07d8578c">
-<link rel="stylesheet" href="/css/fundamentals.css?v=0caf8e2f">
+<link rel="stylesheet" href="/css/fundamentals.css?v=25686f23">
 </head>
 <body>
 <div class="skip-nav" role="navigation" aria-label="Skip links"><a href="#main-content" class="skip-link">Skip to content</a></div>
@@ -88,6 +88,7 @@
       <a href="/fundamentals/power-cube.html">The Power Cube</a>
       <a href="/fundamentals/capabilities.html" aria-current="page">The Capability Approach</a>
       <a href="/fundamentals/gender-needs.html">Gender Needs</a>
+      <a href="/fundamentals/livelihoods.html">Sustainable Livelihoods</a>
       <a href="/fundamentals/who-counts.html">Who Counts</a>
     </nav>
     <p class="hero-credit">The approach belongs to <b>Amartya Sen</b>, developed across &ldquo;Equality of What?&rdquo; (1979), <i>Commodities and Capabilities</i> (1985) and <i>Development as Freedom</i> (1999). The list of ten central capabilities is <b>Martha Nussbaum&rsquo;s</b>. ImpactMojo added the Indian evidence. <a href="#credits">Full credits &darr;</a></p>

--- a/fundamentals/gender-needs.html
+++ b/fundamentals/gender-needs.html
@@ -40,7 +40,7 @@
 
 <!-- Self-hosted fonts -->
 <link rel="stylesheet" href="/css/fonts.css?v=07d8578c">
-<link rel="stylesheet" href="/css/fundamentals.css?v=0caf8e2f">
+<link rel="stylesheet" href="/css/fundamentals.css?v=25686f23">
 </head>
 <body>
 <div class="skip-nav" role="navigation" aria-label="Skip links"><a href="#main-content" class="skip-link">Skip to content</a></div>
@@ -88,6 +88,7 @@
       <a href="/fundamentals/power-cube.html">The Power Cube</a>
       <a href="/fundamentals/capabilities.html">The Capability Approach</a>
       <a href="/fundamentals/gender-needs.html" aria-current="page">Gender Needs</a>
+      <a href="/fundamentals/livelihoods.html">Sustainable Livelihoods</a>
       <a href="/fundamentals/who-counts.html">Who Counts</a>
     </nav>
     <p class="hero-credit">The distinction belongs to <b>Caroline Moser</b>, from &ldquo;Gender Planning in the Third World&rdquo; (1989) and <i>Gender Planning and Development</i> (1993), built on <b>Maxine Molyneux&rsquo;s</b> separation of practical and strategic interests (1985). ImpactMojo added the Indian evidence and the plot. <a href="#credits">Full credits &darr;</a></p>

--- a/fundamentals/index.html
+++ b/fundamentals/index.html
@@ -16,7 +16,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <!-- SEO Meta Tags -->
-<meta name="description" content="Fundamentals — the frameworks development work runs on, made interactive and backed by Indian evidence. The Wheel of Power &amp; Powerlessness, Arnstein's Ladder of Citizen Participation, Gaventa's Power Cube, the Capability Approach, Moser's practical and strategic gender needs, and Who Counts, each with the survey, statute or judgment behind every position, and an honest account of what the evidence leaves unsettled.">
+<meta name="description" content="Fundamentals — the frameworks development work runs on, made interactive and backed by Indian evidence. The Wheel of Power &amp; Powerlessness, Arnstein's Ladder of Citizen Participation, Gaventa's Power Cube, the Capability Approach, Moser's practical and strategic gender needs, the Sustainable Livelihoods Framework, and Who Counts, each with the survey, statute or judgment behind every position, and an honest account of what the evidence leaves unsettled.">
 <meta name="keywords" content="wheel of power and privilege, Indian wheel of power and powerlessness, intersectionality India, caste gender disability data, positionality, NFHS-5, PLFS, Census 2011, The Listeners Collective, ImpactMojo">
 <meta property="og:title" content="Fundamentals | ImpactMojo">
 <meta property="og:description" content="The frameworks development work runs on, made interactive and backed by Indian evidence.">
@@ -40,7 +40,7 @@
 
 <!-- Self-hosted fonts -->
 <link rel="stylesheet" href="/css/fonts.css?v=07d8578c">
-<link rel="stylesheet" href="/css/fundamentals.css?v=0caf8e2f">
+<link rel="stylesheet" href="/css/fundamentals.css?v=25686f23">
 </head>
 <body>
 <div class="skip-nav" role="navigation" aria-label="Skip links"><a href="#main-content" class="skip-link">Skip to content</a></div>
@@ -86,7 +86,7 @@
 <section class="wrap">
   <div class="section-head">
     <span class="kicker">In the series</span>
-    <h2>Six so far</h2>
+    <h2>Seven so far</h2>
     <p>Each framework belongs to someone else and is credited in full on its own page. ImpactMojo supplies the evidence layer underneath.</p>
   </div>
 
@@ -115,6 +115,11 @@
       <h3><a href="/fundamentals/gender-needs.html">Practical &amp; Strategic Gender Needs &rarr;</a></h3>
       <p>Twelve Indian interventions plotted on two axes &mdash; how much each one lifts off a woman&rsquo;s day, and how far it moves the division of labour, assets or authority. Asks <b>whether a programme lightens the load or changes who carries it</b>.</p>
       <p class="who-line">Distinction by Caroline Moser, 1989 &middot; building on Maxine Molyneux, 1985</p>
+    </div>
+    <div class="credit-card">
+      <h3><a href="/fundamentals/livelihoods.html">The Sustainable Livelihoods Framework &rarr;</a></h3>
+      <p>Eight Indian livelihoods drawn as asset pentagons across five capitals, shown together so the shapes can be compared &mdash; a landless labourer&rsquo;s beside a large landholder&rsquo;s. Asks <b>not what a household earns but what it holds</b>.</p>
+      <p class="who-line">Framework by DFID, 1999 &middot; after Chambers &amp; Conway, 1992, and Scoones, 1998</p>
     </div>
     <div class="credit-card">
       <h3><a href="/fundamentals/who-counts.html">Who Counts &rarr;</a></h3>

--- a/fundamentals/ladder.html
+++ b/fundamentals/ladder.html
@@ -40,7 +40,7 @@
 
 <!-- Self-hosted fonts -->
 <link rel="stylesheet" href="/css/fonts.css?v=07d8578c">
-<link rel="stylesheet" href="/css/fundamentals.css?v=0caf8e2f">
+<link rel="stylesheet" href="/css/fundamentals.css?v=25686f23">
 </head>
 <body>
 <div class="skip-nav" role="navigation" aria-label="Skip links"><a href="#main-content" class="skip-link">Skip to content</a></div>
@@ -88,6 +88,7 @@
       <a href="/fundamentals/power-cube.html">The Power Cube</a>
       <a href="/fundamentals/capabilities.html">The Capability Approach</a>
       <a href="/fundamentals/gender-needs.html">Gender Needs</a>
+      <a href="/fundamentals/livelihoods.html">Sustainable Livelihoods</a>
       <a href="/fundamentals/who-counts.html">Who Counts</a>
     </nav>
     <p class="hero-credit">The ladder belongs to <b>Sherry R. Arnstein</b>, from &ldquo;A Ladder of Citizen Participation&rdquo;, <i>Journal of the American Institute of Planners</i> 35(4), July 1969. ImpactMojo added the Indian evidence. <a href="#credits">Full credits &darr;</a></p>

--- a/fundamentals/livelihoods.html
+++ b/fundamentals/livelihoods.html
@@ -16,20 +16,20 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <!-- SEO Meta Tags -->
-<meta name="description" content="John Gaventa&#39;s power cube, made clickable: spaces, levels and forms of power, with the Indian evidence for each of the nine categories and eight documented Indian cases plotted on all three dimensions.">
-<meta name="keywords" content="wheel of power and privilege, Indian wheel of power and powerlessness, intersectionality India, caste gender disability data, positionality, NFHS-5, PLFS, Census 2011, The Listeners Collective, ImpactMojo">
-<meta property="og:title" content="Fundamentals | The Power Cube">
-<meta property="og:description" content="Spaces, levels and forms of power, with the Indian evidence for each and eight cases plotted across all three.">
+<meta name="description" content="The Sustainable Livelihoods Framework, made clickable. Eight Indian livelihoods drawn as asset pentagons — human, social, natural, physical and financial capital — so the shapes can be compared, each with the survey, statute or judgment behind its position.">
+<meta name="keywords" content="sustainable livelihoods framework, DFID 1999, Chambers and Conway, Ian Scoones, asset pentagon, five capitals, vulnerability context, NSS 77th Round, agricultural households India, landless labour, Forest Rights Act, ImpactMojo">
+<meta property="og:title" content="Fundamentals | The Sustainable Livelihoods Framework">
+<meta property="og:description" content="An average Indian agricultural household earns &#8377;4,063 a month from wages and &#8377;3,058 from crop production. The households farming defines earn more from selling labour than from farming.">
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://www.impactmojo.in/fundamentals/power-cube.html">
+<meta property="og:url" content="https://www.impactmojo.in/fundamentals/livelihoods.html">
 <meta property="og:image" content="https://www.impactmojo.in/assets/images/og-card.png">
 <meta property="og:site_name" content="ImpactMojo">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Fundamentals | The Power Cube">
-<meta name="twitter:description" content="Spaces, levels and forms of power, with the Indian evidence for each and eight cases plotted across all three.">
+<meta name="twitter:title" content="Fundamentals | The Sustainable Livelihoods Framework">
+<meta name="twitter:description" content="An average Indian agricultural household earns &#8377;4,063 a month from wages and &#8377;3,058 from crop production. The households farming defines earn more from selling labour than from farming.">
 <meta name="twitter:image" content="https://www.impactmojo.in/assets/images/og-card.png">
 
-<title>Fundamentals | The Power Cube, with Indian evidence</title>
+<title>Fundamentals | The Sustainable Livelihoods Framework</title>
 
 <!-- Favicons -->
 <link href="/assets/images/favicon.png" rel="icon" type="image/png">
@@ -77,20 +77,20 @@
 <section class="hero">
   <div class="hero-inner">
     <span class="eyebrow">Fundamentals</span>
-    <h1>A seat at the table<br><span class="accent">is not the same as power</span></h1>
-    <p>John Gaventa&rsquo;s power cube, made clickable. Three dimensions, nine categories: where a decision gets made, at which level, and whether the power involved is visible at all. Open any category for the Indian evidence, with the source and year given.</p>
-    <p>Eight documented Indian cases are plotted on all three dimensions at once, further down.</p>
+    <h1>Not what a household earns,<br><span class="accent">but what it holds</span></h1>
+    <p>The Sustainable Livelihoods Framework, made clickable. Eight Indian livelihoods drawn as asset pentagons across five capitals &mdash; human, social, natural, physical and financial &mdash; shown together so the shapes can be compared, because the shape is the argument.</p>
+    <p>Open any one for its vulnerability context, the structures that decide what its assets are actually worth, and the evidence behind each corner.</p>
     <nav class="series-nav" aria-label="Fundamentals series">
       <a href="/fundamentals/">All Fundamentals</a>
       <a href="/fundamentals/wheel.html">The Wheel of Power</a>
       <a href="/fundamentals/ladder.html">The Ladder of Participation</a>
-      <a href="/fundamentals/power-cube.html" aria-current="page">The Power Cube</a>
+      <a href="/fundamentals/power-cube.html">The Power Cube</a>
       <a href="/fundamentals/capabilities.html">The Capability Approach</a>
       <a href="/fundamentals/gender-needs.html">Gender Needs</a>
-      <a href="/fundamentals/livelihoods.html">Sustainable Livelihoods</a>
+      <a href="/fundamentals/livelihoods.html" aria-current="page">Sustainable Livelihoods</a>
       <a href="/fundamentals/who-counts.html">Who Counts</a>
     </nav>
-    <p class="hero-credit">The cube belongs to <b>John Gaventa</b>, from &ldquo;Finding the Spaces for Change: A Power Analysis&rdquo;, <i>IDS Bulletin</i> 37(6), 2006, building on Steven Lukes. ImpactMojo added the Indian evidence. <a href="#credits">Full credits &darr;</a></p>
+    <p class="hero-credit">The framework is <b>DFID&rsquo;s</b>, from the Sustainable Livelihoods Guidance Sheets (1999), formalising an argument by <b>Robert Chambers</b> and <b>Gordon Conway</b> (IDS, 1992) and given its analytical shape by <b>Ian Scoones</b> (IDS, 1998). ImpactMojo added the Indian evidence. <a href="#credits">Full credits &darr;</a></p>
   </div>
 </section>
 
@@ -98,48 +98,37 @@
   <div class="wrap">
     <div class="section-head">
       <span class="kicker">How to read it</span>
-      <h2>Three questions, asked together</h2>
-      <p>Gaventa&rsquo;s argument is that the three dimensions only work read as a set. A seat in an invited local space counts for little when the decision was taken at another level, in a form nobody can see. Answering one question and stopping is how power analysis goes wrong.</p>
+      <h2>The average Indian agricultural household earns &#8377;4,063 a month from wages and &#8377;3,058 from crop production.</h2>
+      <p>Both figures are from the same survey. The households that agriculture defines earn more from selling their labour than from farming their land &mdash; which is invisible if you look at income alone, and obvious the moment you look at what they hold.</p>
     </div>
-    <div class="ring-key">
-      <div class="rk rk-power"><b><span class="dot"></span>Spaces</b><span>Closed, invited, or claimed. Who set the table, and on whose terms.</span></div>
-      <div class="rk rk-middle"><b><span class="dot"></span>Levels</b><span>Local, national, global. Where the binding decision actually sits.</span></div>
-      <div class="rk rk-margin"><b><span class="dot"></span>Forms</b><span>Visible, hidden, invisible. Whether you can observe the power at work.</span></div>
-    </div>
+    <div id="capitalKey"></div>
     <div class="notice">
-      <h3>What the cube cannot do</h3>
-      <p>The bottom face is the hardest to evidence. Invisible power is a claim about what people have internalised, and the figures on this page are consistent with that reading without proving it. A norm someone accepts and a constraint they cannot escape look identical in survey data.</p>
-      <p>Hidden power has the same problem in a milder form. The disciplined version names a specific issue kept off the table and who gains from its absence. The undisciplined version explains everything and predicts nothing.</p>
-      <p>The cube also says nothing about who you are. It maps how power operates, not who it operates on. <a href="/fundamentals/wheel.html">The Wheel</a> covers that, and <a href="/fundamentals/ladder.html">the Ladder</a> covers how much of it moved.</p>
+      <h3>Where the framework is contested</h3>
+      <p>The most serious objection is that it flattens power. Five neutral-sounding capitals can be drawn for a landlord and for the labourer on that land without anything in the diagram showing that one is the reason for the other. The framework describes distribution and is close to silent on how the distribution arose &mdash; which is why it should be read beside <a href="/fundamentals/wheel.html">the Wheel of Power</a>.</p>
+      <p>A second objection is that treating credit as an asset is a category error for a household borrowing at distress rates. The evidence on this page bears that out: for households with almost no land, half of all outstanding borrowing is owed to professional moneylenders. Whether that corner of the pentagon is an asset or a liability depends entirely on its terms, and the shape does not show terms.</p>
+      <p>And the pentagon is a stock, not a direction. Two households with identical shapes can be one accumulating and one selling down, and the framework as drawn cannot tell them apart.</p>
     </div>
   </div>
 </section>
 
-<section class="wrap" id="cube-section">
+<section class="wrap" id="shapes-section">
   <div class="section-head">
-    <span class="kicker">The map</span>
-    <h2>Nine categories, each with its evidence</h2>
-    <p>Tap a slice of the cube, or use the buttons under it. Every category has its own shareable link.</p>
+    <span class="kicker">The shapes</span>
+    <h2>Eight livelihoods, drawn to the same scale</h2>
+    <p>Compare them before reading any of them. The totals are less informative than the missing corners &mdash; and one corner, natural capital, turns out to decide how large several of the others can be.</p>
   </div>
-  <div class="wheel-layout">
-    <div class="wheel-stage">
-      <div class="cube-frame"><svg id="cubeSvg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 620 470"></svg></div>
-      <div class="wheel-caption is-empty" id="cubeCaption" aria-live="polite"></div>
-      <div class="picker"><span class="picker-label" id="cubeChipsLabel">Or pick a category</span>
-        <div id="cube" role="group" aria-labelledby="cubeChipsLabel"></div></div>
-    </div>
-    <div class="panel" id="panel" role="region" aria-live="polite" aria-label="Evidence for the selected category"></div>
-  </div>
+  <div id="assetGrid"></div>
 </section>
 
-<section class="band">
-  <div class="wrap">
-    <div class="section-head">
-      <span class="kicker">Plotted</span>
-      <h2>Eight Indian cases, on all three dimensions</h2>
-      <p>The same case reads differently on each face, which is the point of using a cube rather than a list.</p>
-    </div>
-    <div class="case-wrap" id="cases" tabindex="0" role="region" aria-label="Indian cases plotted on the three dimensions of the power cube (scrollable)"></div>
+<section class="wrap" id="detail-section">
+  <div class="section-head">
+    <span class="kicker">In detail</span>
+    <h2>One pentagon at a time</h2>
+    <p>Each livelihood, with the shocks and trends it sits inside, the structures that price its assets, and the evidence for each score.</p>
+  </div>
+  <div class="lv-layout">
+    <div id="assetPentagon"></div>
+    <div class="panel" id="livePanel" role="region" aria-live="polite" aria-label="Detail for the selected livelihood"></div>
   </div>
 </section>
 
@@ -147,23 +136,39 @@
   <div class="wrap">
     <div class="section-head">
       <span class="kicker">Credit where it is owed</span>
-      <h2>Whose cube this is</h2>
+      <h2>Whose framework this is</h2>
     </div>
     <div class="credits">
       <div class="credit-card">
-        <h3>Finding the Spaces for Change</h3>
-        <p><b>John Gaventa</b>, Institute of Development Studies. The three dimensions, the nine categories and the argument that they must be read together are his.</p>
-        <p class="who-line"><i>IDS Bulletin</i> 37(6), 2006 &middot; teaching resources at powercube.net, run by IDS</p>
+        <h3>The framework as drawn</h3>
+        <p><b>DFID</b>, <i>Sustainable Livelihoods Guidance Sheets</i> (1999). The asset pentagon, the vulnerability context, and the transforming structures and processes are set out there in the form used on this page.</p>
+        <p class="who-line">UK Department for International Development</p>
       </div>
       <div class="credit-card">
-        <h3>What it builds on</h3>
-        <p><b>Steven Lukes</b>, <i>Power: A Radical View</i> (1974), for the three dimensions of power, and <b>Lisa VeneKlasen and Valerie Miller</b> (2002) for the visible, hidden and invisible formulation.</p>
+        <h3>The argument underneath it</h3>
+        <p><b>Robert Chambers</b> and <b>Gordon R. Conway</b>, &ldquo;Sustainable Rural Livelihoods: Practical Concepts for the 21st Century&rdquo;, IDS Discussion Paper 296 (1992). The definition of a livelihood as capabilities, assets and activities, and the case for starting from what people have, are theirs.</p>
+        <p class="who-line">Institute of Development Studies, Sussex</p>
+      </div>
+      <div class="credit-card">
+        <h3>The analytical shape</h3>
+        <p><b>Ian Scoones</b>, &ldquo;Sustainable Rural Livelihoods: A Framework for Analysis&rdquo;, IDS Working Paper 72 (1998), which set out the capitals, the institutional processes and the livelihood strategies as an analytical sequence rather than a checklist.</p>
+        <p class="who-line">Institute of Development Studies, Sussex</p>
       </div>
       <div class="credit-card">
         <h3>What ImpactMojo added</h3>
-        <p>The interactive cube, 23 pieces of Indian evidence across the nine categories, and eight documented Indian cases plotted on all three dimensions, each with a named source and year.</p>
+        <p>The eight Indian livelihoods, the scoring of each on the five capitals, the small-multiple comparison, and the evidence: the survey, statute or judgment behind each position, with a named source and year, plus a note on what each shape does not settle.</p>
         <p class="who-line">ImpactMojo, 2026 &middot; content CC BY-NC-ND 4.0 &middot; code MIT</p>
       </div>
+      <div class="credit-card">
+        <h3>Sources drawn on</h3>
+        <p>MoSPI, NSS 77th Round &mdash; Land and Livestock Holdings and the Situation Assessment Survey of Agricultural Households (2018&ndash;19) &middot; MoSPI Time Use Survey (2024) &middot; MoSPI Periodic Labour Force Survey (2023&ndash;24) &middot; Forest Rights Act (2006) &middot; <i>Orissa Mining Corporation v Ministry of Environment &amp; Forests</i> (2013) &middot; MGNREGA (2005) &middot; Inter-State Migrant Workmen Act (1979) &middot; state Marine Fishing Regulation Acts &middot; Department of Food &amp; Public Distribution, ONORC.</p>
+      </div>
+    </div>
+    <div class="notice">
+      <h3>Using this in a workshop</h3>
+      <p>Draw the pentagon for a household the group works with, from memory, before looking at any data. Then ask which corner the programme is actually adding to, and which corner is the one that limits the household. They are very often not the same corner, and that mismatch is usually the most useful hour of the day.</p>
+      <p>Then ask the harder question the framework invites: which of the five capitals could this household lose without anybody recording that anything had been lost? For the pastoralist and the fisher on this page the answer is the one their livelihood rests on.</p>
+      <p>If you reproduce the framework, credit DFID, Chambers and Conway, and Scoones. If you reproduce this evidence or the scoring, credit ImpactMojo &mdash; and the scores are ours, so argue with them in the open.</p>
     </div>
   </div>
 </section>
@@ -204,7 +209,7 @@
     </div>
   </div>
   <div class="footer-bottom">
-    <p>&copy; 2026 ImpactMojo. Code: MIT | Content: CC BY-NC-ND 4.0 &middot; The Power Cube &copy; John Gaventa / IDS, 2006; statistics &copy; their respective sources, cited on the page.</p>
+    <p>&copy; 2026 ImpactMojo. Code: MIT | Content: CC BY-NC-ND 4.0 &middot; The capability approach is Amartya Sen&rsquo;s; the ten central capabilities are Martha Nussbaum&rsquo;s. Statistics &copy; their respective sources, cited on the page.</p>
   </div>
 </footer>
 
@@ -248,11 +253,11 @@
 </script>
 
 <!-- ===== The wheel ===== -->
-<script src="/js/cube-data.js?v=48e71e66"></script>
-<script src="/js/cube.js?v=2ec37bfa"></script>
+<script src="/js/ladder-data.js?v=7f09fe93"></script>
+<script src="/js/ladder.js?v=4cfe05d9"></script>
 <script>
 (function(){
-  function go(){ if (window.FCube) window.FCube.init(); }
+  function go(){ if (window.FLadder) window.FLadder.init(); }
   if (document.readyState !== 'loading') go(); else document.addEventListener('DOMContentLoaded', go);
 })();
 </script>
@@ -266,5 +271,7 @@
 <script src="/js/config.js?v=bd5dcf94"></script>
 <script src="/js/auth.js?v=90f23f77"></script>
 <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
+<script src="/js/livelihoods-data.js?v=513917e8"></script>
+<script src="/js/livelihoods.js?v=bea08ace"></script>
 </body>
 </html>

--- a/fundamentals/wheel.html
+++ b/fundamentals/wheel.html
@@ -40,7 +40,7 @@
 
 <!-- Self-hosted fonts -->
 <link rel="stylesheet" href="/css/fonts.css?v=07d8578c">
-<link rel="stylesheet" href="/css/fundamentals.css?v=0caf8e2f">
+<link rel="stylesheet" href="/css/fundamentals.css?v=25686f23">
 </head>
 <body>
 <div class="skip-nav" role="navigation" aria-label="Skip links"><a href="#main-content" class="skip-link">Skip to content</a></div>
@@ -88,6 +88,7 @@
       <a href="/fundamentals/power-cube.html">The Power Cube</a>
       <a href="/fundamentals/capabilities.html">The Capability Approach</a>
       <a href="/fundamentals/gender-needs.html">Gender Needs</a>
+      <a href="/fundamentals/livelihoods.html">Sustainable Livelihoods</a>
       <a href="/fundamentals/who-counts.html">Who Counts</a>
     </nav>
     <p class="hero-credit">The wheel is not ours. It was built in 2022&ndash;23 by <a href="https://thelistenerscollective.org/indian-wheel-of-power-powerlessness/" target="_blank" rel="noopener">The Listeners Collective</a>, Bengaluru, adapting Sylvia Duckworth&rsquo;s Wheel of Power/Privilege. ImpactMojo added the evidence behind each position. <a href="#credits">Full credits &darr;</a></p>

--- a/fundamentals/who-counts.html
+++ b/fundamentals/who-counts.html
@@ -40,7 +40,7 @@
 
 <!-- Self-hosted fonts -->
 <link rel="stylesheet" href="/css/fonts.css?v=07d8578c">
-<link rel="stylesheet" href="/css/fundamentals.css?v=0caf8e2f">
+<link rel="stylesheet" href="/css/fundamentals.css?v=25686f23">
 </head>
 <body>
 <div class="skip-nav" role="navigation" aria-label="Skip links"><a href="#main-content" class="skip-link">Skip to content</a></div>
@@ -87,6 +87,7 @@
       <a href="/fundamentals/power-cube.html">The Power Cube</a>
       <a href="/fundamentals/capabilities.html">The Capability Approach</a>
       <a href="/fundamentals/gender-needs.html">Gender Needs</a>
+      <a href="/fundamentals/livelihoods.html">Sustainable Livelihoods</a>
       <a href="/fundamentals/who-counts.html" aria-current="page">Who Counts</a>
     </nav>
     <p class="hero-credit">For what India does measure, and measures well, see <a href="/explorers.html">The Data Room</a> &mdash; twelve interactive explorers built on the official surveys. This page is its opposite number.</p>

--- a/js/livelihoods-data.js
+++ b/js/livelihoods-data.js
@@ -1,0 +1,189 @@
+/* =============================================================================
+   ImpactMojo — Fundamentals: The Sustainable Livelihoods Framework
+   -----------------------------------------------------------------------------
+   The framework is DFID's, set out in the Sustainable Livelihoods Guidance
+   Sheets (1999). It formalised an argument made by Robert Chambers and Gordon
+   Conway in "Sustainable Rural Livelihoods: Practical Concepts for the 21st
+   Century" (IDS Discussion Paper 296, 1992), and given its analytical shape by
+   Ian Scoones in "Sustainable Rural Livelihoods: A Framework for Analysis"
+   (IDS Working Paper 72, 1998).
+
+   Its central move is to stop asking what a household earns and start asking
+   what it holds. Five capitals — human, social, natural, physical, financial —
+   are drawn as a pentagon whose shape changes from household to household. A
+   livelihood is what someone can construct out of that shape, inside a
+   vulnerability context they do not control, and through structures and
+   processes that decide what each asset is actually worth.
+
+   ImpactMojo adds the Indian evidence.
+
+   THE SHAPE IS THE POINT. Two households with the same income can hold
+   completely different pentagons, and will survive completely different shocks.
+   The framework's practical use is that it makes the missing corner visible.
+
+   Scores are 0-100, assigned by the editorial team from the evidence attached
+   to each case. They are comparative rather than absolute, and they are
+   arguable — which is why the evidence sits under each one.
+
+   Every figure is from a named source with a year.
+   ============================================================================= */
+
+window.LIVELIHOODS = (function () {
+  "use strict";
+
+  /* The five capitals, in the order they are drawn, clockwise from the top. */
+  var capitals = [
+    { id: "human", name: "Human", color: "#B45309", short: "H",
+      gloss: "Labour, skill, health, education — what a household can do with its own bodies.",
+      detail: "The one asset almost every household has some of, and the one that is spent by using it. Illness converts human capital into a financial liability faster than any other shock in the Indian data." },
+    { id: "social", name: "Social", color: "#6D28D9", short: "S",
+      gloss: "Networks, membership, claims on others, and the relationships that produce them.",
+      detail: "The most contested of the five. Networks that carry a household through a bad season are the same networks that enforce who may do which work, so social capital is not automatically an asset to everyone inside it." },
+    { id: "natural", name: "Natural", color: "#15803D", short: "N",
+      gloss: "Land, water, forest, grazing, fish — the resource base a livelihood draws on.",
+      detail: "In India this is mostly land, and land is also what makes the other capitals accessible: it is the collateral that opens institutional credit, and the address that opens a scheme." },
+    { id: "physical", name: "Physical", color: "#0369A1", short: "P",
+      gloss: "Infrastructure and producer goods: road, power, water, tools, transport, storage.",
+      detail: "Largely supplied by the state rather than accumulated by the household, which makes it the capital most responsive to policy and the one most unevenly distributed by geography." },
+    { id: "financial", name: "Financial", color: "#BE185D", short: "F",
+      gloss: "Savings, credit, remittances, pensions, insurance — stocks and inflows of money.",
+      detail: "The framework treats credit as an asset. Indian evidence complicates that: for households without land, credit arrives on terms that make it closer to a liability, which the case data below shows directly." }
+  ];
+
+  /* Shocks, trends and seasonality — the context a household does not choose. */
+  var contexts = [
+    { id: "shock", name: "Shocks", gloss: "Sudden and mostly unpredictable: illness, death, flood, drought, crop or livestock loss, eviction, a factory closing." },
+    { id: "trend", name: "Trends", gloss: "Slow and directional: groundwater decline, soil loss, mechanisation, price movements, the shrinking of common land." },
+    { id: "season", name: "Seasonality", gloss: "Predictable and still punishing: the lean months between harvests, when prices are highest and work is scarcest." }
+  ];
+
+  /* ------------------------------------------------------------------ cases */
+  var cases = [
+    {
+      id: "marginal",
+      name: "A marginal farmer",
+      short: "One hectare or less, rainfed",
+      assets: { human: 55, social: 50, natural: 32, physical: 38, financial: 28 },
+      strategy: "Farm the plot, and sell labour for the rest of the year. The household is classified as agricultural, and most of its income is not from its own farm.",
+      context: { shock: "Crop failure, and illness — the two shocks that convert a marginal holding into a sold one.", trend: "Falling water tables and rising input costs, against output prices that move with a market the household does not enter on good terms.", season: "Income arrives twice a year and expenses arrive monthly." },
+      structures: "Whether the plot is recorded in the household's name decides access to institutional credit, crop insurance and most scheme entitlements. A tenant farming the same land holds the natural capital and not the papers.",
+      reading: "The defining shape of Indian agriculture: a household whose natural capital is real but too small to carry it, so human capital is sold to fill the gap. That is not a failure of farming — it is the arithmetic of the holding.",
+      complication: "The pentagon looks the same for a household one bad season from selling the land and for one steadily accumulating. Assets are a stock, and the framework does not by itself show which direction the stock is moving.",
+      evidence: [
+        { stat: "70.4%", detail: "of agricultural households possess one hectare or less. 0.37% possess more than ten.", source: "MoSPI, NSS 77th Round, Land and Livestock Holdings, All India", year: "2018-19" },
+        { stat: "₹4,063", detail: "The average agricultural household's monthly income from wages, against ₹3,058 from crop production. Wages are the larger share, for the households that agriculture defines.", source: "MoSPI, NSS 77th Round, Situation Assessment Survey, All India, both paid-out and imputed expenditure", year: "2018-19" },
+        { stat: "₹8,337", detail: "Total average monthly income per agricultural household — ₹4,063 wages, ₹3,058 crop, ₹641 non-farm business, ₹611 pension and remittance, ₹441 animal farming, ₹134 leasing out land.", source: "MoSPI, NSS 77th Round, Situation Assessment Survey, All India", year: "2018-19" }
+      ]
+    },
+    {
+      id: "landless",
+      name: "A landless labourer",
+      short: "Human capital, sold by the day",
+      assets: { human: 52, social: 42, natural: 8, physical: 26, financial: 12 },
+      strategy: "Sell labour, locally when there is work and elsewhere when there is not. MGNREGA in the gap, where it functions.",
+      context: { shock: "Any illness at all. With no asset to sell, a lost working fortnight is met by borrowing.", trend: "Mechanisation of the operations that used to absorb the most hired labour, particularly harvesting.", season: "The lean season is the whole problem: work disappears exactly when prices rise." },
+      structures: "Credit. Without land there is no collateral, and the terms available change completely — which is the sharpest single finding in the Indian asset data.",
+      reading: "The pentagon collapses on the natural axis, and the collapse propagates: no land means no collateral, no collateral means no institutional credit, and no institutional credit means borrowing at rates that keep the financial corner permanently small.",
+      complication: "Human capital is not evenly sellable. Caste decides which work is available and at what rate, and the framework's five axes have no place to record that. Read this case beside the Wheel of Power.",
+      evidence: [
+        { stat: "50.3%", detail: "of the amount of loan outstanding to households possessing under 0.01 hectares is owed to professional moneylenders. For households with more than ten hectares it is 5.2%.", source: "MoSPI, NSS 77th Round, distribution of loan outstanding by source, All India", year: "2018-19" },
+        { stat: "13.5%", detail: "of the landless households' outstanding credit comes from commercial banks. For the largest holdings it is 55.8%. Land is what buys access to the banking system.", source: "MoSPI, NSS 77th Round, distribution of loan outstanding by source, All India", year: "2018-19" },
+        { stat: "One-third", detail: "MGNREGA guarantees up to 100 days per rural household at a statutory wage, with at least a third of beneficiaries to be women. It is the one part of this pentagon the state supplies directly.", source: "MGNREGA 2005, s.3 and Schedule II", year: "2005" }
+      ]
+    },
+    {
+      id: "large",
+      name: "A large landholder",
+      short: "Ten hectares and up, irrigated",
+      assets: { human: 62, social: 78, natural: 88, physical: 76, financial: 82 },
+      strategy: "Farm at a scale that carries a bad year, and use land as the instrument that opens everything else.",
+      context: { shock: "The same weather, absorbed rather than survived.", trend: "The same input prices, paid from a position that can hedge or store.", season: "Storage and credit both convert seasonality from a crisis into a decision about when to sell." },
+      structures: "The same structures, working the other way round. Procurement, insurance and institutional credit are all built around recorded land, and this is the household that has it.",
+      reading: "Included as the contrast case, because the framework's value is comparative. The pentagon is close to full, and the reason is not that this household works harder — it is that one corner, natural capital, unlocks the other four.",
+      complication: "0.37% of agricultural households are in this class. A framework that shows what a full pentagon looks like should also say how rare it is.",
+      evidence: [
+        { stat: "55.8%", detail: "of outstanding credit to households with more than ten hectares comes from commercial banks, and a further 5.8% from regional rural banks. Institutional sources are the majority of the borrowing.", source: "MoSPI, NSS 77th Round, distribution of loan outstanding by source, All India", year: "2018-19" },
+        { stat: "0.37%", detail: "of agricultural households possess more than ten hectares.", source: "MoSPI, NSS 77th Round, Land and Livestock Holdings, All India", year: "2018-19" },
+        { stat: "₹2,081", detail: "Monthly wage income of the largest ST agricultural households, against ₹5,400 for those with almost no land. Wage dependence falls as landholding rises — the two capitals substitute for one another.", source: "MoSPI, NSS 77th Round, Situation Assessment Survey, ST households, All India", year: "2018-19" }
+      ]
+    },
+    {
+      id: "forest",
+      name: "A forest-dwelling household",
+      short: "Natural capital, held without title",
+      assets: { human: 48, social: 62, natural: 66, physical: 18, financial: 16 },
+      strategy: "Collect and sell minor forest produce, cultivate a recorded or unrecorded plot, and take wage work in the season.",
+      context: { shock: "Eviction, and the criminalisation of ordinary use.", trend: "Diversion of forest land, and the slow contest over whether the community's claim is recognised at all.", season: "Forest produce is intensely seasonal and its prices are set by traders who are not." },
+      structures: "The Forest Rights Act 2006, and whether its individual and community claims have actually been recorded. This case exists to show that natural capital and the legal recognition of it are different assets.",
+      reading: "A pentagon with a large natural corner and almost nothing on the physical or financial axes. The gap is not remoteness alone: an asset the state does not recognise cannot be pledged, insured or compensated when it is taken.",
+      complication: "Community forest rights are held collectively, and the framework's household pentagon has no clean way to draw an asset that belongs to a village rather than a family. The score here is a compromise and should be read as one.",
+      evidence: [
+        { stat: "2006", detail: "The Scheduled Tribes and Other Traditional Forest Dwellers (Recognition of Forest Rights) Act recognises individual and community rights over forest land and produce, and records that these rights pre-existed the state's own claim rather than being created by it.", source: "Forest Rights Act 2006, preamble and s.3", year: "2006" },
+        { stat: "s.3(1)(c)", detail: "grants the right of ownership, access, use and disposal of minor forest produce traditionally collected — the provision that turns collection from a tolerated activity into a property right.", source: "Forest Rights Act 2006", year: "2006" },
+        { stat: "2013", detail: "In the Niyamgiri decision the Supreme Court referred the question of a bauxite mine to the gram sabhas of the affected villages, which then refused consent. It remains the clearest Indian instance of a community's natural capital being treated as a right to decide rather than a resource to compensate.", source: "Orissa Mining Corporation v Ministry of Environment & Forests, Supreme Court of India", year: "2013" }
+      ]
+    },
+    {
+      id: "pastoralist",
+      name: "A pastoralist household",
+      short: "Wealth that walks, on land nobody records",
+      assets: { human: 50, social: 70, natural: 44, physical: 20, financial: 34 },
+      strategy: "Move herds along established routes between seasons, converting grazing that cannot be owned into milk, wool and animals that can be sold.",
+      context: { shock: "Disease in the herd, and a blocked route.", trend: "The steady enclosure of commons and the fencing of migration corridors — a decline in an asset that appears in no land record.", season: "The migration itself is the seasonal strategy, not a response to a bad year." },
+      structures: "Whether grazing commons and migration routes have any legal standing. Mostly they do not, which is why this household's natural capital can shrink without anything being recorded as lost.",
+      reading: "The case that shows what the framework catches and conventional statistics miss. Livestock is visible, mobile and countable; the grazing that sustains it is a common-pool resource with no title, so a pastoralist can be dispossessed without a single transaction appearing anywhere.",
+      complication: "Social capital scores high here because the migration depends on long-standing arrangements with settled villages along the route. Those same arrangements are the first thing to break when land use changes, so this is the least stable high score on the board.",
+      evidence: [
+        { stat: "s.3(1)(d)", detail: "The Forest Rights Act recognises community rights of use and entitlement including grazing, \u201cboth settled or transhumant\u201d, and traditional seasonal resource access for nomadic and pastoralist communities. It is the clearest statutory acknowledgement that a migration route is an asset.", source: "Forest Rights Act 2006", year: "2006" },
+        { stat: "s.3(1)(e)", detail: "extends rights to nomadic and pastoralist communities specifically, alongside primitive tribal groups and pre-agricultural communities \u2014 a category the land record has no other way of reaching.", source: "Forest Rights Act 2006", year: "2006" }
+      ]
+    },
+    {
+      id: "fisher",
+      name: "A small-scale marine fisher",
+      short: "A common-pool resource, and a boat",
+      assets: { human: 54, social: 66, natural: 40, physical: 44, financial: 30 },
+      strategy: "Fish from a small craft, sell to an agent at the landing, and stay off the water in the ban and the monsoon.",
+      context: { shock: "Cyclone, and a season that does not arrive.", trend: "Stock decline, and competition from mechanised vessels working the same water with entirely different capital.", season: "The monsoon ban is both a conservation measure and a guaranteed annual income gap." },
+      structures: "Who is allowed to fish where, and who buys the catch. The agent who provides the pre-season advance is usually also the buyer, which is the arrangement that decides the price.",
+      reading: "Natural capital that no one owns and everyone draws on, which is exactly the case Ostrom's work is about. The financial corner is small not because credit is unavailable but because the credit available is tied to the sale.",
+      complication: "Scoring a common-pool resource on a household pentagon is a compromise, the same one the pastoralist case makes. The asset is real, it is not the household's, and its condition depends on everyone else's use of it.",
+      evidence: [
+        { stat: "State law", detail: "Marine fishing inside territorial waters is regulated by state Marine Fishing Regulation Acts rather than by a single national statute, so the rules on gear, zone and season \u2014 and therefore what this household\u2019s natural capital is worth \u2014 change at every state boundary.", source: "State Marine Fishing Regulation Acts, from 1978 onward", year: "1978\u2013" },
+        { stat: "61 days", detail: "The annual monsoon fishing ban on the east and west coasts is a conservation measure that is also a guaranteed income gap, which is why it appears in this pentagon under seasonality rather than under shocks.", source: "Department of Fisheries, uniform ban period", year: "2015\u2013" }
+      ]
+    },
+    {
+      id: "migrant",
+      name: "A seasonal migrant worker",
+      short: "A livelihood assembled across two places",
+      assets: { human: 58, social: 34, natural: 22, physical: 24, financial: 26 },
+      strategy: "Leave after the harvest for construction or brick kiln work, return for the season, and hold both ends of the arrangement together.",
+      context: { shock: "Injury at a site with no employer on record, and a lockdown.", trend: "Rising dependence on the destination and falling returns at the origin.", season: "The whole strategy is seasonal: the migration is what the lean months are for." },
+      structures: "Portability. Almost every entitlement a household holds — ration, school place, health cover, voter registration — is administered at the place of residence, and this household has two.",
+      reading: "The pentagon with the distinctive dent: human capital is the highest corner, social capital the lowest, because the networks that would ordinarily buffer a shock are four hundred kilometres from where the shock happens.",
+      complication: "The framework was built for a household in one place. A livelihood constructed across two locations has two vulnerability contexts and two sets of structures, and one pentagon cannot hold both.",
+      evidence: [
+        { stat: "2020", detail: "The One Nation One Ration Card reform made a ration entitlement portable across states, addressing exactly the structural problem this case describes — a household's claims following its residence rather than its person.", source: "Department of Food & Public Distribution, ONORC rollout", year: "2020" },
+        { stat: "1979", detail: "The Inter-State Migrant Workmen Act required registration of contractors and licensing of establishments employing migrant labour. Its coverage in practice is the gap this pentagon records.", source: "Inter-State Migrant Workmen (Regulation of Employment and Conditions of Service) Act", year: "1979" }
+      ]
+    },
+    {
+      id: "homebased",
+      name: "A home-based worker",
+      short: "Piece rates, inside the house",
+      assets: { human: 46, social: 38, natural: 6, physical: 22, financial: 20 },
+      strategy: "Take piece-rate work from a contractor — garments, beedi, agarbatti, assembly — and fit it around unpaid domestic work that does not reduce.",
+      context: { shock: "The contractor not returning. There is no employment relationship to enforce.", trend: "Piece rates that fall in real terms while the work stays the same.", season: "Order flow, which is somebody else's market and arrives without notice." },
+      structures: "Whether this counts as employment at all. Most statutory protections attach to establishments of ten or more workers, and this workplace is a room.",
+      reading: "The flattest pentagon on the board, and the one most invisible to statistics. Work done inside the home is under-recorded as work, so a household can be fully occupied and appear economically inactive.",
+      complication: "This is where the livelihoods framework and the gender-needs framework have to be read together. The pentagon shows a household's assets; it cannot show that the human capital in this case is being spent twice, on paid piece work and on the 305 minutes of unpaid work a day that continue alongside it.",
+      evidence: [
+        { stat: "305 min", detail: "Average daily unpaid work by women, against 56 minutes for men. Home-based paid work is fitted around this, not instead of it.", source: "MoSPI, Time Use Survey 2024, average time per person per day, All India", year: "2024" },
+        { stat: "28.0%", detail: "Urban female labour force participation, 15 years and above, against 47.6% rural. Home-based work sits close to the boundary of what the survey counts as participation.", source: "MoSPI, Periodic Labour Force Survey", year: "2023-24" }
+      ]
+    }
+  ];
+
+  return { capitals: capitals, contexts: contexts, cases: cases };
+})();

--- a/js/livelihoods.js
+++ b/js/livelihoods.js
@@ -1,0 +1,223 @@
+/* =============================================================================
+   ImpactMojo — Fundamentals: The Sustainable Livelihoods Framework
+   -----------------------------------------------------------------------------
+   The asset pentagon, drawn as DFID drew it, and drawn eight times over so the
+   shapes can be compared. The framework's claim is that the shape matters more
+   than the total, so the page shows all eight at once as small multiples and
+   the selected one at size. A single large chart would have hidden the point.
+   ============================================================================= */
+
+(function () {
+  "use strict";
+
+  var D = window.LIVELIHOODS;
+  if (!D) return;
+
+  /* ------------------------------------------------------------ ink chooser */
+  function chan(c) {
+    c /= 255;
+    return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  }
+  function lum(hex) {
+    var h = hex.replace("#", "");
+    if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+    return 0.2126 * chan(parseInt(h.slice(0, 2), 16)) +
+           0.7152 * chan(parseInt(h.slice(2, 4), 16)) +
+           0.0722 * chan(parseInt(h.slice(4, 6), 16));
+  }
+  function contrast(a, b) {
+    var la = lum(a), lb = lum(b);
+    return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+  }
+  /* Compare both candidate inks against the fill and keep the better one. */
+  function readableOn(hex) {
+    return contrast("#241a20", hex) > contrast("#ffffff", hex) ? "#241a20" : "#ffffff";
+  }
+
+  function esc(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    });
+  }
+
+  var NS = "http://www.w3.org/2000/svg";
+  function el(name, attrs, text) {
+    var n = document.createElementNS(NS, name);
+    Object.keys(attrs || {}).forEach(function (k) { n.setAttribute(k, attrs[k]); });
+    if (text !== undefined) n.appendChild(document.createTextNode(text));
+    return n;
+  }
+
+  var selected = D.cases[0].id;
+
+  /* Vertex i of a regular pentagon, clockwise from the top, at radius r. */
+  function vertex(cx, cy, r, i) {
+    var a = -Math.PI / 2 + (i * 2 * Math.PI) / 5;
+    return [cx + r * Math.cos(a), cy + r * Math.sin(a)];
+  }
+
+  function polygon(cx, cy, R, values) {
+    return D.capitals.map(function (cap, i) {
+      var p = vertex(cx, cy, R * (values[cap.id] / 100), i);
+      return p[0].toFixed(1) + "," + p[1].toFixed(1);
+    }).join(" ");
+  }
+
+  function ring(cx, cy, R, frac) {
+    return D.capitals.map(function (_, i) {
+      var p = vertex(cx, cy, R * frac, i);
+      return p[0].toFixed(1) + "," + p[1].toFixed(1);
+    }).join(" ");
+  }
+
+  /* --------------------------------------------------------- one pentagon */
+  function pentagon(c, size, withLabels) {
+    /* The box is wider than tall when labelled. A square one clipped the left
+       and right vertices' names — FINANCIAL and SOCIAL sit at the widest
+       points of a pentagon and are the two longest words, so the horizontal
+       padding has to carry a whole word on each side while the vertical only
+       has to carry a line and a number. */
+    var pad = withLabels ? (size < 300 ? 30 : 38) : 6;
+    var sidePad = withLabels ? (size < 300 ? 62 : 78) : 0;
+    var H = size, W = size + 2 * sidePad;
+    var cx = W / 2, cy = size / 2, R = size / 2 - pad;
+
+    var svg = el("svg", {
+      class: "lv-pent" + (withLabels ? " is-big" : ""),
+      viewBox: "0 0 " + W + " " + H,
+      preserveAspectRatio: "xMidYMid meet",
+      role: "img",
+      "aria-label": c.name + ". " + D.capitals.map(function (cap) {
+        return cap.name + " " + c.assets[cap.id];
+      }).join(", ") + ", each out of 100."
+    });
+
+    [0.25, 0.5, 0.75, 1].forEach(function (f) {
+      svg.appendChild(el("polygon", { class: "lv-grid", points: ring(cx, cy, R, f) }));
+    });
+    D.capitals.forEach(function (_, i) {
+      var p = vertex(cx, cy, R, i);
+      svg.appendChild(el("line", { class: "lv-spoke", x1: cx, y1: cy, x2: p[0], y2: p[1] }));
+    });
+
+    svg.appendChild(el("polygon", { class: "lv-shape", points: polygon(cx, cy, R, c.assets) }));
+
+    D.capitals.forEach(function (cap, i) {
+      var v = vertex(cx, cy, R * (c.assets[cap.id] / 100), i);
+      svg.appendChild(el("circle", {
+        class: "lv-node", cx: v[0], cy: v[1], r: withLabels ? 5 : 3, fill: cap.color
+      }));
+      if (!withLabels) return;
+      var lp = vertex(cx, cy, R + (size < 300 ? 14 : 18), i);
+      /* Anchor by which side of the centre the vertex is on, so a label never
+         runs back across the chart. */
+      var anchor = Math.abs(lp[0] - cx) < 2 ? "middle" : (lp[0] > cx ? "start" : "end");
+      /* Nudge the side labels clear of the shape rather than letting them ride
+         the vertex, which is what pushed them off the edge. */
+      if (anchor === "start") lp[0] += 6;
+      if (anchor === "end") lp[0] -= 6;
+      svg.appendChild(el("text", {
+        class: "lv-axis lv-ax-" + cap.id, x: lp[0], y: lp[1] + 4, "text-anchor": anchor
+      }, cap.name));
+      svg.appendChild(el("text", {
+        class: "lv-val lv-ax-" + cap.id, x: lp[0], y: lp[1] + 21, "text-anchor": anchor
+      }, String(c.assets[cap.id])));
+    });
+
+    return svg;
+  }
+
+  /* ------------------------------------------------------- small multiples */
+  function drawGrid() {
+    var host = document.getElementById("assetGrid");
+    if (!host) return;
+    host.innerHTML = "";
+    D.cases.forEach(function (c) {
+      var b = document.createElement("button");
+      b.type = "button";
+      b.className = "lv-thumb" + (c.id === selected ? " is-on" : "");
+      b.setAttribute("data-case", c.id);
+      b.setAttribute("aria-pressed", c.id === selected ? "true" : "false");
+      b.appendChild(pentagon(c, 120, false));
+      var cap = document.createElement("span");
+      cap.innerHTML = "<b>" + esc(c.name) + "</b><span>" + esc(c.short) + "</span>";
+      b.appendChild(cap);
+      b.addEventListener("click", function () { select(c.id); });
+      host.appendChild(b);
+    });
+  }
+
+  function drawBig() {
+    var host = document.getElementById("assetPentagon");
+    if (!host) return;
+    var c = D.cases.filter(function (x) { return x.id === selected; })[0];
+    host.innerHTML = "";
+    host.appendChild(pentagon(c, host.clientWidth < 420 ? 320 : 400, true));
+  }
+
+  /* ----------------------------------------------------------------- panel */
+  function drawPanel() {
+    var host = document.getElementById("livePanel");
+    var c = D.cases.filter(function (x) { return x.id === selected; })[0];
+    if (!host || !c) return;
+    var h = [];
+    h.push('<div class="lv-head"><h3>' + esc(c.name) + "</h3><p>" + esc(c.short) + "</p></div>");
+
+    h.push('<h4>The strategy</h4><p>' + esc(c.strategy) + "</p>");
+
+    h.push('<h4>Vulnerability context</h4><dl class="lv-ctx">');
+    D.contexts.forEach(function (x) {
+      h.push("<dt>" + esc(x.name) + "</dt><dd>" + esc(c.context[x.id]) + "</dd>");
+    });
+    h.push("</dl>");
+
+    h.push("<h4>Structures and processes that decide what the assets are worth</h4><p>" +
+           esc(c.structures) + "</p>");
+    h.push("<h4>How to read the shape</h4><p>" + esc(c.reading) + "</p>");
+    h.push('<h4>What this does not settle</h4><p class="lv-comp">' + esc(c.complication) + "</p>");
+
+    if (c.evidence && c.evidence.length) {
+      h.push('<h4>The evidence</h4><ul class="lv-ev">');
+      c.evidence.forEach(function (e) {
+        h.push("<li><b>" + esc(e.stat) + "</b> &mdash; " + esc(e.detail) +
+               ' <span class="lv-src">' + esc(e.source) + ", " + esc(e.year) + "</span></li>");
+      });
+      h.push("</ul>");
+    }
+    host.innerHTML = h.join("");
+  }
+
+  function select(id) {
+    selected = id;
+    drawGrid();
+    drawBig();
+    drawPanel();
+  }
+
+  function buildKey() {
+    var host = document.getElementById("capitalKey");
+    if (!host) return;
+    host.innerHTML = D.capitals.map(function (cap) {
+      return '<div class="lv-key"><span class="lv-key-sw" style="background:' + esc(cap.color) +
+             ";color:" + esc(readableOn(cap.color)) + '">' + esc(cap.short) + "</span>" +
+             "<b>" + esc(cap.name) + "</b><p>" + esc(cap.gloss) + "</p>" +
+             '<p class="lv-key-d">' + esc(cap.detail) + "</p></div>";
+    }).join("");
+  }
+
+  function init() {
+    buildKey();
+    select(selected);
+    var t;
+    window.addEventListener("resize", function () {
+      clearTimeout(t);
+      t = setTimeout(drawBig, 150);
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/scripts/check-diagram-contrast.py
+++ b/scripts/check-diagram-contrast.py
@@ -43,6 +43,7 @@ DIAGRAMS = [
     ("js/fundamentals-data.js", "js/fundamentals-wheel.js", "#241a20"),
     ("js/capabilities-data.js", "js/capabilities.js", "#241a20"),
     ("js/gender-needs-data.js", "js/gender-needs.js", "#241a20"),
+    ("js/livelihoods-data.js", "js/livelihoods.js", "#241a20"),
 ]
 
 # The wheel does not paint on the base colour: each ring is a mix of it.
@@ -70,6 +71,14 @@ QUAD_LABELS = [
                           ("#15803d", "#166534"), ("#b45309", "#92400e")]),
     ("dark", "#141a26", [("#0369a1", "#7dd3fc"), ("#6d28d9", "#c4b5fd"),
                          ("#15803d", "#6ee7b7"), ("#b45309", "#fcd34d")]),
+]
+
+# The livelihoods pentagon names each axis beside the chart, on the page ground
+# rather than on any fill, so those labels need the same treatment. All five
+# capital colours fail on the dark ground; the light ones are the base colours.
+AXIS_LABELS = [
+    ("light", "#f7fafc", ["#b45309", "#6d28d9", "#15803d", "#0369a1", "#be185d"]),
+    ("dark", "#141a26", ["#fcd34d", "#c4b5fd", "#6ee7b7", "#7dd3fc", "#f9a8d4"]),
 ]
 
 AA_NORMAL = 4.5
@@ -176,6 +185,15 @@ def main():
                 problems.append(
                     "gender-needs quadrant label %s on its %s wash (%s) is "
                     "%.2f:1, below %.1f" % (ink, theme, wash, got, AA_NORMAL)
+                )
+
+    for theme, ground, inks in AXIS_LABELS:
+        for ink in inks:
+            got = contrast(ink, ground)
+            if got < AA_NORMAL:
+                problems.append(
+                    "livelihoods axis label %s on the %s page ground is %.2f:1, "
+                    "below %.1f" % (ink, theme, got, AA_NORMAL)
                 )
 
     if problems:

--- a/service-worker.js
+++ b/service-worker.js
@@ -22,7 +22,7 @@
 
 'use strict';
 
-const VERSION = 'v13-2026-08-19';
+const VERSION = 'v14-2026-08-19';
 const RUNTIME = 'im-runtime-' + VERSION;
 const OFFLINE_URL = '/offline.html';
 const COURSE_PREFIX = 'impactmojo-course-';

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -738,6 +738,7 @@
   <url><loc>https://www.impactmojo.in/fundamentals/wheel.html</loc><lastmod>2026-08-19</lastmod></url>
   <url><loc>https://www.impactmojo.in/fundamentals/capabilities.html</loc><lastmod>2026-08-19</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.impactmojo.in/fundamentals/gender-needs.html</loc><lastmod>2026-08-19</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.impactmojo.in/fundamentals/livelihoods.html</loc><lastmod>2026-08-19</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://www.impactmojo.in/fundamentals/ladder.html</loc><lastmod>2026-08-19</lastmod></url>
   <url><loc>https://www.impactmojo.in/fundamentals/power-cube.html</loc><lastmod>2026-08-19</lastmod></url>
   <url><loc>https://www.impactmojo.in/fundamentals/who-counts.html</loc><lastmod>2026-08-19</lastmod></url>


### PR DESCRIPTION
DFID's *Sustainable Livelihoods Guidance Sheets* (1999), formalising the argument **Robert Chambers** and **Gordon Conway** made in IDS Discussion Paper 296 (1992) and given its analytical shape by **Ian Scoones** in IDS Working Paper 72 (1998). All three are credited on the page.

## Its own diagram form: the pentagon, drawn eight times

The framework's claim is that **the shape matters more than the total**, so the page leads with small multiples — all eight livelihoods to the same scale, side by side — and shows the selected one at size beside its detail. A single chart would have hidden the argument.

You can see the large landholder's pentagon is nearly full, the landless labourer's collapses on the natural axis, and the home-based worker's is the smallest on the page, before reading a word.

Eight cases: a marginal farmer, a landless labourer, **a large landholder as the deliberate contrast**, a forest-dwelling household, a pastoralist, a small-scale marine fisher, a seasonal migrant and a home-based worker. Each carries a vulnerability context split into shocks, trends and seasonality, and a note on the structures and processes that decide what its assets are actually worth.

## 20 sourced entries, most new to the site

From the NSS 77th Round, pulled from MoSPI rather than written from memory:

> An average agricultural household earns **₹4,063 a month from wages against ₹3,058 from crop production** — total ₹8,337, of which farming is under half. The households that agriculture *defines* earn more from selling labour than from farming.

- **70.4%** of agricultural households possess one hectare or less. **0.37%** possess more than ten.
- Wage income falls as landholding rises: ₹5,400/month for ST households with almost no land, ₹2,081 for those over ten hectares. The two capitals substitute for one another.

And the sharpest one, which is the framework's central claim stated in Indian data:

| Credit source | Under 0.01 ha | Over 10 ha |
|---|---|---|
| Professional moneylender | **50.3%** | 5.2% |
| Commercial bank | 13.5% | **55.8%** |

Land is what buys access to the banking system. The pentagon's natural corner is not just one asset among five — it is what decides how large several of the others can be.

Plus the Forest Rights Act 2006 — including **s.3(1)(e)**, which reaches transhumant grazing and nomadic communities the land record has no other way of seeing — *Orissa Mining Corporation v MoEF* (2013), MGNREGA, the Inter-State Migrant Workmen Act 1979, ONORC, and the state Marine Fishing Regulation Acts.

## Where it says it is contested

That five neutral-sounding capitals can be drawn for a landlord and for the labourer on that land without anything in the diagram showing that one is the reason for the other — so it points the reader at the Wheel of Power. That treating credit as an asset is a category error for a household borrowing at distress rates, **which this page's own evidence demonstrates**. And that a pentagon is a stock rather than a direction: an accumulating household and a liquidating one can be drawn identically.

The pastoralist and fisher cases both say plainly that scoring a common-pool resource on a household pentagon is a compromise. The home-based worker case says the pentagon cannot show human capital being spent twice, and sends the reader to the gender-needs page.

## Two things caught by measuring, not by looking

- **`FINANCIAL` and `SOCIAL` sit at the widest points of a pentagon and are the two longest words**, so a square viewBox clipped both. The labelled chart is now wider than it is tall. Caught by asserting every text bbox sits inside the viewBox, not by glancing at a screenshot — the clipped labels looked plausible until measured.
- **All five capital colours fail AA as axis labels on the dark page ground** — the same trap the gender-needs quadrant labels fell into one version earlier. They print on the page, not on any fill, so the fill's ink chooser never reaches them. Theme-aware inks now, and `check-diagram-contrast.py` grew an `AXIS_LABELS` section that fails when they drift.

## Verification

Chromium at 390px and 1280px, light and dark: 8 thumbnails, 5 capital keys, the panel populates, `scrollWidth === clientWidth`, and after the fix **no text escapes the viewBox and no two text boxes overlap** in any combination.

All guards green: counts, internal links (855 pages), social images (1,164 refs), theme contrast, diagram contrast (74 fills, 7 renderers), tap traps, Fundamentals index count, mojibake, book companions, questionnaire privacy, asset stamps, minified CSS and the service worker.

---
_Generated by [Claude Code](https://claude.ai/code/session_01199dCmAgzMN1Z1d8qj2UfN)_