### PR TITLE
Stop the product-order lead capture failing silently

### DIFF
--- a/js/product-order.js
+++ b/js/product-order.js
@@ -74,6 +74,8 @@
     function captureLead() {
       if (captured) return;
       captured = true;
+      // Set before the attempt so a double-click cannot double-post, and
+      // cleared again below if the post fails, so the next click retries.
       try {
         var product = (form.querySelector('[name="product"]') || {}).value || "";
         var body = new URLSearchParams({
@@ -83,9 +85,28 @@
           product: product,
           upi_ref: "" // empty ⇒ pre-payment lead; submission-created skips the confirm email
         }).toString();
+        // Netlify Forms answers 200 for a submission it has classified as spam,
+        // so a resolved promise is not delivery -- but a non-OK status or a
+        // network failure definitely is not, and both were being discarded.
+        // This is the pre-payment lead: losing it means an abandoned cart we
+        // never hear about. The completed order is unaffected; that goes
+        // through imxSubmitBothFromElement, which writes a row and reports
+        // failure to the buyer.
         fetch("/", { method: "POST", headers: { "Content-Type": "application/x-www-form-urlencoded" }, body: body })
-          .catch(function () {});
-      } catch (e) { /* non-blocking */ }
+          .then(function (r) {
+            if (!r.ok) {
+              captured = false;
+              console.warn("[ProductOrder] lead capture rejected: HTTP " + r.status);
+            }
+          })
+          .catch(function (err) {
+            captured = false;
+            console.warn("[ProductOrder] lead capture failed to send:", err && err.message ? err.message : err);
+          });
+      } catch (e) {
+        captured = false;
+        console.warn("[ProductOrder] lead capture threw:", e && e.message ? e.message : e);
+      }
     }
 
     var revealed = false;


### PR DESCRIPTION
Found by sweeping every catch block in shipped JS, prompted by "how many more silent problems do we have".

## The bug

Before payment, the product form posts the buyer's name, email and product to Netlify Forms, so an abandoned cart is still visible to you. That post discarded every failure three ways over:

```js
fetch("/", {...}).catch(function () {});   // network failure swallowed
                                            // no response.ok check → 4xx/5xx counts as success
} catch (e) { /* non-blocking */ }          // anything else swallowed
```

And `captured = true` was set *before* the attempt and never cleared, so a failed capture was never retried.

Now a non-OK status or a thrown error is logged and clears `captured`, so the next click retries. The double-click guard still holds on the success path.

## Scope

**This is the pre-payment lead only.** A completed order goes through `imxSubmitBothFromElement`, which writes a durable row *and* sends the notification, and tells the buyer to WhatsApp if it fails. That path was already sound and is untouched — I checked it before changing anything, because it's the one that carries money.

## The sweep behind it

| | |
|---|---|
| catch blocks in shipped JS | 138 |
| silent (empty or comment-only) | 84 |
| wrapping an operation that can lose data | **6** |
| genuinely wrong | **1** (this one) |

The other five: two best-effort profile-name lookups on the verify pages that fall back to "Verified Learner", one translation fetch that degrades to untranslated text, one `caches.delete()` that matched my pattern by accident, and one already fixed in #961.

Also swept: the other five Supabase edge functions, for the undefined-client bug that had silently prevented every certificate email. None of them repeat it.

## Verification

`node --check` passes. Guards pass: write-path, internal links, social images, mojibake, counts, conflict markers, asset stamps.

---
_Generated by [Claude Code](https://claude.ai/code/session_01199dCmAgzMN1Z1d8qj2UfN)_