### PR TITLE
Guard the Supabase write path, and fix nine writes that could fail without a trace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,35 @@ jobs:
       - name: Check content counts match data/counts.json
         run: python3 scripts/check-counts.py
 
+  supabase-writes:
+    name: Supabase write-path guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      # Static only: needs no credentials, so it runs on every push. Catches a
+      # write whose result is discarded — the shape that hid the dead
+      # user_progress sync for eight months, since supabase-js resolves with
+      # { data, error } rather than throwing.
+      - name: Every Supabase write surfaces its errors
+        run: python3 scripts/check-supabase-writes.py
+
+  supabase-writes-live:
+    name: Supabase write-path guard (live insert counts)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Hits the live database, so schedule/dispatch only — same reasoning as
+    # supabase-anon below. Skips gracefully when SUPABASE_PAT is absent.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Assert every written table has ever received a row
+        env:
+          SUPABASE_PAT: ${{ secrets.SUPABASE_PAT }}
+        run: python3 scripts/check-supabase-writes.py --live
+
   supabase-anon:
     name: Supabase anon-exposure guard
     runs-on: ubuntu-latest

--- a/404.html
+++ b/404.html
@@ -1932,7 +1932,7 @@ document.addEventListener('click', function(e) {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/mojini-ai.js?v=db5170eb" defer></script>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to ImpactMojo are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.221.0] - 2026-08-20
+
+### Added
+
+- **`scripts/check-supabase-writes.py` — a guard for the class of bug that hid the dead progress sync.** `supabase-js` *resolves* with `{ data, error }` rather than throwing, so `await sb.from('t').upsert({...})` reports a rejected write exactly as it reports a successful one, and any `try/catch` around it can never fire. That is how `user_progress` reached 0 rows ever inserted against 17,022 reads without anyone noticing (#960).
+
+  The static half runs on every push and needs no credentials: it finds every `.from('table')` chained to a mutating verb and fails when the result is discarded, or captured and never checked. It accepts the three legitimate shapes — `var { error } = await …`, `var res = await …` followed by a read of `res.error`, and `.then(cb)` where `cb` inspects `.error` — and a line may opt out with `write-ignore`.
+
+  The live half (`--live`, scheduled only, skips gracefully without `SUPABASE_PAT`) asserts that every table the code writes to has a non-zero `n_tup_ins`. A table with a writer that has never received a row is either broken or never wired to a UI; both are worth knowing, and neither should be silent.
+
+### Fixed
+
+- **Nine Supabase writes could fail without any trace**, found by the new guard and fixed:
+  - `js/course-progress.js` — the `user_progress` upsert behind #960, whose `catch` carried the comment "Silently fail".
+  - `account.html` — notification preferences showed **"Saved"** unconditionally, a false success of exactly the kind the form rebuild removed elsewhere; and marking a notification read.
+  - `admin/index.html` ×2 — feature flags and site metadata saved with no confirmation that anything was written.
+  - `org-dashboard.html` ×2 — deleting a discussion post, and the "fire-and-forget" upsert that makes an organisation's creator a member, where a failure leaves the creator outside their own org.
+  - `portfolio.html` — the portfolio headline update.
+  - `js/auth.js` — `last_active_at` recorded the day in `localStorage` inside a `.then` that ran even on failure, so a failed write suppressed its own retry for the rest of the day.
+
+### Notes on building the guard
+
+Three defects in the guard and its own tooling were caught by testing rather than reading, all of them the guard-passes-anyway failure mode:
+
+- The first regex backtracked catastrophically and **hung** on a long line. A hung CI job neither passes nor fails — it reads as "still running", the exact failure this repo already documents. Replaced with a bounded linear scan.
+- Reformatting a call across several lines made the single-line matcher **go blind to it**: the detected count silently fell from 17 to 13, and the guard "passed" partly because it had stopped looking. Now matched across the whole file text, which also surfaced four writes the first version never saw at all — including one in `js/auth.js`. A false positive was fixed the same way: `portfolio.html` checks `result.error` inside a `.then` callback, which the first classifier did not understand.
+- **The script that added this entry silently did nothing.** It used `str.replace()` against an anchor that did not exist on the branch, with no assertion, so the entry was never written and nothing reported it — the same shape as the bug the entry describes. The anchor is now asserted before the write.
+
 ## [10.219.1] - 2026-08-20
 
 ### Changed

--- a/ImpactMojo_PressKit.html
+++ b/ImpactMojo_PressKit.html
@@ -1042,7 +1042,7 @@ function cp(btn){
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
   <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/Labs/before-we-fall-apart-lab.html
+++ b/Labs/before-we-fall-apart-lab.html
@@ -1066,7 +1066,7 @@ function clearAll() {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
 <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/Labs/community-lab.html
+++ b/Labs/community-lab.html
@@ -1527,7 +1527,7 @@ body.dark-mode .level-none, [data-theme="dark"] .level-none, html.dark .level-no
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/Labs/design-thinking-lab.html
+++ b/Labs/design-thinking-lab.html
@@ -1620,7 +1620,7 @@ body { padding-top: 56px; }
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/Labs/disability-inclusive-mel-lab.html
+++ b/Labs/disability-inclusive-mel-lab.html
@@ -826,7 +826,7 @@ updateProgress();
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
   <script src="/js/state-manager.js?v=62445627"></script>
   <script src="/js/config.js?v=bd5dcf94"></script>
-  <script src="/js/auth.js?v=90f23f77"></script>
+  <script src="/js/auth.js?v=97cb7b85"></script>
   <script src="/js/premium.js?v=80699517"></script>
   <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>

--- a/Labs/gender-studies-lab.html
+++ b/Labs/gender-studies-lab.html
@@ -1013,7 +1013,7 @@ loadState(); renderRoles(); renderAccess(); renderMargGroups(); renderInterventi
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/Labs/impact-evaluation-lab.html
+++ b/Labs/impact-evaluation-lab.html
@@ -1025,7 +1025,7 @@ updateProgress();
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
   <script src="/js/state-manager.js?v=62445627"></script>
   <script src="/js/config.js?v=bd5dcf94"></script>
-  <script src="/js/auth.js?v=90f23f77"></script>
+  <script src="/js/auth.js?v=97cb7b85"></script>
   <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/Labs/impact-partnerships-lab.html
+++ b/Labs/impact-partnerships-lab.html
@@ -1541,7 +1541,7 @@ body { padding-top: 56px; }
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/Labs/livelihoods-value-chain-lab.html
+++ b/Labs/livelihoods-value-chain-lab.html
@@ -1025,7 +1025,7 @@ updateProgress();
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
 <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/Labs/mel-lab.html
+++ b/Labs/mel-lab.html
@@ -1370,7 +1370,7 @@ try { updateProgress(); } catch (e) {}
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/Labs/nvc-mediation-lab.html
+++ b/Labs/nvc-mediation-lab.html
@@ -948,7 +948,7 @@ function exportNotes() {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
 <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/Labs/policy-advocacy-lab.html
+++ b/Labs/policy-advocacy-lab.html
@@ -904,7 +904,7 @@ renderDecisionMakers(); renderEvidence(); renderStakeholders(); renderObjectives
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/Labs/policy-analysis-lab.html
+++ b/Labs/policy-analysis-lab.html
@@ -1125,7 +1125,7 @@ document.addEventListener('DOMContentLoaded', () => PAL.init());
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/Labs/rct-readiness-lab.html
+++ b/Labs/rct-readiness-lab.html
@@ -998,7 +998,7 @@ updateProgress();
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
   <script src="/js/state-manager.js?v=62445627"></script>
   <script src="/js/config.js?v=bd5dcf94"></script>
-  <script src="/js/auth.js?v=90f23f77"></script>
+  <script src="/js/auth.js?v=97cb7b85"></script>
   <script src="/js/premium.js?v=80699517"></script>
   <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>

--- a/Labs/resource-sustainability-lab.html
+++ b/Labs/resource-sustainability-lab.html
@@ -1558,7 +1558,7 @@ body { padding-top: 56px; }
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/Labs/risk-mitigation-lab.html
+++ b/Labs/risk-mitigation-lab.html
@@ -1461,7 +1461,7 @@ renderRiskList();
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/Labs/sampling-basics-lab.html
+++ b/Labs/sampling-basics-lab.html
@@ -362,7 +362,7 @@ input[type=range]{width:100%;accent-color:var(--accent)}
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/theme.js?v=ca787a55"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>

--- a/Labs/sampling-design-lab.html
+++ b/Labs/sampling-design-lab.html
@@ -1099,7 +1099,7 @@ body.facil-on .facil{display:block}
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/premium.js?v=80699517"></script>
 <script src="/js/theme.js?v=ca787a55"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>

--- a/Labs/sampling-toolkit.html
+++ b/Labs/sampling-toolkit.html
@@ -221,7 +221,7 @@ a{color:var(--accent)}
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/theme.js?v=ca787a55"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>

--- a/Labs/storytelling-lab.html
+++ b/Labs/storytelling-lab.html
@@ -1355,7 +1355,7 @@ body { padding-top: 56px; }
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/Labs/toc-lab.html
+++ b/Labs/toc-lab.html
@@ -1493,7 +1493,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/Labs/urban-boundaries-lab.html
+++ b/Labs/urban-boundaries-lab.html
@@ -730,7 +730,7 @@ restoreNote();
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
   <script src="/js/state-manager.js?v=62445627"></script>
   <script src="/js/config.js?v=bd5dcf94"></script>
-  <script src="/js/auth.js?v=90f23f77"></script>
+  <script src="/js/auth.js?v=97cb7b85"></script>
   <script src="/js/premium.js?v=80699517"></script>
   <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>

--- a/about.html
+++ b/about.html
@@ -2625,7 +2625,7 @@ document.addEventListener('click', function(e) {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/mojini-ai.js?v=db5170eb" defer></script>

--- a/accessibility.html
+++ b/accessibility.html
@@ -1747,7 +1747,7 @@ document.addEventListener('click', function(e) {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/mojini-ai.js?v=db5170eb" defer></script>

--- a/account.html
+++ b/account.html
@@ -2725,7 +2725,14 @@ h1, h2, h3, h4, h5, h6 {
                 updated_at: new Date().toISOString()
             };
 
-            await sb.from('notification_preferences').upsert(prefs, { onConflict: 'user_id' });
+            var { error: prefsError } = await sb.from('notification_preferences')
+                .upsert(prefs, { onConflict: 'user_id' });
+            if (prefsError) {
+                // Never claim "Saved" for a write the database rejected.
+                console.error('[Account] Notification preferences failed to save:', prefsError.message);
+                alert('Could not save your notification preferences. Please try again.');
+                return;
+            }
 
             var saved = document.getElementById('notifPrefsSaved');
             saved.style.display = 'block';
@@ -2836,7 +2843,9 @@ h1, h2, h3, h4, h5, h6 {
         try {
             var user = window.ImpactMojoAuth && ImpactMojoAuth.getUser();
             if (user) {
-                await sb.from('notifications').update({ is_read: true }).eq('id', notifId);
+                var { error: readError } = await sb.from('notifications')
+                    .update({ is_read: true }).eq('id', notifId);
+                if (readError) console.warn('[Account] Could not mark notification read:', readError.message);
             }
             if (link) window.location.href = link;
             else await window.loadRecentNotifications();

--- a/admin/index.html
+++ b/admin/index.html
@@ -2358,7 +2358,13 @@ async function ssSaveFlags() {
     // Try to save to Supabase site_settings table
     try {
         if (typeof supabaseClient !== 'undefined') {
-            await supabaseClient.from('site_settings').upsert({ id: 'feature_flags', value: flags, updated_at: new Date().toISOString() });
+            var { error: flagsError } = await supabaseClient.from('site_settings')
+                .upsert({ id: 'feature_flags', value: flags, updated_at: new Date().toISOString() });
+            if (flagsError) {
+                console.error('[Admin] Failed to save feature_flags:', flagsError.message);
+                alert('Could not save feature flags. Please try again.');
+                return;
+            }
         }
     } catch(e) { /* fallback to localStorage only */ }
     ssShowToast('Feature flags saved');
@@ -2384,7 +2390,13 @@ async function ssSaveMetadata() {
 
     try {
         if (typeof supabaseClient !== 'undefined') {
-            await supabaseClient.from('site_settings').upsert({ id: 'site_metadata', value: meta, updated_at: new Date().toISOString() });
+            var { error: metaError } = await supabaseClient.from('site_settings')
+                .upsert({ id: 'site_metadata', value: meta, updated_at: new Date().toISOString() });
+            if (metaError) {
+                console.error('[Admin] Failed to save site_metadata:', metaError.message);
+                alert('Could not save site metadata. Please try again.');
+                return;
+            }
         }
     } catch(e) { /* fallback to localStorage only */ }
     ssShowToast('Metadata saved');

--- a/ai-policy.html
+++ b/ai-policy.html
@@ -1287,7 +1287,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/bct-repository.html
+++ b/bct-repository.html
@@ -2587,7 +2587,7 @@ window.addEventListener('hashchange', handleHash);
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/blog.html
+++ b/blog.html
@@ -3127,7 +3127,7 @@ document.addEventListener('click', function(e) {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/mojini-ai.js?v=db5170eb" defer></script>

--- a/catalog.html
+++ b/catalog.html
@@ -3245,7 +3245,7 @@ document.addEventListener('click', function(e) {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/resource-launch.js?v=64efc9da" defer></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>

--- a/challenges.html
+++ b/challenges.html
@@ -1010,7 +1010,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/climate-trace-india.html
+++ b/climate-trace-india.html
@@ -1208,7 +1208,7 @@ document.querySelectorAll('.tab-btn').forEach(btn => {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>

--- a/contact.html
+++ b/contact.html
@@ -1716,7 +1716,7 @@ document.addEventListener('DOMContentLoaded', function() {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/mojini-ai.js?v=db5170eb" defer></script>

--- a/content-marketing-kit.html
+++ b/content-marketing-kit.html
@@ -1747,7 +1747,7 @@ function gt(id,i){gcs(id).cur=i;upd(id);}
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/courses/causal/index.html
+++ b/courses/causal/index.html
@@ -4240,7 +4240,7 @@ body.dark-mode .soon-badge, [data-theme="dark"] .soon-badge, html.dark .soon-bad
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 
 <!-- Deferred scripts -->
 <script defer src="../../js/course-loader.js"></script>

--- a/courses/dataviz/index.html
+++ b/courses/dataviz/index.html
@@ -4934,7 +4934,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 
 <!-- Deferred scripts -->
 <script defer src="../../js/course-loader.js"></script>

--- a/courses/devai/index.html
+++ b/courses/devai/index.html
@@ -2080,7 +2080,7 @@ body.dark-mode .quiz-option:hover, [data-theme="dark"] .quiz-option:hover, html.
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 
 <!-- Deferred scripts -->
 <script defer src="../../js/course-loader.js"></script>

--- a/courses/devecon/index.html
+++ b/courses/devecon/index.html
@@ -4183,7 +4183,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 
 <!-- Deferred scripts -->
 <script defer src="../../js/course-loader.js"></script>

--- a/courses/gandhi/index.html
+++ b/courses/gandhi/index.html
@@ -3922,7 +3922,7 @@ body.dark-mode .question-type, [data-theme="dark"] .question-type, html.dark .qu
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 
 <!-- Deferred scripts -->
 <script defer src="../../js/course-loader.js"></script>

--- a/courses/gender/index.html
+++ b/courses/gender/index.html
@@ -2598,7 +2598,7 @@ sections.forEach(section => {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 
 <!-- Deferred scripts -->
 <script defer src="../../js/course-loader.js"></script>

--- a/courses/intervention/index.html
+++ b/courses/intervention/index.html
@@ -4248,7 +4248,7 @@ body.dark-mode .soon-badge, [data-theme="dark"] .soon-badge, html.dark .soon-bad
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 
 <!-- Deferred scripts -->
 <script defer src="../../js/course-loader.js"></script>

--- a/courses/law/index.html
+++ b/courses/law/index.html
@@ -4125,7 +4125,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 
 <!-- Deferred scripts -->
 <script defer src="../../js/course-loader.js"></script>

--- a/courses/livelihoods/index.html
+++ b/courses/livelihoods/index.html
@@ -3998,7 +3998,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script defer src="../../js/course-loader.js"></script>
 <script defer src="../../js/course-progress.js"></script>
 <script defer src="/js/paper-excerpt.js?v=55de7c20"></script>

--- a/courses/media/index.html
+++ b/courses/media/index.html
@@ -4103,7 +4103,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 
 <!-- Deferred scripts -->
 <script defer src="../../js/course-loader.js"></script>

--- a/courses/mel/index.html
+++ b/courses/mel/index.html
@@ -4166,7 +4166,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 
 <!-- Deferred scripts -->
 <script defer src="../../js/course-loader.js"></script>

--- a/courses/nothing-about-us/index.html
+++ b/courses/nothing-about-us/index.html
@@ -4085,7 +4085,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 
 <!-- Deferred scripts -->
 <script defer src="../../js/course-loader.js"></script>

--- a/courses/nvc-rj/index.html
+++ b/courses/nvc-rj/index.html
@@ -3969,7 +3969,7 @@ body.dark-mode ::selection, [data-theme="dark"] ::selection, html.dark ::selecti
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 
 <!-- Deferred scripts -->
 <script defer src="../../js/course-loader.js"></script>

--- a/courses/poa/index.html
+++ b/courses/poa/index.html
@@ -4245,7 +4245,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 
 <!-- Deferred scripts -->
 <script defer src="../../js/course-loader.js"></script>

--- a/courses/pubchoice/index.html
+++ b/courses/pubchoice/index.html
@@ -5705,7 +5705,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 
 <!-- Deferred scripts -->
 <script defer src="../../js/course-loader.js"></script>

--- a/courses/pubpol/index.html
+++ b/courses/pubpol/index.html
@@ -1629,7 +1629,7 @@ body.dark-mode, [data-theme="dark"] {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 
 <!-- Deferred scripts -->
 <script defer src="../../js/course-loader.js"></script>

--- a/courses/sel/index.html
+++ b/courses/sel/index.html
@@ -3908,7 +3908,7 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 
 <!-- Deferred scripts -->
 <script defer src="../../js/course-loader.js"></script>

--- a/courses/social-movements/index.html
+++ b/courses/social-movements/index.html
@@ -2996,7 +2996,7 @@ body.dark-mode .question-type, [data-theme="dark"] .question-type, html.dark .qu
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 
 <!-- Deferred scripts -->
 <script defer src="../../js/course-loader.js"></script>

--- a/data-protection.html
+++ b/data-protection.html
@@ -2005,7 +2005,7 @@ function addBotMessage(text) {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/mojini-ai.js?v=db5170eb" defer></script>

--- a/dataverse-india.html
+++ b/dataverse-india.html
@@ -734,7 +734,7 @@ updatePlanCount();
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
   <script src="/js/state-manager.js?v=62445627"></script>
   <script src="/js/config.js?v=bd5dcf94"></script>
-  <script src="/js/auth.js?v=90f23f77"></script>
+  <script src="/js/auth.js?v=97cb7b85"></script>
   <script src="/js/premium.js?v=80699517"></script>
   <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>

--- a/dataverse-rubrics.html
+++ b/dataverse-rubrics.html
@@ -592,7 +592,7 @@ if (state.selected && RUBRICS.some(function(r){return r.id===state.selected;})) 
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
   <script src="/js/state-manager.js?v=62445627"></script>
   <script src="/js/config.js?v=bd5dcf94"></script>
-  <script src="/js/auth.js?v=90f23f77"></script>
+  <script src="/js/auth.js?v=97cb7b85"></script>
   <script src="/js/premium.js?v=80699517"></script>
   <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>

--- a/dataverse.html
+++ b/dataverse.html
@@ -2341,7 +2341,7 @@ body.dark-mode .tag, [data-theme="dark"] .tag, html.dark .tag { background: #2B3
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -1461,7 +1461,7 @@ function addBotMessage(text) {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/mojini-ai.js?v=db5170eb" defer></script>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.221.0 — August 20, 2026 (Nine ways to fail silently, closed)
+
+### Fixed
+
+- Saving your notification preferences said "Saved" even when it hadn't been. That, and eight other places where the site could fail to save something without telling you or anyone else, now report the failure.
+
 ## v10.219.0 — August 19, 2026 (The wiki stopped quoting numbers nobody checked)
 
 ### Fixed

--- a/dojos.html
+++ b/dojos.html
@@ -2102,7 +2102,7 @@ body { padding-top: 70px; }
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/theme.js?v=ca787a55"></script>
 <script>
 // Standard three-way theme + mobile menu (sets data-theme attr AND body class so

--- a/faq.html
+++ b/faq.html
@@ -2551,7 +2551,7 @@ function searchFAQ() {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/mojini-ai.js?v=db5170eb" defer></script>

--- a/fundamentals/capabilities.html
+++ b/fundamentals/capabilities.html
@@ -293,7 +293,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/capabilities-data.js?v=d17660cb"></script>
 <script src="/js/capabilities.js?v=38dfea19"></script>

--- a/fundamentals/gender-needs.html
+++ b/fundamentals/gender-needs.html
@@ -278,7 +278,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/gender-needs-data.js?v=0f47dd22"></script>
 <script src="/js/gender-needs.js?v=21d89be6"></script>

--- a/fundamentals/index.html
+++ b/fundamentals/index.html
@@ -235,7 +235,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>
 </html>

--- a/fundamentals/ladder.html
+++ b/fundamentals/ladder.html
@@ -261,7 +261,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>
 </html>

--- a/fundamentals/livelihoods.html
+++ b/fundamentals/livelihoods.html
@@ -270,7 +270,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/livelihoods-data.js?v=513917e8"></script>
 <script src="/js/livelihoods.js?v=bea08ace"></script>

--- a/fundamentals/power-cube.html
+++ b/fundamentals/power-cube.html
@@ -265,7 +265,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>
 </html>

--- a/fundamentals/social-model.html
+++ b/fundamentals/social-model.html
@@ -275,7 +275,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/social-model-data.js?v=3e2d978d"></script>
 <script src="/js/social-model.js?v=8599dd2b"></script>

--- a/fundamentals/wheel.html
+++ b/fundamentals/wheel.html
@@ -348,7 +348,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>
 </html>

--- a/fundamentals/who-counts.html
+++ b/fundamentals/who-counts.html
@@ -252,7 +252,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>
 </html>

--- a/game-library.html
+++ b/game-library.html
@@ -1295,7 +1295,7 @@ body.dark-mode .skip-link, [data-theme="dark"] .skip-link, html.dark .skip-link 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/grievance.html
+++ b/grievance.html
@@ -1887,7 +1887,7 @@ function addBotMessage(text) {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/mojini-ai.js?v=db5170eb" defer></script>

--- a/handouts.html
+++ b/handouts.html
@@ -1949,7 +1949,7 @@ loadHandouts();
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/mojini-ai.js?v=db5170eb" defer></script>

--- a/js/auth.js
+++ b/js/auth.js
@@ -991,7 +991,13 @@ const ImpactMojoAuth = {
             supabaseClient.from('profiles')
                 .update({ last_active_at: new Date().toISOString() })
                 .eq('id', userId)
-                .then(function () { try { localStorage.setItem(key, today); } catch (e) {} });
+                .then(function (result) {
+                    if (result && result.error) {
+                        console.warn('[Auth] last_active_at not recorded:', result.error.message);
+                        return;   // do not mark today as done — let it retry
+                    }
+                    try { localStorage.setItem(key, today); } catch (e) {}
+                });
         } catch (e) { /* best-effort */ }
     },
 

--- a/js/course-progress.js
+++ b/js/course-progress.js
@@ -257,7 +257,7 @@
             var isComplete = percentage >= 100;
             var now = new Date().toISOString();
 
-            await sb.from('user_progress').upsert({
+            var { error: syncError } = await sb.from('user_progress').upsert({
                 user_id: user.id,
                 course_id: courseId,
                 course_name: COURSE_NAMES[courseId],
@@ -269,8 +269,17 @@
             }, {
                 onConflict: 'user_id,course_id'
             });
+
+            // supabase-js RESOLVES with { data, error } rather than throwing, so
+            // the catch below never saw a rejected write. Progress is still kept
+            // in localStorage either way, but a cloud failure must be visible
+            // somewhere or it stays invisible for months — which it did.
+            if (syncError) {
+                console.error('[CourseProgress] Cloud sync failed for ' + courseId +
+                              ': ' + syncError.message);
+            }
         } catch (e) {
-            // Silently fail — user can still track locally
+            console.error('[CourseProgress] Cloud sync threw for ' + courseId + ':', e);
         }
     }
 

--- a/live-projects.html
+++ b/live-projects.html
@@ -1328,7 +1328,7 @@ body.dark-mode .card-tag, [data-theme="dark"] .card-tag, html.dark .card-tag { b
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/org-dashboard.html
+++ b/org-dashboard.html
@@ -2498,7 +2498,12 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
             // Auto-add admin as member (fire-and-forget)
             supabaseClient.from('organization_members')
                 .upsert({ org_id: org.id, user_id: profile.id, role: 'admin', status: 'active', joined_at: new Date().toISOString() },
-                    { onConflict: 'org_id,user_id', ignoreDuplicates: true }).then(function() {});
+                    { onConflict: 'org_id,user_id', ignoreDuplicates: true })
+                .then(function (result) {
+                    if (result && result.error) {
+                        console.error('[Org] Creator was not added as a member:', result.error.message);
+                    }
+                });
 
             // Load data
             await Promise.all([loadMembers(), loadPaths()]);
@@ -3450,7 +3455,8 @@ body.dark-mode .v3-paper-plane { opacity: 0.10; }
     window.deleteDiscussionPost = async function(postId, cohortId) {
         if (!confirm('Delete this post?')) return;
         try {
-            await sb.from('cohort_discussions').delete().eq('id', postId);
+            var { error: delError } = await sb.from('cohort_discussions').delete().eq('id', postId);
+            if (delError) throw delError;
             await window.openCohortDiscussion(cohortId);
         } catch (e) {
             console.error('Delete post error:', e);

--- a/podcast.html
+++ b/podcast.html
@@ -2058,7 +2058,7 @@ function addBotMessage(text) {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/mojini-ai.js?v=db5170eb" defer></script>

--- a/portfolio.html
+++ b/portfolio.html
@@ -1155,7 +1155,11 @@ function savePortfolio() {
         supabaseClient.from('profiles')
             .update({ portfolio_headline: headline })
             .eq('id', userId)
-            .then(function() {});
+            .then(function (result) {
+                if (result && result.error) {
+                    showStatus('Could not save your headline: ' + result.error.message, 'error');
+                }
+            });
 
         // Upsert portfolio items
         if (portfolioItems.length > 0) {

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1401,7 +1401,7 @@ function addBotMessage(text) {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/mojini-ai.js?v=db5170eb" defer></script>

--- a/products.html
+++ b/products.html
@@ -528,7 +528,7 @@ renderPacks('subjectPacks', SUBJECT);
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/theme.js?v=ca787a55"></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/refund-policy.html
+++ b/refund-policy.html
@@ -1548,7 +1548,7 @@ function addBotMessage(text) {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/mojini-ai.js?v=db5170eb" defer></script>

--- a/scripts/check-supabase-writes.py
+++ b/scripts/check-supabase-writes.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Supabase write-path guard.
+
+Two failures hid the same bug for eight months, and this guards both.
+
+`user_progress` had 0 rows ever inserted against 17,022 reads, while the
+code that writes it looked fine. Two things kept that invisible:
+
+  1. The call discarded its result:
+
+         await sb.from('user_progress').upsert({ ... });
+
+     supabase-js RESOLVES with { data, error } — it does not throw. A
+     rejected insert is therefore indistinguishable from a successful one
+     unless you read `error`. The surrounding try/catch could never fire.
+
+  2. Nothing ever asserted that a table the code writes to had in fact
+     received a write.
+
+STATIC mode (default, no credentials, runs on every push) catches (1): a
+write whose result is thrown away, or captured and never checked.
+
+LIVE mode (--live, needs SUPABASE_PAT, scheduled only) catches (2): for
+every table the code writes to, assert pg_stat_user_tables.n_tup_ins > 0.
+A table with a writer that has never once received a row is either a dead
+feature or a broken one; both are worth knowing.
+
+A line can opt out with the token "write-ignore" (e.g. a deliberate
+fire-and-forget where losing the write is genuinely acceptable).
+
+Usage:
+  python3 scripts/check-supabase-writes.py           # static, exit 1 on findings
+  python3 scripts/check-supabase-writes.py --live    # also probe insert counts
+  python3 scripts/check-supabase-writes.py --list    # show every write call found
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+SKIP_PREFIXES = ("Backups/", "node_modules/", "tests/", "netlify-resource-template/")
+SCAN_SUFFIXES = (".js", ".html", ".mjs")
+
+# A write through PostgREST or Storage: `.from('t')` … then a mutating verb.
+#
+# Written to be linear-time. An earlier version used a nested optional group
+# with `[^;]*?` inside a `.*?` lead, which backtracked catastrophically on a
+# long line and hung — and a guard that hangs is worse than no guard, because
+# a hung CI job neither passes nor fails, it just reads as "still running".
+#
+# So: match `.from('table')` on its own, then look at the bounded text that
+# follows to find the verb. No nested quantifiers, nothing to backtrack into.
+FROM_RE = re.compile(
+    r"""(?P<obj>[A-Za-z_$][\w$.]*)
+        \.(?:storage\.)?from\(\s*['"](?P<table>[A-Za-z_]\w*)['"]\s*\)
+    """,
+    re.VERBOSE,
+)
+VERBS = ("insert", "upsert", "update", "delete", "upload", "remove")
+# How much of the chain after `.from('t')` may be searched for the verb.
+CHAIN_WINDOW = 300
+
+
+def verb_after(tail):
+    """First mutating verb in the method chain following `.from('t')`.
+
+    Deliberately a plain scan rather than a regex: the chain is unbounded in
+    shape, and any regex expressing it needs nested quantifiers, which is what
+    made the first version of this guard hang. Stops at `;` so a later
+    statement on the same line cannot be attributed to this call.
+    """
+    stop = tail.find(";")
+    window = tail[:stop] if stop != -1 else tail[:CHAIN_WINDOW]
+    best, pos = None, len(window) + 1
+    for v in VERBS:
+        i = window.find("." + v + "(")
+        if i == -1:
+            i = window.find(". " + v + "(")
+        if i != -1 and i < pos:
+            best, pos = v, i
+    return best
+
+OPT_OUT = "write-ignore"
+# How far after the call to look for a check of the captured result.
+LOOKAHEAD = 20
+
+
+def tracked_files():
+    out = subprocess.run(["git", "ls-files"], capture_output=True, text=True,
+                         cwd=ROOT, check=True).stdout.splitlines()
+    return [f for f in out
+            if f.endswith(SCAN_SUFFIXES) and not f.startswith(SKIP_PREFIXES)]
+
+
+THEN_RE = re.compile(r"\.\s*then\s*\(\s*(?:async\s+)?(?:function\s*)?\(?\s*"
+                     r"(?P<param>[A-Za-z_$][\w$]*)?")
+
+
+def then_checks_error(tail):
+    """True when the call is consumed by .then(cb) and cb inspects `.error`.
+
+    supabase-js is promise-based, so this is a legitimate way to handle a
+    failure and must not be reported. `.then(function () {…})` with no
+    parameter cannot inspect anything, so it stays a finding.
+    """
+    m = THEN_RE.search(tail[:CHAIN_WINDOW])
+    if not m:
+        return False
+    param = m.group("param")
+    if not param:
+        return False
+    body = tail[m.end(): m.end() + CHAIN_WINDOW * 2]
+    return re.search(rf"\b{re.escape(param)}\s*(?:\.|\?\.)\s*error\b", body) is not None
+
+
+def classify(lines, idx, col, tail):
+    """Return (status, detail). status in {'ok','discarded','unchecked'}."""
+    if then_checks_error(tail):
+        return "ok", "handled in .then callback"
+
+    # Everything on the line before this call decides how its result is handled.
+    before = lines[idx][:col].rstrip()
+    if before.endswith("await"):
+        before = before[:-len("await")].rstrip()
+
+    # Destructured: `var { error } = await ...` / `const { data, error } = ...`
+    destructured = re.search(r"\{([^{}]*)\}\s*=\s*$", before)
+    if destructured:
+        names = [n.strip().split(":")[-1].strip()
+                 for n in destructured.group(1).split(",")]
+        if any(n == "error" or n.endswith("Error") for n in names):
+            return "ok", "destructured error"
+        # `{ data } = await ...` — data captured, error dropped
+        return "unchecked", "destructures result but not `error`"
+
+    # Assigned to a variable: `var res = await ...`
+    assigned = re.search(r"(?:var|let|const)\s+([A-Za-z_$][\w$]*)\s*=\s*$", before)
+    if assigned:
+        var = assigned.group(1)
+        window = "\n".join(lines[idx: idx + LOOKAHEAD])
+        if re.search(rf"\b{re.escape(var)}\s*(?:\.|\?\.)\s*error\b", window):
+            return "ok", f"checks {var}.error"
+        return "unchecked", f"captures result as `{var}` but never reads {var}.error"
+
+    # Plain assignment to an existing name, or a return — treat as captured.
+    if re.search(r"(?:=|return)\s*$", before):
+        return "ok", "result returned or assigned"
+
+    # Nothing captures it at all.
+    return "discarded", "result discarded — a rejected write is indistinguishable from success"
+
+
+def scan():
+    findings, calls = [], []
+    for rel in tracked_files():
+        path = ROOT / rel
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if ".from(" not in text:
+            continue
+        lines = text.splitlines()
+        # Offset of the first character of each line, so a match anywhere in
+        # the file maps back to a line. The chain is searched across the whole
+        # text, not just the rest of one line: formatting a long call over
+        # several lines must not make the guard go blind to it. (It did —
+        # reformatting four calls dropped the detected count from 17 to 13.)
+        starts, off = [], 0
+        for ln in lines:
+            starts.append(off)
+            off += len(ln) + 1
+
+        def line_of(pos):
+            lo, hi = 0, len(starts) - 1
+            while lo < hi:
+                mid = (lo + hi + 1) // 2
+                if starts[mid] <= pos:
+                    lo = mid
+                else:
+                    hi = mid - 1
+            return lo
+
+        for m in FROM_RE.finditer(text):
+            verb = verb_after(text[m.end():m.end() + CHAIN_WINDOW])
+            if verb is None:
+                continue                          # a read, not a write
+            idx = line_of(m.start())
+            if OPT_OUT in lines[idx]:
+                continue
+            table = m.group("table")
+            calls.append((rel, idx + 1, table, verb))
+            status, detail = classify(lines, idx, m.start() - starts[idx],
+                                      text[m.end():])
+            if status != "ok":
+                findings.append((rel, idx + 1, table, verb, status, detail,
+                                 lines[idx].strip()[:100]))
+    return findings, calls
+
+
+# ----------------------------------------------------------------- live mode
+
+def live_insert_counts(tables):
+    """n_tup_ins per table via the Supabase Management API. Needs SUPABASE_PAT."""
+    pat = os.environ.get("SUPABASE_PAT")
+    if not pat:
+        return None, "SUPABASE_PAT is not set"
+    ref = "ddyszmfffyedolkcugld"
+    names = ",".join("'%s'" % t.replace("'", "") for t in sorted(tables))
+    sql = ("select relname, n_tup_ins from pg_stat_user_tables "
+           f"where schemaname='public' and relname in ({names});")
+    req = urllib.request.Request(
+        f"https://api.supabase.com/v1/projects/{ref}/database/query",
+        data=json.dumps({"query": sql}).encode(),
+        headers={"Authorization": f"Bearer {pat}",
+                 "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=45) as r:
+            rows = json.loads(r.read().decode())
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as e:
+        return None, f"query failed: {e}"
+    return {row["relname"]: row["n_tup_ins"] for row in rows}, None
+
+
+def main(argv):
+    findings, calls = scan()
+
+    if "--list" in argv:
+        print(f"{len(calls)} Supabase write calls across "
+              f"{len({c[0] for c in calls})} files:\n")
+        for rel, ln, table, verb in sorted(calls):
+            print(f"  {rel}:{ln}  {verb:<6} -> {table}")
+        return 0
+
+    failed = False
+
+    if findings:
+        failed = True
+        print(f"FAIL - {len(findings)} Supabase write(s) whose failure would be "
+              f"silent:\n")
+        for rel, ln, table, verb, status, detail, src in findings:
+            print(f"  {rel}:{ln}")
+            print(f"      {verb} -> {table}: {detail}")
+            print(f"      {src}")
+        print("\n  supabase-js resolves with { data, error } rather than throwing,")
+        print("  so a try/catch around one of these cannot fire. Destructure")
+        print("  `error` and act on it, or mark the line `write-ignore` if losing")
+        print("  the write is genuinely acceptable.")
+    else:
+        print(f"PASS - all {len(calls)} Supabase writes surface their errors.")
+
+    if "--live" in argv:
+        tables = sorted({c[2] for c in calls})
+        counts, err = live_insert_counts(tables)
+        print()
+        if err:
+            print(f"SKIP - live insert-count probe not run ({err}).")
+        else:
+            never = [t for t in tables
+                     if t in counts and counts[t] == 0]
+            absent = [t for t in tables if t not in counts]
+            for t in sorted(counts):
+                mark = "never written" if counts[t] == 0 else f"{counts[t]} inserts"
+                print(f"  {t:<28} {mark}")
+            if absent:
+                print(f"\n  not present in this database: {', '.join(absent)}")
+            if never:
+                failed = True
+                print(f"\nFAIL - {len(never)} table(s) have writing code but have "
+                      f"NEVER received a row:")
+                for t in never:
+                    print(f"    {t}")
+                print("\n  Either the feature is broken or it was never wired to a")
+                print("  UI. Both are worth knowing; neither should be silent.")
+            else:
+                print("\nPASS - every table with a writer has received writes.")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/status.html
+++ b/status.html
@@ -760,7 +760,7 @@ setInterval(runAllChecks, 60000);
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/theme.js?v=ca787a55"></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/teach.html
+++ b/teach.html
@@ -1723,7 +1723,7 @@ document.addEventListener('click', function(e) {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/mojini-ai.js?v=db5170eb" defer></script>
 </body>

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -1497,7 +1497,7 @@ function addBotMessage(text) {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/mojini-ai.js?v=db5170eb" defer></script>

--- a/testimonials.html
+++ b/testimonials.html
@@ -1093,7 +1093,7 @@ function filterLang(lang) {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/the-long-view.html
+++ b/the-long-view.html
@@ -598,7 +598,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>
 </html>

--- a/toc-builder.html
+++ b/toc-builder.html
@@ -1344,7 +1344,7 @@ document.addEventListener('keydown', function(e){
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/toc-workbench.html
+++ b/toc-workbench.html
@@ -1379,7 +1379,7 @@ window.addEventListener('scroll', function(){
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/transparency.html
+++ b/transparency.html
@@ -1532,7 +1532,7 @@ window.addEventListener('resize', function() {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>

--- a/updates.html
+++ b/updates.html
@@ -1049,7 +1049,7 @@ function toggleCard(card) {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script>
 // Standard three-way theme + mobile menu (sets data-theme attr AND body class so
 // both paired (impact-bold.css) and standalone [data-theme] rules resolve)

--- a/upgrade.html
+++ b/upgrade.html
@@ -781,7 +781,7 @@ body { padding-top: 56px; }
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 
 <!-- Language Translation -->
 

--- a/verify-certificate.html
+++ b/verify-certificate.html
@@ -1056,7 +1056,7 @@ document.addEventListener('DOMContentLoaded', function() {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 </body>

--- a/verify.html
+++ b/verify.html
@@ -683,7 +683,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]) {
 <!-- Supabase + config + auth (auth NOT required to use this page; client used only for the public anon read) -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/theme.js?v=ca787a55"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
 

--- a/workshops.html
+++ b/workshops.html
@@ -1848,7 +1848,7 @@ function addBotMessage(text) {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
-<script src="/js/auth.js?v=90f23f77"></script>
+<script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/mojini-ai.js?v=db5170eb" defer></script>


### PR DESCRIPTION
Closes the class of failure behind #960, and fixes nine live instances of it.

## The mechanism

`supabase-js` **resolves** with `{ data, error }` rather than throwing. So this:

```js
await sb.from('user_progress').upsert({ ... });
} catch (e) {
    // Silently fail — user can still track locally
}
```

reports a rejected write exactly as it reports a successful one, and the `catch` can never fire. That is how `user_progress` reached **0 rows ever inserted against 17,022 reads** with nothing red anywhere.

## The guard

**Static half** — every push, no credentials. Finds each `.from('table')` chained to a mutating verb (`insert`/`upsert`/`update`/`delete`/`upload`/`remove`) and fails when the result is discarded, or captured and never read. It accepts the three legitimate shapes:

| Shape | Verdict |
|---|---|
| `var { error } = await sb.from(…)…` | ok |
| `var res = await …` then `if (res.error)` | ok |
| `.then(function (r) { if (r.error) … })` | ok |
| `await sb.from(…).upsert(…)` — nothing captures it | **fail** |
| `var res = await …` and `res.error` never read | **fail** |
| `.then(function () {})` — no param, can't inspect | **fail** |

A line can opt out with `write-ignore`.

**Live half** — `--live`, scheduled/dispatch only, skips gracefully without `SUPABASE_PAT`. Asserts every table the code writes to has non-zero `n_tup_ins`. A writer whose table has never once received a row is either broken or never wired to a UI; both are worth knowing.

## Nine writes fixed

| Where | What was silent |
|---|---|
| `js/course-progress.js` | the `user_progress` upsert behind #960 |
| `account.html` | preferences showed **"Saved"** unconditionally — false success of the kind the form rebuild removed elsewhere |
| `account.html` | marking a notification read |
| `admin/index.html` ×2 | feature flags, site metadata |
| `org-dashboard.html` | deleting a discussion post |
| `org-dashboard.html` | the creator-becomes-member upsert — a failure leaves the creator outside their own org |
| `portfolio.html` | portfolio headline |
| `js/auth.js` | `last_active_at` wrote the day to `localStorage` inside a `.then` that ran even on failure, so a failed write **suppressed its own retry** for the rest of the day |

## Two defects in the guard itself

Both found by testing it, not reading it, and both are the guard-passes-anyway shape this repo keeps hitting:

- The first regex **backtracked catastrophically and hung**. A hung CI job neither passes nor fails — it reads as "still running", exactly the failure `.claude/rules/testing.md` already documents. Replaced with a bounded linear scan; now runs in 0.38s.
- Reformatting a call across several lines made the single-line matcher **go blind to it** — detections fell from 17 to 13 and it "passed" partly for that reason. Now matched across the whole file, which also surfaced **four writes the first version never saw**, one in `js/auth.js`.
- A false positive went the same way: `portfolio.html` checks `result.error` inside a `.then` callback, which the first classifier didn't understand.

## Verification

Negative tests, run against the final detector:

- reintroducing the original `user_progress` bug → flagged
- `.then(function () {})` with no parameter → flagged
- `write-ignore` → silences
- a captured result whose `.error` is never read → flagged
- both test files restored byte-identical afterwards

All 13 local guards pass, plus the service-worker contract test.

`--live` could not run from this session (the Management API SQL endpoint 403s here, same restriction as workflow dispatch), so it is wired to schedule-only and skips when the secret is absent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01199dCmAgzMN1Z1d8qj2UfN)_