### PR TITLE
Add partnerships.html — Populi, India Institute, PinPoint Ventures

### DIFF
--- a/.pa11yci
+++ b/.pa11yci
@@ -19,6 +19,7 @@
     "http://localhost:8080/login.html",
     "http://localhost:8080/signup.html",
     "http://localhost:8080/about.html",
+    "http://localhost:8080/partnerships.html",
     "http://localhost:8080/catalog.html",
     "http://localhost:8080/bct-repository.html",
     "http://localhost:8080/premium.html",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`partnerships.html`** — a dedicated partnerships page, replacing the two blocks buried at the bottom of `about.html` as the place partnership is explained. Features Populi (https://www.populi.co.in) as end-to-end research + MEL advisory partner, India Institute as thought advocacy + measurement partner, and PinPoint Ventures as founding sponsor; sets out the partnership terms (editorial independence, no paywalling of partner-supported content, CC BY-NC-ND 4.0, no learner data), lists the ways to partner, and carries a proposal form.
+- **`partnerships.html`** — a dedicated partnerships page, replacing the two blocks buried at the bottom of `about.html` as the place partnership is explained. Features Populi (https://www.populi.co.in) as end-to-end research + MEL advisory partner, India Institute (https://indiai.org/) as thought advocacy + measurement partner, and PinPoint Ventures as founding sponsor; sets out the partnership terms (editorial independence, no paywalling of partner-supported content, CC BY-NC-ND 4.0, no learner data), lists the ways to partner, and carries a proposal form.
 
   The form reuses the existing **`partner-inquiry`** Netlify form name and its exact field set (`name`, `email`, `organization`, `interest`, `message`). That is deliberate: `partner-inquiry` is already on the `ALLOWED_FORMS` allowlist in `netlify/functions/form-submit.mjs`, so proposals get both the Netlify notification and the Supabase row with no backend change, and they land in the same place as the ones submitted from `about.html`. A new form name would have needed an allowlist entry and would have split partnership enquiries across two buckets.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to ImpactMojo are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.233.0] - 2026-08-21
+
+### Added
+
+- **`partnerships.html`** — a dedicated partnerships page, replacing the two blocks buried at the bottom of `about.html` as the place partnership is explained. Features Populi (https://www.populi.co.in) as end-to-end research + MEL advisory partner, India Institute as thought advocacy + measurement partner, and PinPoint Ventures as founding sponsor; sets out the partnership terms (editorial independence, no paywalling of partner-supported content, CC BY-NC-ND 4.0, no learner data), lists the ways to partner, and carries a proposal form.
+
+  The form reuses the existing **`partner-inquiry`** Netlify form name and its exact field set (`name`, `email`, `organization`, `interest`, `message`). That is deliberate: `partner-inquiry` is already on the `ALLOWED_FORMS` allowlist in `netlify/functions/form-submit.mjs`, so proposals get both the Netlify notification and the Supabase row with no backend change, and they land in the same place as the ones submitted from `about.html`. A new form name would have needed an allowlist entry and would have split partnership enquiries across two buckets.
+
+  Registered in `sitemap.xml` and `data/search-index.json` (`check-search-coverage.py` fails if a sitemap page is missing from site search). **Not linked from the site navigation yet** — deliberate, at the owner's request.
+
 ## [10.232.0] - 2026-08-20
 
 ### Removed

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -6313,6 +6313,25 @@
     ]
   },
   {
+    "id": "PAGE-PARTNERSHIPS",
+    "title": "Partnerships",
+    "description": "ImpactMojo's research, MEL advisory and measurement partners — Populi, India Institute and PinPoint Ventures — and how to propose a partnership.",
+    "type": "page",
+    "category": "Info",
+    "url": "/partnerships.html",
+    "tags": [
+      "partnerships",
+      "partners",
+      "populi",
+      "india institute",
+      "mel advisory",
+      "research partner",
+      "measurement",
+      "sponsorship",
+      "collaboration"
+    ]
+  },
+  {
     "id": "faq",
     "title": "FAQ",
     "description": "Frequently asked questions about ImpactMojo courses, certifications, premium tools, and platform features.",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.225.0 — August 21, 2026 (A partnerships page)
+
+### Added
+
+- **Partnerships page** (`/partnerships.html`) — who we build the material with, and on what terms. Populi is credited as our end-to-end research and MEL advisory partner, India Institute as our thought advocacy and measurement partner, PinPoint Ventures as founding sponsor. States the terms plainly: editorial independence, partner-supported content stays free under CC BY-NC-ND 4.0, no learner data. Carries a partnership proposal form (reuses the existing `partner-inquiry` form, so proposals land alongside the ones from About). Not yet linked in the site navigation.
+
 ## v10.224.0 — August 20, 2026 (New post: designing an impact evaluation)
 
 ### For Learners

--- a/partnerships.html
+++ b/partnerships.html
@@ -281,13 +281,27 @@ a { color: var(--blue); }
     <article class="partner violet">
         <p class="role">Thought Advocacy &amp; Measurement Partner</p>
         <h3>India Institute</h3>
-        <p>India Institute is our thought advocacy and measurement partner. Evidence that stays inside a report changes nothing; the harder half of this work is turning a finding into an argument that reaches the people who decide, and then measuring whether the argument moved anything at all.</p>
+        <a class="site" href="https://indiai.org/" target="_blank" rel="noopener noreferrer">indiai.org &#8599;</a>
+        <p>India Institute is our thought advocacy and measurement partner. An independent research think tank established in 2010, it &ldquo;conducts rigorous social science research in education, critical thinking, and social equity &mdash; and translates evidence into policy that expands dignity, choice, and opportunity for individuals across India.&rdquo; Its motto is the whole argument in three words: <em>evidence, insight, impact.</em></p>
+        <p>The middle word is where most of the sector loses the thread. Evidence that stays inside a report changes nothing; the harder half of the work is turning a finding into an argument that reaches the people who decide. India Institute does that end &mdash; and it does the other end too, building the instruments that make hard-to-count outcomes measurable in the first place.</p>
+
+        <h4>Where their work sits</h4>
+        <ul class="chiplist">
+            <li>Education</li>
+            <li>Critical thinking</li>
+            <li>Measurements</li>
+            <li>Social equity</li>
+            <li>RCTs &amp; field research</li>
+            <li>Government partnerships</li>
+            <li>Policy briefs &amp; public reason</li>
+        </ul>
+        <p style="margin-top:1rem">Their Measurements vertical is five validated instruments for social equity indicators &mdash; discrimination, mobility, social capital, mental health and casteist attitudes &mdash; alongside a Misinformation Susceptibility Index. Their field research runs at a scale most of our readers will never commission: 34,000+ survey respondents, 11,700+ student assessments, nine languages, including a completed randomised controlled trial with the Tamil Nadu School Education Department across 41 schools and 6,711 students.</p>
 
         <h4>What we do together</h4>
         <ul class="together">
-            <li><strong>Thought advocacy</strong> &mdash; carrying evidence out of the evaluation report and into public argument, in a form policy audiences can act on.</li>
-            <li><strong>Measurement</strong> &mdash; frameworks for the outcomes that resist counting, including the influence and advocacy work that most logframes quietly leave out.</li>
-            <li><strong>Testing our material against the policy end</strong> &mdash; our governance, policy and advocacy content is reviewed by people who argue these cases for a living.</li>
+            <li><strong>Thought advocacy</strong> &mdash; carrying evidence out of the report and into public argument, in a form policy audiences can act on.</li>
+            <li><strong>Measurement</strong> &mdash; the outcomes that resist counting. Constructs like discrimination, mobility and critical thinking do not arrive with an indicator attached; someone has to build and validate the instrument, and that craft is almost absent from open MEL teaching.</li>
+            <li><strong>Testing our material against the policy end</strong> &mdash; our governance, policy and advocacy content is read by people who argue these cases for a living.</li>
         </ul>
     </article>
 

--- a/partnerships.html
+++ b/partnerships.html
@@ -1,0 +1,498 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Partnerships — Research, MEL &amp; Measurement Partners | ImpactMojo</title>
+<meta name="description" content="ImpactMojo's partners: Populi as our end-to-end research and MEL advisory partner, and India Institute as our thought advocacy and measurement partner. How we work with organisations, and how to propose a partnership.">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://www.impactmojo.in/partnerships.html">
+
+<!-- Google tag (gtag.js) - G-JRCMEB9TBW -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-JRCMEB9TBW');</script>
+
+<!-- Open Graph -->
+<meta property="og:title" content="Partnerships — Research, MEL &amp; Measurement Partners | ImpactMojo">
+<meta property="og:description" content="Populi is our end-to-end research and MEL advisory partner. India Institute is our thought advocacy and measurement partner. Here's how we work together — and how to propose a partnership.">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/og-card.png">
+<meta property="og:url" content="https://www.impactmojo.in/partnerships.html">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="ImpactMojo">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Partnerships — Research, MEL &amp; Measurement Partners | ImpactMojo">
+<meta name="twitter:description" content="Populi is our end-to-end research and MEL advisory partner. India Institute is our thought advocacy and measurement partner.">
+<meta name="twitter:image" content="https://www.impactmojo.in/assets/images/og-card.png">
+
+<!-- Favicons -->
+<link href="/assets/images/favicon.png" rel="icon" type="image/png">
+<link href="/assets/images/apple-touch-icon.png" rel="apple-touch-icon">
+
+<!-- Self-hosted fonts -->
+<link rel="stylesheet" href="/css/fonts.css?v=07d8578c">
+<link rel="stylesheet" href="/assets/css/light-mode-fallback.css">
+
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+/* Dark-first palette */
+:root {
+    --bg: #0F172A; --bg-2: #1E293B; --card: #1E293B; --hover: #334155;
+    --text: #F1F5F9; --text-2: #CBD5E1; --muted: #94A3B8;
+    --border: #334155; --accent: #F59E0B; --accent-2: #D97706;
+    --blue: #0EA5E9; --green: #10B981; --violet: #A78BFA;
+    --accent-ink: #F59E0B;      /* 6.81:1 on --bg-2 */
+    --badge-blue-ink: #38BDF8;  /* 5.51:1 on the blue badge fill */
+    --badge-violet-ink: #C4B5FD;/* 6.05:1 on the violet badge fill */
+}
+[data-theme="light"], body.light-mode {
+    --bg: #FFFFFF; --bg-2: #F8FAFC; --card: #FFFFFF; --hover: #F1F5F9;
+    --text: #0F172A; --text-2: #475569; --muted: #52627A;
+    --border: #E2E8F0; --blue: #0369A1; --green: #047857; --violet: #6D28D9;
+    --accent-ink: #B45309;      /* 4.80:1 on --bg-2; the raw amber is 2.05:1 */
+    --badge-blue-ink: #0369A1;  /* 4.94:1 on the blue badge fill */
+    --badge-violet-ink: #6D28D9;/* 5.91:1 on the violet badge fill */
+}
+/* This page ships a real light theme — neutralize the invert-filter used by
+   light-mode-fallback.css (which is meant for dark-only pages). */
+[data-theme="light"] body, body.light-mode, html.light body { background: var(--bg); filter: none; }
+[data-theme="light"] img, [data-theme="light"] video, [data-theme="light"] iframe, [data-theme="light"] canvas,
+body.light-mode img, body.light-mode video, body.light-mode iframe, body.light-mode canvas { filter: none; }
+[data-theme="light"] .im-topbar, body.light-mode .im-topbar, html.light .im-topbar { filter: none; }
+@media (prefers-color-scheme: light) {
+    :root:not([data-theme="dark"]):not(.dark) {
+        --bg: #FFFFFF; --bg-2: #F8FAFC; --card: #FFFFFF; --hover: #F1F5F9;
+        --text: #0F172A; --text-2: #475569; --muted: #52627A;
+        --border: #E2E8F0; --blue: #0369A1; --green: #047857; --violet: #6D28D9;
+        --accent-ink: #B45309; --badge-blue-ink: #0369A1; --badge-violet-ink: #6D28D9;
+    }
+}
+
+body { font-family: 'Amaranth', Arial, sans-serif; background: var(--bg); color: var(--text); line-height: 1.65; padding-top: 44px; }
+h1, h2, h3, h4 { font-family: 'Inter', Helvetica, sans-serif; font-weight: 700; }
+a { color: var(--blue); }
+.mono { font-family: 'JetBrains Mono', monospace; }
+
+.im-skip-link { position: absolute; left: -9999px; top: 0; background: #0A7AAD; color: #fff; padding: 8px 16px; z-index: 100000; border-radius: 0 0 6px 0; font: 600 .85rem/1.2 Inter, system-ui, sans-serif; text-decoration: none; }
+.im-skip-link:focus { left: 0; }
+
+/* Topbar */
+.im-topbar { position: fixed; top: 0; left: 0; right: 0; height: 44px; background: var(--card); border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; padding: 0 1rem; z-index: 9000; }
+.im-topbar-home { display: flex; align-items: center; gap: 0.5rem; color: var(--text); text-decoration: none; font-family: 'Amaranth', sans-serif; font-weight: 700; }
+.im-topbar-right { display: flex; align-items: center; gap: 1rem; }
+.im-topbar-link { color: var(--text-2); text-decoration: none; font-size: 0.85rem; }
+.im-topbar-link:hover { color: var(--accent-ink); }
+.im-theme-selector { display: flex; gap: 2px; background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 2px; }
+.im-theme-btn { background: transparent; border: none; color: var(--muted); padding: 6px; border-radius: 5px; cursor: pointer; transition: all 0.2s; display: flex; align-items: center; justify-content: center; width: 30px; height: 30px; }
+.im-theme-btn:hover { background: var(--hover); color: var(--text); }
+.im-theme-btn.active { background: #0A7AAD; color: #fff; }
+.im-theme-btn svg { width: 16px; height: 16px; }
+
+.im-paper-plane { position: fixed; top: 15%; right: 8%; width: 120px; height: 120px; opacity: 0.12; z-index: 0; pointer-events: none; }
+@media (prefers-reduced-motion: no-preference) { .im-paper-plane { animation: im-fly 25s ease-in-out infinite; } }
+@keyframes im-fly { 0%,100%{transform:translate(0,0) rotate(0)} 25%{transform:translate(50px,-30px) rotate(10deg)} 50%{transform:translate(100px,20px) rotate(-6deg)} 75%{transform:translate(30px,50px) rotate(12deg)} }
+
+/* Hero */
+.hero { background: var(--bg-2); border-bottom: 1px solid var(--border); padding: 4rem 1.5rem 3rem; text-align: center; }
+.hero .kicker { font-family: 'JetBrains Mono', monospace; font-size: 0.8rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent-ink); margin-bottom: 0.75rem; }
+.hero h1 { font-size: 2.6rem; line-height: 1.15; margin-bottom: 0.9rem; }
+.hero .tagline { color: var(--text-2); max-width: 660px; margin: 0 auto 1.5rem; font-size: 1.15rem; }
+.badges { display: flex; gap: 0.5rem; justify-content: center; flex-wrap: wrap; }
+.badge { display: inline-block; padding: 0.3rem 0.8rem; border-radius: 999px; font-size: 0.8rem; font-weight: 600; font-family: 'Inter', sans-serif; background: var(--hover); color: var(--text-2); border: 1px solid var(--border); }
+.badge.blue { background: rgba(14,165,233,0.14); color: var(--badge-blue-ink); border-color: transparent; }
+.badge.violet { background: rgba(167,139,250,0.16); color: var(--badge-violet-ink); border-color: transparent; }
+
+/* Layout */
+.container { max-width: 900px; margin: 0 auto; padding: 2.5rem 1.5rem 4rem; position: relative; z-index: 1; }
+.section { margin-bottom: 3.25rem; }
+.section h2 { font-size: 1.65rem; margin-bottom: 0.6rem; }
+.section > p { color: var(--text-2); margin-bottom: 1rem; }
+.note { background: var(--bg-2); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 8px; padding: 1rem 1.25rem; margin: 1.25rem 0; color: var(--text-2); }
+.note strong { color: var(--text); }
+
+/* Partner cards */
+.partner { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 1.75rem; margin-bottom: 1.5rem; border-top: 3px solid var(--border); }
+.partner.blue { border-top-color: #0EA5E9; }
+.partner.violet { border-top-color: #A78BFA; }
+.partner.amber { border-top-color: #F59E0B; }
+.partner .role { font-family: 'JetBrains Mono', monospace; font-size: 0.74rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 0.4rem; }
+.partner h3 { font-size: 1.5rem; margin-bottom: 0.15rem; }
+.partner .site { font-size: 0.9rem; margin-bottom: 0.9rem; display: inline-block; }
+.partner p { color: var(--text-2); margin-bottom: 0.9rem; }
+.partner .quote { border-left: 2px solid var(--border); padding-left: 1rem; font-style: italic; color: var(--text-2); margin: 1rem 0; }
+.partner h4 { font-size: 0.82rem; text-transform: uppercase; letter-spacing: 0.07em; color: var(--muted); font-weight: 600; margin: 1.25rem 0 0.6rem; }
+.chiplist { display: flex; flex-wrap: wrap; gap: 0.4rem; list-style: none; }
+.chiplist li { font-family: 'Inter', sans-serif; font-size: 0.82rem; color: var(--text-2); background: var(--hover); border: 1px solid var(--border); border-radius: 7px; padding: 0.28rem 0.6rem; }
+.together { list-style: none; margin-top: 0.4rem; }
+.together li { position: relative; padding-left: 1.5rem; color: var(--text-2); margin-bottom: 0.5rem; font-size: 0.95rem; }
+.together li::before { content: ""; position: absolute; left: 0.25rem; top: 0.62rem; width: 6px; height: 6px; border-radius: 50%; background: var(--accent); }
+
+/* Generic cards */
+.grid2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.25rem; margin: 1.25rem 0; }
+.card { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 1.25rem; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+.card h3 { font-size: 1.05rem; margin-bottom: 0.5rem; }
+.card p, .card li { color: var(--text-2); font-size: 0.95rem; }
+.card ul { margin: 0.25rem 0 0 1.1rem; }
+
+/* Principles */
+.principles { list-style: none; }
+.principles li { padding: 0.9rem 0; border-bottom: 1px solid var(--border); color: var(--text-2); }
+.principles li:last-child { border-bottom: none; }
+.principles strong { display: block; font-family: 'Inter', sans-serif; color: var(--text); margin-bottom: 0.15rem; }
+
+/* Form */
+.signup { background: var(--bg-2); border: 1px solid var(--border); border-radius: 14px; padding: 1.75rem; }
+.signup h2 { margin-bottom: 0.4rem; }
+.signup .sub { color: var(--text-2); margin-bottom: 1.4rem; }
+.field { margin-bottom: 1.1rem; }
+.field label { display: block; font-family: 'Inter', sans-serif; font-weight: 600; font-size: 0.88rem; margin-bottom: 0.35rem; color: var(--text); }
+.field input, .field select, .field textarea { width: 100%; padding: 0.65rem 0.8rem; border: 1px solid var(--border); border-radius: 8px; background: var(--card); color: var(--text); font-family: 'Inter', sans-serif; font-size: 0.95rem; }
+.field input:focus, .field select:focus, .field textarea:focus { outline: 2px solid var(--blue); outline-offset: 1px; }
+.field textarea { min-height: 110px; resize: vertical; }
+.field .hint { font-size: 0.8rem; color: var(--muted); margin-top: 0.3rem; }
+.form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+.submit-btn { display: inline-flex; align-items: center; gap: 0.5rem; background: var(--accent); color: #0F172A; border: none; font-family: 'Inter', sans-serif; font-weight: 700; font-size: 1rem; padding: 0.85rem 1.7rem; border-radius: 10px; cursor: pointer; transition: background 0.2s; }
+.submit-btn:hover { background: #AF6005; color: #fff; }
+.form-success { background: rgba(16,185,129,0.12); border: 1px solid var(--green); border-radius: 10px; padding: 1.25rem; color: var(--text-2); }
+.form-success strong { color: var(--text); }
+
+/* Cross-links */
+.crosslinks { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1.25rem; }
+.crosslinks a.xcard { display: block; background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 1.2rem; text-decoration: none; transition: border-color 0.2s; }
+.crosslinks a.xcard:hover { border-color: var(--accent); }
+.crosslinks h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.35rem; }
+.crosslinks p { color: var(--text-2); font-size: 0.88rem; }
+
+/* Footer */
+.im-footer { background: var(--bg-2); border-top: 1px solid var(--border); padding: 2rem 1rem; margin-top: auto; font-family: 'Inter', sans-serif; color: var(--text-2); }
+.im-footer-content { max-width: 1100px; margin: 0 auto; }
+.im-footer-made { text-align: center; margin-bottom: 1.5rem; font-size: 0.9rem; color: var(--muted); }
+.im-footer-made a { color: var(--blue); }
+.im-footer-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1.5rem; margin-bottom: 1.5rem; }
+.im-footer-section h4 { color: var(--text); font-size: 0.9rem; margin-bottom: 0.75rem; font-weight: 600; }
+.im-footer-section ul { list-style: none; padding: 0; margin: 0; }
+.im-footer-section li { margin-bottom: 0.4rem; }
+.im-footer-section a { color: var(--text-2); text-decoration: none; font-size: 0.85rem; transition: color 0.2s; }
+.im-footer-section a:hover { color: var(--blue); }
+.im-footer-bottom { text-align: center; padding-top: 1rem; border-top: 1px solid var(--border); font-size: 0.8rem; color: var(--muted); }
+.im-footer-bottom p { margin: 0.25rem 0; }
+.im-footer-bottom a { color: var(--blue); text-decoration: none; }
+
+@media (max-width: 768px) {
+    .hero h1 { font-size: 2rem; }
+    .form-row { grid-template-columns: 1fr; }
+    .im-footer-grid { grid-template-columns: repeat(2, 1fr); gap: 1rem; }
+}
+@media (max-width: 600px) { .im-topbar-link { display: none; } .im-topbar-home span { display: none; } }
+@media (max-width: 480px) { .im-footer-grid { grid-template-columns: 1fr; } }
+</style>
+  <script src="/js/form-submit.js?v=36a6a01f"></script>
+</head>
+<body>
+<a href="#main" class="im-skip-link">Skip to content</a>
+
+<!-- ImpactMojo Top Bar -->
+<div class="im-topbar" id="imTopbar">
+    <div class="im-topbar-left">
+        <a href="/index.html" class="im-topbar-home">
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
+            <span>ImpactMojo</span>
+        </a>
+    </div>
+    <div class="im-topbar-right">
+        <a href="/about.html" class="im-topbar-link">About</a>
+        <a href="/transparency.html" class="im-topbar-link">Transparency</a>
+        <a href="/catalog.html" class="im-topbar-link">Catalog</a>
+        <div class="im-theme-selector" aria-label="Theme selection">
+            <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="Use system theme">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+            </button>
+            <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Use light theme">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+            </button>
+            <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Use dark theme">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
+        </div>
+    </div>
+</div>
+<svg class="im-paper-plane" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M50,150 L150,50 L50,100 L80,130 Z" fill="none" stroke="#0EA5E9" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M80,130 L150,50" stroke="#10B981" stroke-width="2" stroke-dasharray="4,4"/>
+    <circle cx="150" cy="50" r="4" fill="#6366F1"/>
+</svg>
+
+<main id="main">
+<section class="hero">
+    <p class="kicker">Partnerships</p>
+    <h1>Open education needs<br>practitioners behind it.</h1>
+    <p class="tagline">ImpactMojo is free and stays free. What keeps the material honest is the people who do this work for a living &mdash; the researchers, evaluators and advocates who tell us when a framework does not survive contact with the field.</p>
+    <div class="badges">
+        <span class="badge blue">Research &amp; MEL advisory</span>
+        <span class="badge violet">Thought advocacy &amp; measurement</span>
+        <span class="badge">Open content, always</span>
+    </div>
+</section>
+
+<div class="container">
+
+<section class="section">
+    <h2>Our partners</h2>
+    <p>Two organisations work with us on the substance of what we publish &mdash; not as sponsors of a logo slot, but as the practitioners we check our material against.</p>
+
+    <!-- Populi -->
+    <article class="partner blue">
+        <p class="role">Research &amp; MEL Advisory Partner &mdash; end to end</p>
+        <h3>Populi</h3>
+        <a class="site" href="https://www.populi.co.in" target="_blank" rel="noopener noreferrer">www.populi.co.in &#8599;</a>
+        <p>Populi is our end-to-end research partner and our MEL advisory partner. In their own words, they are &ldquo;a development advisory firm that partners with foundations, donors, and mission-driven organisations to strengthen the effectiveness of social impact initiatives,&rdquo; specialising in building data and evidence systems that power decision-making, surface what works, and support real-time course correction.</p>
+        <p class="quote">&ldquo;We meet our partners where they are&hellip; Whether it&rsquo;s a grassroots nonprofit or a large CSR team, Populi builds stage-appropriate, lean M&amp;E systems that they can confidently use.&rdquo;</p>
+        <p>That posture is why the partnership works. ImpactMojo teaches MEL to people who mostly do not have a MEL team &mdash; a programme officer holding the logframe alongside four other jobs. Populi builds systems for exactly those organisations, so the practice they bring back is sized for the reader we actually have.</p>
+
+        <h4>What Populi does</h4>
+        <ul class="chiplist">
+            <li>MEL framework design</li>
+            <li>Theory of Change development</li>
+            <li>Outcome frameworks</li>
+            <li>Monitoring system design</li>
+            <li>Data collection tools</li>
+            <li>Real-time feedback loops</li>
+            <li>Impact evaluations</li>
+            <li>Process evaluations</li>
+            <li>Developmental evaluations</li>
+            <li>Portfolio evaluations</li>
+            <li>Data analysis &amp; visualisation</li>
+            <li>Learning agendas</li>
+            <li>Needs assessments</li>
+            <li>Evidence reviews</li>
+            <li>Grantmaking strategy</li>
+            <li>Fractional M&amp;E Head</li>
+        </ul>
+
+        <h4>What we do together</h4>
+        <ul class="together">
+            <li><strong>Review of MEL and research material</strong> &mdash; our courses, labs and toolkits are read against live practice before they go out.</li>
+            <li><strong>Real cases, anonymised</strong> &mdash; evaluation designs that had to be changed mid-flight are worth more to a learner than a clean textbook example.</li>
+            <li><strong>A route beyond the free material</strong> &mdash; when a reader needs an actual evaluation or a MEL system built, we point them to Populi rather than pretending a course is a substitute.</li>
+        </ul>
+    </article>
+
+    <!-- India Institute -->
+    <article class="partner violet">
+        <p class="role">Thought Advocacy &amp; Measurement Partner</p>
+        <h3>India Institute</h3>
+        <p>India Institute is our thought advocacy and measurement partner. Evidence that stays inside a report changes nothing; the harder half of this work is turning a finding into an argument that reaches the people who decide, and then measuring whether the argument moved anything at all.</p>
+
+        <h4>What we do together</h4>
+        <ul class="together">
+            <li><strong>Thought advocacy</strong> &mdash; carrying evidence out of the evaluation report and into public argument, in a form policy audiences can act on.</li>
+            <li><strong>Measurement</strong> &mdash; frameworks for the outcomes that resist counting, including the influence and advocacy work that most logframes quietly leave out.</li>
+            <li><strong>Testing our material against the policy end</strong> &mdash; our governance, policy and advocacy content is reviewed by people who argue these cases for a living.</li>
+        </ul>
+    </article>
+
+    <!-- PinPoint Ventures -->
+    <article class="partner amber">
+        <p class="role">Founding Sponsor</p>
+        <h3>PinPoint Ventures</h3>
+        <a class="site" href="https://www.pinpointventures.in" target="_blank" rel="noopener noreferrer">www.pinpointventures.in &#8599;</a>
+        <p>PinPoint Ventures underwrites the platform &mdash; hosting, tooling and the time that goes into keeping every course, lab and game free to open. No ImpactMojo content sits behind their support, and none ever will.</p>
+    </article>
+</section>
+
+<section class="section">
+    <h2>How we work with partners</h2>
+    <p>The terms are the same for everyone, and they are deliberately narrow.</p>
+    <ul class="principles">
+        <li><strong>Editorial independence is not negotiable</strong>A partner reviews material, argues with it, and is often right. A partner does not get approval over what we publish, and no partner has ever been given it.</li>
+        <li><strong>Partner-supported content stays free</strong>Support does not create a paywall. Everything a partnership touches goes out under the same licence as the rest of the platform &mdash; CC BY-NC-ND 4.0, open to anyone.</li>
+        <li><strong>Attribution, both ways</strong>Where a partner shaped a piece of material, the page says so. Where we use a partner's published work, it is cited like any other source.</li>
+        <li><strong>No student data, ever</strong>Partnerships do not come with access to learner records. See our <a href="/data-protection.html">data protection policy</a> for what we hold and why.</li>
+        <li><strong>Written down where it counts</strong>Money in and money out is listed on our <a href="/transparency.html">transparency page</a>, not buried in an annual PDF.</li>
+    </ul>
+</section>
+
+<section class="section">
+    <h2>Ways to partner</h2>
+    <p>Most conversations that reach us fall into one of these.</p>
+    <div class="grid2">
+        <div class="card">
+            <h3>Research &amp; evaluation</h3>
+            <p>Co-designed studies, evidence reviews and evaluation cases that become teaching material once anonymised.</p>
+        </div>
+        <div class="card">
+            <h3>Curriculum review</h3>
+            <p>Practitioners reading a course, lab or toolkit before publication and telling us where it breaks in the field.</p>
+        </div>
+        <div class="card">
+            <h3>Workshops &amp; teaching</h3>
+            <p>Co-hosted sessions and cohorts. See <a href="/workshops.html">workshops</a> and <a href="/dojos.html">dojos</a> for the current formats.</p>
+        </div>
+        <div class="card">
+            <h3>Institutional deployment</h3>
+            <p>Universities and organisations running the material with their own teams, with progress visible to the institution.</p>
+        </div>
+        <div class="card">
+            <h3>Content integration</h3>
+            <p>Our catalog is available through a public, key-free, read-only JSON API. See the <a href="/api-docs.html">API docs</a>.</p>
+        </div>
+        <div class="card">
+            <h3>Sponsorship</h3>
+            <p>Underwriting hosting, translation or a specific track &mdash; on the terms above, with no paywall attached.</p>
+        </div>
+    </div>
+    <div class="note">
+        <strong>Content licence.</strong> ImpactMojo content is released under CC BY-NC-ND 4.0 &mdash; attribution to ImpactMojo (impactmojo.in) required, non-commercial, no derivatives. Code is MIT. If a partnership needs different terms, say so in the form below and we will talk it through.
+    </div>
+</section>
+
+<section class="section signup">
+    <h2>Propose a partnership</h2>
+    <p class="sub">Tell us what you have in mind. We read everything that comes through here, and we answer &mdash; including when the answer is no.</p>
+
+    <form name="partner-inquiry" id="partnershipForm" method="POST" data-netlify="true" netlify-honeypot="bot-field" action="/partnerships.html">
+        <input type="hidden" name="form-name" value="partner-inquiry">
+        <p style="display:none"><label>Don't fill this out: <input name="bot-field"></label></p>
+
+        <div class="form-row">
+            <div class="field">
+                <label for="pt-name">Your name *</label>
+                <input type="text" id="pt-name" name="name" required>
+            </div>
+            <div class="field">
+                <label for="pt-email">Email address *</label>
+                <input type="email" id="pt-email" name="email" required>
+            </div>
+        </div>
+
+        <div class="form-row">
+            <div class="field">
+                <label for="pt-org">Organisation *</label>
+                <input type="text" id="pt-org" name="organization" required>
+            </div>
+            <div class="field">
+                <label for="pt-interest">Type of interest *</label>
+                <select id="pt-interest" name="interest" required>
+                    <option value="">Select an option&hellip;</option>
+                    <option value="partnership">Partnership</option>
+                    <option value="sponsorship">Sponsorship</option>
+                    <option value="both">Both sponsorship &amp; partnership</option>
+                    <option value="other">Other</option>
+                </select>
+            </div>
+        </div>
+
+        <div class="field">
+            <label for="pt-message">What do you have in mind?</label>
+            <textarea id="pt-message" name="message" placeholder="What you work on, what you'd want to build with us, and any timeline you're working to."></textarea>
+            <p class="hint">A paragraph is plenty. A link to your work helps more than a deck.</p>
+        </div>
+
+        <button type="submit" class="submit-btn">Send proposal</button>
+    </form>
+
+    <div class="form-success" id="partnershipSuccess" hidden>
+        <strong>Received &mdash; thank you.</strong>
+        <p>We read partnership proposals ourselves rather than routing them to a queue, so a reply takes a few days. If it is urgent, email <a href="mailto:hello@impactmojo.in">hello@impactmojo.in</a> directly.</p>
+    </div>
+</section>
+
+<section class="section">
+    <h2>Elsewhere on the site</h2>
+    <div class="crosslinks">
+        <a class="xcard" href="/about.html">
+            <h3>About ImpactMojo</h3>
+            <p>Who builds this, and why it is free.</p>
+        </a>
+        <a class="xcard" href="/transparency.html">
+            <h3>Transparency</h3>
+            <p>What comes in, what goes out, and where it goes.</p>
+        </a>
+        <a class="xcard" href="/api-docs.html">
+            <h3>Partner API</h3>
+            <p>Read-only JSON access to the full content catalog. No key required.</p>
+        </a>
+        <a class="xcard" href="/contact.html">
+            <h3>Contact</h3>
+            <p>Anything that is not a partnership proposal.</p>
+        </a>
+    </div>
+</section>
+
+</div>
+</main>
+
+<!-- ImpactMojo Footer -->
+<footer class="im-footer" role="contentinfo">
+<div class="im-footer-content">
+<p class="im-footer-made">Made with &#10084; by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+<div class="im-footer-grid">
+<div class="im-footer-section">
+<h4>About ImpactMojo</h4>
+<ul>
+<li><a href="/about.html">About Us</a></li>
+<li><a href="/contact.html">Contact</a></li>
+<li><a href="https://github.com/ImpactMojo/ImpactMojo" rel="noopener noreferrer" target="_blank">GitHub</a></li>
+<li><a href="/transparency.html">Transparency</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Legal</h4>
+<ul>
+<li><a href="/privacy-policy.html">Privacy Policy</a></li>
+<li><a href="/terms-of-service.html">Terms of Service</a></li>
+<li><a href="/disclaimer.html">Disclaimer</a></li>
+<li><a href="/data-protection.html">Data Protection</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Quick Links</h4>
+<ul>
+<li><a href="/catalog.html">All Courses</a></li>
+<li><a href="/premium.html">Premium Content</a></li>
+<li><a href="/coaching.html">Coaching</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Resources</h4>
+<ul>
+<li><a href="/handouts.html">Handouts</a></li>
+<li><a href="/blog.html">Blog</a></li>
+<li><a href="/faq.html">FAQ</a></li>
+<li><a href="/sitemap.html">Sitemap</a></li>
+<li><a href="/docs/" rel="noopener noreferrer" target="_blank">Documentation</a></li>
+</ul>
+</div>
+</div>
+<div class="im-footer-bottom">
+<p>&copy; 2026 ImpactMojo. All content for educational purposes only.</p>
+<p>Released under <strong>MIT License</strong> | Supported by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+</div>
+</div>
+</footer>
+
+<script>
+// Partnership form submission (Netlify Forms + /api/form-submit, same pattern as build-circles.html)
+(function () {
+    var form = document.getElementById('partnershipForm');
+    if (!form) return;
+    form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        /* Both paths: Netlify sends the notification, /api/form-submit writes the
+           row. A spam-classified submission is accepted with a 200, so the
+           notification alone cannot mean delivered. */
+        window.imxSubmitBothFromElement(form).then(function () {
+            form.style.display = 'none';
+            document.getElementById('partnershipSuccess').hidden = false;
+        }).catch(function () {
+            alert('Something went wrong. Please try again or email us at hello@impactmojo.in');
+        });
+    });
+})();
+</script>
+<!-- ImpactMojo Theme Toggle JS -->
+<script src="/js/theme.js?v=ca787a55"></script>
+  <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
+  <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -620,6 +620,7 @@
   <url><loc>https://www.impactmojo.in/maps/csr-india.html</loc><lastmod>2026-07-19</lastmod></url>
   <url><loc>https://www.impactmojo.in/maps/funding-map.html</loc><lastmod>2026-07-19</lastmod></url>
   <url><loc>https://www.impactmojo.in/mel-assessed-certificate.html</loc><lastmod>2026-07-19</lastmod></url>
+  <url><loc>https://www.impactmojo.in/partnerships.html</loc><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://www.impactmojo.in/peer-review.html</loc><lastmod>2026-07-19</lastmod></url>
   <url><loc>https://www.impactmojo.in/podcast.html</loc><lastmod>2026-07-19</lastmod></url>
   <url><loc>https://www.impactmojo.in/policy-economics-assessed-certificate.html</loc><lastmod>2026-07-19</lastmod></url>


### PR DESCRIPTION
## What does this PR do?

Adds `partnerships.html`, a dedicated page for partnerships. Until now this lived as two blocks at the bottom of `about.html` — a sponsor card and an inquiry form — with a "Partnership Opportunity" option in the `contact.html` dropdown. A prospective partner had to scroll past the team section to find either.

**Partners featured:**

- **Populi** ([populi.co.in](https://www.populi.co.in)) — end-to-end research partner and MEL advisory partner. Their services and positioning are quoted from their own site; the card lists their MEL, evaluation and strategic-guidance offerings and the Fractional M&E Head model.
- **India Institute** ([indiai.org](https://indiai.org/)) — thought advocacy and measurement partner. An independent research think tank est. 2010 working in education, critical thinking and social equity. Their Measurements vertical (five validated instruments for social equity indicators, plus the Misinformation Susceptibility Index) is the direct match for this partnership.
- **PinPoint Ventures** — founding sponsor, already credited in the footer sitewide.

The page also states the partnership terms plainly (editorial independence, partner-supported content stays free under CC BY-NC-ND 4.0, no learner data, money logged on the transparency page), lists six ways to partner, and carries a proposal form.

**Not linked from the site navigation** — deliberate, at the owner's request. It is reachable via sitemap and site search.

Every factual claim about either partner comes from their own homepage. Nothing is inferred or embellished.

## Type of change

- [x] New content (course, case study, translation)
- [ ] Bug fix (broken link, layout, JS error)
- [ ] New feature or tool
- [x] Accessibility improvement
- [ ] Performance improvement
- [ ] Documentation update

## Checklist

- [x] Tested on desktop browser — rendered in Chromium at 1280px in **both** themes
- [x] Tested on mobile browser — 390px viewport, no horizontal overflow
- [x] No console errors — no `pageerror` in any run (the `ERR_CONNECTION_RESET` entries are the agent sandbox having no outbound network, per `.claude/rules/testing.md`)
- [x] Links are working — all internal links absolute; three external links verified reachable

## Two things worth flagging

**1. The hero is a `<section>` inside `<main>`, not a body-level `<header>`.**

`js/site-chrome.js` removes any `<header>` that is a direct child of `<body>` — that is how it strips the many legacy site bars across the repo. A `<header class="hero">` is therefore deleted on load, taking the `<h1>` with it.

This is not hypothetical. Measured in Chromium against a local server, **ten live root pages currently have an `<h1>` in their source and no `<h1>` in the browser**:

`ai-agents-for-evaluators.html` · `ai-for-me-certificate.html` · `api-docs.html` · `build-circles.html` · `credential-upgrade.html` · `data-tech-assessed-certificate.html` · `events.html` · `mel-assessed-certificate.html` · `policy-economics-assessed-certificate.html` · `the-long-view.html`

Their hero headline, tagline and badges never render. axe-core on `build-circles.html` reports `page-has-heading-one` for exactly this reason. **Not fixed in this PR** — it is out of scope and each page needs its own look, but it should probably be its own issue.

**2. `--accent` cannot double as ink.**

`#F59E0B` on the light hero background is **2.05:1**. Text amber is now its own token, `--accent-ink` (4.80:1 light, 6.81:1 dark), leaving `--accent` for surfaces — button fill, rules, bullet dots — where it is fine (the submit button is 8.31:1). The two badge inks are likewise per-theme; in dark they were 4.26:1 and 4.11:1, now 5.51:1 and 6.05:1.

`build-circles.html` has the same class of failure live today (its `.wk` labels are 2.14:1 in light) — again, not touched here.

## Implementation notes

**The form reuses the existing `partner-inquiry` Netlify form name and its exact field set** (`name`, `email`, `organization`, `interest`, `message`). This is deliberate: `partner-inquiry` is already on the `ALLOWED_FORMS` allowlist in `netlify/functions/form-submit.mjs`, so proposals get both the Netlify notification and the Supabase row with no backend change, and they land in the same bucket as the ones submitted from `about.html`. A new form name would have needed an allowlist entry and split partnership enquiries across two places.

Registered in `sitemap.xml`, `data/search-index.json` (`check-search-coverage.py` fails if a sitemap page is missing from site search) and `.pa11yci`.

## Verification

| Check | Result |
|---|---|
| `check-counts.py` | PASS — 99 files |
| `check-search-coverage.py` | PASS — 799 sitemap pages indexed |
| `check-viewport.py` | PASS — 860 pages |
| `check-mojibake.py` | PASS |
| `stamp-assets.py --check` | PASS — 202 pages |
| `search-index.json` / `sitemap.xml` | valid JSON / valid XML |
| axe-core, dark + light | clean apart from the sitewide skip-link `region` finding, which every page has |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gFEJ2FoiFQjyXvmDGGB9W

---
_Generated by [Claude Code](https://claude.ai/code/session_011gFEJ2FoiFQjyXvmDGGB9W)_