### PR TITLE
Give course progress partial credit, and pass a module on a majority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to ImpactMojo are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.223.0] - 2026-08-20
+
+### Changed
+
+- **Course progress now gives partial credit, and a module passes on a majority.** Two changes to `js/course-progress.js`, both prompted by a diagnosis that turned out to be wrong.
+
+  A module used to require a clean sweep — every graded question correct. MEL delivers 12 modules of 4 questions, so finishing it meant 48 correct answers with no allowance for a single question that reads badly. `PASS_RATIO` is now 0.75: 3 of 4, 2 of 2, 5 of 6. MEL's bar falls from 48 to 36.
+
+  Progress was also all-or-nothing inside a module: the figure written to `user_progress` was `completedModules / totalModules`, which moves only when a whole module lands, so a learner three questions in had nothing on their account page and we could not see where people stop. Each module now contributes a fractional score capped at 1, and a correct answer syncs immediately rather than waiting for the module to finish (`queueSync` already debounces 3s, so a run of quick answers is still one write). One correct answer in MEL now reads 3% instead of 0%.
+
+  **Completion semantics are unchanged.** 100% is still reachable only when every module has passed, which is what the `on_course_completed` trigger keys on. Verified against MEL's real shape: 11 of 12 modules gives 92%, every module at exactly the pass mark gives 100%, and eleven modules complete with one at 2 of 4 does **not** reach 100%.
+
+### Corrected
+
+- **The #960 diagnosis was substantially wrong, and is retracted here.** I read the static HTML of the course pages, found all six graded questions inside `<section id="course-assessment">` and none in the module sections, and concluded that `scanModules()` found nothing, `totalModules` stayed 0, and the tracker never booted for any learner.
+
+  Module bodies are not in the HTML. They are injected at runtime by `js/course-loader.js` from the `course_content` table, which holds 246 modules across 19 courses — **202 with `quiz_html`, 186 of those graded**. Asking the live endpoint for MEL returns 14 modules, none locked even for an anonymous visitor, 12 of them carrying 4 graded questions each inside the correct module section. The tracker boots, the quizzes are wired, and the handshake between loader and tracker works in both directions.
+
+  What remains true is only the measurement: `user_progress` has 0 rows ever inserted against 17,022 reads, and `certificates` 0 ever, with 54 signed-in users. The likeliest explanation is now the ordinary one — a demanding completion bar that nobody has cleared — which is what the two changes above address. A browser check while signed in would settle it.
+
+  Recorded rather than quietly amended, because the wrong diagnosis was detailed and confident enough to have justified writing roughly 663 quiz questions that already existed.
+
 ## [10.221.0] - 2026-08-20
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,13 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.223.0 — August 20, 2026 (Course progress counts partial work)
+
+### For Learners
+
+- **Your progress bar moves as you go.** It used to sit at zero until you got every question in a module right; now each correct answer counts, and both the bar and your account page show it.
+- **A module no longer needs a perfect score.** Getting the majority right — 3 of 4 — completes it.
+
 ## v10.221.0 — August 20, 2026 (Nine ways to fail silently, closed)
 
 ### Fixed

--- a/js/course-progress.js
+++ b/js/course-progress.js
@@ -68,6 +68,39 @@
     // =========================================================
     // STATE
     // =========================================================
+    // How much of a module's quiz must be right for the module to count.
+    //
+    // This was a clean sweep: every graded question in the module correct.
+    // With four questions per module across twelve modules, finishing a
+    // course meant 48 correct answers with no allowance for one that simply
+    // reads badly. A majority keeps the module meaningful without making a
+    // single awkward question a wall.
+    const PASS_RATIO = 0.75;                 // 3 of 4; 2 of 2; 5 of 6
+
+    function questionsToPass(total) {
+        return Math.max(1, Math.ceil(total * PASS_RATIO));
+    }
+
+    // Progress with partial credit inside a module.
+    //
+    // The headline number used to be completedModules / totalModules, which
+    // moves only when a whole module lands — so a learner three questions
+    // into a module saw nothing, and neither did their account page. This
+    // gives each module a fractional score, capped at 1, and still reaches
+    // 100 exactly when every module has passed. The certificate trigger fires
+    // at >= 100, so the completion condition is unchanged.
+    function overallPercentage() {
+        var ids = Object.keys(moduleData);
+        if (!ids.length) return 0;
+        var earned = 0;
+        for (var i = 0; i < ids.length; i++) {
+            var m = moduleData[ids[i]];
+            var need = questionsToPass(m.total);
+            earned += Math.min(1, m.correct.size / need);
+        }
+        return Math.round((earned / ids.length) * 100);
+    }
+
     let moduleData = {};    // { module1: { total: 4, correct: Set([0,1,2,3]) }, ... }
     let completedModules = new Set();
     let totalModules = 0;
@@ -141,8 +174,7 @@
         // Check if we have local progress to migrate
         if (completedModules.size === 0) return;
 
-        var percentage = totalModules > 0
-            ? Math.round((completedModules.size / totalModules) * 100) : 0;
+        var percentage = overallPercentage();
 
         // Check if cloud already has progress for this course
         try {
@@ -250,9 +282,7 @@
             var { data: { user } } = await sb.auth.getUser();
             if (!user) return;
 
-            var percentage = totalModules > 0
-                ? Math.round((completedModules.size / totalModules) * 100)
-                : 0;
+            var percentage = overallPercentage();
 
             var isComplete = percentage >= 100;
             var now = new Date().toISOString();
@@ -317,7 +347,11 @@
 
     function updateProgressBar() {
         var count = completedModules.size;
-        var pct = totalModules > 0 ? Math.round((count / totalModules) * 100) : 0;
+        // The bar shows the same fractional figure that is written to the
+        // database, so a learner mid-module sees the fill move rather than
+        // nothing at all. The "n / total" count still reports whole modules
+        // passed, which is what that label means.
+        var pct = overallPercentage();
 
         var fill = document.querySelector('.cpb-fill');
         var countEl = document.querySelector('.cpb-count');
@@ -493,8 +527,17 @@
 
         mod.correct.add(idx);
 
-        // Check if all questions in this module are correct
-        if (mod.correct.size >= mod.total) {
+        // Record the answer even when the module is not finished. Progress is
+        // fractional now, so a learner part-way through a module has something
+        // real to show on /account.html, and we can see where people stop
+        // rather than only who reached the end. queueSync debounces by 3s, so
+        // a run of quick answers still costs one write.
+        saveProgress();
+        updateProgressBar();
+        queueSync();
+
+        // Module passed?
+        if (mod.correct.size >= questionsToPass(mod.total)) {
             completedModules.add(modId);
             saveProgress();
             updateProgressBar();

--- a/service-worker.js
+++ b/service-worker.js
@@ -22,7 +22,7 @@
 
 'use strict';
 
-const VERSION = 'v15-2026-08-19';
+const VERSION = 'v16-2026-08-20';
 const RUNTIME = 'im-runtime-' + VERSION;
 const OFFLINE_URL = '/offline.html';
 const COURSE_PREFIX = 'impactmojo-course-';


### PR DESCRIPTION
Implements both things you asked for, and retracts the #960 diagnosis that prompted them.

## 1. A module passes on a majority

It required a clean sweep — every graded question correct. MEL delivers 12 modules of 4 questions, so finishing meant **48 correct answers** with no allowance for one question that simply reads badly.

`PASS_RATIO = 0.75` → 3 of 4, 2 of 2, 5 of 6. MEL's bar falls from 48 to 36.

## 2. Partial credit inside a module

The figure written to `user_progress` was `completedModules / totalModules`, which only moves when a whole module lands. A learner three questions into a module had nothing on their account page, and you had no way to see where people stop.

Each module now contributes a fractional score capped at 1, and a correct answer syncs immediately rather than waiting for the module to finish. `queueSync` already debounces 3s, so a run of quick answers is still one write.

**Completion semantics are unchanged** — 100% is reachable only when every module has passed, which is what `on_course_completed` keys on. Checked against MEL's real shape:

| State | Result |
|---|---|
| 1 correct answer | **3%** (was 0%) |
| 6 of 12 modules | 50% |
| 11 of 12 modules | 92% |
| every module at exactly 3/4 | **100%** → certificate |
| 11 modules complete + one at 2/4 | **not** 100% |

The progress bar uses the same fractional figure, so the fill moves mid-module; the "n / total" label still counts whole modules passed, which is what it means.

## Retraction: my #960 diagnosis was wrong

I read the static HTML, found all six graded questions in `<section id="course-assessment">` and none in module sections, and concluded `totalModules` stayed 0 so the tracker never booted for anyone.

**Module bodies aren't in the HTML.** They're injected at runtime by `js/course-loader.js` from `course_content` — 246 modules across 19 courses, **202 with `quiz_html`, 186 graded**. The live endpoint returns 14 MEL modules, none locked even anonymously, 12 carrying 4 graded questions each *inside the correct module section*. The tracker boots, the quizzes are wired, the loader↔tracker handshake works both ways.

What survives is only the measurement: `user_progress` 0 rows ever inserted against 17,022 reads, `certificates` 0 ever, 54 signed-in users. The likeliest explanation is now the ordinary one — a demanding bar nobody has cleared — which is what this PR addresses.

It's recorded in `CHANGELOG.md` rather than quietly amended, because the wrong diagnosis was confident enough to have justified writing ~663 quiz questions **that already existed**.

## Verification

`node --check` passes. Arithmetic tested against MEL's real shape, including the negative case (can't reach 100% without passing every module). Guards pass: write-path, counts, internal links, mojibake, conflict markers, asset stamps, service-worker contract. `service-worker.js` VERSION → v16 for the changed stamps.

Still worth a browser check: sign in, answer one module, confirm the `user_progress` row appears.

---
_Generated by [Claude Code](https://claude.ai/code/session_01199dCmAgzMN1Z1d8qj2UfN)_