### PR TITLE
Refresh CI actions and the axe toolchain (clears 7 dependabot PRs)

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 22
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
       - name: Check asset stamps
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
       - name: Check diagram contrast
@@ -140,7 +140,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
 
@@ -247,7 +247,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
 
@@ -316,7 +316,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 22
 
@@ -442,7 +442,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 22
 

--- a/.github/workflows/delete-stale-branches.yml
+++ b/.github/workflows/delete-stale-branches.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Delete (or preview) the listed branches
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/post-discussion.yml
+++ b/.github/workflows/post-discussion.yml
@@ -25,7 +25,7 @@ jobs:
     # job neither passes nor fails -- which reads as "still running".
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Create the discussion
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish-mcp-server.yml
+++ b/.github/workflows/publish-mcp-server.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
           registry-url: 'https://npm.pkg.github.com'

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Mirror changelog + roadmap into the wiki
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "impactmojo",
       "version": "1.0.0",
       "devDependencies": {
-        "@axe-core/cli": "^4.11.3",
-        "@axe-core/puppeteer": "^4.11.3",
-        "axe-core": "^4.11.4",
+        "@axe-core/cli": "^4.12.1",
+        "@axe-core/puppeteer": "^4.13.0",
+        "axe-core": "^4.13.0",
         "http-server": "^14.1.1",
         "puppeteer": "^25.7.0"
       },
@@ -40,24 +40,14 @@
         "node": ">=8"
       }
     },
-    "node_modules/@axe-core/cli/node_modules/axe-core": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
-      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@axe-core/puppeteer": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@axe-core/puppeteer/-/puppeteer-4.11.3.tgz",
-      "integrity": "sha512-ftQOYpDc9loAamK8nZ4ccc/f2V3/KsEp4SlbrAcbXLVXYJKbbRBvEkcPZpPkzTYOQydp4Ft+1gw2ceA/Y3kLBw==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/puppeteer/-/puppeteer-4.13.0.tgz",
+      "integrity": "sha512-y43krMJveVzxIZckPxo/2cHG5x4NBNF8fuwNcCYlTWV9cVtm5bagKZ6EmJO6EcKj37hsIL+nWUHGhTCvz4GNNg==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "axe-core": "~4.11.4"
+        "axe-core": "~4.13.0"
       },
       "engines": {
         "node": ">=6.4.0"
@@ -77,16 +67,6 @@
       },
       "peerDependencies": {
         "selenium-webdriver": ">3.0.0-beta  || >=2.53.1 || >4.0.0-alpha"
-      }
-    },
-    "node_modules/@axe-core/webdriverjs/node_modules/axe-core": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
-      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@bazel/runfiles": {
@@ -199,9 +179,9 @@
       "license": "MIT"
     },
     "node_modules/axe-core": {
-      "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
-      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "serve": "npx http-server -p 8080 -s"
   },
   "devDependencies": {
-    "@axe-core/cli": "^4.11.3",
-    "@axe-core/puppeteer": "^4.11.3",
-    "axe-core": "^4.11.4",
+    "@axe-core/cli": "^4.12.1",
+    "@axe-core/puppeteer": "^4.13.0",
+    "axe-core": "^4.13.0",
     "http-server": "^14.1.1",
     "puppeteer": "^25.7.0"
   }


### PR DESCRIPTION
Clears seven open dependabot PRs by applying their bumps directly on current main, rather than merging seven branches cut between 6 July and 17 August — each of which would need rebasing in turn over the same lockfile.

| Bump | Supersedes |
|---|---|
| `actions/checkout` v4 → v7 (2 files; the other 25 uses were already v7) | #793 |
| `actions/setup-node` v6 → v7 (6 uses) | #839 |
| `actions/setup-python` v6 → v7 (3 uses) | #840 |
| `actions/github-script` v7 → v9 (1 use) | #930 |
| `axe-core` ^4.11.4 → ^4.13.0 | #931 |
| `@axe-core/puppeteer` ^4.11.3 → ^4.13.0 | #932 |
| `@axe-core/cli` ^4.11.3 → ^4.12.1 | #672 |

**#671 is superseded, not applied** — it bumps puppeteer 24.43.1 → 25.3.0, and main is already on ^25.7.0.

## Verification

- All **13 local guards** pass: counts, internal links (856 pages), mojibake, social images (1,166 refs), theme contrast, diagram contrast, tap traps, Fundamentals index, book companions, conflict markers, i18n quality, asset stamps, min-CSS.
- `node scripts/test-service-worker.mjs` passes (7 groups).
- `npm install` resolves every axe package to **4.13.0**; `require('axe-core').version` confirms it.
- Every workflow file still parses as YAML.

The lockfile was regenerated with `npm install --package-lock-only`, not hand-edited.

## One thing CI cannot check

`actions/github-script` v9 is used only in `delete-stale-branches.yml`, which runs on manual dispatch — so no CI run exercises it. Its script uses `github.rest.*`, `core.info` and `context.repo`, all unchanged across v7…v9; the jump is a runner-version bump. Worth knowing before the next branch cleanup, since that workflow was used successfully an hour ago on v7.

The supabase-js bump (#837) is deliberately **not** in this PR — it touches auth on every page and needs a browser smoke test, so it gets its own PR and preview.

---
_Generated by [Claude Code](https://claude.ai/code/session_01199dCmAgzMN1Z1d8qj2UfN)_