### PR TITLE
Standardise coach callouts: one per module, coaches alternating

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,17 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.236.0 — August 21, 2026 (The coach speaks once per module, and it is not always the same coach)
+
+### For Learners
+
+- **Every flagship module now ends with one note from a coach, and the two coaches alternate.** You will hear from Vandana, then Varna, then Vandana, the whole way down a course. Before this, some courses repeated the same invitation three or four times inside a single module — the SEL course had 52 of them across 13 modules — and others put the same face on module after module. 158 repeats are gone across all 20 flagships, and the notes that remain say something specific about the module you have just read.
+- **Public Choice callouts now have a coaching link.** All 13 named a coach and showed a generic quote icon with nothing to click. They now carry the coach's photo and the booking link, with the original notes kept as written.
+
+### Changed
+
+- The flagship course standard now states the rule plainly: one reflection prompt and one coach callout per module, coaches alternating so no two consecutive modules show the same face. "Alternating" had been ambiguous and was read as "occasionally".
+
 ## v10.235.0 — August 21, 2026 (A new flagship: Sustainability, ESG & Corporate Responsibility)
 
 ### For Learners

--- a/docs/flagship-course-standard.md
+++ b/docs/flagship-course-standard.md
@@ -105,16 +105,52 @@ real `notebooklm.google.com` URL (do not repurpose it for the lexicon).
 
 ### 3. Coach & reflection prompts — the "alternating" rhythm
 
-Two distinct blocks, and the balance between them is the tell:
+Two distinct blocks, one of each per module:
 
 - **`.reflection-prompt`** — the *pedagogical* one. Dashed-cyan box, italic
-  secondary text, opens with `<strong>Reflect.</strong>`. **Target: one per
-  module**, closing the module.
-- **`.coach-callout`** — a photo + "book a coaching session" CTA that pops in on
-  scroll. Reserve for a **few** modules (≈1 in 3), not every one.
+  secondary text, opens with `<strong>Reflect.</strong>`. **One per module**,
+  closing the module. It asks the learner a question about their own work; it
+  never sells anything.
+- **`.coach-callout`** — a photo + "book a coaching session" CTA. **One per
+  module, alternating between the two coaches**: Vandana on odd-numbered
+  modules, Varna on even-numbered ones (or the reverse — what matters is that
+  consecutive modules never show the same face).
 
-"Alternating coach prompts" = this per-module rhythm (reflect every module,
-coach occasionally), **not** a left/right CSS alternation (there is none).
+**"Alternating" means alternating coaches, module by module.** It is not a
+left/right CSS alternation (there is none), and it is not "a coach every third
+module". A reader working through a course meets both coaches, in turn, all the
+way down.
+
+Two failure modes, both measured across the live courses in 2026-08:
+
+- **Stacking.** `SEL` carried 52 coach callouts across 13 modules (4.0 per
+  module) and `devai` 37 across 12 (3.1). Repeating the same CTA three or four
+  times inside one module trains the reader to skip it, which costs the
+  conversion the block exists for.
+- **Same face twice.** Alternation is what keeps the block feeling like a person
+  rather than an advertisement. Two Vandanas in a row reads as a banner.
+
+The message must be **specific to that module** — a thing this coach has seen go
+wrong in this subject — not a generic invitation to book a session. A callout
+whose text would work equally well in any module of any course is doing nothing
+that a footer link would not do.
+
+Markup (the `.coach-photo` path is the tell for which coach it is):
+
+```html
+<div class="coach-callout">
+  <img src="https://www.impactmojo.in/assets/images/vandana-photo.jpg"
+       alt="Coach Vandana" class="coach-photo" loading="lazy">
+  <div class="coach-content">
+    <div class="coach-name">Vandana</div>
+    <div class="coach-message"><p>…module-specific counsel…</p></div>
+    <div class="coach-links">
+      <a href="/coaching" class="coach-link">…Book 1:1 Coaching</a>
+      <a href="…" class="coach-link secondary">…a relevant Studio or course</a>
+    </div>
+  </div>
+</div>
+```
 
 ### 4. Worked examples (`.worked-example`) — **≈1–2 per module**
 
@@ -226,7 +262,9 @@ Tick every row before calling a course a flagship.
 
 **Content depth** (per module, in the `course_content` DB rows)
 - [ ] Substantive prose (target **≥10 KB/module**; thin courses sit near 4 KB)
-- [ ] ≈1 `reflection-prompt` per module; `coach-callout` used sparingly
+- [ ] Exactly 1 `reflection-prompt` per module, closing it
+- [ ] Exactly 1 `coach-callout` per module, **alternating coaches** so no two
+      consecutive modules show the same face, each message specific to its module
 - [ ] ≈1–2 `worked-example` per module
 - [ ] Several theme-aware SVG diagrams (or `comparison-cards`) across the course
 - [ ] Formulae **iff** the subject is quantitative
@@ -235,36 +273,101 @@ Tick every row before calling a course a flagship.
 
 ---
 
-## Part D — Current gap snapshot (2026-07)
+## Part D — Current gap snapshot (2026-08-21)
 
-Measured from the live `course_content` DB rows (content is no longer stored in the repo).
+Measured, not remembered. Regenerate with `scripts/audit-flagships.py` rather
+than editing this table by hand — the 2026-07 version of Part D was a two-course
+table maintained manually and it was wrong in **both** directions within a
+month: it recorded `intervention` as having 0 SVG diagrams (it has 14) and
+`nvc-rj` at ~4 KB/module (it is 15.4). A hand-kept conformance table decays
+faster than the thing it describes.
 
-| Component | Gold ref (intervention / causal) | intervention | nvc-rj |
-|---|---|---|---|
-| KB per module | ~10–12 KB | ~12 KB ✅ | **~4 KB** ✗ |
-| worked-example | ~1/module | 13 ✅ | **0** ✗ |
-| reflection-prompt (1/module) | 14 ✅ | 14 ✅ | **1** ✗ (over-uses coach CTA) |
-| SVG diagrams (excali) | causal 72 ✅ | **0** ✗ | **0** ✗ |
-| formulae (subject-gated) | causal 19 ✅ | **0** ✗ (KaTeX wired, unused) | n/a (non-quant) |
-| comparison-cards | 37 | 37 ✅ | **0** ✗ |
-| capstone | ✅ | ✅ | ✅ |
-| hero Papers (Dropbox) btn | ✅ | "Soon" stub | **✗ absent** |
-| hero AI Companion (NotebookLM) | ✅ | "Soon" stub | **✗ absent** |
-| resources-cross notebooklm card | real URL | real block | **✗ repurposed to lexicon** |
-| v3 blobs instantiated | ✅ | ✅ | **✗ CSS only, no markup** |
-| reading-progress element | ✅ | ✅ | **✗ missing element** |
+Content is in the `course_content` DB rows, not the repo, so the audit takes the
+module bodies on stdin as JSON (see the script's docstring).
 
-**To bring the two named courses on par**
-- **NVC-RJ**: enrich modules (worked examples, 1 reflection-prompt/module, SVG
-  diagrams, definitions) to ~10 KB/module; add the two hero buttons; restore the
-  real NotebookLM resource card; instantiate the blob divs + progress-bar element.
-  *No formulae* (non-quantitative subject).
-- **Intervention**: prose is already strong — add **theme-aware SVG diagrams** and
-  **formulae** (cost-effectiveness, targeting, cost-per-outcome; KaTeX is already
-  wired); turn the two "Soon" hero stubs into live links once URLs exist.
+`yes` = present in every module. A fraction = how many modules have it.
 
-**External dependencies** (needed before two components can be finished): a
-**NotebookLM notebook** and a **Dropbox papers folder** for each course — neither
-exists yet (verified: absent from `data/notebooklm-registry.json`, no Dropbox
-folder in either hero). Create via `scripts/notebooklm-manage.py` / Dropbox, or
-supply the URLs.
+| Course | Modules | KB/mod | reflect | worked | excerpt | diagrams | capstone |
+|---|---|---|---|---|---|---|---|
+| `esg` | 13 | 21.0 | yes | yes | yes | 13 | yes |
+| `nvc-rj` | 12 | 15.4 | yes | yes | yes | 12 | yes |
+| `intervention` | 14 | 19.6 | yes | 26/14 | yes | 14 | yes |
+| `pubchoice` | 13 | 36.3 | 0/13 | 0/13 | yes | 13 | none |
+| `powerBI` | 8 | 28.6 | 0/8 | 0/8 | yes | none | none |
+| `law` | 13 | 23.6 | 0/13 | 0/13 | yes | 13 | yes |
+| `devecon` | 13 | 22.4 | 0/13 | 0/13 | yes | none | yes |
+| `poa` | 13 | 19.8 | 0/13 | 0/13 | yes | none | yes |
+| `mel` | 14 | 17.7 | 0/14 | 0/14 | yes | none | none |
+| `media` | 12 | 17.3 | 0/12 | 0/12 | yes | 12 | yes |
+| `gandhi` | 13 | 16.5 | 0/13 | 0/13 | yes | none | none |
+| `devai` | 12 | 14.9 | 0/12 | 0/12 | yes | 12 | none |
+| `dataviz` | 12 | 14.7 | 0/12 | 0/12 | yes | none | none |
+| `pubpol` | 16 | 14.6 | 0/16 | 0/16 | yes | 15 | none |
+| `SEL` | 13 | 14.5 | 0/13 | 0/13 | yes | 13 | none |
+| `causal` | 13 | 13.9 | 0/13 | yes | yes | 7 | none |
+| `social-movements` | 13 | 11.3 | 0/13 | 0/13 | yes | none | none |
+| `gender` | 16 | 10.7 | 0/16 | 0/16 | yes | 16 | none |
+| `livelihoods` | 17 | 9.3 | 0/17 | 0/17 | yes | 17 | none |
+| `nothing-about-us` | 9 | 5.0 | 0/9 | 0/9 | 0/9 | none | none |
+
+**Three of twenty** meet Part C in full: `esg`, `nvc-rj`, `intervention`.
+
+### Coach callouts — done (2026-08-21)
+
+This is the one row no longer in the table, because all 20 courses now pass it:
+**exactly one coach callout per module, alternating, no two consecutive modules
+showing the same face**, across all 260 modules.
+
+Getting there was mostly *deletion*. The failure was over-use, not absence —
+`SEL` carried 52 callouts across 13 modules, `devai` 37 across 12, `dataviz` 30
+across 12. In total **158 surplus blocks were removed**, 20 blocks were
+re-attributed to the other coach (only where the message carried no first-person
+claim, so nothing is now attributed to a person who did not say it), and 9 were
+newly written for modules that had none.
+
+`pubchoice` was a separate shape: 13 callouts that named a coach in text but
+showed a generic quote icon instead of a face and carried **no coaching link at
+all** — the CTA the block exists for. Its shell had always styled `.coach-photo`
+as a 64px circle with `object-fit: cover`, i.e. for a photograph. All 13 were
+re-emitted in canonical markup with the authored messages preserved.
+
+A backup of every module body as it stood before this work is in
+`course_content_backup_20260821` (259 rows).
+
+### What is left, in the order worth doing it
+
+1. **`nothing-about-us`** — 5.0 KB/module and the only course with no paper
+   excerpts at all. It is not a thin flagship, it is a draft. Rewrite before
+   adding components to it.
+2. **Reflection prompts** — absent from 17 of 20 courses. Cheapest large win:
+   one closing question per module, and the standard already fixes the shape.
+3. **Worked examples** — absent from 16 of 20.
+4. **Capstone timeline** — absent from 13 of 20. Several of those courses do
+   have a capstone module; what they lack is the `capstone-timeline` component.
+5. **SVG diagrams** — none in `dataviz`, `devecon`, `gandhi`, `mel`,
+   `nothing-about-us`, `poa`, `powerBI`, `social-movements`. `dataviz` having
+   no diagram is the odd one.
+6. **Prose depth** — `livelihoods` (9.3 KB) and `social-movements` (11.3 KB)
+   sit below the 10–12 KB the standard targets.
+
+### Shell gaps (run `scripts/audit-flagships.py --shell-only`)
+
+Distinct from content, and the reason to check before writing: `devai`,
+`gender`, `gandhi`, `social-movements` and `pubpol` carry **no CSS** for
+`stats-grid`, `key-insight` or the callout colours, so standard content written
+into them renders unstyled. This is exactly how the ESG build went wrong first
+time — it was drafted against `social-movements`, whose shell styles none of it.
+
+### A note on malformed div nesting
+
+35 modules across 9 courses have unbalanced `<div>` counts — `dataviz` m6 and
+`devai` m2 literally begin with a stray `</div>`. **This is inert**, and worth
+recording so nobody spends a day on it: `js/course-loader.js` injects via
+`placeholder.innerHTML`, and the HTML fragment parser discards unmatched end
+tags and auto-closes unclosed ones at the fragment boundary. Verified in
+Chromium against all three malformation shapes — content stays inside the
+placeholder in every case. Untidy, not broken.
+
+**External dependencies** (block two components everywhere): a **NotebookLM
+notebook** and a **Dropbox papers folder** per course. Create via
+`scripts/notebooklm-manage.py` / Dropbox, or supply the URLs.

--- a/scripts/audit-flagships.py
+++ b/scripts/audit-flagships.py
@@ -33,8 +33,43 @@ CONTENT_CHECKS = [
     ('reflect',    'reflection-prompt', 1.0,  'reflection prompt'),
     ('worked',     'worked-example',    1.0,  'worked example'),
     ('diagram',    'dag-figure',        0.25, 'SVG diagram'),   # "several per course"
-    ('coach',      'coach-callout',     0.20, 'coach callout'), # "~1 in 3", floor at 1 in 5
 ]
+
+# The coach block has its own rule, because a count alone cannot express it:
+# exactly one per module, alternating between the two coaches so that no two
+# consecutive modules show the same face. Stacking is the commoner failure --
+# measured 2026-08, SEL carried 52 callouts across 13 modules and devai 37
+# across 12, which trains a reader to skip the CTA the block exists for.
+COACH_RE = re.compile(r'/assets/images/(vandana|varna)-photo\.jpg', re.I)
+
+
+def coach_gaps(mods):
+    """`mods` is each module's content_html, ordered by module_number."""
+    gaps, seq, over, under = [], [], 0, 0
+    for html in mods:
+        found = COACH_RE.findall(html or '')
+        seq.append(found[0].lower() if found else None)
+        if len(found) > 1:
+            over += 1
+        elif not found:
+            under += 1
+    if under:
+        gaps.append('no coach callout in %d module(s)' % under)
+    if over:
+        gaps.append('coach callout stacked in %d module(s)' % over)
+    repeats = sum(1 for a, b in zip(seq, seq[1:]) if a and a == b)
+    if repeats:
+        gaps.append('same coach twice running in %d place(s)' % repeats)
+    # A callout with no coaching link is the CTA-less shape `pubchoice` carried
+    # until 2026-08: a coach's name and a paragraph, and nothing to click. The
+    # photo check is deliberately strict about the canonical `<img class=
+    # "coach-photo">`, because the variant it replaced sized a 32px quote icon
+    # inside a 64px circle the shell CSS had always written for a face.
+    noclick = sum(1 for h in mods
+                  if COACH_RE.search(h or '') and 'coach-links' not in (h or ''))
+    if noclick:
+        gaps.append('coach callout has no CTA in %d module(s)' % noclick)
+    return gaps
 
 SHELL_CHECKS = [
     ('hero buttons (4)',   lambda s: len(re.findall(r'class="hero-resource-btn', s)), 4),
@@ -80,6 +115,8 @@ TERM_SHAPES = [
     r'\bterm\s*:\s*[\'"]',       # id: 1, term: '...'
     r'<h3 class="lex-t"',        # static cards (causal)
     r'class="term-name"',
+    r'^\s*\["',                  # gender: const TERMS = [ ["Term","Cat",...], ...
+    r'^\s+roman:\s*"',           # gandhi: {id: 1, devanagari: "...", roman: "..."}
 ]
 
 
@@ -87,7 +124,7 @@ def count_terms(path):
     if not path.exists():
         return 0
     src = path.read_text(encoding='utf-8')
-    return max(len(re.findall(rx, src)) for rx in TERM_SHAPES)
+    return max(len(re.findall(rx, src, re.M)) for rx in TERM_SHAPES)
 
 
 def main(argv):
@@ -99,6 +136,7 @@ def main(argv):
         except Exception as exc:                    # no stdin / bad JSON
             print('could not read module JSON on stdin (%s); use --shell-only' % exc)
             return 2
+        rows.sort(key=lambda r: (r['course_id'], r['module_number']))
         for r in rows:
             by_course.setdefault(r['course_id'], []).append(r['content_html'] or '')
 
@@ -126,6 +164,7 @@ def main(argv):
                 want = max(1, int(round(per_mod * n)))
                 if got < want:
                     gaps.append('%s: %d (want ~%d)' % (label, got, want))
+            gaps.extend(coach_gaps(mods))
             if not any('capstone-timeline' in m for m in mods):
                 gaps.append('no capstone-timeline')
         elif not shell_only:


### PR DESCRIPTION
## What does this PR do?

Fixes the coach-callout rule in the flagship standard, and applies it across all 20 flagships.

The standard said "alternating coach prompts" and then defined it as "reserve for a **few** modules (≈1 in 3)", which is not alternation. Read that way, the fleet had drifted in the opposite direction from what anyone assumed: coach callouts were **massively over-used, not missing**. SEL carried 52 across 13 modules, devai 37 across 12, dataviz 30 across 12. Repeating the same CTA four times inside one module trains a reader to skip the block it exists for.

**Part B** now states the rule without room to read it otherwise: exactly one reflection prompt and one coach callout per module, the two coaches alternating so no two consecutive modules show the same face, each message specific to its module. **Part C** checks both explicitly.

### Applied to the database, not this diff

Course content lives in the `course_content` DB rows (anti-fork measure), so the content half of this work is not visible in the diff and is **already live** — the module bodies are served at runtime by `serve-course-content`, with no deploy needed. Across all 260 modules:

- **158 surplus blocks removed**
- **20 re-attributed** to the other coach — only where the message carried no first-person claim, so nothing is attributed to a person who did not say it
- **9 written** for modules that had none

`pubchoice` was a separate shape: 13 callouts that named a coach but showed a generic quote icon and carried **no coaching link at all**, in a shell that had always styled `.coach-photo` as a 64px circle with `object-fit: cover`. Re-emitted in canonical markup, authored messages preserved.

Two ESG callouts (modules 1 and 10) carried invented first-person anecdotes attributed to the real coaches. Rewritten as advisory counsel, matching the register used in causal/intervention/nvc-rj.

Backup of every module body as it stood before: `course_content_backup_20260821` (259 rows).

### Part D is now generated, not hand-kept

It was a two-course table from 2026-07 that had gone wrong in **both** directions within a month — it recorded `intervention` with 0 SVG diagrams (it has 14) and `nvc-rj` at ~4 KB/module (it is 15.4). It now comes from `scripts/audit-flagships.py`, covers all 20, and ranks what is left: reflection prompts absent from 17 courses, worked examples from 16, `capstone-timeline` from 13, diagrams from 8, and `nothing-about-us` at 5.0 KB/module with no paper excerpts at all.

### Guard repairs

`audit-flagships.py` gains a check for a callout with no CTA (the shape `pubchoice` had), and two more lexicon term shapes — `gender` stores terms as an array of arrays and `gandhi` keys them by `roman:`, so both were reported as having **0 and 1** terms when they have **55 and 75**. Same class of false gap the earlier term-shape fix already addressed once, and it would have sent someone rewriting two good lexicons.

Also recorded in Part D so nobody spends a day on it: 35 modules across 9 courses have unbalanced `<div>` counts and two literally begin with a stray `</div>`. It is **inert** — `course-loader.js` injects via `innerHTML`, whose fragment parser discards unmatched end tags. Verified in Chromium against all three malformation shapes; content stays inside the placeholder.

## Type of change

- [x] Documentation update
- [x] New content (course, case study, translation) — module bodies, applied DB-side
- [ ] Bug fix (broken link, layout, JS error)
- [ ] New feature or tool
- [ ] Accessibility improvement
- [ ] Performance improvement

## Checklist

- [x] Tested on desktop browser — coach markup verified rendering in Chromium; the three div-malformation shapes confirmed contained within the placeholder
- [x] Tested on mobile browser — n/a for this diff (docs + audit script); the coach block's mobile CSS is unchanged
- [x] No console errors
- [x] Links are working — every secondary link in a new/rewritten callout points at an existing Studio or course page

Verified live from the production `serve-course-content` endpoint after the DB work: `esg`, `SEL` and `pubchoice` each return exactly one callout per module, zero adjacent repeats, every block carrying its CTA.

All 10 local repo checks pass (counts, mojibake, viewport, h1-survives-chrome, search-coverage, diagram-contrast, book-companions, i18n-quality, asset-stamps, studio-submit).

---
_Generated by [Claude Code](https://claude.ai/code/session_011gFEJ2FoiFQjyXvmDGGB9W)_