### PR TITLE
Put the 33 paid product pages into site search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to ImpactMojo are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.222.0] - 2026-08-20
+
+### Fixed
+
+- **33 paid product pages were absent from site search.** Every one is live, ungated and priced — the four ₹499 assessment banks, the ₹99 checklists, the ₹199 budget template, the workbooks, refreshers, posters and templates. They were in `sitemap.xml`, so Google could find them, but ImpactMojo's own search could not: someone already on the site looking for "logframe" or "field readiness checklist" got nothing.
+
+  Entries are generated from each page's own `<title>` and `<meta name="description">` rather than written by hand, so they cannot drift from the page. A description that opened by restating the title is trimmed, since that wastes the whole search snippet. Categories are derived from the slug (Assessment Banks 4, Templates 11, Workbooks 4, Refreshers 4, Checklists 3, Toolkits 3, Decks 2, Posters 2), and each entry carries its price as a tag.
+
+  1,087 → 1,120 entries. Verified after writing: valid JSON on re-read, no duplicate id or URL anywhere in the file, no entry missing a required field, and **all 33 URLs resolve to a real `index.html`**. The sitemap-not-indexed gap falls from 162 to 129; the only `/products` path still outside search is `/products.html` itself, which is the listing page and already has an anchor entry.
+
 ## [10.221.0] - 2026-08-20
 
 ### Added

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -16184,5 +16184,511 @@
     ],
     "type": "showcase",
     "category": "Showcase"
+  },
+  {
+    "id": "PROD-ASSESSMENT-AI-FOR-ME",
+    "title": "AI for Monitoring & Evaluation — 500-Question Assessment Bank",
+    "description": "500 original MCQs with a full answer key and explanations. Buy for ₹499 via UPI.",
+    "type": "product",
+    "category": "Assessment Banks",
+    "url": "/products/assessment-ai-for-me/",
+    "tags": [
+      "assessment",
+      "premium",
+      "paid",
+      "₹499"
+    ]
+  },
+  {
+    "id": "PROD-ASSESSMENT-DATA-TECH",
+    "title": "Data & Technology for Development — 500-Question Assessment Bank",
+    "description": "500 original MCQs with a full answer key and explanations. Buy for ₹499 via UPI.",
+    "type": "product",
+    "category": "Assessment Banks",
+    "url": "/products/assessment-data-tech/",
+    "tags": [
+      "assessment",
+      "data",
+      "tech",
+      "premium",
+      "paid",
+      "₹499"
+    ]
+  },
+  {
+    "id": "PROD-ASSESSMENT-MEL",
+    "title": "Monitoring, Evaluation & Learning — 500-Question Assessment Bank",
+    "description": "500 original MCQs with a full answer key and explanations. Buy for ₹499 via UPI.",
+    "type": "product",
+    "category": "Assessment Banks",
+    "url": "/products/assessment-mel/",
+    "tags": [
+      "assessment",
+      "mel",
+      "premium",
+      "paid",
+      "₹499"
+    ]
+  },
+  {
+    "id": "PROD-ASSESSMENT-POLICY-ECON",
+    "title": "Policy & Economics for Development — 500-Question Assessment Bank",
+    "description": "500 original MCQs with a full answer key and explanations. Buy for ₹499 via UPI.",
+    "type": "product",
+    "category": "Assessment Banks",
+    "url": "/products/assessment-policy-econ/",
+    "tags": [
+      "assessment",
+      "econ",
+      "policy",
+      "premium",
+      "paid",
+      "₹499"
+    ]
+  },
+  {
+    "id": "PROD-BUDGET",
+    "title": "Activity Budget & Costing Template",
+    "description": "An activity-based budget with live formulas — enter days and rates, and subtotal, contingency and total compute themselves.",
+    "type": "product",
+    "category": "Templates",
+    "url": "/products/budget/",
+    "tags": [
+      "budget",
+      "premium",
+      "paid",
+      "₹199"
+    ]
+  },
+  {
+    "id": "PROD-CHECKLIST-ETHICS-DPDP",
+    "title": "Ethics & DPDP Consent Checklist",
+    "description": "Cover informed consent and India's DPDP 2023 essentials before you collect a single personal record.",
+    "type": "product",
+    "category": "Checklists",
+    "url": "/products/checklist-ethics-dpdp/",
+    "tags": [
+      "checklist",
+      "dpdp",
+      "ethics",
+      "premium",
+      "paid",
+      "₹99"
+    ]
+  },
+  {
+    "id": "PROD-CHECKLIST-FIELD-READINESS",
+    "title": "Field Data-Collection Readiness Checklist",
+    "description": "The pre-flight checklist for any data-collection round — team, tools, ethics, logistics, data security.",
+    "type": "product",
+    "category": "Checklists",
+    "url": "/products/checklist-field-readiness/",
+    "tags": [
+      "checklist",
+      "field",
+      "readiness",
+      "premium",
+      "paid",
+      "₹99"
+    ]
+  },
+  {
+    "id": "PROD-CHECKLIST-PROPOSAL-REVIEW",
+    "title": "Proposal Review Checklist",
+    "description": "Score incoming research/evaluation bids against your ToR, consistently and defensibly.",
+    "type": "product",
+    "category": "Checklists",
+    "url": "/products/checklist-proposal-review/",
+    "tags": [
+      "checklist",
+      "proposal",
+      "review",
+      "premium",
+      "paid",
+      "₹99"
+    ]
+  },
+  {
+    "id": "PROD-COMMISSIONING-WORKBOOK",
+    "title": "Commissioning Research — Workbook",
+    "description": "A guided, fill-in workbook to think a study through — before you write a single line of the ToR.",
+    "type": "product",
+    "category": "Workbooks",
+    "url": "/products/commissioning-workbook/",
+    "tags": [
+      "commissioning",
+      "workbook",
+      "premium",
+      "paid",
+      "₹499"
+    ]
+  },
+  {
+    "id": "PROD-DATA-CONSENT",
+    "title": "Data Management & Consent Pack",
+    "description": "A ready-to-adapt consent form, data management plan and a DPDP 2023 compliance checklist.",
+    "type": "product",
+    "category": "Toolkits",
+    "url": "/products/data-consent/",
+    "tags": [
+      "consent",
+      "data",
+      "premium",
+      "paid",
+      "₹199"
+    ]
+  },
+  {
+    "id": "PROD-DONOR-REPORT",
+    "title": "Donor Report Template",
+    "description": "A narrative report structure funders actually read — results first, with honest learning built in.",
+    "type": "product",
+    "category": "Templates",
+    "url": "/products/donor-report/",
+    "tags": [
+      "donor",
+      "report",
+      "premium",
+      "paid",
+      "₹199"
+    ]
+  },
+  {
+    "id": "PROD-EVALUATION-ESSENTIALS-KIT",
+    "title": "Evaluation Essentials Kit",
+    "description": "All 27 ImpactMojo products: every template, all four workbooks, both trainer decks, plus the refreshers, posters and checklists, for ₹2,499.",
+    "type": "product",
+    "category": "Toolkits",
+    "url": "/products/evaluation-essentials-kit/",
+    "tags": [
+      "essentials",
+      "evaluation",
+      "kit",
+      "premium",
+      "paid",
+      "₹2,499"
+    ]
+  },
+  {
+    "id": "PROD-FGD-GUIDE",
+    "title": "FGD Facilitator's Guide",
+    "description": "Everything to run a real focus group — setup, consent, a question route with probes, and what to do afterward.",
+    "type": "product",
+    "category": "Templates",
+    "url": "/products/fgd-guide/",
+    "tags": [
+      "fgd",
+      "guide",
+      "premium",
+      "paid",
+      "₹199"
+    ]
+  },
+  {
+    "id": "PROD-INTRO-MEL-DECK",
+    "title": "Introduction to MEL — Trainer Deck",
+    "description": "A 10-slide, editable workshop deck with facilitator notes — MEL basics, theory of change, indicators, methods and pitfalls.",
+    "type": "product",
+    "category": "Decks",
+    "url": "/products/intro-mel-deck/",
+    "tags": [
+      "deck",
+      "intro",
+      "mel",
+      "premium",
+      "paid",
+      "₹499"
+    ]
+  },
+  {
+    "id": "PROD-LOGFRAME",
+    "title": "Logframe Template",
+    "description": "A logical framework that actually tracks — results levels, indicators, baselines, targets, means of verification and assumptions, ready to fill.",
+    "type": "product",
+    "category": "Templates",
+    "url": "/products/logframe/",
+    "tags": [
+      "logframe",
+      "premium",
+      "paid",
+      "₹199"
+    ]
+  },
+  {
+    "id": "PROD-MEL-FROM-SCRATCH-WORKBOOK",
+    "title": "MEL from Scratch — 90-Day Workbook",
+    "description": "Stand up a working MEL system in 90 days — a fill-in workbook that takes you from theory of change to a system people actually use.",
+    "type": "product",
+    "category": "Workbooks",
+    "url": "/products/mel-from-scratch-workbook/",
+    "tags": [
+      "mel",
+      "scratch",
+      "workbook",
+      "premium",
+      "paid",
+      "₹499"
+    ]
+  },
+  {
+    "id": "PROD-MEL-PLAN",
+    "title": "MEL Plan Template",
+    "description": "A monitoring, evaluation & learning plan with an indicator matrix, methods, roles, ethics and a reporting schedule — ready to fill.",
+    "type": "product",
+    "category": "Templates",
+    "url": "/products/mel-plan/",
+    "tags": [
+      "mel",
+      "plan",
+      "premium",
+      "paid",
+      "₹199"
+    ]
+  },
+  {
+    "id": "PROD-NOTES-NOTHING-ABOUT-US",
+    "title": "Nothing About Us Without Us — Course Notes (PDF)",
+    "description": "Nothing About Us Without Us: Disability, Justice & Development — the complete flagship course notes as a printable PDF (9 modules, 48 pages). Every module's core ideas, South Asian scholarship, worked examples and key readings. ₹350 via UPI.",
+    "type": "product",
+    "category": "Toolkits",
+    "url": "/products/notes-nothing-about-us/",
+    "tags": [
+      "notes",
+      "premium",
+      "paid",
+      "₹350"
+    ]
+  },
+  {
+    "id": "PROD-POSTER-ECONOMETRICS",
+    "title": "Econometrics Formulae Poster",
+    "description": "An A3 poster of the workhorse econometrics — OLS, DiD, fixed effects, IV/2SLS, RD, logit.",
+    "type": "product",
+    "category": "Posters",
+    "url": "/products/poster-econometrics/",
+    "tags": [
+      "econometrics",
+      "poster",
+      "premium",
+      "paid",
+      "₹149"
+    ]
+  },
+  {
+    "id": "PROD-POSTER-MEL-STATS",
+    "title": "MEL & Statistics Formulae Poster",
+    "description": "An A3 wall poster of the MEL & statistics formulae you reach for — sample size, SE, CIs, effect sizes, tests.",
+    "type": "product",
+    "category": "Posters",
+    "url": "/products/poster-mel-stats/",
+    "tags": [
+      "mel",
+      "poster",
+      "stats",
+      "premium",
+      "paid",
+      "₹149"
+    ]
+  },
+  {
+    "id": "PROD-PROPOSAL-SCORING",
+    "title": "Proposal Scoring Rubric",
+    "description": "A weighted scoring sheet for assessing bids against your ToR — criteria, weights and an auto-calculated total.",
+    "type": "product",
+    "category": "Templates",
+    "url": "/products/proposal-scoring/",
+    "tags": [
+      "proposal",
+      "scoring",
+      "premium",
+      "paid",
+      "₹199"
+    ]
+  },
+  {
+    "id": "PROD-REFRESHER-CAUSAL-DESIGNS",
+    "title": "Causal Designs — Refresher",
+    "description": "RCTs, RD, DiD, matching, pre-post — ranked, explained, and matched to your question, on one page.",
+    "type": "product",
+    "category": "Refreshers",
+    "url": "/products/refresher-causal-designs/",
+    "tags": [
+      "causal",
+      "designs",
+      "refresher",
+      "premium",
+      "paid",
+      "₹99"
+    ]
+  },
+  {
+    "id": "PROD-REFRESHER-OECD-DAC",
+    "title": "OECD-DAC Criteria — Refresher",
+    "description": "The six OECD-DAC evaluation criteria, and the exact question each one asks — one page.",
+    "type": "product",
+    "category": "Refreshers",
+    "url": "/products/refresher-oecd-dac/",
+    "tags": [
+      "dac",
+      "oecd",
+      "refresher",
+      "premium",
+      "paid",
+      "₹99"
+    ]
+  },
+  {
+    "id": "PROD-REFRESHER-QUANT-QUAL-MIXED",
+    "title": "Quant vs Qual vs Mixed — Refresher",
+    "description": "What each method family answers, its strengths, and how to combine them — one page.",
+    "type": "product",
+    "category": "Refreshers",
+    "url": "/products/refresher-quant-qual-mixed/",
+    "tags": [
+      "mixed",
+      "qual",
+      "quant",
+      "refresher",
+      "premium",
+      "paid",
+      "₹99"
+    ]
+  },
+  {
+    "id": "PROD-REFRESHER-SAMPLING",
+    "title": "Sampling & Sample Size — Refresher",
+    "description": "The one-page sampling reference you'll actually keep open — designs, what drives sample size, and the pitfalls.",
+    "type": "product",
+    "category": "Refreshers",
+    "url": "/products/refresher-sampling/",
+    "tags": [
+      "refresher",
+      "sampling",
+      "premium",
+      "paid",
+      "₹99"
+    ]
+  },
+  {
+    "id": "PROD-RESULTS-FRAMEWORK",
+    "title": "Results Framework & Indicator Bank",
+    "description": "A results framework to complete, plus a starter bank of sector indicators to draw from.",
+    "type": "product",
+    "category": "Templates",
+    "url": "/products/results-framework/",
+    "tags": [
+      "framework",
+      "results",
+      "premium",
+      "paid",
+      "₹199"
+    ]
+  },
+  {
+    "id": "PROD-STAKEHOLDER-MAP",
+    "title": "Stakeholder Mapping Template",
+    "description": "Map who matters by interest, influence and stance — and decide how to engage each one.",
+    "type": "product",
+    "category": "Templates",
+    "url": "/products/stakeholder-map/",
+    "tags": [
+      "map",
+      "stakeholder",
+      "premium",
+      "paid",
+      "₹199"
+    ]
+  },
+  {
+    "id": "PROD-SURVEY-DESIGN-WORKBOOK",
+    "title": "Survey Design Workbook",
+    "description": "Go from a research question to a field-ready questionnaire — without designing in the usual errors.",
+    "type": "product",
+    "category": "Workbooks",
+    "url": "/products/survey-design-workbook/",
+    "tags": [
+      "design",
+      "survey",
+      "workbook",
+      "premium",
+      "paid",
+      "₹499"
+    ]
+  },
+  {
+    "id": "PROD-SURVEY-INSTRUMENT",
+    "title": "Survey Instrument Template",
+    "description": "A structured questionnaire you can adapt — consent, profile, core modules and enumerator notes, built to avoid the usual traps.",
+    "type": "product",
+    "category": "Templates",
+    "url": "/products/survey-instrument/",
+    "tags": [
+      "instrument",
+      "survey",
+      "premium",
+      "paid",
+      "₹199"
+    ]
+  },
+  {
+    "id": "PROD-TOC-CANVAS",
+    "title": "Theory of Change Canvas",
+    "description": "A one-page canvas to map your results chain and surface the assumptions it depends on.",
+    "type": "product",
+    "category": "Templates",
+    "url": "/products/toc-canvas/",
+    "tags": [
+      "canvas",
+      "toc",
+      "premium",
+      "paid",
+      "₹199"
+    ]
+  },
+  {
+    "id": "PROD-TOC-DECK",
+    "title": "Theory of Change — Trainer Deck",
+    "description": "An editable trainer deck on building and using a theory of change — results chains, assumptions, and turning a ToC into indicators.",
+    "type": "product",
+    "category": "Decks",
+    "url": "/products/toc-deck/",
+    "tags": [
+      "deck",
+      "toc",
+      "premium",
+      "paid",
+      "₹499"
+    ]
+  },
+  {
+    "id": "PROD-TOC-WORKSHOP-WORKBOOK",
+    "title": "Theory of Change — Workshop Workbook",
+    "description": "Run a half-day theory-of-change workshop and walk out with a finished, assumption-tested results chain.",
+    "type": "product",
+    "category": "Workbooks",
+    "url": "/products/toc-workshop-workbook/",
+    "tags": [
+      "toc",
+      "workbook",
+      "workshop",
+      "premium",
+      "paid",
+      "₹499"
+    ]
+  },
+  {
+    "id": "PROD-TOR-TEMPLATE",
+    "title": "ToR Template — get research worth paying for",
+    "description": "The ToR Template that gets you useful research — an editable Terms of Reference with guidance for every section, plus a costing sheet. Buy for ₹199 via UPI.",
+    "type": "product",
+    "category": "Templates",
+    "url": "/products/tor-template/",
+    "tags": [
+      "template",
+      "tor",
+      "premium",
+      "paid",
+      "₹199"
+    ]
   }
 ]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.222.0 — August 20, 2026 (Site search can find the paid resources)
+
+### For Learners
+
+- **Searching the site now finds the practice resources.** The assessment banks, checklists, templates, workbooks, refreshers and posters were live and linked, but typing "logframe" or "field readiness" into site search returned nothing. All 33 are now findable.
+
 ## v10.221.0 — August 20, 2026 (Nine ways to fail silently, closed)
 
 ### Fixed


### PR DESCRIPTION
33 live, priced product pages were invisible to the site's own search.

## What was wrong

Every one is live, ungated and priced — the four ₹499 assessment banks, the ₹99 checklists, the ₹199 budget template, plus workbooks, refreshers, posters and templates. They were all in `sitemap.xml`, so Google could find them. ImpactMojo's own search could not.

The practical effect: someone already on the site, already interested, typing "logframe" or "field readiness checklist" got nothing back.

## How the entries were made

Generated from each page's own `<title>` and `<meta name="description">` rather than written by hand, so they cannot drift from the page they describe. Two cleanups applied:

- A description that opened by restating the title is trimmed — that duplication would have consumed the entire search snippet.
- Tag stopwords filtered, so slug fragments like `for` don't become tags.

Categories derive from the slug:

| Category | Count |
|---|---|
| Templates | 11 |
| Assessment Banks | 4 |
| Workbooks | 4 |
| Refreshers | 4 |
| Checklists | 3 |
| Toolkits | 3 |
| Decks | 2 |
| Posters | 2 |

Each entry carries its price as a tag (`₹499`, `₹199`, `₹99`) alongside `premium` and `paid`.

## Verification

**1,087 → 1,120 entries.** Checked after writing, by re-reading from disk rather than trusting the in-memory object:

- valid JSON on re-read (and `python3 -m json.tool` passes)
- no duplicate `id` anywhere in the file
- no duplicate `url` anywhere in the file
- no entry missing `id`, `title`, `url` or `type`
- **all 33 URLs resolve to a real `index.html`**

Guards pass: counts, internal links (856 pages), mojibake, conflict markers.

The sitemap-not-indexed gap falls from 162 to 129. The only `/products` path still outside search is `/products.html` itself — the listing page, which already has a `#downloads` anchor entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01199dCmAgzMN1Z1d8qj2UfN)_