### PR TITLE
Instructor kit, a working request form, and three Fundamentals pages that threw on every load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to ImpactMojo are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.237.0] - 2026-08-21
+
+### Changed
+
+- **`blog/animal-welfare-and-the-fifty-rupee-fine.html`** gains a section drawing on Animal Ask's *Leverage Points: strategic prioritisation for Animal Advocacy in India* (August 2026), read from the source rather than summarised from coverage of it.
+
+  The report's seventh priority is enforcement of existing law, which it calls "arguably ... the highest-leverage systemic reform if it could be achieved" — the same conclusion this post reached by deflating a single number. The section says so and immediately says why that is not corroboration: a shared conclusion reached twice is still one conclusion. What the report adds is specificity, so the post now names the mechanisms behind "pass the penalty revision" — making PCA offences **cognizable** (they are not, so police cannot register a case without a magistrate's order, which stops enforcement before the fine is ever reached), authorising SPCA inspectors to impose monetary penalties directly, and funding SPCAs with farmed-animal investigators.
+
+  Two findings are included **because** they sit awkwardly with the post's own framing. On scale: ~627M layer hens, 3.4B broilers slaughtered a year, ~320M male chicks, 21–94B shrimp, 10B+ fin-fish — against which an estimated 90% of organised groups work on strays and companions, which is a corrective to writing about this subject through the courts. On litigation: the report's view that it "has overpromised and underdelivered" because judgments "arrived before social, market, and political alignment existed to sustain them" directly complicates this post's opening premise that the argument was settled in 2014, and the section says so rather than burying it.
+
+  Also carries the report's finding that framing is "a strategic variable, not a cosmetic one" — welfare-only asks meet structural resistance where livelihoods, nutrition, food-safety or environmental framings travel — and reproduces the authors' own stated limits, including that they worked from outside India.
+
+  Read time 11 → 16 min (1,710 → 2,473 words); search-index description and tags updated.
+
 ## [10.236.0] - 2026-08-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to ImpactMojo are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.236.0] - 2026-08-21
+
+### Added
+
+- **`instructor-kit.html`** — the thing `teach.html` has been promising. A 14-week M&E teaching spine mapped to real assets, with a column for what to teach from and a column for what to set as work; a section on the studio exports that work as gradeable artefacts; assessment, licensing, and an explicit "what is not here".
+
+  Two things it deliberately does not do. It does not claim everything is free: the practice packs are freemium (first two of four modules), and a first draft of this page said "nothing in this kit is behind a login or a payment", listed the packs as free, and used them in six of fourteen weeks. That was wrong — `practice-packs/index.html` states the terms plainly — and it was caught by checking rather than by reading back what I had written. Packs are now marked with a bullet, explained once, and the headline claim is gone. It also says outright that there is **no ESG or CSR material** and no LMS integration, rather than padding the mapping.
+
+  All 54 internal links were resolved against the filesystem before publishing. Prices in the paid section were read out of `premium.html` and `products.html` rather than recalled.
+
+- **An instructor-kit autoresponder** in `netlify/functions/submission-created.mjs`. The function previously acted on `product-order` and `subscription-payment` and returned 200 for everything else, so an instructor-kit request produced no acknowledgement at all — the requester waited on a promise nobody had scheduled. It now sends them a receipt with the five-working-day expectation and links to the free material, and sends a workable brief to the admin address. Adds `esc()` and `looksLikeEmail()` to that file; `looksLikeEmail` was referenced before being defined in the first draft and would have thrown at runtime.
+
+### Changed
+
+- **The instructor-kit form asks what it needs to answer.** It previously collected name, email, institution and one free-text "what do you teach, and to whom?". It now also asks for the course or paper name, its level (UG / PG / MPhil-PhD / diploma / professional / mixed), and a description prompting for weeks, class size and intended outcomes — which is what a mapping actually requires.
+
+- **`teach.html` now loads `/js/form-submit.js`.** The page posted natively to Netlify Forms and never called `/api/form-submit`, so `instructor-kit` sat on the `ALLOWED_FORMS` allowlist in `form-submit.mjs` doing nothing and no durable row was ever written. A dropped notification email was a lost lead. The form now takes both paths and shows a real success state instead of Netlify's generic page.
+
 ## [10.235.0] - 2026-08-21
 
 ### Added

--- a/DataDives/datadive.css
+++ b/DataDives/datadive.css
@@ -24,6 +24,7 @@
   --dv-text-soft: #3F3F46;
   --dv-muted: #6B6560;
   --dv-accent: #2563EB;
+  --dv-cta-ink: #FFFFFF;      /* 5.17:1 on #2563EB */
   --dv-accent-soft: #EAF1FE;
   --dv-teal: #0F766E;
   --dv-teal-soft: #E7F3F1;
@@ -53,6 +54,7 @@ html.dark {
   --dv-text-soft: #CBD5E1;
   --dv-muted: #94A3B8;
   --dv-accent: #60A5FA;
+  --dv-cta-ink: #0F172A;      /* 7.02:1 on #60A5FA */
   --dv-accent-soft: rgba(96, 165, 250, 0.12);
   --dv-teal: #2DD4BF;
   --dv-teal-soft: rgba(45, 212, 191, 0.10);
@@ -247,7 +249,11 @@ html.dark .dv-tip b { color: #0F172A; }
 .dv-cta { padding: 1.75rem; background: var(--dv-accent-soft); border-radius: var(--dv-radius); text-align: center; margin-top: 2.5rem; }
 .dv-cta h3 { font-family: 'Inter', sans-serif; font-size: 1.2rem; margin: 0 0 .5rem; color: var(--dv-accent); }
 .dv-cta p { font-size: .95rem; color: var(--dv-text-soft); margin: 0 0 1rem; }
-.dv-cta a { display: inline-block; background: var(--dv-accent); color: #fff !important; font-family: 'Inter', sans-serif; font-weight: 600; padding: .65rem 1.5rem; border-radius: 8px; text-decoration: none; }
+.dv-cta a { display: inline-block; background: var(--dv-accent); color: var(--dv-cta-ink) !important; font-family: 'Inter', sans-serif; font-weight: 600; padding: .65rem 1.5rem; border-radius: 8px; text-decoration: none; }
+/* --dv-accent is a light blue in dark mode (#60A5FA), so white ink on it is
+   2.54:1 — an axe-core serious failure on every Data Dive. The button ink has
+   to follow the theme: white on the light theme's #2563EB is 5.17:1, and dark
+   ink on the dark theme's #60A5FA is 7.02:1. */
 
 /* ===== Fancy chart polish: gradients, shadows, entrance animation ===== */
 .dv-stop-a0 { stop-color: var(--dv-series); }

--- a/blog/animal-welfare-and-the-fifty-rupee-fine.html
+++ b/blog/animal-welfare-and-the-fifty-rupee-fine.html
@@ -458,7 +458,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
             <div class="article-meta">
                 <span class="meta-item">ImpactMojo Editorial</span>
                 <span class="meta-item">19 August 2026</span>
-                <span class="meta-item">11 min read</span>
+                <span class="meta-item">16 min read</span>
             </div>
             <div class="article-tags"><span class="article-tag">animal welfare</span><span class="article-tag">India</span><span class="article-tag">law</span><span class="article-tag">enforcement</span></div>
         </header>
@@ -672,6 +672,32 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
             </ul>
 
             <p>The 2023 Constitution Bench, revisiting the 2014 judgment, upheld state amendments permitting jallikattu, kambala and bullock-cart racing. Read alongside <i>Nagaraja</i>, it marks out the shape of what Indian courts will and will not do: animal dignity survives as a constitutional principle, and a legislature that regulates a practice rather than banning it will generally be allowed to proceed. The courts have gone about as far as courts can go. What is left is administrative — a notification, a schedule of fines, a statistical series — and none of it is waiting on anybody&rsquo;s philosophy.</p>
+
+            <h2>A prioritisation exercise reaches the same place</h2>
+
+            <p>In August 2026 Animal Ask published <a href="https://www.animalask.org/post/leverage-points-animal-advocacy-india" target="_blank" rel="noopener noreferrer">Leverage Points</a>, a strategic prioritisation of animal advocacy in India built from stakeholder consultation and two workshops with domestic advocates, researchers, industry and policy experts. It sets out seven priority areas for funders and organisations deciding where to put limited money and people.</p>
+
+            <p>The seventh is enforcement of existing law. Their assessment of it is blunter than ours: <i>&ldquo;arguably this would be the highest-leverage systemic reform if it could be achieved.&rdquo;</i> Elsewhere they put the case for it structurally &mdash; every welfare law, &ldquo;from cage provisions to slaughter standards to tethering, is currently constrained by issues with enforcement, detection, inspection, and penalty gaps&rdquo;, which makes reform there a multiplier on the value of every other policy win.</p>
+
+            <p>That is the same conclusion this piece reached from a different direction. We got here by deflating a single number; they got here by ranking seven problems against each other. It is worth saying plainly that neither route is evidence for the other &mdash; a shared conclusion reached twice is still one conclusion &mdash; but the report does something this piece could not, which is specify the ask.</p>
+
+            <p>Where we said &ldquo;pass the penalty revision&rdquo;, they name the mechanisms:</p>
+
+            <ul>
+                <li><b>Make offences cognizable.</b> Under the PCA as it stands, cruelty offences are non-cognizable, which means police cannot register a case or investigate without a magistrate&rsquo;s order. The fine is the visible half of the enforcement problem; this is the half that stops a case beginning at all.</li>
+                <li><b>Give SPCA inspectors the power to impose monetary penalties directly.</b> Detection without a sanction the detector can apply is a report that goes into a drawer.</li>
+                <li><b>Fund functional SPCAs</b> with small teams of staff focused on farmed animals, who investigate and refer cases to Animal Husbandry officers for corrective action.</li>
+            </ul>
+
+            <p>Two of their other findings sit awkwardly against the framing of this piece, which is a reason to include them rather than not.</p>
+
+            <p>The first is about scale, and it is a corrective to writing about Indian animal welfare through the lens of the courts. Roughly 627 million layer hens are alive at any moment, more than 85% on commercial farms where cages are widespread. Some 3.4 billion broiler chickens are slaughtered a year, 97.6% of them fast-growing breeds. Around 320 million male chicks are killed annually. Shrimp production of about a million tonnes represents somewhere between 21 and 94 billion individuals. Fin-fish exceed ten billion a year and have, by the report&rsquo;s account, the weakest evidence base of any major farmed group. Against those numbers, an estimated 90% of organised animal welfare groups in India work on stray and companion animals.</p>
+
+            <p>The second is about litigation, and it complicates the story this piece opens with. We began with <i>Nagaraja</i> and the Law Commission as evidence that the argument was settled a decade ago. The report&rsquo;s reading is that litigation &ldquo;has overpromised and underdelivered&rdquo;, because judgments &ldquo;have arrived before social, market, and political alignment existed to sustain them&rdquo;. On that account a ₹50 fine that nobody revised is not a gap between principle and administration at all. It is what a win looks like when it arrives ahead of the conditions that would make it stick &mdash; which is a less comfortable diagnosis, and points at slower work than notifying a rule.</p>
+
+            <p>There is also a finding here for anyone who designs campaigns rather than reads about them. The report records that Indian stakeholders &ldquo;consistently report that asks framed around animal welfare alone face structural resistance, while the same underlying reform framed around farmer livelihoods, child nutrition, food safety, public health, employment, or environmental protection travels much further&rdquo;, and that the religious and caste dimensions of food politics make this sharper still: asks that read as Western, Hindu-vegetarian or implicitly anti-Muslim carry substantial risk. Framing, in their words, is &ldquo;a strategic variable, not a cosmetic one&rdquo;. That is a claim about what works, made by people who asked practitioners, and it is testable in a way most advocacy advice is not.</p>
+
+            <p>Animal Ask are explicit about the limits of the exercise: substantial evidence gaps remain for aquatic animals, insects and wild populations; several interventions are exploratory; and they note that as a team working from outside India they will lack local knowledge that consultation can reduce but not remove. They ask that the seven areas be read as a starting framework rather than a fixed hierarchy. The full report is available as a PDF from the page linked above, and it is the version of record.</p>
 
             <h2>Where the sources are</h2>
 

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -2,7 +2,7 @@
   {
     "id": "BLOG061",
     "title": "Animal Welfare Law and the Fifty-Rupee Fine",
-    "description": "India read animal dignity into the right to life in 2014 and drafted cage-free rules in 2017. The maximum fine for a first offence of cruelty is still the fifty rupees set in 1960 — worth ₹3.79 in 1986-87 money. Four charts on the distance between what the law demands and what it costs to break, including the finding that slaughter restrictions appear to have worsened welfare across the herd.",
+    "description": "India's Prevention of Cruelty to Animals Act sets a maximum first-offence fine of fifty rupees, unchanged since 1960 and worth ₹3.79 today. Plus what Animal Ask's 2026 prioritisation of Indian animal advocacy says about enforcement as the highest-leverage reform, and why framing decides whether an ask travels.",
     "type": "blog",
     "category": "Policy",
     "url": "/blog/animal-welfare-and-the-fifty-rupee-fine.html",
@@ -14,7 +14,10 @@
       "enforcement",
       "livestock census",
       "stray cattle",
-      "law"
+      "law",
+      "animal ask",
+      "prioritisation",
+      "advocacy"
     ]
   },
   {

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -13550,6 +13550,25 @@
     ]
   },
   {
+    "id": "PAGE-INSTRUCTORKIT",
+    "title": "Instructor Kit",
+    "description": "A free 14-week monitoring and evaluation teaching spine mapped to ImpactMojo's open courses, slide decks, studios, practice packs and case challenges, with assignments that grade themselves. CC BY-NC-ND 4.0.",
+    "type": "page",
+    "category": "Teaching",
+    "url": "/instructor-kit.html",
+    "tags": [
+      "teaching",
+      "instructor",
+      "syllabus",
+      "mel",
+      "monitoring and evaluation",
+      "curriculum",
+      "faculty",
+      "open licence",
+      "classroom"
+    ]
+  },
+  {
     "id": "book-summary-ai-and-the-death-of-the-author",
     "title": "Reading Backwards: AI, Authorship and the Death of the Author — Interactive Companion",
     "description": "An interactive companion to the feature that asks a question sixty years of literary theory told us to ignore — who, or what, actually wrote this? — and traces how AI has forced readers, teachers and…",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.229.0 — August 21, 2026 (The fifty-rupee fine, revisited)
+
+### For Learners
+
+- **Animal Welfare Law and the Fifty-Rupee Fine** now carries a section on Animal Ask's 2026 prioritisation of Indian animal advocacy — which reaches the same conclusion about enforcement from a different direction, names the specific legal mechanisms (making offences cognizable, SPCA penalty powers), sets the scale against which court cases are a small lever, and reports that how an ask is framed decides whether it travels.
+
 ## v10.228.0 — August 21, 2026 (An instructor kit, and a form that answers you)
 
 ### For Learners

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,16 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.228.0 — August 21, 2026 (An instructor kit, and a form that answers you)
+
+### For Learners
+
+- **Instructor Kit** — a ready-made 14-week monitoring-and-evaluation teaching plan, mapped week by week to material you can open today: the MEL flagship, the 101 decks, the studios whose exports work as gradeable assignments, and the case challenges. It says plainly which parts are free, which are part-free, and what the paid extras cost. Free to use in any classroom under CC BY-NC-ND 4.0.
+
+### Changed
+
+- **Requesting an instructor kit now asks the right questions and answers you back.** The form asks what your course is called, at what level, and what it covers — the things needed to actually map a kit — and you get an immediate acknowledgement with a five-working-day commitment instead of silence.
+
 ## v10.227.0 — August 21, 2026 (Four new Data Dives, and flow charts)
 
 ### For Learners

--- a/fundamentals/gender-needs.html
+++ b/fundamentals/gender-needs.html
@@ -261,15 +261,6 @@
 })();
 </script>
 
-<!-- ===== The wheel ===== -->
-<script src="/js/ladder-data.js?v=7f09fe93"></script>
-<script src="/js/ladder.js?v=4cfe05d9"></script>
-<script>
-(function(){
-  function go(){ if (window.FLadder) window.FLadder.init(); }
-  if (document.readyState !== 'loading') go(); else document.addEventListener('DOMContentLoaded', go);
-})();
-</script>
 
 <!-- ===== Translation ===== -->
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
@@ -281,6 +272,6 @@
 <script src="/js/auth.js?v=97cb7b85"></script>
 <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/gender-needs-data.js?v=0f47dd22"></script>
-<script src="/js/gender-needs.js?v=21d89be6"></script>
+<script src="/js/gender-needs.js?v=a00832b6"></script>
 </body>
 </html>

--- a/fundamentals/livelihoods.html
+++ b/fundamentals/livelihoods.html
@@ -253,15 +253,6 @@
 })();
 </script>
 
-<!-- ===== The wheel ===== -->
-<script src="/js/ladder-data.js?v=7f09fe93"></script>
-<script src="/js/ladder.js?v=4cfe05d9"></script>
-<script>
-(function(){
-  function go(){ if (window.FLadder) window.FLadder.init(); }
-  if (document.readyState !== 'loading') go(); else document.addEventListener('DOMContentLoaded', go);
-})();
-</script>
 
 <!-- ===== Translation ===== -->
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>

--- a/fundamentals/social-model.html
+++ b/fundamentals/social-model.html
@@ -258,15 +258,6 @@
 })();
 </script>
 
-<!-- ===== The wheel ===== -->
-<script src="/js/ladder-data.js?v=7f09fe93"></script>
-<script src="/js/ladder.js?v=4cfe05d9"></script>
-<script>
-(function(){
-  function go(){ if (window.FLadder) window.FLadder.init(); }
-  if (document.readyState !== 'loading') go(); else document.addEventListener('DOMContentLoaded', go);
-})();
-</script>
 
 <!-- ===== Translation ===== -->
 <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>

--- a/instructor-kit.html
+++ b/instructor-kit.html
@@ -1,0 +1,473 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Instructor Kit — teach a full M&amp;E course from open material | ImpactMojo</title>
+<meta name="description" content="A free, ready-to-teach kit for monitoring and evaluation courses: a 14-week spine mapped to ImpactMojo's open courses, decks, studios and practice packs, with assignments that grade themselves. CC BY-NC-ND 4.0.">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://www.impactmojo.in/instructor-kit.html">
+
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JRCMEB9TBW"></script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-JRCMEB9TBW');</script>
+
+<meta property="og:title" content="Instructor Kit | ImpactMojo">
+<meta property="og:description" content="A 14-week M&E teaching spine mapped to free, openly licensed material — courses, decks, studios, practice packs and case challenges.">
+<meta property="og:image" content="https://www.impactmojo.in/assets/images/og-card.png">
+<meta property="og:url" content="https://www.impactmojo.in/instructor-kit.html">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="ImpactMojo">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Instructor Kit | ImpactMojo">
+<meta name="twitter:description" content="A 14-week M&E teaching spine mapped to free, openly licensed material.">
+
+<link href="/assets/images/favicon.png" rel="icon" type="image/png">
+<link href="/assets/images/apple-touch-icon.png" rel="apple-touch-icon">
+<link rel="stylesheet" href="/css/fonts.css?v=07d8578c">
+<link rel="stylesheet" href="/assets/css/light-mode-fallback.css">
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+/* Dark-first palette */
+:root {
+    --bg: #0F172A; --bg-2: #1E293B; --card: #1E293B; --hover: #334155;
+    --text: #F1F5F9; --text-2: #CBD5E1; --muted: #94A3B8;
+    --border: #334155; --accent: #F59E0B; --accent-2: #D97706;
+    --blue: #0EA5E9; --green: #10B981; --violet: #A78BFA;
+    --accent-ink: #F59E0B;      /* 6.81:1 on --bg-2 */
+    --badge-blue-ink: #38BDF8;  /* 5.51:1 on the blue badge fill */
+    --badge-violet-ink: #C4B5FD;/* 6.05:1 on the violet badge fill */
+}
+[data-theme="light"], body.light-mode {
+    --bg: #FFFFFF; --bg-2: #F8FAFC; --card: #FFFFFF; --hover: #F1F5F9;
+    --text: #0F172A; --text-2: #475569; --muted: #52627A;
+    --border: #E2E8F0; --blue: #0369A1; --green: #047857; --violet: #6D28D9;
+    --accent-ink: #B45309;      /* 4.80:1 on --bg-2; the raw amber is 2.05:1 */
+    --badge-blue-ink: #0369A1;  /* 4.94:1 on the blue badge fill */
+    --badge-violet-ink: #6D28D9;/* 5.91:1 on the violet badge fill */
+}
+/* This page ships a real light theme — neutralize the invert-filter used by
+   light-mode-fallback.css (which is meant for dark-only pages). */
+[data-theme="light"] body, body.light-mode, html.light body { background: var(--bg); filter: none; }
+[data-theme="light"] img, [data-theme="light"] video, [data-theme="light"] iframe, [data-theme="light"] canvas,
+body.light-mode img, body.light-mode video, body.light-mode iframe, body.light-mode canvas { filter: none; }
+[data-theme="light"] .im-topbar, body.light-mode .im-topbar, html.light .im-topbar { filter: none; }
+@media (prefers-color-scheme: light) {
+    :root:not([data-theme="dark"]):not(.dark) {
+        --bg: #FFFFFF; --bg-2: #F8FAFC; --card: #FFFFFF; --hover: #F1F5F9;
+        --text: #0F172A; --text-2: #475569; --muted: #52627A;
+        --border: #E2E8F0; --blue: #0369A1; --green: #047857; --violet: #6D28D9;
+        --accent-ink: #B45309; --badge-blue-ink: #0369A1; --badge-violet-ink: #6D28D9;
+    }
+}
+
+body { font-family: 'Amaranth', Arial, sans-serif; background: var(--bg); color: var(--text); line-height: 1.65; padding-top: 44px; }
+h1, h2, h3, h4 { font-family: 'Inter', Helvetica, sans-serif; font-weight: 700; }
+a { color: var(--blue); }
+.mono { font-family: 'JetBrains Mono', monospace; }
+
+.im-skip-link { position: absolute; left: -9999px; top: 0; background: #0A7AAD; color: #fff; padding: 8px 16px; z-index: 100000; border-radius: 0 0 6px 0; font: 600 .85rem/1.2 Inter, system-ui, sans-serif; text-decoration: none; }
+.im-skip-link:focus { left: 0; }
+
+/* Topbar */
+.im-topbar { position: fixed; top: 0; left: 0; right: 0; height: 44px; background: var(--card); border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; padding: 0 1rem; z-index: 9000; }
+.im-topbar-home { display: flex; align-items: center; gap: 0.5rem; color: var(--text); text-decoration: none; font-family: 'Amaranth', sans-serif; font-weight: 700; }
+.im-topbar-right { display: flex; align-items: center; gap: 1rem; }
+.im-topbar-link { color: var(--text-2); text-decoration: none; font-size: 0.85rem; }
+.im-topbar-link:hover { color: var(--accent-ink); }
+.im-theme-selector { display: flex; gap: 2px; background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 2px; }
+.im-theme-btn { background: transparent; border: none; color: var(--muted); padding: 6px; border-radius: 5px; cursor: pointer; transition: all 0.2s; display: flex; align-items: center; justify-content: center; width: 30px; height: 30px; }
+.im-theme-btn:hover { background: var(--hover); color: var(--text); }
+.im-theme-btn.active { background: #0A7AAD; color: #fff; }
+.im-theme-btn svg { width: 16px; height: 16px; }
+
+.im-paper-plane { position: fixed; top: 15%; right: 8%; width: 120px; height: 120px; opacity: 0.12; z-index: 0; pointer-events: none; }
+@media (prefers-reduced-motion: no-preference) { .im-paper-plane { animation: im-fly 25s ease-in-out infinite; } }
+@keyframes im-fly { 0%,100%{transform:translate(0,0) rotate(0)} 25%{transform:translate(50px,-30px) rotate(10deg)} 50%{transform:translate(100px,20px) rotate(-6deg)} 75%{transform:translate(30px,50px) rotate(12deg)} }
+
+/* Hero */
+.hero { background: var(--bg-2); border-bottom: 1px solid var(--border); padding: 4rem 1.5rem 3rem; text-align: center; }
+.hero .kicker { font-family: 'JetBrains Mono', monospace; font-size: 0.8rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent-ink); margin-bottom: 0.75rem; }
+.hero h1 { font-size: 2.6rem; line-height: 1.15; margin-bottom: 0.9rem; }
+.hero .tagline { color: var(--text-2); max-width: 660px; margin: 0 auto 1.5rem; font-size: 1.15rem; }
+.badges { display: flex; gap: 0.5rem; justify-content: center; flex-wrap: wrap; }
+.badge { display: inline-block; padding: 0.3rem 0.8rem; border-radius: 999px; font-size: 0.8rem; font-weight: 600; font-family: 'Inter', sans-serif; background: var(--hover); color: var(--text-2); border: 1px solid var(--border); }
+.badge.blue { background: rgba(14,165,233,0.14); color: var(--badge-blue-ink); border-color: transparent; }
+.badge.violet { background: rgba(167,139,250,0.16); color: var(--badge-violet-ink); border-color: transparent; }
+
+/* Layout */
+.container { max-width: 900px; margin: 0 auto; padding: 2.5rem 1.5rem 4rem; position: relative; z-index: 1; }
+.section { margin-bottom: 3.25rem; }
+.section h2 { font-size: 1.65rem; margin-bottom: 0.6rem; }
+.section > p { color: var(--text-2); margin-bottom: 1rem; }
+.note { background: var(--bg-2); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 8px; padding: 1rem 1.25rem; margin: 1.25rem 0; color: var(--text-2); }
+.note strong { color: var(--text); }
+
+/* Partner cards */
+.partner { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 1.75rem; margin-bottom: 1.5rem; border-top: 3px solid var(--border); }
+.partner.blue { border-top-color: #0EA5E9; }
+.partner.violet { border-top-color: #A78BFA; }
+.partner.amber { border-top-color: #F59E0B; }
+.partner .role { font-family: 'JetBrains Mono', monospace; font-size: 0.74rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 0.4rem; }
+.partner h3 { font-size: 1.5rem; margin-bottom: 0.15rem; }
+.partner .site { font-size: 0.9rem; margin-bottom: 0.9rem; display: inline-block; }
+.partner p { color: var(--text-2); margin-bottom: 0.9rem; }
+.partner .quote { border-left: 2px solid var(--border); padding-left: 1rem; font-style: italic; color: var(--text-2); margin: 1rem 0; }
+.partner h4 { font-size: 0.82rem; text-transform: uppercase; letter-spacing: 0.07em; color: var(--muted); font-weight: 600; margin: 1.25rem 0 0.6rem; }
+.chiplist { display: flex; flex-wrap: wrap; gap: 0.4rem; list-style: none; }
+.chiplist li { font-family: 'Inter', sans-serif; font-size: 0.82rem; color: var(--text-2); background: var(--hover); border: 1px solid var(--border); border-radius: 7px; padding: 0.28rem 0.6rem; }
+.together { list-style: none; margin-top: 0.4rem; }
+.together li { position: relative; padding-left: 1.5rem; color: var(--text-2); margin-bottom: 0.5rem; font-size: 0.95rem; }
+.together li::before { content: ""; position: absolute; left: 0.25rem; top: 0.62rem; width: 6px; height: 6px; border-radius: 50%; background: var(--accent); }
+
+/* Generic cards */
+.grid2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.25rem; margin: 1.25rem 0; }
+.card { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 1.25rem; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+.card h3 { font-size: 1.05rem; margin-bottom: 0.5rem; }
+.card p, .card li { color: var(--text-2); font-size: 0.95rem; }
+.card ul { margin: 0.25rem 0 0 1.1rem; }
+
+/* Principles */
+.principles { list-style: none; }
+.principles li { padding: 0.9rem 0; border-bottom: 1px solid var(--border); color: var(--text-2); }
+.principles li:last-child { border-bottom: none; }
+.principles strong { display: block; font-family: 'Inter', sans-serif; color: var(--text); margin-bottom: 0.15rem; }
+
+/* Form */
+.signup { background: var(--bg-2); border: 1px solid var(--border); border-radius: 14px; padding: 1.75rem; }
+.signup h2 { margin-bottom: 0.4rem; }
+.signup .sub { color: var(--text-2); margin-bottom: 1.4rem; }
+.field { margin-bottom: 1.1rem; }
+.field label { display: block; font-family: 'Inter', sans-serif; font-weight: 600; font-size: 0.88rem; margin-bottom: 0.35rem; color: var(--text); }
+.field input, .field select, .field textarea { width: 100%; padding: 0.65rem 0.8rem; border: 1px solid var(--border); border-radius: 8px; background: var(--card); color: var(--text); font-family: 'Inter', sans-serif; font-size: 0.95rem; }
+.field input:focus, .field select:focus, .field textarea:focus { outline: 2px solid var(--blue); outline-offset: 1px; }
+.field textarea { min-height: 110px; resize: vertical; }
+.field .hint { font-size: 0.8rem; color: var(--muted); margin-top: 0.3rem; }
+.form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+.submit-btn { display: inline-flex; align-items: center; gap: 0.5rem; background: var(--accent); color: #0F172A; border: none; font-family: 'Inter', sans-serif; font-weight: 700; font-size: 1rem; padding: 0.85rem 1.7rem; border-radius: 10px; cursor: pointer; transition: background 0.2s; }
+.submit-btn:hover { background: #AF6005; color: #fff; }
+.form-success { background: rgba(16,185,129,0.12); border: 1px solid var(--green); border-radius: 10px; padding: 1.25rem; color: var(--text-2); }
+.form-success strong { color: var(--text); }
+
+/* Cross-links */
+.crosslinks { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1.25rem; }
+.crosslinks a.xcard { display: block; background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 1.2rem; text-decoration: none; transition: border-color 0.2s; }
+.crosslinks a.xcard:hover { border-color: var(--accent); }
+.crosslinks h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.35rem; }
+.crosslinks p { color: var(--text-2); font-size: 0.88rem; }
+
+/* Footer */
+.im-footer { background: var(--bg-2); border-top: 1px solid var(--border); padding: 2rem 1rem; margin-top: auto; font-family: 'Inter', sans-serif; color: var(--text-2); }
+.im-footer-content { max-width: 1100px; margin: 0 auto; }
+.im-footer-made { text-align: center; margin-bottom: 1.5rem; font-size: 0.9rem; color: var(--muted); }
+.im-footer-made a { color: var(--blue); }
+.im-footer-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1.5rem; margin-bottom: 1.5rem; }
+.im-footer-section h4 { color: var(--text); font-size: 0.9rem; margin-bottom: 0.75rem; font-weight: 600; }
+.im-footer-section ul { list-style: none; padding: 0; margin: 0; }
+.im-footer-section li { margin-bottom: 0.4rem; }
+.im-footer-section a { color: var(--text-2); text-decoration: none; font-size: 0.85rem; transition: color 0.2s; }
+.im-footer-section a:hover { color: var(--blue); }
+.im-footer-bottom { text-align: center; padding-top: 1rem; border-top: 1px solid var(--border); font-size: 0.8rem; color: var(--muted); }
+.im-footer-bottom p { margin: 0.25rem 0; }
+.im-footer-bottom a { color: var(--blue); text-decoration: none; }
+
+@media (max-width: 768px) {
+    .hero h1 { font-size: 2rem; }
+    .form-row { grid-template-columns: 1fr; }
+    .im-footer-grid { grid-template-columns: repeat(2, 1fr); gap: 1rem; }
+}
+@media (max-width: 600px) { .im-topbar-link { display: none; } .im-topbar-home span { display: none; } }
+@media (max-width: 480px) { .im-footer-grid { grid-template-columns: 1fr; } }
+
+/* --- instructor kit --- */
+.kit-lead { font-size: 1.05rem; color: var(--text-2); max-width: 70ch; }
+table.kit { width: 100%; border-collapse: collapse; margin: 1.25rem 0; font-size: 0.92rem; }
+table.kit th, table.kit td { text-align: left; padding: 0.7rem 0.8rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+table.kit th { font-family: 'Inter', sans-serif; font-size: 0.74rem; letter-spacing: 0.07em; text-transform: uppercase; color: var(--muted); font-weight: 600; }
+table.kit td:first-child { white-space: nowrap; font-family: 'JetBrains Mono', monospace; font-size: 0.82rem; color: var(--accent-ink); }
+table.kit tr:last-child td { border-bottom: none; }
+.kit-scroll { overflow-x: auto; }
+.kit-note { background: var(--bg-2); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 8px; padding: 1rem 1.25rem; margin: 1.5rem 0; color: var(--text-2); }
+.kit-note strong { color: var(--text); }
+.kit-gap { border-left-color: var(--muted); }
+ul.kit-list { list-style: none; margin: 0.75rem 0; }
+ul.kit-list li { position: relative; padding-left: 1.4rem; margin-bottom: 0.55rem; color: var(--text-2); }
+ul.kit-list li::before { content: ""; position: absolute; left: 0.25rem; top: 0.62rem; width: 6px; height: 6px; border-radius: 50%; background: var(--accent); }
+ul.kit-list strong { color: var(--text); }
+.kit-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; margin: 1.25rem 0; }
+.kit-card { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 1.1rem 1.2rem; }
+.kit-card h3 { font-size: 1rem; margin-bottom: 0.35rem; }
+.kit-card p { color: var(--text-2); font-size: 0.9rem; }
+.kit-card a { font-size: 0.9rem; }
+@media (max-width: 640px) { table.kit { font-size: 0.85rem; } }
+</style>
+  <script src="/js/form-submit.js?v=36a6a01f"></script>
+</head>
+<body>
+<a href="#main" class="im-skip-link">Skip to content</a>
+
+<!-- ImpactMojo Top Bar -->
+<div class="im-topbar" id="imTopbar">
+    <div class="im-topbar-left">
+        <a href="/index.html" class="im-topbar-home">
+            <img src="/assets/images/ImpactMojo%20Logo.png" alt="ImpactMojo" width="24" height="24" style="border-radius:4px;">
+            <span>ImpactMojo</span>
+        </a>
+    </div>
+    <div class="im-topbar-right">
+        <a href="/about.html" class="im-topbar-link">About</a>
+        <a href="/transparency.html" class="im-topbar-link">Transparency</a>
+        <a href="/catalog.html" class="im-topbar-link">Catalog</a>
+        <div class="im-theme-selector" aria-label="Theme selection">
+            <button class="im-theme-btn" data-imtheme="system" title="System theme" aria-label="Use system theme">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+            </button>
+            <button class="im-theme-btn" data-imtheme="light" title="Light theme" aria-label="Use light theme">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+            </button>
+            <button class="im-theme-btn" data-imtheme="dark" title="Dark theme" aria-label="Use dark theme">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
+        </div>
+    </div>
+</div>
+
+<main id="main">
+<section class="hero">
+    <p class="kicker">Instructor Kit</p>
+    <h1>A full M&amp;E course,<br>from open material.</h1>
+    <p class="tagline">A 14-week spine for a monitoring and evaluation course, mapped to open ImpactMojo material &mdash; courses, slide decks, browser studios and case challenges. Almost all of it is free to open with no login. Where something is not, this page says so.</p>
+    <div class="badges">
+        <span class="badge blue">CC BY-NC-ND 4.0</span>
+        <span class="badge violet">No login required</span>
+        <span class="badge">Adapt the sequence freely</span>
+        <span class="badge">Paid extras listed at the end, with prices</span>
+    </div>
+</section>
+
+<div class="container">
+
+<section class="section">
+    <h2>What you can use</h2>
+    <p class="kit-lead">ImpactMojo publishes 70 courses, 35 interactive labs, 135 games, 90 handouts and 18 practice packs. The courses, decks, studios, games, handouts and case challenges are free to open and free to teach from; the practice packs are free for their first two modules. This kit picks out the parts that carry an M&amp;E syllabus and says what each one is <em>for</em> in a classroom &mdash; which are readings, which are lectures, which are assignments, and which are the two hours before a deadline when students actually learn the thing.</p>
+    <div class="kit-grid">
+        <div class="kit-card">
+            <h3>The flagship course</h3>
+            <p>Long-form modules with South Asian cases, reflection prompts and a curated lexicon. This is the reading spine.</p>
+            <a href="/courses/mel/">MEL for Development &#8599;</a>
+        </div>
+        <div class="kit-card">
+            <h3>101 slide decks</h3>
+            <p>~100 native HTML slides you can present directly &mdash; keyboard and touch navigation, light and dark. No PowerPoint needed.</p>
+            <a href="/101-courses/mel-basics.html">MEL Basics 101 &#8599;</a>
+        </div>
+        <div class="kit-card">
+            <h3>Studios</h3>
+            <p>Browser workbenches. Students build a Theory of Change, a LogFrame or a sampling plan and export it &mdash; the export is the assignment.</p>
+            <a href="/Labs/">All studios &#8599;</a>
+        </div>
+        <div class="kit-card">
+            <h3>Practice packs <span style="font-weight:400;color:var(--muted);font-size:.8rem">&mdash; part free</span></h3>
+            <p>Four-module sprints on one task each, ending in a deliverable. <strong>The first two modules of every pack are free</strong>; modules 3&ndash;4 and the capstone builder need Premium or a &#8377;299 single-pack unlock.</p>
+            <a href="/practice-packs/">All practice packs &#8599;</a>
+        </div>
+        <div class="kit-card">
+            <h3>Case challenges</h3>
+            <p>Realistic case packets with rubrics. Good as a capstone or a graded group assignment.</p>
+            <a href="/challenges.html">All challenges &#8599;</a>
+        </div>
+        <div class="kit-card">
+            <h3>Data explorers</h3>
+            <p>NFHS, PLFS, ASER, UDISE and more, already loaded and queryable in the browser &mdash; for students who need real Indian data, not a teaching dataset.</p>
+            <a href="/explorers.html">All explorers &#8599;</a>
+        </div>
+    </div>
+</section>
+
+<section class="section">
+    <h2>A 14-week spine</h2>
+    <p class="kit-lead">Built for a one-semester postgraduate M&amp;E paper of roughly two hours a week. Treat it as a starting point: the sequence is ordinary, and the point is the mapping, not the order.</p>
+    <div class="kit-scroll">
+    <table class="kit">
+        <thead><tr><th>Week</th><th>Topic</th><th>Teach from</th><th>Set as work</th></tr></thead>
+        <tbody>
+            <tr><td>1</td><td>What M&amp;E is for, and who it serves</td><td><a href="/101-courses/mel-basics.html">MEL Basics 101</a>, deck 1</td><td>Read <a href="/courses/mel/">MEL flagship</a>, opening modules</td></tr>
+            <tr><td>2</td><td>Theory of Change</td><td>Flagship: ToC modules</td><td><a href="/Labs/toc-lab.html">ToC Studio</a> &mdash; build and export one for a real programme</td></tr>
+            <tr><td>3</td><td>From ToC to LogFrame</td><td><a href="/practice-packs/logframe-building/">Practice pack: LogFrame building</a> <span style="color:var(--muted)">&#9679;</span></td><td><a href="/Labs/logframe-builder-lab.html">LogFrame Studio</a> export, graded against the pack&rsquo;s checklist</td></tr>
+            <tr><td>4</td><td>Indicators, and what resists counting</td><td>Flagship: indicators; <a href="/fundamentals/who-counts.html">Who Counts</a></td><td>Draft an indicator set; critique a partner&rsquo;s</td></tr>
+            <tr><td>5</td><td>Writing a ToR</td><td><a href="/practice-packs/tor-writing/">Practice pack: ToR writing</a> <span style="color:var(--muted)">&#9679;</span></td><td>Write a ToR for a mid-term review</td></tr>
+            <tr><td>6</td><td>Sampling</td><td>Flagship: sampling modules</td><td><a href="/Labs/sampling-design-lab.html">Sampling Studio</a> &mdash; design and justify a plan</td></tr>
+            <tr><td>7</td><td>Survey instruments</td><td><a href="/practice-packs/survey-instrument/">Practice pack: survey instrument</a> <span style="color:var(--muted)">&#9679;</span></td><td>Build and pilot a short instrument in pairs</td></tr>
+            <tr><td>8</td><td>Qualitative methods</td><td><a href="/practice-packs/focus-group-discussion/">Practice pack: FGD</a> <span style="color:var(--muted)">&#9679;</span></td><td>Run and write up a practice FGD</td></tr>
+            <tr><td>9</td><td>Attribution and contribution</td><td><a href="/101-courses/impact-eval.html">Impact Evaluation 101</a></td><td><a href="/challenges/causal-attribution-audit/">Challenge: causal attribution audit</a></td></tr>
+            <tr><td>10</td><td>Impact evaluation designs</td><td><a href="/Labs/impact-evaluation-lab.html">Impact Evaluation Studio</a></td><td>Choose a design for a given programme; defend it</td></tr>
+            <tr><td>11</td><td>Costing and value for money</td><td><a href="/practice-packs/programme-costing/">Practice pack: programme costing</a> <span style="color:var(--muted)">&#9679;</span></td><td><a href="/challenges/devecon-cost-effectiveness/">Challenge: cost-effectiveness</a></td></tr>
+            <tr><td>12</td><td>Equity and GESI in evaluation</td><td><a href="/fundamentals/gender-needs.html">Practical and strategic gender needs</a></td><td><a href="/challenges/gender-gesi-audit/">Challenge: GESI audit</a></td></tr>
+            <tr><td>13</td><td>Reporting, and the politics of it</td><td><a href="/practice-packs/donor-reporting/">Practice pack: donor reporting</a> <span style="color:var(--muted)">&#9679;</span></td><td><a href="/practice-packs/critiquing-evidence/">Practice pack: critiquing evidence</a> <span style="color:var(--muted)">&#9679;</span></td></tr>
+            <tr><td>14</td><td>Capstone</td><td>&mdash;</td><td><a href="/challenges/mel-logframe-redesign/">Challenge: LogFrame redesign</a>, presented and defended</td></tr>
+        </tbody>
+    </table>
+    </div>
+    <div class="kit-note">
+        <strong>&#9679; marks a practice pack.</strong> The first two of its four modules are free to use with a class &mdash; enough for the worked example and the first exercise. Modules 3&ndash;4 and the capstone builder are paid (&#8377;299 for one pack, or &#8377;399/month for all eighteen). Every other link on this page is free.
+    </div>
+    <div class="kit-note">
+        <strong>If you have fewer weeks.</strong> The load-bearing four are 2, 3, 9 and 10 &mdash; Theory of Change, LogFrame, attribution, and design. Everything else can be compressed or set as reading. If you have more, the sector-specific practice packs (<a href="/practice-packs/health-evaluation/">health</a>, <a href="/practice-packs/education-evaluation/">education</a>, <a href="/practice-packs/climate-evaluation/">climate</a>, <a href="/practice-packs/livelihoods-evaluation/">livelihoods</a>, <a href="/practice-packs/governance-evaluation/">governance</a>) each add a week without new theory.
+    </div>
+</section>
+
+<section class="section">
+    <h2>Assignments that mark themselves</h2>
+    <p class="kit-lead">The studios were built so that the thing a student exports is a gradeable artefact. You are marking a LogFrame, not an essay about LogFrames.</p>
+    <ul class="kit-list">
+        <li><strong>ToC Studio</strong> &mdash; exports a causal chain with assumptions made explicit. Mark the assumptions, not the boxes: that is where the thinking is.</li>
+        <li><strong>LogFrame Studio</strong> &mdash; exports a full matrix. The practice pack on LogFrame building carries a checklist you can hand out as the rubric.</li>
+        <li><strong>Sampling Studio</strong> &mdash; exports a plan with the arithmetic shown, so you can see whether a student understood power or guessed a number.</li>
+        <li><strong>Impact Evaluation Studio</strong> &mdash; exports a design with its identifying assumption stated. Mark whether the assumption is plausible for the case, which is the whole skill.</li>
+        <li><strong>Case challenges</strong> &mdash; ship with rubrics. Designed for groups, and they work as an end-of-term defence.</li>
+    </ul>
+    <div class="kit-note">
+        <strong>On plagiarism.</strong> Studio exports are built from choices a student makes about a specific programme, so two honest submissions do not look alike. That is a side effect rather than a design goal, but it is a real one.
+    </div>
+</section>
+
+<section class="section">
+    <h2>Assessment and certificates</h2>
+    <ul class="kit-list">
+        <li><strong>Assess Yourself</strong> &mdash; every flagship course ends with a six-question auto-graded self-check, with a per-question explanation. Useful as a pre-read gate rather than as summative assessment.</li>
+        <li><strong>Free certificates</strong> &mdash; learners who complete a course earn a verifiable certificate at no cost. Verified institutional versions are a paid add-on; the learner-facing certificate is not.</li>
+        <li><strong>Lexicons</strong> &mdash; each flagship has a curated glossary. Worth handing out in week 1; the vocabulary is most of the barrier for students new to the sector.</li>
+    </ul>
+</section>
+
+<section class="section">
+    <h2>Licensing, in plain language</h2>
+    <p class="kit-lead">All content is <strong>CC BY-NC-ND 4.0</strong>. Use any of it in your classroom, workshop or training programme with a credit line &mdash; &ldquo;Content from ImpactMojo &mdash; impactmojo.in&rdquo;. You can charge for your facilitation; you cannot charge for the materials themselves, or publish modified versions. For adaptations or translations, <a href="/contact.html">talk to us</a> &mdash; we are flexible with mission-aligned use.</p>
+</section>
+
+<section class="section">
+    <h2>What is not here</h2>
+    <div class="kit-note kit-gap">
+        <p style="margin-bottom:.6rem"><strong>ESG and CSR.</strong> ImpactMojo has no dedicated ESG course, and CSR appears only in passing inside a few 101 decks &mdash; not as taught material. If your paper covers corporate sustainability reporting, ESG frameworks or CSR compliance under the Companies Act, this kit will not carry that half of it, and we would rather say so than pad the mapping.</p>
+        <p style="margin-bottom:.6rem"><strong>Nearest adjacent material</strong>, if useful: <a href="/101-courses/climate-essentials.html">Climate Essentials 101</a>, <a href="/practice-packs/climate-evaluation/">the climate evaluation practice pack</a>, and <a href="/101-courses/dev-architecture.html">Development Architecture 101</a> for how the funding system is put together.</p>
+        <p style="margin:0"><strong>No LMS integration.</strong> There is no SCORM package and no gradebook sync. Everything is a URL; students open it and you mark what they export.</p>
+    </div>
+</section>
+
+<section class="section">
+    <h2>What costs money, and what it adds</h2>
+    <p class="kit-lead">Everything above teaches a course on its own. These are the things instructors most often ask for that we charge for &mdash; mostly because they are editable, printable or gradeable in ways an open web page is not. Prices are per item, one-off, unless marked otherwise.</p>
+
+    <div class="kit-scroll">
+    <table class="kit">
+        <thead><tr><th>Price</th><th>What it is</th><th>What it adds over the free version</th></tr></thead>
+        <tbody>
+            <tr><td>&#8377;350</td><td><strong>Course Notes PDF</strong><br>MEL for Development &mdash; 14 modules, 101 pp</td><td>The course stays free to read online. This is the print-ready version: one PDF for offline or low-connectivity classrooms, and something students can annotate and keep.</td></tr>
+            <tr><td>&#8377;499</td><td><strong>Assessment Question Bank</strong><br>MEL &mdash; 500 original MCQs</td><td>The free in-course check is six questions. This is 500, with a full answer key and per-question explanations &mdash; enough to set a real exam, and to set a different one next year.</td></tr>
+            <tr><td>&#8377;499</td><td><strong>Trainer Decks</strong><br>Introduction to MEL; Theory of Change</td><td>The free 101 decks are HTML you present as-is. These are editable PowerPoint with facilitator notes &mdash; for when you need to cut, reorder or add your own institution&rsquo;s cases.</td></tr>
+            <tr><td>&#8377;199</td><td><strong>Templates</strong><br>LogFrame, ToR, MEL Plan, ToC Canvas, Survey Instrument, Stakeholder Map, Donor Report, Activity Budget, Results Framework</td><td>The studios build these in the browser and export them. These are editable Word and Excel skeletons with guidance in every section &mdash; better when students must submit in a format your department already uses.</td></tr>
+            <tr><td>&#8377;499</td><td><strong>Workbooks</strong><br>MEL from Scratch (90-day), ToC Workshop, Survey Design, Commissioning Research</td><td>Step-by-step, blank page to finished output. Works as a structured multi-week assignment when you want the process documented, not just the artefact.</td></tr>
+            <tr><td>&#8377;299</td><td><strong>Practice pack, single</strong><br>any one of eighteen</td><td>Unlocks modules 3&ndash;4 and the capstone builder on a pack whose first two modules you have already used free.</td></tr>
+            <tr><td>&#8377;99&ndash;149</td><td><strong>Refreshers, checklists, posters</strong><br>Causal designs, OECD-DAC criteria, sampling, ethics &amp; DPDP consent; A3 formulae posters</td><td>One-page explainers and wall posters. Cheap handouts for the week a method needs to stick, and the posters survive a whole semester on a lab wall.</td></tr>
+            <tr><td>&#8377;2,499</td><td><strong>Teaching Kit bundle</strong></td><td>The question banks, templates, workbooks, trainer decks, refreshers, posters and checklists in one purchase &mdash; over 60% off buying them separately. This is the one to look at if you are equipping a paper rather than filling a single gap.</td></tr>
+        </tbody>
+    </table>
+    </div>
+
+    <div class="kit-grid" style="margin-top:1.5rem">
+        <div class="kit-card">
+            <h3>Premium &mdash; &#8377;399/month</h3>
+            <p>All eighteen practice packs in full, plus the research-design tools and certificates. &#8377;3,990/year if you pay annually. Sensible if your students will use packs across a whole semester rather than one or two.</p>
+            <a href="/premium.html">See what is included &#8599;</a>
+        </div>
+        <div class="kit-card">
+            <h3>Assessed certificate tracks &mdash; &#8377;2,499</h3>
+            <p>Self-paced tracks ending in a capstone and a verifiable credential &mdash; AI for M&amp;E, MEL, Data &amp; Technology, Policy &amp; Economics. For students who want something to show an employer beyond the free completion certificate.</p>
+            <a href="/premium.html">Explore the tracks &#8599;</a>
+        </div>
+        <div class="kit-card">
+            <h3>Workshops &amp; team training</h3>
+            <p>If you would rather we ran the session, or trained your faculty to. Priced per engagement.</p>
+            <a href="/workshops.html">Workshops &#8599;</a>
+        </div>
+    </div>
+
+    <div class="kit-note kit-gap">
+        <strong>Institutions in South Asia, and anyone for whom this is a barrier:</strong> write to us. The free half of this kit is the point of ImpactMojo, and we would rather your students had the material than that we held a &#8377;499 line. <a href="/contact.html">Get in touch</a> and say what you need.
+    </div>
+</section>
+
+<section class="section">
+    <h2>Want this mapped to your syllabus?</h2>
+    <p class="kit-lead">This page is the general kit. If you send us your course &mdash; what it is called, at what level, and what you want students to be able to do by the end &mdash; we will map it by hand and send that back. It is free, whether or not your institution ever pays us anything, and we reply within five working days.</p>
+    <p><a href="/teach.html#kit" style="display:inline-block;background:var(--accent);color:#0F172A;font-family:'Inter',sans-serif;font-weight:700;padding:0.8rem 1.6rem;border-radius:10px;text-decoration:none;">Request a mapped kit &rarr;</a></p>
+</section>
+
+<section class="section">
+    <h2>Related pages</h2>
+    <div class="crosslinks">
+        <a class="xcard" href="/teach.html"><h3>Teach with ImpactMojo</h3><p>What is in a teaching kit, and the request form.</p></a>
+        <a class="xcard" href="/catalog.html"><h3>Full catalog</h3><p>Every course, lab, game and handout.</p></a>
+        <a class="xcard" href="/workshops.html"><h3>Workshops</h3><p>If you want us to run the session instead.</p></a>
+        <a class="xcard" href="/api-docs.html"><h3>Partner API</h3><p>Read-only JSON access to the catalog, no key needed.</p></a>
+    </div>
+</section>
+
+</div>
+</main>
+
+<!-- ImpactMojo Footer -->
+<footer class="im-footer" role="contentinfo">
+<div class="im-footer-content">
+<p class="im-footer-made">Made with &#10084; by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+<div class="im-footer-grid">
+<div class="im-footer-section">
+<h4>About ImpactMojo</h4>
+<ul>
+<li><a href="/about.html">About Us</a></li>
+<li><a href="/contact.html">Contact</a></li>
+<li><a href="https://github.com/ImpactMojo/ImpactMojo" rel="noopener noreferrer" target="_blank">GitHub</a></li>
+<li><a href="/transparency.html">Transparency</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Legal</h4>
+<ul>
+<li><a href="/privacy-policy.html">Privacy Policy</a></li>
+<li><a href="/terms-of-service.html">Terms of Service</a></li>
+<li><a href="/disclaimer.html">Disclaimer</a></li>
+<li><a href="/data-protection.html">Data Protection</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Quick Links</h4>
+<ul>
+<li><a href="/catalog.html">All Courses</a></li>
+<li><a href="/premium.html">Premium Content</a></li>
+<li><a href="/coaching.html">Coaching</a></li>
+</ul>
+</div>
+<div class="im-footer-section">
+<h4>Resources</h4>
+<ul>
+<li><a href="/handouts.html">Handouts</a></li>
+<li><a href="/blog.html">Blog</a></li>
+<li><a href="/faq.html">FAQ</a></li>
+<li><a href="/sitemap.html">Sitemap</a></li>
+<li><a href="/docs/" rel="noopener noreferrer" target="_blank">Documentation</a></li>
+</ul>
+</div>
+</div>
+<div class="im-footer-bottom">
+<p>&copy; 2026 ImpactMojo. All content for educational purposes only.</p>
+<p>Released under <strong>MIT License</strong> | Supported by <a href="https://www.pinpointventures.in" rel="noopener noreferrer" target="_blank">PinPoint Ventures</a></p>
+</div>
+</div>
+</footer>
+
+<!-- ImpactMojo Theme Toggle JS -->
+<script src="/js/theme.js?v=ca787a55"></script>
+  <script src="/js/translate-sarvam.js?v=de32c2b0" defer></script>
+  <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
+</body>
+</html>

--- a/instructor-kit.html
+++ b/instructor-kit.html
@@ -272,8 +272,8 @@ ul.kit-list strong { color: var(--text); }
             <a href="/practice-packs/">All practice packs &#8599;</a>
         </div>
         <div class="kit-card">
-            <h3>Case challenges</h3>
-            <p>Realistic case packets with rubrics. Good as a capstone or a graded group assignment.</p>
+            <h3>Case challenges <span style="font-weight:400;color:var(--muted);font-size:.8rem">&mdash; 9 of 15 free</span></h3>
+            <p>Realistic case packets with rubrics. Good as a capstone or a graded group assignment. Nine are on the free Explorer tier; six need Practitioner. Every challenge used in the spine below is one of the free nine.</p>
             <a href="/challenges.html">All challenges &#8599;</a>
         </div>
         <div class="kit-card">
@@ -299,12 +299,12 @@ ul.kit-list strong { color: var(--text); }
             <tr><td>6</td><td>Sampling</td><td>Flagship: sampling modules</td><td><a href="/Labs/sampling-design-lab.html">Sampling Studio</a> &mdash; design and justify a plan</td></tr>
             <tr><td>7</td><td>Survey instruments</td><td><a href="/practice-packs/survey-instrument/">Practice pack: survey instrument</a> <span style="color:var(--muted)">&#9679;</span></td><td>Build and pilot a short instrument in pairs</td></tr>
             <tr><td>8</td><td>Qualitative methods</td><td><a href="/practice-packs/focus-group-discussion/">Practice pack: FGD</a> <span style="color:var(--muted)">&#9679;</span></td><td>Run and write up a practice FGD</td></tr>
-            <tr><td>9</td><td>Attribution and contribution</td><td><a href="/101-courses/impact-eval.html">Impact Evaluation 101</a></td><td><a href="/challenges/causal-attribution-audit/">Challenge: causal attribution audit</a></td></tr>
+            <tr><td>9</td><td>Attribution and contribution</td><td><a href="/101-courses/impact-eval.html">Impact Evaluation 101</a></td><td><a href="/challenges.html">Challenge: Stress-Test an Impact Claim</a></td></tr>
             <tr><td>10</td><td>Impact evaluation designs</td><td><a href="/Labs/impact-evaluation-lab.html">Impact Evaluation Studio</a></td><td>Choose a design for a given programme; defend it</td></tr>
-            <tr><td>11</td><td>Costing and value for money</td><td><a href="/practice-packs/programme-costing/">Practice pack: programme costing</a> <span style="color:var(--muted)">&#9679;</span></td><td><a href="/challenges/devecon-cost-effectiveness/">Challenge: cost-effectiveness</a></td></tr>
-            <tr><td>12</td><td>Equity and GESI in evaluation</td><td><a href="/fundamentals/gender-needs.html">Practical and strategic gender needs</a></td><td><a href="/challenges/gender-gesi-audit/">Challenge: GESI audit</a></td></tr>
+            <tr><td>11</td><td>Costing, and what happens when the money stops</td><td><a href="/practice-packs/programme-costing/">Practice pack: programme costing</a> <span style="color:var(--muted)">&#9679;</span></td><td><a href="/challenges.html">Challenge: Manage a Donor Exit</a></td></tr>
+            <tr><td>12</td><td>Equity and GESI in evaluation</td><td><a href="/fundamentals/gender-needs.html">Practical and strategic gender needs</a></td><td><a href="/challenges.html">Challenge: Conduct a GESI Audit</a></td></tr>
             <tr><td>13</td><td>Reporting, and the politics of it</td><td><a href="/practice-packs/donor-reporting/">Practice pack: donor reporting</a> <span style="color:var(--muted)">&#9679;</span></td><td><a href="/practice-packs/critiquing-evidence/">Practice pack: critiquing evidence</a> <span style="color:var(--muted)">&#9679;</span></td></tr>
-            <tr><td>14</td><td>Capstone</td><td>&mdash;</td><td><a href="/challenges/mel-logframe-redesign/">Challenge: LogFrame redesign</a>, presented and defended</td></tr>
+            <tr><td>14</td><td>Capstone</td><td>&mdash;</td><td><a href="/challenges.html">Challenge: Redesign a Flawed Logframe</a>, presented and defended</td></tr>
         </tbody>
     </table>
     </div>

--- a/js/gender-needs.js
+++ b/js/gender-needs.js
@@ -64,7 +64,7 @@
     return lines;
   }
 
-  var selected = null;
+  var selected = D.cases[0].id;
 
   /* ------------------------------------------------------------- the plot */
   function draw() {
@@ -249,6 +249,7 @@
     buildPicker();
     buildLegend();
     draw();
+    select(selected);   /* siblings do this; without it the panel loads blank */
     var t;
     window.addEventListener("resize", function () {
       clearTimeout(t);

--- a/netlify/functions/submission-created.mjs
+++ b/netlify/functions/submission-created.mjs
@@ -75,6 +75,12 @@ const FILES = {
   "AI for M&E Assessment — 500-Question Bank": "assessments/ai-for-me-500-assessment.pdf",
 };
 
+const looksLikeEmail = (v) => typeof v === "string" && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v.trim());
+
+const esc = (v) => String(v == null ? "" : v)
+  .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+  .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+
 const sign = (parts) => crypto.createHmac("sha256", ADMIN_KEY).update(parts.join("|")).digest("hex").slice(0, 32);
 
 async function sendMail(to, subject, html) {
@@ -103,6 +109,44 @@ export const handler = async (event) => {
   // yet — skip the action email. The real "I've paid" submission carries a
   // upi_ref and flows through normally below.
   if (form === "product-order" && !upiRef) {
+    return { statusCode: 200 };
+  }
+
+  // Instructor-kit requests are not payments; they are a promise. The page
+  // says we reply within five working days, and before this the requester got
+  // nothing at all — no acknowledgement, no expectation set, just silence
+  // until someone happened to read the Netlify notification. Send a receipt
+  // to them and a workable brief to us, then stop.
+  if (form === "instructor-kit") {
+    const name = (data.name || "").trim();
+    const course = (data.course_name || "").trim();
+    const level = (data.level || "").trim();
+    const institution = (data.institution || "").trim();
+    const description = (data.course_description || "").trim();
+
+    if (looksLikeEmail(email)) {
+      await sendMail(email, "Your ImpactMojo instructor kit — on its way",
+        `<p>${name ? "Hi " + esc(name) + "," : "Hello,"}</p>
+         <p>Thanks for asking for an instructor kit${course ? ` for <strong>${esc(course)}</strong>` : ""}. This is an automatic receipt so you know it arrived.</p>
+         <p>We map these by hand against your syllabus rather than sending a standard pack, so it takes <strong>up to five working days</strong>. It will come from hello@impactmojo.in — worth checking your spam folder.</p>
+         <p>Nothing is gated in the meantime. Everything is already free to browse:</p>
+         <ul>
+           <li><a href="${SITE}/catalog.html">The full catalog</a> — every course, lab, game and handout</li>
+           <li><a href="${SITE}/courses/">Flagship courses</a> — ~13 modules each, with auto-graded self-checks</li>
+           <li><a href="${SITE}/Labs/">Studios</a> — browser workbenches whose outputs work as gradeable assignments</li>
+           <li><a href="${SITE}/teach.html">Teaching with ImpactMojo</a> — licensing in plain language</li>
+         </ul>
+         <p>All of it is CC BY-NC-ND 4.0: use it in your classroom with a credit line. You can charge for your facilitation, not for the materials.</p>
+         <p>— ImpactMojo</p>`);
+    }
+
+    await sendMail(ADMIN_EMAIL, `Instructor kit request: ${course || "(course not given)"}`,
+      `<p><strong>${esc(name) || "(no name)"}</strong>${institution ? " — " + esc(institution) : ""}<br>
+       ${esc(email)}</p>
+       <p><strong>Course:</strong> ${esc(course) || "—"}<br>
+       <strong>Level:</strong> ${esc(level) || "—"}</p>
+       <p><strong>Describes it as:</strong><br>${esc(description).replace(/\n/g, "<br>") || "—"}</p>
+       <p style="font-size:12px;color:#94A3B8">An acknowledgement has already gone to the requester promising a mapped kit within five working days.</p>`);
     return { statusCode: 200 };
   }
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -612,6 +612,7 @@
   <url><loc>https://www.impactmojo.in/field-radio.html</loc><lastmod>2026-07-19</lastmod></url>
   <url><loc>https://www.impactmojo.in/game-library.html</loc><lastmod>2026-07-19</lastmod></url>
   <url><loc>https://www.impactmojo.in/grievance.html</loc><lastmod>2026-07-19</lastmod></url>
+  <url><loc>https://www.impactmojo.in/instructor-kit.html</loc><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://www.impactmojo.in/handouts.html</loc><lastmod>2026-07-19</lastmod></url>
   <url><loc>https://www.impactmojo.in/impact-dashboard.html</loc><lastmod>2026-07-19</lastmod></url>
   <url><loc>https://www.impactmojo.in/impactlex/</loc><lastmod>2026-07-19</lastmod></url>

--- a/teach.html
+++ b/teach.html
@@ -1425,6 +1425,7 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
 
 <section style="max-width:900px;margin:2.5rem auto 0;">
   <h2 style="font-family:'Inter',sans-serif;">What's in a teaching kit</h2>
+<p style="color:var(--text-secondary);margin:0 0 1rem;">In a hurry? The <a href="/instructor-kit.html"><strong>ready-made instructor kit</strong></a> maps a full 14-week M&amp;E course to material you can open today &mdash; no form, no wait.</p>
   <p style="color:var(--text-secondary);">Every flagship course comes with the pieces you'd otherwise build yourself:</p>
   <ul style="line-height:2;margin:0.75rem 0 0 1.25rem;">
     <li><strong>The course itself</strong> — ~13 modules with South Asian cases, reflection prompts and a curated lexicon</li>
@@ -1443,25 +1444,45 @@ main li a[href]:not([class*="btn"]):not([class*="button"]):not([role="button"]) 
   <p style="line-height:1.7;">All content is <strong>CC BY-NC-ND 4.0</strong>: use any of it freely in your classroom, workshop or training programme with a credit line ("Content from ImpactMojo — impactmojo.in"). You can charge for your facilitation, not for the materials themselves. For adaptations or translations, <a href="/contact.html">talk to us</a> — we're flexible with mission-aligned use.</p>
 </section>
 
-<section style="max-width:900px;margin:2.5rem auto 3rem;">
+<section id="kit" style="max-width:900px;margin:2.5rem auto 3rem;">
   <h2 style="font-family:'Inter',sans-serif;">Request an instructor kit</h2>
-  <p style="color:var(--text-secondary);margin-bottom:1rem;">Tell us what you teach and to whom, and we'll send a mapped kit — which flagship, deck, studios, games and challenges fit your syllabus — plus a sample syllabus mapping. Free, whether or not your institution ever pays us anything.</p>
-  <form name="instructor-kit" method="POST" data-netlify="true" netlify-honeypot="bot-field" style="display:grid;gap:1rem;max-width:560px;">
-    <p style="display:none"><label>Don't fill this out: <input name="bot-field"></label></p>
-    <label style="display:grid;gap:0.3rem;font-weight:600;">Your name
-      <input type="text" name="name" required style="padding:0.7rem 0.9rem;border:1px solid var(--border-color);border-radius:10px;background:var(--card-bg);color:var(--text-primary);font-family:inherit;">
-    </label>
-    <label style="display:grid;gap:0.3rem;font-weight:600;">Email
-      <input type="email" name="email" required style="padding:0.7rem 0.9rem;border:1px solid var(--border-color);border-radius:10px;background:var(--card-bg);color:var(--text-primary);font-family:inherit;">
-    </label>
-    <label style="display:grid;gap:0.3rem;font-weight:600;">Institution / organisation
-      <input type="text" name="institution" style="padding:0.7rem 0.9rem;border:1px solid var(--border-color);border-radius:10px;background:var(--card-bg);color:var(--text-primary);font-family:inherit;">
-    </label>
-    <label style="display:grid;gap:0.3rem;font-weight:600;">What do you teach, and to whom?
-      <textarea name="teaching_context" rows="4" required style="padding:0.7rem 0.9rem;border:1px solid var(--border-color);border-radius:10px;background:var(--card-bg);color:var(--text-primary);font-family:inherit;"></textarea>
-    </label>
-    <button type="submit" class="btn btn-primary" style="justify-self:start;padding:0.85rem 1.75rem;background:linear-gradient(135deg,#667eea,#764ba2);color:#fff;-webkit-text-fill-color:#fff;border:none;border-radius:10px;font-weight:700;cursor:pointer;font-size:1rem;">Request my kit &rarr;</button>
-  </form>
+<p style="color:var(--text-secondary);margin-bottom:1rem;">Tell us what you teach and to whom, and we&rsquo;ll send a mapped kit &mdash; which flagship, deck, studios, games and challenges fit your syllabus &mdash; plus a sample syllabus mapping. Free, whether or not your institution ever pays us anything. <strong>We reply within five working days.</strong></p>
+<form name="instructor-kit" id="instructorKitForm" method="POST" data-netlify="true" netlify-honeypot="bot-field" action="/teach.html" style="display:grid;gap:1rem;max-width:560px;">
+<input type="hidden" name="form-name" value="instructor-kit">
+<p style="display:none"><label>Don't fill this out: <input name="bot-field"></label></p>
+<label style="display:grid;gap:0.3rem;font-weight:600;">Your name
+<input type="text" name="name" required style="padding:0.7rem 0.9rem;border:1px solid var(--border-color);border-radius:10px;background:var(--card-bg);color:var(--text-primary);font-family:inherit;">
+</label>
+<label style="display:grid;gap:0.3rem;font-weight:600;">Email
+<input type="email" name="email" required style="padding:0.7rem 0.9rem;border:1px solid var(--border-color);border-radius:10px;background:var(--card-bg);color:var(--text-primary);font-family:inherit;">
+</label>
+<label style="display:grid;gap:0.3rem;font-weight:600;">Institution / organisation
+<input type="text" name="institution" style="padding:0.7rem 0.9rem;border:1px solid var(--border-color);border-radius:10px;background:var(--card-bg);color:var(--text-primary);font-family:inherit;">
+</label>
+<label style="display:grid;gap:0.3rem;font-weight:600;">Name of the course or paper you teach
+<input type="text" name="course_name" required placeholder="e.g. Monitoring &amp; Evaluation for Development Practice" style="padding:0.7rem 0.9rem;border:1px solid var(--border-color);border-radius:10px;background:var(--card-bg);color:var(--text-primary);font-family:inherit;">
+</label>
+<label style="display:grid;gap:0.3rem;font-weight:600;">At what level?
+<select name="level" required style="padding:0.7rem 0.9rem;border:1px solid var(--border-color);border-radius:10px;background:var(--card-bg);color:var(--text-primary);font-family:inherit;">
+<option value="">Select one&hellip;</option>
+<option value="Undergraduate">Undergraduate</option>
+<option value="Postgraduate / Master's">Postgraduate / Master&rsquo;s</option>
+<option value="MPhil / PhD">MPhil / PhD</option>
+<option value="Diploma / certificate">Diploma / certificate</option>
+<option value="Professional / in-service training">Professional / in-service training</option>
+<option value="Mixed / other">Mixed / other</option>
+</select>
+</label>
+<label style="display:grid;gap:0.3rem;font-weight:600;">Describe the course
+<textarea name="course_description" rows="4" required placeholder="What it covers, how many weeks or sessions, roughly how many students, and what you want them to be able to do by the end." style="padding:0.7rem 0.9rem;border:1px solid var(--border-color);border-radius:10px;background:var(--card-bg);color:var(--text-primary);font-family:inherit;"></textarea>
+<span style="font-weight:400;font-size:0.85rem;color:var(--text-secondary);">The more specific this is, the more useful the mapping. A syllabus outline pasted in is ideal.</span>
+</label>
+<button type="submit" class="btn btn-primary" style="justify-self:start;padding:0.85rem 1.75rem;background:linear-gradient(135deg,#667eea,#764ba2);color:#fff;-webkit-text-fill-color:#fff;border:none;border-radius:10px;font-weight:700;cursor:pointer;font-size:1rem;">Request my kit &rarr;</button>
+</form>
+<div id="instructorKitSuccess" hidden style="max-width:560px;padding:1.25rem 1.5rem;border:1px solid var(--border-color);border-left:4px solid #10B981;border-radius:10px;background:var(--card-bg);">
+<p style="margin:0 0 .5rem;font-weight:700;">Request received &mdash; thank you.</p>
+<p style="margin:0;color:var(--text-secondary);">We read these ourselves and map the kit by hand, so it takes up to five working days. It will come from hello@impactmojo.in &mdash; worth checking your spam folder if you don&rsquo;t see it. In the meantime everything is already free to browse: <a href="/catalog.html">the full catalog</a>, <a href="/courses/">flagship courses</a> and <a href="/Labs/">the studios</a>.</p>
+</div>
   <p style="margin-top:1.5rem;color:var(--text-secondary);">Running team training instead? See <a href="/workshops.html">Workshops</a> or the <a href="/premium.html">Organization tier</a> for dashboards and progress reports.</p>
 </section>
 
@@ -1724,6 +1745,27 @@ document.addEventListener('click', function(e) {
 <script src="/js/state-manager.js?v=62445627"></script>
 <script src="/js/config.js?v=bd5dcf94"></script>
 <script src="/js/auth.js?v=97cb7b85"></script>
+  <script src="/js/form-submit.js?v=36a6a01f"></script>
+  <script>
+  /* Netlify Forms sends the notification; /api/form-submit writes the durable
+     row. Before this, teach.html posted natively and never called the second
+     path, so `instructor-kit` sat on the ALLOWED_FORMS allowlist doing nothing
+     and a lost notification email was a lost lead. */
+  (function () {
+    var f = document.getElementById('instructorKitForm');
+    if (!f) return;
+    f.addEventListener('submit', function (e) {
+      e.preventDefault();
+      window.imxSubmitBothFromElement(f).then(function () {
+        f.style.display = 'none';
+        document.getElementById('instructorKitSuccess').hidden = false;
+        document.getElementById('instructorKitSuccess').scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }).catch(function () {
+        alert('Something went wrong. Please try again, or email hello@impactmojo.in directly.');
+      });
+    });
+  })();
+  </script>
   <script src="/js/site-chrome.js?v=39a1bdf4" defer></script>
 <script src="/js/mojini-ai.js?v=db5170eb" defer></script>
 </body>


### PR DESCRIPTION
## What does this PR do?

Two unrelated things that came out of the same session: a live bug on Fundamentals, and building the instructor kit `teach.html` has been promising.

### 1. Fundamentals — a blank panel and three pages throwing on load

`gender-needs.html`, `livelihoods.html` and `social-model.html` each loaded `/js/ladder-data.js` and `/js/ladder.js` and called `FLadder.init()`, which writes into `#panel`. **Only `ladder.html` has a `#panel`.** Every load threw `Cannot set properties of null (setting 'innerHTML')`. The block is a copy-paste leftover — its own HTML comment says *"The wheel"* while it loads the ladder.

The user-visible half was **`gender-needs.html` opening with a completely blank panel**. Its two sibling pages both default-select their first case:

```js
livelihoods.js:  var selected = D.cases[0].id;    + select(selected)
social-model.js: var selected = D.domains[0].id;  + select(selected)
gender-needs.js: var selected = null;             + (never calls select)
```

The stray `ladder.js` was evidently meant to cover that with an empty state and could not, because it wrote to an element that isn't there. `gender-needs` now defaults like its siblings — the page goes from **8,640 to 10,289 characters** of rendered text on load.

`capabilities.html` also loads `ladder.js` and is **not** changed here: it does have a `#panel`, and its own `capabilities.js` overwrites the ladder copy afterwards, so it renders correctly today. It's order-dependent and downloads two files it doesn't need — worth cleaning up separately rather than folding into a bug fix.

**None of these three pages is in the axe-core CI list** (wheel, index, ladder, power-cube, who-counts), which is why CI never saw any of it.

Also here, from running axe over the Data Dives directly: the "Pitch a Data Dive" CTA was white on `var(--dv-accent)`, which is `#60A5FA` in dark mode — **2.54:1**, a serious contrast failure on all eleven dives, new and pre-existing. The ink is now its own theme token: white on light's `#2563EB` is 5.17:1, dark ink on dark's `#60A5FA` is 7.02:1. Re-run over six dives in both themes: **zero serious violations, where there were four.** Neither CI audit would have caught it — axe runs ten hardcoded pages, pa11y nineteen, and no Data Dive is in either list.

### 2. `instructor-kit.html` — the thing the page promises

`teach.html` has promised "a mapped kit — which flagship, deck, studios, games and challenges fit your syllabus". Nothing was automated behind it, so a requester got no acknowledgement, no expectation and no timeline.

The new page is a 14-week M&E spine with separate columns for *what to teach from* and *what to set as work*, a section on the studio exports that work as gradeable artefacts, assessment, licensing in plain language, an explicit "what is not here", and a paid section with real prices.

**A first draft of this page was wrong and it is worth recording how.** It claimed *"nothing in this kit is behind a login or a payment"*, listed practice packs as free, and used them in six of the fourteen weeks. `practice-packs/index.html` states the actual terms: first two of four modules free, the rest ₹299 a pack or ₹399/month. I had grepped a pack for "Free" and matched a table of **third-party tools** (KoboToolbox, DHIS2) rather than the pack's own terms. Packs are now marked with a bullet, explained once, and the headline claim is gone. Labs, challenges, explorers, 101 decks and the flagship courses were each checked for gating markers before being described as free.

The page also says outright that there is **no ESG or CSR material** and no LMS integration, rather than padding the mapping.

### 3. The form

- Asks what a mapping actually needs: course/paper name, level (UG / PG / MPhil-PhD / diploma / professional / mixed), and a description prompting for weeks, class size and intended outcomes — replacing one free-text field.
- **`teach.html` now loads `/js/form-submit.js`.** It had posted natively to Netlify Forms and never called `/api/form-submit`, so `instructor-kit` sat on the `ALLOWED_FORMS` allowlist writing nothing — a dropped notification email was a lost lead. Both paths now run, with a real success state instead of Netlify's generic page.
- **An autoresponder** in `submission-created.mjs`: a receipt to the requester with the five-working-day commitment and links to the free material, plus a usable brief to the admin address. `looksLikeEmail()` was referenced before being defined in my first pass and **would have thrown on the first submission**; it and `esc()` are now defined there, and the escaper is exercised against a script-tag payload.

## Type of change

- [x] Bug fix (broken link, layout, JS error)
- [x] New content (course, case study, translation)
- [x] Accessibility improvement
- [ ] New feature or tool
- [ ] Performance improvement
- [ ] Documentation update

## Checklist

- [x] Tested on desktop browser — kit renders in light and dark at 1200px; all nine Fundamentals pages re-checked
- [x] Tested on mobile browser — kit at 390px, no horizontal overflow
- [x] No console errors — **all nine Fundamentals pages now throw nothing at all**, where three threw on every load
- [x] Links are working — all 54 internal links in the kit resolved against the filesystem before publishing

axe-core on the kit: **0 serious/critical** in light, dark and mobile. Prices were read out of `premium.html` and `products.html`, not recalled.

## Verification

| Check | Result |
|---|---|
| `check-counts.py` | PASS — 100 files |
| `check-search-coverage.py` | PASS — 804 sitemap pages indexed |
| `check-viewport.py` | PASS — 865 pages |
| `check-mojibake.py` | PASS |
| `stamp-assets.py --check` | PASS — 203 pages |
| `search-index.json` / `sitemap.xml` | valid JSON / valid XML |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gFEJ2FoiFQjyXvmDGGB9W

---
_Generated by [Claude Code](https://claude.ai/code/session_011gFEJ2FoiFQjyXvmDGGB9W)_