### PR TITLE
Add a workflow that can cut a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,107 @@
+# Cut a tagged GitHub Release from the top of CHANGELOG.md.
+#
+# Why a workflow: tag pushes are rejected (403) from a Claude Code session on
+# both the session proxy and a direct PAT, and the GitHub MCP server has no
+# create-release tool. Tags on this repo had drifted to v10.79.0 while the
+# changelog was at 10.224.0, because nothing could write one. A workflow runs
+# on GitHub with its own GITHUB_TOKEN, so it can.
+#
+# Safety: dry-run by default, refuses a version that is not in CHANGELOG.md,
+# refuses a tag that already exists, and tags whatever the default branch
+# points at when it runs.
+name: Cut a release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release, e.g. 10.224.0. Leave blank for the newest entry in CHANGELOG.md.'
+        required: false
+        default: ''
+      dry_run:
+        description: 'Preview the tag and notes without creating anything.'
+        type: boolean
+        required: false
+        default: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Tag and release
+    runs-on: ubuntu-latest
+    # Without this a hung step inherits GitHub's 360-minute default and the
+    # job neither passes nor fails -- which reads as "still running".
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Tag and publish
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+            const dryRun = context.payload.inputs.dry_run !== 'false';
+            const asked = (context.payload.inputs.version || '').trim().replace(/^v/, '');
+
+            const changelog = fs.readFileSync('CHANGELOG.md', 'utf8');
+
+            // Sections look like:  ## [10.224.0] - 2026-08-20
+            const heads = [...changelog.matchAll(/^## \[(\d+\.\d+\.\d+)\](?: - (\S+))?/gm)];
+            if (!heads.length) { core.setFailed('No `## [x.y.z]` sections found in CHANGELOG.md'); return; }
+
+            const version = asked || heads[0][1];
+            const idx = heads.findIndex(h => h[1] === version);
+            if (idx === -1) {
+              core.setFailed(`Version ${version} has no section in CHANGELOG.md. Newest is ${heads[0][1]}.`);
+              return;
+            }
+
+            const start = heads[idx].index + heads[idx][0].length;
+            const end = idx + 1 < heads.length ? heads[idx + 1].index : changelog.length;
+            const body = changelog.slice(start, end).trim();
+            if (!body) { core.setFailed(`Section ${version} in CHANGELOG.md is empty.`); return; }
+
+            const tag = `v${version}`;
+            let exists = false;
+            try {
+              await github.rest.git.getRef({ owner, repo, ref: `tags/${tag}` });
+              exists = true;
+            } catch (e) {
+              if (e.status !== 404) throw e;
+            }
+
+            const repoInfo = await github.rest.repos.get({ owner, repo });
+            const branch = repoInfo.data.default_branch;
+            const head = await github.rest.repos.getBranch({ owner, repo, branch });
+            const sha = head.data.commit.sha;
+
+            const summary = core.summary
+              .addHeading(dryRun ? `Dry run — ${tag} not created` : `Released ${tag}`)
+              .addRaw(`\nTag \`${tag}\` at \`${sha.slice(0, 8)}\` on \`${branch}\`${heads[idx][2] ? ` · dated ${heads[idx][2]}` : ''}\n\n`);
+
+            if (exists) {
+              await summary.addRaw(`Tag \`${tag}\` already exists — nothing to do. Bump the version in CHANGELOG.md first.\n`).write();
+              core.setFailed(`Tag ${tag} already exists`);
+              return;
+            }
+
+            if (dryRun) {
+              await summary
+                .addRaw('### Release notes that would be published\n\n')
+                .addRaw(body.length > 40000 ? body.slice(0, 40000) + '\n\n_(truncated in this preview)_\n' : body + '\n')
+                .addRaw('\n_Re-run with `dry_run` unchecked to publish._\n')
+                .write();
+              core.info(`Dry run: would tag ${sha} as ${tag}`);
+              return;
+            }
+
+            await github.rest.git.createRef({ owner, repo, ref: `refs/tags/${tag}`, sha });
+            const release = await github.rest.repos.createRelease({
+              owner, repo, tag_name: tag, name: tag, body, draft: false, prerelease: false,
+            });
+
+            await summary.addRaw(`Published: ${release.data.html_url}\n`).write();
+            core.info(`Released ${tag} -> ${release.data.html_url}`);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to ImpactMojo are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.225.0] - 2026-08-20
+
+### Added
+
+- **A workflow that can actually cut a release** (`.github/workflows/release.yml`). Tags on this repo had drifted to `v10.79.0` while the changelog was at 10.224.0 — 153 changelog sections against 7 tags — because nothing in the toolchain could write one. A tag push is rejected 403 both through the session proxy and through a direct PAT, and the GitHub MCP server has no create-release tool, so every release since v10.79.0 was silently skipped rather than refused.
+
+  The workflow runs on GitHub with its own token, reads the notes out of `CHANGELOG.md` rather than restating them, and tags whatever the default branch points at when it runs. Dry-run by default: the first click prints the tag, the commit and the notes to the job summary without creating anything. It refuses a version with no section in the changelog, refuses an empty section, and refuses a tag that already exists. Parser verified against the real file: 153 sections, correct boundaries, no bleed into the next entry.
+
 ## [10.224.0] - 2026-08-20
 
 ### Added


### PR DESCRIPTION
Tags on this repo are at `v10.79.0`. `CHANGELOG.md` is at 10.224.0. That is **153 changelog sections against 7 tags**, and the reason is that nothing in the toolchain can write a tag:

- `git push origin v10.224.0` through the session proxy → **403**
- the same push through a direct `$GITHUB_PAT` → **403**
- `api.github.com` directly → `GitHub access is not enabled for this session`
- the GitHub MCP server has `get_release_by_tag` and `list_releases`, but no create

So every release since v10.79.0 was skipped in silence rather than refused — the same failure shape the rest of today's work has been about.

## What this adds

`.github/workflows/release.yml`, dispatched by hand. It runs on GitHub with its own `GITHUB_TOKEN`, so it can do what the session cannot.

- Reads the release notes **out of `CHANGELOG.md`** rather than restating them, so the tag and the changelog cannot drift apart
- Tags whatever the default branch points at when it runs
- `version` input is optional — blank takes the newest entry
- **Dry-run by default.** The first click prints the tag, the target commit and the full notes to the job summary and creates nothing
- Refuses a version with no section in the changelog, an empty section, or a tag that already exists

## Verification

The parser is the part worth checking, since a bad regex publishes empty or wrong notes. Run against the real `CHANGELOG.md`:

```
sections found: 153
newest: 10.224.0 dated 2026-08-20
10.224.0 -> body 1582 chars, ends: " 1,171, and `nfhs.html` now points at a real file."
10.223.0 -> body 2794 chars, ends: "g roughly 663 quiz questions that already existed."
10.0.0   -> body 2689 chars, ends: "t rendering code from admin and transparency pages"
unknown version lookup -> -1
```

Correct boundaries at the top, the middle and the last section; no bleed into the following entry; an unknown version returns `-1`, which is the path that calls `setFailed`. YAML parses.

## To use it

Actions → **Cut a release** → Run workflow. Leave the version blank and leave dry-run checked for the first pass to read the notes, then re-run with dry-run unchecked to publish. That will cut `v10.225.0` covering everything merged today.

---
_Generated by [Claude Code](https://claude.ai/code/session_01199dCmAgzMN1Z1d8qj2UfN)_