### PR TITLE
New post: designing an impact evaluation, and a guard that skipped www-less URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to ImpactMojo are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.224.0] - 2026-08-20
+
+### Added
+
+- **Blog: "Designing an Impact Evaluation: Eight Steps, and When to Take Them"** (`/blog/designing-an-impact-evaluation.html`, Methods, ~1,360 words). Built from an eight-step impact-evaluation guidance deck, but argued rather than summarised: the steps are drawn as a sequence, and the sixth of them, the counterfactual, is a constraint set by how the programme rolls out rather than a stage the evaluator reaches. Covers what that changes about rationale, unit of variation, theory of change and budget; the three rollout situations and what each permits (randomised phase-in, eligibility thresholds, universal entitlement); and planning dissemination for a null result. Indexed, in the sitemap, carded on `blog.html` with an inline SVG rather than a missing image file.
+
+### Fixed
+
+- **`scripts/check-social-images.py` skipped every reference written without the `www.`** It compared each URL against a single origin string, `https://www.impactmojo.in`, and treated anything else beginning with `http` as an external host that is somebody else's problem. `nfhs.html` pointed `og:image` at `https://impactmojo.in/assets/og-default.png` — a file that does not exist — and the missing four characters were enough for the guard to wave it through. The page has been sharing with no preview image, and the guard that exists to catch exactly that reported PASS.
+
+  It now recognises all four spellings of our own origin (`http`/`https` × with/without `www.`), which raises the number of images actually checked from 1,168 to 1,171, and `nfhs.html` now points at a real file.
+
 ## [10.221.0] - 2026-08-20
 
 ### Added

--- a/blog.html
+++ b/blog.html
@@ -1919,6 +1919,41 @@ code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !imp
         <section class="blog-grid" id="blogGrid">
 
             <!-- Post: Animal Welfare Law and the Fifty-Rupee Fine (newest) -->
+            <article class="blog-card" data-category="methods" data-tags="impact-evaluation,counterfactual,research-design,theory-of-change,methods">
+                <div class="blog-card-image">
+                    <svg viewBox="0 0 400 200" role="img" aria-label="A treated group and a comparison group diverging after a programme starts" style="width:100%;height:100%;display:block;background:linear-gradient(135deg,#0F3D2E 0%,#177A5A 100%)">
+                        <line x1="200" y1="34" x2="200" y2="168" stroke="#ffffff" stroke-width="2" stroke-dasharray="5 5" opacity="0.55"/>
+                        <polyline points="40,132 120,126 200,122 280,88 360,58" fill="none" stroke="#ffffff" stroke-width="4"/>
+                        <polyline points="40,132 120,127 200,123 280,119 360,114" fill="none" stroke="#ffffff" stroke-width="4" stroke-dasharray="7 5" opacity="0.75"/>
+                        <text x="366" y="52" text-anchor="end" fill="#ffffff" font-family="system-ui,sans-serif" font-size="13" font-weight="700">treated</text>
+                        <text x="366" y="130" text-anchor="end" fill="#ffffff" opacity="0.85" font-family="system-ui,sans-serif" font-size="13">comparison</text>
+                        <text x="200" y="26" text-anchor="middle" fill="#ffffff" opacity="0.9" font-family="system-ui,sans-serif" font-size="12">programme starts</text>
+                    </svg>
+                </div>
+                <div class="blog-card-content">
+                    <div class="blog-card-meta">
+                        <span class="blog-card-category methods">Methods</span>
+                        <span class="blog-card-date">Aug 20, 2026</span>
+                    </div>
+                    <h2 class="blog-card-title">
+                        <a href="blog/designing-an-impact-evaluation.html">Designing an Impact Evaluation: Eight Steps, and When to Take Them</a>
+                    </h2>
+                    <p class="blog-card-excerpt">The standard guidance lists eight steps in order. In practice the sixth one, the counterfactual, constrains every step before it, and teams that reach it last usually find their options already gone. What to ask in the first meeting instead.</p>
+                    <div class="blog-card-tags">
+                        <span class="blog-card-tag">Impact Evaluation</span>
+                        <span class="blog-card-tag">Counterfactual</span>
+                        <span class="blog-card-tag">New</span>
+                    </div>
+                    <div class="blog-card-footer">
+                        <span class="blog-card-author">The ImpactMojo Team</span>
+                        <span class="blog-card-readtime">
+                            <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+                            7 min
+                        </span>
+                    </div>
+                </div>
+            </article>
+
             <article class="blog-card">
                 <div class="blog-card-image">
                     <svg viewBox="0 0 400 200" role="img" aria-label="A flat line at fifty rupees over a falling curve" style="width:100%;height:100%;display:block;background:linear-gradient(135deg,#7a2a13 0%,#b4581f 100%)">

--- a/blog/designing-an-impact-evaluation.html
+++ b/blog/designing-an-impact-evaluation.html
@@ -1,0 +1,633 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<!-- Version 2.0.0 - December 2, 2025 -->
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-JRCMEB9TBW');
+</script>
+
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate, max-age=0">
+<meta http-equiv="Pragma" content="no-cache">
+<meta http-equiv="Expires" content="-1">
+<meta name="version" content="2.0.20260820">
+
+<meta name="description" content="The standard guidance lists eight steps in order. In practice the sixth one, the counterfactual, constrains every step before it — and teams that reach it last usually find their options already gone."/>
+<meta property="og:title" content="Designing an Impact Evaluation: Eight Steps, and When to Take Them">
+<meta property="og:description" content="The standard guidance lists eight steps in order. In practice the sixth one, the counterfactual, constrains every step before it — and teams that reach it last usually find their options already gone.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://www.impactmojo.in/blog/designing-an-impact-evaluation.html">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/og-card.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:site_name" content="ImpactMojo">
+<meta property="article:author" content="The ImpactMojo Team">
+<meta property="article:published_time" content="2026-08-20">
+<meta property="article:section" content="Methods">
+<meta property="article:tag" content="sample size">
+<meta property="article:tag" content="RCT">
+<meta property="article:tag" content="evaluation">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image" content="https://www.impactmojo.in/assets/images/blog/sample-size-matters-og.png">
+
+<title>Designing an Impact Evaluation: Eight Steps, and When to Take Them — ImpactMojo Blog</title>
+<link href="../assets/images/favicon.png" rel="icon" type="image/png"/>
+<link href="../assets/images/apple-touch-icon.png" rel="apple-touch-icon"/>
+<link rel="stylesheet" href="/css/fonts.css">
+
+<!-- ImpactMojo Fonts: Amaranth (body) + Inter (headings) + JetBrains Mono (code) -->
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+:root {
+    --primary-bg: #FFFFFF;
+    --secondary-bg: #F8FAFC;
+    --text-primary: #0F172A;
+    --text-secondary: #475569;
+    --text-muted: #52627A;
+    --card-bg: #FFFFFF;
+    --hover-bg: #F1F5F9;
+    --border-color: #E2E8F0;
+    --nav-bg: rgba(255, 255, 255, 0.95);
+    --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.07);
+    --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.1);
+}
+@media (prefers-color-scheme: dark) { :root {
+    --primary-bg: #0F172A;
+    --secondary-bg: #1E293B;
+    --accent-color: #0EA5E9;
+    --accent-hover: #0284C7;
+    --secondary-accent: #6366F1;
+    --success-color: #10B981;
+    --warning-color: #F59E0B;
+    --danger-color: #EF4444;
+    --text-primary: #F1F5F9;
+    --text-secondary: #CBD5E1;
+    --text-muted: #94A3B8;
+    --card-bg: #1E293B;
+    --hover-bg: #334155;
+    --border-color: #334155;
+    --gradient-primary: linear-gradient(135deg, #0EA5E9 0%, #6366F1 100%);
+    --nav-bg: rgba(15, 23, 42, 0.95);
+    --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
+    --shadow-lg: 0 10px 25px rgba(0, 0, 0, 0.2);
+} }
+body.light-mode, [data-theme="light"] {
+    --primary-bg: #FFFFFF;
+    --secondary-bg: #F8FAFC;
+    --text-primary: #0F172A;
+    --text-secondary: #475569;
+    --text-muted: #52627A;
+    --card-bg: #FFFFFF;
+    --hover-bg: #F1F5F9;
+    --border-color: #E2E8F0;
+    --nav-bg: rgba(255, 255, 255, 0.95);
+    --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.07);
+    --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.1);
+}
+body.dark-mode, [data-theme="dark"] {
+    --primary-bg: #0F172A;
+    --secondary-bg: #1E293B;
+    --accent-color: #0EA5E9;
+    --accent-hover: #0284C7;
+    --secondary-accent: #6366F1;
+    --success-color: #10B981;
+    --warning-color: #F59E0B;
+    --danger-color: #EF4444;
+    --text-primary: #F1F5F9;
+    --text-secondary: #CBD5E1;
+    --text-muted: #94A3B8;
+    --card-bg: #1E293B;
+    --hover-bg: #334155;
+    --border-color: #334155;
+    --gradient-primary: linear-gradient(135deg, #0EA5E9 0%, #6366F1 100%);
+    --nav-bg: rgba(15, 23, 42, 0.95);
+    --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
+    --shadow-lg: 0 10px 25px rgba(0, 0, 0, 0.2);
+}
+
+
+body { font-family: 'Amaranth', sans-serif; background: var(--primary-bg); color: var(--text-primary); line-height: 1.8; min-height: 100vh; transition: background 0.3s ease, color 0.3s ease; }
+.header { position: fixed; top: 0; left: 0; right: 0; background: var(--nav-bg); backdrop-filter: blur(20px); z-index: 1000; border-bottom: 1px solid var(--border-color); }
+.nav-container { max-width: 900px; margin: 0 auto; padding: 1rem 1.5rem; display: flex; justify-content: space-between; align-items: center; }
+.logo-container { display: flex; align-items: center; gap: 0.5rem; text-decoration: none; }
+.logo-container img { border-radius: 6px; }
+.logo-main { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 700; background: var(--gradient-primary); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+.nav-right { display: flex; align-items: center; gap: 1rem; }
+.back-link { display: flex; align-items: center; gap: 0.25rem; color: var(--text-secondary); text-decoration: none; font-family: 'Amaranth', sans-serif; font-size: 0.9rem; padding: 0.5rem 0.75rem; border-radius: 6px; transition: all 0.2s ease; }
+.back-link:hover { background: #283242; color: var(--accent-color); }
+.back-link svg { width: 18px; height: 18px; fill: none; stroke: currentColor; stroke-width: 2; }
+
+.article-container { max-width: 750px; margin: 0 auto; padding: 3rem 1.5rem; }
+.article-header { margin-bottom: 2.5rem; text-align: center; }
+.article-category { display: inline-block; background: #5E61F1; color: white; font-family: 'Amaranth', sans-serif; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; padding: 0.25rem 0.75rem; border-radius: 20px; margin-bottom: 1rem; }
+.article-title { font-family: 'Inter', sans-serif; font-size: 2.5rem; font-weight: 800; line-height: 1.2; margin-bottom: 1.25rem; }
+.article-meta { display: flex; flex-wrap: wrap; justify-content: center; gap: 1.5rem; color: var(--text-muted); font-family: 'Amaranth', sans-serif; font-size: 0.9rem; margin-bottom: 1rem; }
+.article-meta span { display: flex; align-items: center; gap: 0.35rem; }
+.article-meta svg { width: 16px; height: 16px; fill: none; stroke: currentColor; stroke-width: 2; }
+.article-tags { display: flex; flex-wrap: wrap; justify-content: center; gap: 0.5rem; }
+.article-tag { background: #F1F5F9; color: var(--text-muted); font-family: 'Amaranth', sans-serif; font-size: 0.75rem; padding: 0.25rem 0.6rem; border-radius: 12px; }
+
+.article-content { font-size: 1.1rem; color: var(--text-primary); }
+.article-content p { margin-bottom: 1.5rem; }
+.article-content h2 { font-family: 'Inter', sans-serif; font-size: 1.75rem; font-weight: 700; margin: 2.5rem 0 1rem; color: var(--text-primary); }
+.article-content h3 { font-family: 'Inter', sans-serif; font-size: 1.35rem; font-weight: 600; margin: 2rem 0 0.75rem; color: var(--text-primary); }
+.article-content strong { color: var(--text-primary); font-weight: 700; }
+.article-content ul, .article-content ol { margin: 1.5rem 0; padding-left: 1.5rem; }
+.article-content li { margin-bottom: 0.75rem; }
+.article-content blockquote { border-left: 4px solid var(--secondary-accent); padding: 1rem 1.5rem; margin: 2rem 0; background: var(--secondary-bg); border-radius: 0 8px 8px 0; font-style: italic; color: var(--text-secondary); }
+
+.article-illustration { margin: 2.5rem 0; text-align: center; }
+.article-illustration img { max-width: 100%; height: auto; border-radius: 12px; box-shadow: var(--shadow-lg); }
+.article-illustration figcaption { margin-top: 0.75rem; font-family: 'Amaranth', sans-serif; font-size: 0.85rem; color: var(--text-muted); font-style: italic; }
+
+/* Concept Grid */
+.concept-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem; margin: 2rem 0; }
+.concept-card { background: var(--secondary-bg); border: 1px solid var(--border-color); border-radius: 12px; padding: 1.25rem; }
+.concept-icon { font-size: 1.5rem; margin-bottom: 0.5rem; }
+.concept-name { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 700; margin-bottom: 0.35rem; color: var(--accent-color); }
+.concept-desc { font-family: 'Amaranth', sans-serif; font-size: 0.85rem; color: var(--text-secondary); line-height: 1.5; }
+
+/* Formula Box */
+.formula-box { background: var(--secondary-bg); border: 1px solid var(--border-color); border-radius: 12px; padding: 1.5rem; margin: 2rem 0; text-align: center; }
+.formula-title { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 700; margin-bottom: 1rem; color: var(--text-muted); }
+.formula { font-family: 'Amaranth', sans-serif; font-size: 1.4rem; font-style: italic; color: var(--text-primary); margin-bottom: 1rem; letter-spacing: 0.5px; }
+.formula-legend { text-align: left; font-family: 'Amaranth', sans-serif; font-size: 0.85rem; color: var(--text-secondary); }
+.formula-legend p { margin-bottom: 0.35rem; }
+
+/* Warning Box */
+.warning-box { background: rgba(245, 158, 11, 0.1); border: 1px solid var(--warning-color); border-radius: 12px; padding: 1.25rem; margin: 2rem 0; }
+.warning-title { font-family: 'Amaranth', sans-serif; font-size: 0.85rem; font-weight: 700; color: var(--warning-color); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 0.5rem; display: flex; align-items: center; gap: 0.5rem; }
+.warning-text { font-family: 'Amaranth', sans-serif; font-size: 0.95rem; color: var(--text-secondary); line-height: 1.5; }
+
+/* Design Effect Table */
+.de-table { width: 100%; border-collapse: collapse; margin: 1.5rem 0; font-family: 'Amaranth', sans-serif; font-size: 0.9rem; }
+.de-table th, .de-table td { padding: 0.75rem; text-align: center; border: 1px solid var(--border-color); }
+.de-table th { background: var(--secondary-bg); font-weight: 600; color: var(--text-muted); text-transform: uppercase; font-size: 0.75rem; letter-spacing: 0.5px; }
+.de-table td { color: var(--text-secondary); }
+.de-table tr:nth-child(even) td { background: var(--hover-bg); }
+
+/* Worked Example */
+.worked-example { background: var(--secondary-bg); border: 1px solid var(--border-color); border-radius: 12px; padding: 1.5rem; margin: 2rem 0; }
+.worked-example h4 { font-family: 'Inter', sans-serif; font-size: 1.1rem; font-weight: 700; margin-bottom: 1rem; color: var(--success-color); }
+.example-step { display: flex; gap: 1rem; margin-bottom: 0.75rem; font-family: 'Amaranth', sans-serif; font-size: 0.9rem; }
+.step-num { background: #0B835B; color: white; width: 24px; height: 24px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 0.75rem; font-weight: 700; flex-shrink: 0; }
+.step-text { color: var(--text-secondary); }
+.example-result { background: rgba(16, 185, 129, 0.15); border-radius: 8px; padding: 1rem; margin-top: 1rem; text-align: center; }
+.result-label { font-family: 'Amaranth', sans-serif; font-size: 0.8rem; color: var(--success-color); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 0.25rem; }
+.result-value { font-family: 'Inter', sans-serif; font-size: 1.5rem; font-weight: 700; color: var(--text-primary); }
+
+/* Checklist */
+.checklist { background: var(--secondary-bg); border: 1px solid var(--border-color); border-radius: 12px; padding: 1.5rem; margin: 2rem 0; }
+.checklist h4 { font-family: 'Inter', sans-serif; font-size: 1.1rem; font-weight: 700; margin-bottom: 1rem; color: var(--text-primary); }
+.checklist-item { display: flex; align-items: flex-start; gap: 0.75rem; margin-bottom: 0.75rem; font-family: 'Amaranth', sans-serif; font-size: 0.95rem; color: var(--text-secondary); }
+.checklist-item::before { content: '☐'; color: var(--accent-color); font-size: 1.1rem; flex-shrink: 0; }
+
+.share-section { margin-top: 3rem; padding-top: 2rem; border-top: 1px solid var(--border-color); text-align: center; }
+.share-section h4 { font-family: 'Amaranth', sans-serif; font-size: 0.9rem; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 1rem; }
+.share-buttons { display: flex; justify-content: center; gap: 0.75rem; }
+.share-btn { display: flex; align-items: center; justify-content: center; width: 44px; height: 44px; border-radius: 50%; background: var(--secondary-bg); border: 1px solid var(--border-color); color: var(--text-secondary); text-decoration: none; transition: all 0.2s ease; }
+.share-btn:hover { background: #0A7AAD; border-color: var(--accent-color); color: white; transform: translateY(-2px); }
+.share-btn svg { width: 20px; height: 20px; fill: currentColor; }
+
+.newsletter-cta { background: var(--secondary-bg); border: 1px solid var(--border-color); border-radius: 12px; padding: 2rem; margin: 3rem 0; text-align: center; }
+.newsletter-cta h3 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 700; margin-bottom: 0.5rem; }
+.newsletter-cta p { color: var(--text-secondary); margin-bottom: 1rem; font-family: 'Amaranth', sans-serif; font-size: 0.95rem; }
+.newsletter-btn { display: inline-flex; align-items: center; gap: 0.5rem; background: var(--gradient-primary); color: white; text-decoration: none; padding: 0.75rem 1.5rem; border-radius: 8px; font-family: 'Amaranth', sans-serif; font-weight: 600; font-size: 0.95rem; transition: all 0.2s ease; }
+.newsletter-btn:hover { transform: translateY(-2px); box-shadow: var(--shadow-lg); }
+
+.related-posts { margin-top: 3rem; padding-top: 2rem; border-top: 1px solid var(--border-color); }
+.related-posts h3 { font-family: 'Inter', sans-serif; font-size: 1.25rem; font-weight: 700; margin-bottom: 1.5rem; text-align: center; }
+.related-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1.25rem; }
+.related-card { background: var(--secondary-bg); border: 1px solid var(--border-color); border-radius: 12px; padding: 1.25rem; text-decoration: none; transition: all 0.2s ease; }
+.related-card:hover { border-color: var(--accent-color); transform: translateY(-3px); }
+.related-card-category { font-family: 'Amaranth', sans-serif; font-size: 0.7rem; font-weight: 600; text-transform: uppercase; color: var(--accent-color); margin-bottom: 0.5rem; }
+.related-card-title { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 600; color: var(--text-primary); line-height: 1.3; }
+
+.footer { background: var(--secondary-bg); border-top: 1px solid var(--border-color); padding: 2rem; text-align: center; margin-top: 3rem; }
+.footer p { font-family: 'Amaranth', sans-serif; color: var(--text-muted); font-size: 0.875rem; margin-bottom: 0.5rem; }
+.footer a { color: var(--accent-color); text-decoration: none; }
+.footer a:hover { text-decoration: underline; }
+
+@media (max-width: 768px) { .article-title { font-size: 2rem; } .concept-grid { grid-template-columns: 1fr; } .related-grid { grid-template-columns: 1fr; } }
+@media (max-width: 600px) { .article-container { padding: 2rem 1rem; } .article-title { font-size: 1.75rem; } .article-content { font-size: 1rem; } .article-meta { flex-direction: column; gap: 0.5rem; } .de-table { font-size: 0.8rem; } .de-table th, .de-table td { padding: 0.5rem; } }
+</style>
+<style>
+/* ===== ImpactMojo Design System ===== */
+:root {
+    --im-primary-bg: #0F172A;
+    --im-secondary-bg: #1E293B;
+    --im-accent: #0EA5E9;
+    --im-accent-hover: #0284C7;
+    --im-secondary-accent: #6366F1;
+    --im-success: #10B981;
+    --im-text-primary: #F1F5F9;
+    --im-text-secondary: #94A3B8;
+    --im-text-muted: #64748B;
+    --im-card-bg: #1E293B;
+    --im-hover-bg: #334155;
+    --im-border: #334155;
+    --im-nav-bg: rgba(15, 23, 42, 0.95);
+    --im-gradient: linear-gradient(135deg, #0EA5E9 0%, #6366F1 100%);
+}
+[data-theme="light"] {
+    --im-primary-bg: #F8FAFC;
+    --im-secondary-bg: #FFFFFF;
+    --im-accent: #0284C7;
+    --im-accent-hover: #0369A1;
+    --im-text-primary: #0F172A;
+    --im-text-secondary: #475569;
+    --im-text-muted: #64748B;
+    --im-card-bg: #FFFFFF;
+    --im-hover-bg: #F1F5F9;
+    --im-border: #E2E8F0;
+    --im-nav-bg: rgba(248, 250, 252, 0.95);
+}
+
+/* ImpactMojo Top Bar */
+.im-topbar {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 9999;
+    background: var(--im-nav-bg, rgba(15, 23, 42, 0.95));
+    backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px);
+    border-bottom: 1px solid var(--im-border, #334155);
+    padding: 0.5rem 1rem;
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 0.75rem; flex-wrap: wrap;
+    font-family: 'Inter', sans-serif;
+}
+.im-topbar a { text-decoration: none; }
+.im-topbar-left {
+    display: flex; align-items: center; gap: 0.75rem;
+}
+.im-topbar-home {
+    display: flex; align-items: center; gap: 0.5rem;
+    color: var(--im-text-primary, #F1F5F9);
+    font-weight: 700; font-size: 1rem;
+    background: var(--im-gradient);
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+.im-topbar-home svg { width: 24px; height: 24px; flex-shrink: 0; }
+.im-topbar-right {
+    display: flex; align-items: center; gap: 0.5rem;
+}
+.im-premium-btn {
+    background: var(--im-gradient);
+    color: #fff !important;
+    padding: 0.35rem 0.85rem;
+    border-radius: 6px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    display: flex; align-items: center; gap: 0.35rem;
+    transition: opacity 0.2s;
+    -webkit-text-fill-color: #fff;
+}
+.im-premium-btn:hover { opacity: 0.9; }
+.im-premium-btn svg { width: 14px; height: 14px; }
+
+/* Theme Selector - 3 mode */
+.im-theme-selector {
+    display: flex; gap: 2px;
+    background: var(--im-card-bg, #1E293B);
+    border: 1px solid var(--im-border, #334155);
+    border-radius: 8px; padding: 2px;
+}
+.im-theme-btn {
+    background: transparent; border: none;
+    color: var(--im-text-secondary, #94A3B8);
+    padding: 6px; border-radius: 5px; cursor: pointer;
+    transition: all 0.2s; display: flex; align-items: center;
+    justify-content: center; width: 30px; height: 30px;
+}
+.im-theme-btn:hover {
+    background: var(--im-hover-bg, #334155);
+    color: var(--im-text-primary, #F1F5F9);
+}
+.im-theme-btn.active {
+    background: #027AB8;
+    color: #fff;
+}
+.im-theme-btn svg { width: 16px; height: 16px; }
+
+/* Paper Plane */
+.im-paper-plane {
+    position: fixed; top: 15%; right: 8%;
+    width: 120px; height: 120px;
+    opacity: 0.15; z-index: 0;
+    pointer-events: none;
+    animation: im-fly 25s ease-in-out infinite;
+}
+[data-theme="light"] .im-paper-plane { opacity: 0.2; }
+@keyframes im-fly {
+    0%, 100% { transform: translate(0, 0) rotate(0deg); }
+    20% { transform: translate(60px, -40px) rotate(12deg); }
+    40% { transform: translate(120px, 30px) rotate(-8deg); }
+    60% { transform: translate(40px, 60px) rotate(15deg); }
+    80% { transform: translate(-30px, 20px) rotate(-5deg); }
+}
+
+/* ImpactMojo Footer */
+.im-footer {
+    background: var(--im-secondary-bg, #1E293B);
+    border-top: 1px solid var(--im-border, #334155);
+    padding: 2rem 1rem; margin-top: auto;
+    font-family: 'Inter', sans-serif;
+    color: var(--im-text-secondary, #94A3B8);
+}
+.im-footer-content {
+    max-width: 1100px; margin: 0 auto;
+}
+.im-footer-made {
+    text-align: center; margin-bottom: 1.5rem;
+    font-size: 0.9rem; color: var(--im-text-muted, #64748B);
+}
+.im-footer-made a { color: var(--im-accent, #0EA5E9); }
+.im-footer-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.5rem; margin-bottom: 1.5rem;
+}
+.im-footer-section h4 {
+    font-family: 'Inter', sans-serif;
+    color: var(--im-text-primary, #F1F5F9);
+    font-size: 0.9rem; margin-bottom: 0.75rem;
+    font-weight: 600;
+}
+.im-footer-section ul { list-style: none; padding: 0; margin: 0; }
+.im-footer-section li { margin-bottom: 0.4rem; }
+.im-footer-section a {
+    color: var(--im-text-secondary, #94A3B8);
+    text-decoration: none; font-size: 0.85rem;
+    transition: color 0.2s;
+}
+.im-footer-section a:hover { color: var(--im-accent, #0EA5E9); }
+.im-footer-bottom {
+    text-align: center; padding-top: 1rem;
+    border-top: 1px solid var(--im-border, #334155);
+    font-size: 0.8rem; color: var(--im-text-muted, #64748B);
+}
+.im-footer-bottom p { margin: 0.25rem 0; }
+.im-footer-bottom a { color: var(--im-accent, #0EA5E9); text-decoration: none; }
+
+/* Mobile Responsive */
+@media (max-width: 768px) {
+    .im-topbar { padding: 0.4rem 0.75rem; gap: 0.5rem; }
+    .im-topbar-home { font-size: 0.85rem; }
+    .im-topbar-home svg { width: 20px; height: 20px; }
+    .im-premium-btn { padding: 0.3rem 0.6rem; font-size: 0.75rem; }
+    .im-theme-btn { width: 26px; height: 26px; padding: 4px; }
+    .im-theme-btn svg { width: 14px; height: 14px; }
+    .im-paper-plane { width: 80px; height: 80px; top: 10%; right: 5%; }
+    .im-footer-grid { grid-template-columns: repeat(2, 1fr); gap: 1rem; }
+}
+@media (max-width: 480px) {
+    .im-footer-grid { grid-template-columns: 1fr; }
+    .im-topbar-home span { display: none; }
+}
+
+/* ImpactMojo Global Font Overrides */
+body { font-family: 'Amaranth', sans-serif !important; }
+h1, h2, h3, h4, h5, h6 { font-family: 'Inter', sans-serif !important; }
+code, pre, .monospace, kbd, samp { font-family: 'JetBrains Mono', monospace !important; }
+
+/* WCAG 2.1 AA (1.4.1 Use of Color): inline anchors in content paragraphs must be distinguishable without relying on color alone. Scoped to <main> so nav/footer button-links are unaffected. */
+main p a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]),
+main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) {
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+}
+
+/* Theme-scoped contrast corrections. The pairs below resolve to
+   different colours per theme, so no single value clears WCAG AA in
+   both: a near-white ground needs a dark ink and a near-slate ground
+   a light one. Light values sit on the rules themselves; these carry
+   the dark ones, for the unstamped default and for either explicit
+   choice. Enforced by scripts/check-theme-contrast.py. */
+@media (prefers-color-scheme: dark) { body:not(.light-mode):not([data-theme="light"]) .article-tag { background: #2B3748; } }
+body.dark-mode .article-tag, [data-theme="dark"] .article-tag, html.dark .article-tag { background: #2B3748; }</style>
+<!-- SEO meta (autogenerated) -->
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://www.impactmojo.in/blog/designing-an-impact-evaluation.html">
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "BlogPosting", "headline": "Designing an Impact Evaluation: Eight Steps, and When to Take Them", "description": "Statistical power and sample size calculations explained without the jargon—and why getting the numbers right matters for impact evaluation.", "url": "https://www.impactmojo.in/blog/designing-an-impact-evaluation.html", "inLanguage": "en", "isAccessibleForFree": true, "author": {"@type": "Organization", "name": "ImpactMojo", "url": "https://www.impactmojo.in"}, "publisher": {"@type": "Organization", "name": "ImpactMojo", "url": "https://www.impactmojo.in"}, "datePublished": "2026-08-20", "dateModified": "2026-08-20"}</script>
+</head>
+<body>
+
+
+<header class="header">
+<nav class="nav-container">
+    <a class="logo-container" href="../index.html">
+        <img alt="ImpactMojo" src="../assets/images/ImpactMojo%20Logo.png" width="36" height="36">
+        <div class="logo-main">ImpactMojo</div>
+    </a>
+    <div class="nav-right">
+        <a href="../blog.html" class="back-link">
+            <svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"></polyline></svg>
+            All Posts
+        </a>
+        <div class="im-theme-selector" aria-label="Theme selection">
+            <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="Use system theme">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+            </button>
+            <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Use light theme">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+            </button>
+            <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Use dark theme">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
+        </div>
+    </div>
+</nav>
+</header>
+
+<main class="article-container">
+    <article>
+        <header class="article-header">
+            <span class="article-category">Methods</span>
+            <h1 class="article-title">Designing an Impact Evaluation: Eight Steps, and When to Take Them</h1>
+            <div class="article-meta">
+                <span>
+                    <svg viewBox="0 0 24 24"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+                    The ImpactMojo Team
+                </span>
+                <span>
+                    <svg viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
+                    August 20, 2026
+                </span>
+                <span>
+                    <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"></circle><polyline points="12 6 12 12 16 14"></polyline></svg>
+                    7 min read
+                </span>
+            </div>
+            <div class="article-tags">
+                <span class="article-tag">impact evaluation</span>
+                <span class="article-tag">counterfactual</span>
+                <span class="article-tag">research design</span>
+                <span class="article-tag">theory of change</span>
+            </div>
+        </header>
+
+        <div class="article-content">
+            <p class="article-lead">A programme director asks for an impact evaluation eighteen months after the programme has rolled out to every district it was ever going to reach. The evaluation team works through the guidance in order: rationale, scope, theory of change, budget, questions. At step six they reach the counterfactual and discover there is nobody left to compare against. The decision that ended the evaluation was taken a year and a half earlier, by someone who was not thinking about evaluation at all.</p>
+
+            <p>The standard guidance for designing an impact evaluation lists eight steps. They are the right eight. Drawn as a numbered sequence, though, they suggest that the work proceeds in that order, and it does not. Two of the steps are decisions about the world rather than decisions on paper, and they have to be settled before things that appear earlier in the list.</p>
+
+            <h2>The eight steps</h2>
+
+            <ol>
+                <li><strong>Define rationale and objectives.</strong> Why evaluate at all, what knowledge gap this fills, whether the question is about one context or several.</li>
+                <li><strong>Specify the programme.</strong> Scope, target population, anticipated outcomes.</li>
+                <li><strong>Build a theory of change.</strong> Activities to short, medium and long-term outcomes, with assumptions made explicit.</li>
+                <li><strong>Identify timeline, resources and budget.</strong> Staff time, consultancy, data collection, and where the money comes from.</li>
+                <li><strong>Develop measurable evaluation questions.</strong> Specific and answerable, aligned to the theory of change.</li>
+                <li><strong>Define the counterfactual and data requirements.</strong> Baseline and follow-up for treatment and comparison, standardised indicators.</li>
+                <li><strong>Identify the methodology.</strong> Experimental, quasi-experimental, or non-experimental.</li>
+                <li><strong>Plan dissemination and reporting.</strong> How findings reach the people who could act on them.</li>
+            </ol>
+
+            <p>Nothing on that list is wrong. What follows is about the order.</p>
+
+            <h2>The counterfactual is decided long before you reach it</h2>
+
+            <p>A counterfactual is a claim about what would have happened to the same people, in the same period, without the programme. You cannot observe it. You can only approximate it with a group whose experience stands in for that unobserved case, and whether such a group exists is decided by how the programme is rolled out.</p>
+
+            <p>That decision is usually made by operations, on operational grounds, long before an evaluator is in the room. Once a programme has saturated its target population, the honest set of remaining options is narrow: compare across places that differ for reasons you cannot fully name, compare across time and hope nothing else changed, or accept that you are measuring implementation rather than impact.</p>
+
+            <p>So the practical question at step one is not only "why are we evaluating". It is "what will the comparison be, and does the rollout still allow it". Ask that in the first meeting and it will change the rollout plan, which is the point. Ask it at step six and you are documenting a constraint rather than choosing one.</p>
+
+            <h2>What that changes about the earlier steps</h2>
+
+            <h3>Rationale and objectives</h3>
+
+            <p>Two very different questions hide under "does this work". One is whether the intervention produces the outcome, which needs a counterfactual. The other is whether the intervention was delivered as designed, which needs monitoring data and no comparison group at all. Programmes frequently commission the first and need the second. If nobody has yet established that the training happened, that the transfers arrived, or that the staff were in post, an impact evaluation will produce a null result you cannot interpret: you will not know whether the theory failed or the delivery did.</p>
+
+            <h3>Specifying the programme</h3>
+
+            <p>The unit at which a programme varies is the unit at which you can evaluate it. A scheme delivered through the panchayat varies at panchayat level, whatever the individual-level data you collect, and your effective sample is the number of panchayats rather than the number of households. This is where sample size calculations quietly fall apart, and it is a specification question, settled at step two, not a statistics question settled later.</p>
+
+            <h3>Theory of change</h3>
+
+            <p>A theory of change written for a funder tends to list what the programme intends. A theory of change written for an evaluation has to include the steps that could fail and the assumptions that could turn out false, because those are what the evaluation is for. A diagram in which every arrow is a step the programme controls has no room for the evaluation to find anything.</p>
+
+            <h3>Timeline and budget</h3>
+
+            <p>Baseline data has to be collected before the programme reaches anyone. That single requirement moves evaluation budgeting from the second year of a project to the first, and it is the most common reason a well-designed evaluation is not affordable by the time someone asks for it.</p>
+
+            <p>It is worth checking what already exists before assuming a survey. India is unusually well served here. NSS rounds, NFHS, ASER's annual district-level learning data, and the administrative systems behind MGNREGA and the PDS all provide repeated measurement that predates most projects. Existing data rarely matches the outcome you would have chosen, and that is a real cost. It also rarely costs a crore.</p>
+
+            <h2>Methodology follows the counterfactual</h2>
+
+            <p>Step seven is often where the conversation starts, usually as an argument about whether a randomised trial is appropriate. The order is backwards. A method is a way of constructing a comparison; which methods are available depends on the comparison the world has left you.</p>
+
+            <p>Three situations, and what each permits:</p>
+
+            <ul>
+                <li><strong>The programme cannot reach everyone at once.</strong> Almost always true, and the most useful fact in evaluation design. If the order of the rollout can be randomised, everyone is served and the early group can be compared with the not-yet group. Nobody is denied anything they were otherwise going to receive, which is usually the ethical objection to randomisation and is answered by the design rather than argued with.</li>
+                <li><strong>Eligibility is set by a threshold.</strong> Below a certain landholding, income, or score, you qualify; above it you do not. Households just either side of the line resemble each other closely, and the discontinuity can carry the comparison. This applies to a great deal of Indian social protection, where thresholds are how targeting is done.</li>
+                <li><strong>The programme is a universal entitlement.</strong> MGNREGA guarantees work to any rural household that asks. There is no group without access, so "does MGNREGA work" is not answerable in this frame. What is answerable is which delivery systems make the entitlement real, and that is a different and often more useful question.</li>
+            </ul>
+
+            <p>The third case deserves emphasis, because treating it as a failure wastes the most policy-relevant evidence available. When access is universal, variation in <em>implementation</em> is the thing to study, and the studies that have most changed Indian delivery have done exactly that.</p>
+
+            <h2>Dissemination has to include the null result</h2>
+
+            <p>Step eight is usually written on the assumption that the finding will be positive. Presentations, policy briefs, a workshop.</p>
+
+            <p>Plan for the other outcome while the design is still being agreed, because that is the only moment when everyone can be honest about it. Two questions are worth putting in writing. What finding would cause this programme to change, and who has the authority to make that change? If no answer exists to the second, the evaluation is being commissioned for a reason other than learning, and it is better to know that at the start.</p>
+
+            <p>A null result is also worth publishing on its own terms. The evidence base for South Asian development is skewed by the fact that disappointing findings tend to stay in draft, which means the next team designing a similar programme sees only the successes.</p>
+
+            <h2>A short checklist</h2>
+
+            <p>Before the theory of change workshop, not after:</p>
+
+            <ul>
+                <li>Who will not receive this, and when? If the answer is "nobody", the design conversation is already over.</li>
+                <li>At what unit does the programme vary, and how many of those units are there?</li>
+                <li>What measurement already exists for this population, and how far back does it go?</li>
+                <li>Can the rollout order be randomised without delaying anyone who would otherwise have been served sooner?</li>
+                <li>What finding would change the programme, and who decides?</li>
+            </ul>
+
+            <p>The eight steps are sound as a list of what an evaluation design has to cover. The sequence is where teams lose evaluations they could have run, and the counterfactual is the step that has to move earliest.</p>
+
+        </div>
+
+        <div class="share-section">
+            <h4>Share this article</h4>
+            <div class="share-buttons">
+                <a href="https://twitter.com/intent/tweet?url=https://www.impactmojo.in/blog/sample-size-matters.html&text=Sample%20Size%20Matters%3A%20A%20Practical%20Guide" target="_blank" class="share-btn" title="Share on X/Twitter">
+                    <svg viewBox="0 0 24 24"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+                </a>
+                <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.impactmojo.in/blog/sample-size-matters.html" target="_blank" class="share-btn" title="Share on LinkedIn">
+                    <svg viewBox="0 0 24 24"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+                </a>
+                <a href="https://www.facebook.com/sharer/sharer.php?u=https://www.impactmojo.in/blog/sample-size-matters.html" target="_blank" class="share-btn" title="Share on Facebook">
+                    <svg viewBox="0 0 24 24"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
+                </a>
+                <a href="mailto:?subject=Sample%20Size%20Matters&body=Check%20out%20this%20article%3A%20https://www.impactmojo.in/blog/sample-size-matters.html" class="share-btn" title="Share via Email">
+                    <svg viewBox="0 0 24 24"><path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/></svg>
+                </a>
+            </div>
+        </div>
+
+        <div class="newsletter-cta">
+            <h3>Master Research Methods</h3>
+            <p>Subscribe for practical guides on evaluation design and research methods.</p>
+            <a href="https://varna.substack.com" target="_blank" class="newsletter-btn">
+                Subscribe on Substack →
+            </a>
+        </div>
+
+        <div class="related-posts">
+            <h3>Related Posts</h3>
+            <div class="related-grid">
+                <a href="sample-size-matters.html" class="related-card">
+                    <div class="related-card-category">Methods</div>
+                    <div class="related-card-title">Sample Size Matters: A Practical Guide for Development Practitioners</div>
+                </a>
+                <a href="theory-of-change-pitfalls.html" class="related-card">
+                    <div class="related-card-category">Theory of Change</div>
+                    <div class="related-card-title">5 Common Theory of Change Pitfalls (And How to Avoid Them)</div>
+                </a>
+            </div>
+        </div>
+    </article>
+</main>
+
+<footer class="footer">
+    <p>© 2026 ImpactMojo. Released under <a href="https://opensource.org/licenses/MIT" target="_blank">MIT License</a>.</p>
+    <p>Supported by <a href="https://www.pinpointventures.in" target="_blank">PinPoint Ventures</a></p>
+    <p style="margin-top: 1rem;"><a href="../blog.html">← Back to Learning Loops</a></p>
+    <p style="margin-top: 0.5rem;"><a href="/docs/" rel="noopener noreferrer" target="_blank">Documentation</a></p>
+</footer>
+
+
+<!-- Language Translation (Hindi, Tamil, Bengali, Marathi) -->
+<script src="/js/search.js" defer></script>
+<!-- ImpactMojo Theme Toggle JS -->
+<script src="/js/theme.js"></script>
+<!-- ImpactMojo Paper Plane -->
+<svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M80,130 L150,50" stroke="#10B981" stroke-width="2" stroke-dasharray="4,4"/>
+    <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+    <circle cx="40" cy="155" r="2" fill="#0EA5E9" opacity="0.6"/>
+    <circle cx="35" cy="165" r="1.5" fill="#6366F1" opacity="0.4"/>
+    <circle cx="45" cy="170" r="1" fill="#10B981" opacity="0.5"/>
+</svg>
+
+<!-- Supabase Auth -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.49.1"></script>
+<script src="/js/state-manager.js"></script>
+<script src="/js/config.js"></script>
+<script src="/js/auth.js"></script>
+<script src="/js/translate-sarvam.js" defer></script>
+  <script src="/js/site-chrome.js" defer></script>
+</body>
+</html>

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -16184,5 +16184,24 @@
     ],
     "type": "showcase",
     "category": "Showcase"
+  },
+  {
+    "id": "BLOG-IMPACT-EVAL-DESIGN",
+    "title": "Designing an Impact Evaluation: Eight Steps, and When to Take Them",
+    "description": "The standard guidance lists eight steps in order. In practice the counterfactual constrains every step before it, and teams that reach it last find their options already gone. Randomised phase-in, eligibility thresholds, and what to do when the programme is a universal entitlement.",
+    "type": "blog",
+    "category": "Methods",
+    "url": "/blog/designing-an-impact-evaluation.html",
+    "tags": [
+      "impact evaluation",
+      "counterfactual",
+      "research design",
+      "theory of change",
+      "RCT",
+      "difference-in-differences",
+      "MGNREGA",
+      "evaluation questions",
+      "methods"
+    ]
   }
 ]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.224.0 — August 20, 2026 (New post: designing an impact evaluation)
+
+### For Learners
+
+- **Designing an Impact Evaluation: Eight Steps, and When to Take Them** — the standard guidance lists eight steps in order, but the counterfactual constrains every step before it, and teams that reach it last find their options already gone. Covers randomised phase-in, eligibility thresholds, and what to ask when the programme is a universal entitlement like MGNREGA.
+
 ## v10.221.0 — August 20, 2026 (Nine ways to fail silently, closed)
 
 ### Fixed

--- a/nfhs.html
+++ b/nfhs.html
@@ -11,7 +11,7 @@
 <meta property="og:title" content="NFHS District Explorer — India Health & Development Map">
 <meta property="og:description" content="Explore all 706 Indian districts across 105 NFHS indicators. See the change between NFHS-4 (2015-16) and NFHS-5 (2019-21) on an accessible, mobile-first map.">
 <meta property="og:url" content="https://impactmojo.in/nfhs.html">
-<meta property="og:image" content="https://impactmojo.in/assets/og-default.png">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/og-card.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="NFHS District Explorer — India Health & Development Map">
 <meta name="twitter:description" content="706 districts · 105 indicators · NFHS-4 → NFHS-5 change. A teaching-first, accessible data explorer from ImpactMojo.">

--- a/scripts/check-social-images.py
+++ b/scripts/check-social-images.py
@@ -31,7 +31,17 @@ from pathlib import Path
 from urllib.parse import unquote, urlparse
 
 ROOT = Path(__file__).resolve().parent.parent
-SITE = "https://www.impactmojo.in"
+# Both spellings of our own origin. The bare-domain form is what let a broken
+# reference sit unreported: nfhs.html pointed og:image at
+# https://impactmojo.in/assets/og-default.png, which does not exist, and the
+# guard treated the missing "www." as evidence that the URL belonged to
+# somebody else and skipped it.
+SITE_ORIGINS = (
+    "https://www.impactmojo.in",
+    "https://impactmojo.in",
+    "http://www.impactmojo.in",
+    "http://impactmojo.in",
+)
 
 META = re.compile(
     r'<meta\s+(?:property|name)="((?:og|twitter):image(?::secure_url)?)"\s+content="([^"]+)"',
@@ -56,7 +66,7 @@ def main() -> int:
         for prop, url in META.findall(src):
             # Only our own assets can be checked from here; a CDN or a remote
             # host is somebody else's problem and is left alone.
-            if url.startswith("http") and not url.startswith(SITE):
+            if url.startswith("http") and not url.startswith(SITE_ORIGINS):
                 continue
             path = urlparse(url).path if url.startswith("http") else url
             # A space in a filename arrives as %20 and is a real file.

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -947,4 +947,11 @@
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
+
+  <url>
+    <loc>https://www.impactmojo.in/blog/designing-an-impact-evaluation.html</loc>
+    <lastmod>2026-08-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
A new Methods post built from the eight-step guidance deck, plus a guard fix the post accidentally exposed.

## The post

`/blog/designing-an-impact-evaluation.html` — ~1,360 words, 7 min.

The deck lists eight steps in order. Rather than summarising them, the post argues about the sequence: **the sixth step, the counterfactual, is a constraint set by how the programme rolls out, not a stage the evaluator arrives at.** By the time a team works down the list to step six, the decision has usually been made for them by operations, eighteen months earlier, on grounds that had nothing to do with evaluation.

What it covers:

- What that reordering changes about rationale, unit of variation, theory of change and budget — including the point that a scheme delivered through the panchayat varies at panchayat level, so the effective sample is panchayats, not households
- The three rollout situations and what each permits: randomised phase-in (nobody is denied anything they were otherwise getting, which answers the usual ethical objection by design), eligibility thresholds, and universal entitlements like MGNREGA where the answerable question shifts from access to implementation
- Planning dissemination for a null result, and the two questions worth putting in writing at design time: what finding would change the programme, and who has the authority to make that change

Deliberately avoids precise effect sizes and named citations I could not verify from the source. It points at data that demonstrably exists — NSS, NFHS, ASER, MGNREGA and PDS administrative systems — rather than quoting figures at it.

Fully cross-referenced: card on `blog.html` (inline SVG, no missing image file), search index, `sitemap.xml`, both changelogs, related posts retargeted to *Sample Size Matters* and *5 Common Theory of Change Pitfalls* and both verified to exist.

## The guard fix

`scripts/check-social-images.py` compared each URL against one origin string, `https://www.impactmojo.in`, and treated anything else starting with `http` as an external host to leave alone.

`nfhs.html` pointed `og:image` at `https://impactmojo.in/assets/og-default.png`. That file does not exist. **Four missing characters — the `www.` — were enough for the guard to wave it through**, so the page has been sharing with no preview image while the guard built to catch exactly this reported PASS.

It now recognises all four spellings of our own origin (`http`/`https` × with/without `www.`). Checked images rise from **1,168 to 1,171**, and `nfhs.html` points at a real file.

I found it because I made the same mistake: my first draft cited `og-default.png` too, the guard flagged *my* file, and chasing why it hadn't flagged the existing one turned up the hole.

## Verification

All guards pass: social images, internal links (857 pages), counts, mojibake, conflict markers, tap traps, theme contrast, asset stamps. `search-index.json` valid JSON (1,088 entries), `sitemap.xml` valid XML.

---
_Generated by [Claude Code](https://claude.ai/code/session_01199dCmAgzMN1Z1d8qj2UfN)_