### PR TITLE
Stop listing the right-to-food litigation as absent from the docket

### DIFF
--- a/data/fix-history.json
+++ b/data/fix-history.json
@@ -1,8 +1,15 @@
 {
   "generated_from": "docs/changelog.md",
   "note": "Derived from the changelog, not from GitHub Issues. Dates are the release the fix shipped in, which is what we actually know; issue numbers appear only where one was filed.",
-  "count": 96,
+  "count": 97,
   "entries": [
+    {
+      "title": "The Law Docket listed the right-to-food litigation under \"What is deliberately not here\" — while publishing two of its orders on the same page",
+      "detail": "PUCL v. Union of India is the most consequential right-to-food case in India, and a reader scanning the docket was told it was absent. The note had been written when the docket held neither the mid-day meal order nor the ICDS order; both went in afterwards and the note stayed where it was. It now sits under coverage, where it says the true thing: two orders from a two-decade petition are here, and neither stands for the case as a whole. Nothing is currently listed as set aside. (#1005)",
+      "fixed_on": "2026-08-24",
+      "release": "v10.248.0",
+      "issue": 1005
+    },
     {
       "title": "The docket said six cases had been set aside and listed one",
       "detail": "The sentence was written by hand while the list beneath it was generated from data, so when the list shrank the sentence did not. It now derives from the same data as the list and cannot contradict it. (#1002)",

--- a/data/judgments.json
+++ b/data/judgments.json
@@ -7,11 +7,9 @@
     "what_this_is": "Indian court judgments that changed what development organisations, state programmes and rights-holders can actually do.",
     "what_this_is_not": "Legal advice. Holdings are summarised editorially; the linked judgment is authoritative. Case law changes — check the status field and the date.",
     "verification": "Every entry's case name and decision year were checked against the judgment text, and each entry lists the specific terms confirmed present in that text. Summaries of what a case means are editorial and were not separately adjudicated.",
-    "excluded": [
-      {
-        "case": "The right-to-food litigation as a whole — PUCL v. Union of India, WP(C) 196/2001",
-        "why": "Two orders from this petition are now in the docket — the mid-day meal directions (2 May 2003, restating 28 November 2001) and the ICDS and Anganwadi directions (9 July 2007). The petition ran for two decades and produced far more orders than that, and most are not published as discrete documents that can be verified one by one. Nothing here stands for the whole case."
-      }
+    "excluded": [],
+    "coverage_notes": [
+      "Two orders from the right-to-food litigation (PUCL v. Union of India, WP(C) 196/2001) are in the docket — the mid-day meal directions of 2 May 2003, restating 28 November 2001, and the ICDS and Anganwadi directions of 9 July 2007. That petition ran for two decades and produced far more orders than those two, most of them not published as discrete documents that can be checked one by one. Read the two entries as two orders, not as the case."
     ]
   },
   "judgments": [

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 What's new on ImpactMojo. For the full technical changelog, see [CHANGELOG.md](https://github.com/ImpactMojo/ImpactMojo/blob/main/CHANGELOG.md) in the repository.
 
+## v10.248.0 — August 24, 2026 (A case that was listed as missing while it was there)
+
+### Fixed
+
+- **The Law Docket listed the right-to-food litigation under "What is deliberately not here" — while publishing two of its orders on the same page.** PUCL v. Union of India is the most consequential right-to-food case in India, and a reader scanning the docket was told it was absent. The note had been written when the docket held neither the mid-day meal order nor the ICDS order; both went in afterwards and the note stayed where it was. It now sits under coverage, where it says the true thing: two orders from a two-decade petition are here, and neither stands for the case as a whole. Nothing is currently listed as set aside. (#1005)
+
 ## v10.247.0 — August 24, 2026 (The mid-day meal order)
 
 ### For Learners

--- a/docs/judgments-standard.md
+++ b/docs/judgments-standard.md
@@ -51,11 +51,38 @@ name and decision year, then re-checked: each entry declares terms that must
 appear in the judgment text, and an entry whose terms are absent is dropped
 rather than published.
 
-Six were dropped, and they are listed in `meta.excluded` on the page itself —
-because a docket that shows only what it found looks more complete than it is.
-One drop is worth keeping in mind: a search for *Consumer Education & Research
-Centre v. Union of India* matched **LIC v. CERC**, a different case, and the
+Six were dropped on that check. Five were later found by searching for them
+properly rather than re-running the same query, and are now in the docket; the
+sixth — the right-to-food litigation — turned out to have been dropped on an
+assertion of mine that was simply wrong (I required the phrase "Public
+Distribution" in an order about ICDS). One drop is worth keeping in mind for
+the opposite reason: a search for *Consumer Education & Research Centre v.
+Union of India* matched **LIC v. CERC**, a different case, and the
 name-and-year filter alone let it through. The term check is what caught it.
+
+The lesson from the five is the one that generalises: **"my tool did not find
+it" is not "it is not findable"**, and writing the former up as principled
+restraint makes a research failure look like rigour.
+
+### `meta.excluded` vs `meta.coverage_notes`
+
+Two different claims, and mixing them shipped a bug (#1005).
+
+`meta.excluded` means **absent**: a candidate considered and not published,
+named so that a docket showing only what it found does not look more complete
+than it is. The page renders it under *"What is deliberately not here"*.
+
+`meta.coverage_notes` means **published, but read it narrowly**: a caveat about
+what an entry that *is* here can be taken to stand for. The page renders it
+under *"How these entries were checked"*, beside the Supreme-Court-only scope
+line.
+
+The right-to-food litigation sat in `excluded` while two of its orders were
+live on the same page, because the note was written when the docket had neither
+and nobody moved it when they went in. `scripts/check-judgments.py` now fails
+when an `excluded` entry names a petition number the docket publishes — matched
+on the citation number (`196 of 2001` ≡ `196/2001`) rather than party names,
+since "Union of India" is one side of most of this file.
 
 **What is verified is identity, not interpretation.** That a case exists, has
 this name and this date, and contains these terms — checked. That the summary

--- a/law-guides/development-law-docket.html
+++ b/law-guides/development-law-docket.html
@@ -139,6 +139,7 @@
       <p id="verif"></p>
       <p>Coverage is the Supreme Court of India. High Court and tribunal decisions, and the
       district courts entirely, are outside this first release.</p>
+      <div id="coverage-notes"></div>
     </section>
   </main>
 
@@ -262,6 +263,11 @@
         : 'Nothing is currently set aside. Anything dropped rather than published would be named here.';
       $('excluded-list').innerHTML = ex.map(function(e){
         return '<li><strong>'+esc(e.case)+'</strong> — '+esc(e.why)+'</li>'}).join('');
+      // Caveats about what a published entry can be taken to stand for are not
+      // exclusions — listing them under "not here" said a case was missing that
+      // is in fact in the docket. They belong with coverage.
+      $('coverage-notes').innerHTML = (META.coverage_notes||[])
+        .map(function(n){ return '<p>'+esc(n)+'</p>' }).join('');
       ['q','theme','status','scope'].forEach(function(id){
         $(id).addEventListener('input', render); $(id).addEventListener('change', render);
       });

--- a/scripts/check-judgments.py
+++ b/scripts/check-judgments.py
@@ -61,6 +61,15 @@ ID_RE = re.compile(r'^[a-z0-9]+(-[a-z0-9]+)*$')
 URL_RE = re.compile(r'^https://')
 
 
+def citation_numbers(text):
+    """Petition/citation numbers in a string, normalised so "196 of 2001" and
+    "196/2001" compare equal. These identify a case; party names do not."""
+    out = set()
+    for num, year in re.findall(r'(\d{1,5})\s*(?:of\s*|/)\s*((?:19|20)\d\d)', text):
+        out.add('%s/%s' % (num.lstrip('0') or '0', year))
+    return out
+
+
 def main():
     if not DATA.exists():
         print('FAIL - %s not found.' % DATA.relative_to(ROOT))
@@ -129,6 +138,38 @@ def main():
 
     if not entries:
         failures.append('data/judgments.json holds no entries')
+
+    # An "excluded" entry that names a case the docket actually publishes tells
+    # a reader the opposite of the truth. That shipped: the right-to-food
+    # litigation sat under "What is deliberately not here" while two of its
+    # orders were live on the same page, because the note was written when the
+    # docket had neither and never moved when they went in.
+    #
+    # Matched on the petition/citation number rather than party names, because
+    # the party names in Indian public-interest litigation repeat endlessly
+    # ("Union of India" is one side of most of this file) while "196 of 2001"
+    # identifies exactly one petition. A caveat about what a published entry
+    # stands for belongs in meta.coverage_notes, which the page renders under
+    # coverage instead of under exclusions.
+    published = set()
+    for j in entries:
+        published |= citation_numbers(' '.join(
+            str(j.get(k, '')) for k in ('case', 'source_title', 'holding')))
+    for i, e in enumerate(doc.get('meta', {}).get('excluded', []) or []):
+        if not isinstance(e, dict) or not e.get('case') or not e.get('why'):
+            failures.append('meta.excluded[%d]           needs both "case" and "why"' % i)
+            continue
+        clash = citation_numbers(e['case'] + ' ' + e['why']) & published
+        if clash:
+            failures.append(
+                'meta.excluded[%d]           names %s, which the docket publishes -- '
+                'a coverage caveat belongs in meta.coverage_notes'
+                % (i, ', '.join(sorted(clash))))
+
+    notes = doc.get('meta', {}).get('coverage_notes', [])
+    if not isinstance(notes, list) or any(not isinstance(n, str) or not n.strip()
+                                          for n in notes):
+        failures.append('meta.coverage_notes         must be a list of non-empty strings')
 
     if failures:
         print('FAIL')


### PR DESCRIPTION
Fixes #1005.

The docket published two orders from **PUCL v. Union of India, WP(C) 196/2001** — the mid-day meal directions and the ICDS directions — while naming the same litigation under **"What is deliberately not here"**. A reader scanning the page was told the most consequential right-to-food case in India was missing, on the page that carries it. The intro line contradicted the entry directly beneath it: *"set aside on a weak match"* over *"two orders from this petition are now in the docket"*.

The note was written when the docket held neither order. Both went in later and the note never moved.

## It was never an exclusion

It is a caveat about what two *published* orders can be taken to stand for. That is a different claim from absence, and it belongs beside coverage.

- `meta.excluded` → empty. The section now correctly reads *"Nothing is currently set aside."*
- New `meta.coverage_notes` carries it, rendered under **"How these entries were checked"** next to the existing Supreme-Court-only scope line.

## The guard

`scripts/check-judgments.py` now fails when an `excluded` entry names a petition number the docket publishes.

Matched on the **citation number**, with `196 of 2001` and `196/2001` normalised to one token — not on party names, since "Union of India" is one side of most of this file while `196 of 2001` identifies exactly one petition.

Checked against the real regression rather than assumed. Putting the entry back:

```
FAIL
  meta.excluded[0]  names 196/2001, which the docket publishes -- a coverage caveat belongs in meta.coverage_notes
```

## Same cause as #1002

That one was a hardcoded "Six candidate cases were dropped" above a list of one. Both are a hand-written claim about a generated surface, drifting from what the surface shows. `docs/judgments-standard.md` now spells out `excluded` (absent) vs `coverage_notes` (present, read narrowly), and its own stale "Six were dropped, and they are listed in `meta.excluded`" line is corrected.

## Type of change

- [x] Bug fix (broken link, layout, JS error)
- [ ] New content (course, case study, translation)
- [ ] New feature or tool
- [ ] Accessibility improvement
- [ ] Performance improvement
- [ ] Documentation update

## Checklist

- [x] Tested on desktop browser
- [x] Tested on mobile browser
- [x] No console errors
- [x] Links are working

Chromium render: 61 cards, 0 exclusions, the caveat under coverage. (One console error, `supabase.createClient` — the CDN is blocked in the agent sandbox; sitewide and unrelated to this change.)

Guards pass: judgments, counts, mojibake, fix-issues, viewport, h1-survives-chrome, search-coverage, law-guide drift, asset-stamps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gFEJ2FoiFQjyXvmDGGB9W

---
_Generated by [Claude Code](https://claude.ai/code/session_011gFEJ2FoiFQjyXvmDGGB9W)_